### PR TITLE
Catch `net.Lister` error when starting on already in use port

### DIFF
--- a/internal/services/api/http_service.go
+++ b/internal/services/api/http_service.go
@@ -106,6 +106,10 @@ func (svc *Service) Run() error {
 
 	// Open listener first so the browser can connect
 	listener, err := net.Listen("tcp", svc.listen)
+	if err != nil {
+		return fmt.Errorf("UI server error: %s", err)
+	}
+
 	svc.addr = listener.Addr()
 
 	// Log without the token


### PR DESCRIPTION
Avoids a panic when attempting to start `connect-client` on a port that is already in use.

## Intent
- Fixes #31 

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Directions for Reviewers
To reproduce this issue:
- Run `just`
- Attempt to run the UI with a command like:
  - `./bin/darwin-arm64/connect-client account-ui -i --listen=127.0.0.1:9000`
  - `./bin/darwin-arm64/connect-client publish-ui ~/development/connect-content/bundles/python-flaskapi -i --listen=127.0.0.1:9000`
  - **Note:** be sure to point to the correct bin directory for your OS and architecture.
- Attempt to run the UI again with it already running on port `9000`

