### PR TITLE
Use @typescript-eslint/no-shadow ESLint rule

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -319,7 +319,8 @@ module.exports = {
     strict: 'error',
     'symbol-description': 'error',
     yoda: ['error', 'never'],
-    'no-shadow': [
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': [
       'error',
       {
         builtinGlobals: true,


### PR DESCRIPTION
This replaces our usage of the [`eslint/no-shadow`](https://eslint.org/docs/latest/rules/no-shadow) rule with [`@typescript-eslint/no-shadow`](https://typescript-eslint.io/rules/no-shadow/) to better lint our TypeScript code.

[`no-shadow` incorrectly flags TypeScript enums as shadowing.](https://github.com/typescript-eslint/typescript-eslint/issues/2483). The resolution to this is to use the TypeScript specific rule:

> This rule extends the base [eslint/no-shadow](https://eslint.org/docs/rules/no-shadow) rule. It adds support for TypeScript's this parameters and global augmentation, and adds options for TypeScript features.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Directions for Reviewers
If you'd like to check this you can manually add an enum to the code base and lint (using your IDE or with `just web/lint`):

Here is an example enum to use:

```typescript
export enum ServerType {
    CONNECT = 'connect',
    SHINY_APPS = 'shinyapps',
    CLOUD = 'cloud',
}
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
