### PR TITLE
Enable just building

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,7 +17,10 @@ _uid_args := if "{{ os() }}" == "Linux" {
     }
 
 build: _web
-   just _build
+    just _build
+
+dev: _web_build
+    just _build_dev
 
 certs:
     mkdir -p certs
@@ -40,6 +43,28 @@ test: _web
 [private]
 _build:
     {{ _with_runner }} ./scripts/build.bash ./cmd/connect-client
+
+[private]
+_build_dev:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # translate `just` os/arch strings to the ones `go build` expects
+    os="{{ os() }}"
+    arch="{{ arch() }}"
+
+    # windows and linux strings match
+    if [[ "$os" == "macos" ]]; then
+        os=darwin
+    fi
+
+    if [[ "$arch" == "x86_64" ]]; then
+        arch=amd64
+    elif [[ "$arch" == "aarch64" ]]; then
+        arch=arm64
+    fi
+
+    {{ _with_runner }} ./scripts/build.bash ./cmd/connect-client "$os/$arch"
 
 [private]
 _image:

--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -6,38 +6,42 @@ if [[ -z "$package" ]]; then
   exit 1
 fi
 
-package_name=`basename $package`
-version=`git describe --always --tags`
-	
-platforms=(
-    "darwin/amd64"
-    "darwin/arm64"
-    # "dragonfly/amd64"
-    # "freebsd/386"
-    # "freebsd/amd64"
-    # "freebsd/arm"
-    # "linux/386"
-    "linux/amd64"
-    # "linux/arm"
-    "linux/arm64"
-    # "linux/ppc64"
-    # "linux/ppc64le"
-    # "linux/mips"
-    # "linux/mipsle"
-    # "linux/mips64"
-    # "linux/mips64le"
-    # "netbsd/386"
-    # "netbsd/amd64"
-    # "netbsd/arm"
-    # "openbsd/386"
-    # "openbsd/amd64"
-    # "openbsd/arm"
-    # "plan9/386"
-    # "plan9/amd64"
-    # "solaris/amd64"
-    # "windows/386"
-    "windows/amd64"
-)
+package_name=$(basename "$package")
+version=$(git describe --always --tags)
+
+if [[ -n "$2" ]]; then
+    platforms=("$2")
+else
+    platforms=(
+        "darwin/amd64"
+        "darwin/arm64"
+        # "dragonfly/amd64"
+        # "freebsd/386"
+        # "freebsd/amd64"
+        # "freebsd/arm"
+        # "linux/386"
+        "linux/amd64"
+        # "linux/arm"
+        "linux/arm64"
+        # "linux/ppc64"
+        # "linux/ppc64le"
+        # "linux/mips"
+        # "linux/mipsle"
+        # "linux/mips64"
+        # "linux/mips64le"
+        # "netbsd/386"
+        # "netbsd/amd64"
+        # "netbsd/arm"
+        # "openbsd/386"
+        # "openbsd/amd64"
+        # "openbsd/arm"
+        # "plan9/386"
+        # "plan9/amd64"
+        # "solaris/amd64"
+        # "windows/386"
+        "windows/amd64"
+    )
+fi
 
 for platform in "${platforms[@]}"
 do
@@ -46,11 +50,11 @@ do
 	GOOS=${platform_split[0]}
 	GOARCH=${platform_split[1]}
 	output_name='./bin/'$GOOS'-'$GOARCH/$package_name
-	if [ $GOOS = "windows" ]; then
+	if [ "$GOOS" = "windows" ]; then
 		output_name+='.exe'
 	fi
 
-    env GOOS=$GOOS GOARCH=$GOARCH go build -o $output_name -ldflags "-X project.Version=$version" $package
+    env GOOS="$GOOS" GOARCH="$GOARCH" go build -o "$output_name" -ldflags "-X project.Version=$version" "$package"
 	if [ $? -ne 0 ]; then
    		echo 'An error has occurred! Aborting the script execution...'
 		exit 1

--- a/web/justfile
+++ b/web/justfile
@@ -15,5 +15,3 @@ test: build
 
 start:
     yarn start
-
-


### PR DESCRIPTION
Update the justfile to enable a build-only cycle that builds the UI and a platform-native binary. The current `just build` target take a long time since it runs lint and tests.