### PR TITLE
ignore deployment metadata from other folks

### DIFF
--- a/test/sample-content/.gitignore
+++ b/test/sample-content/.gitignore
@@ -1,0 +1,2 @@
+.posit/
+rsconnect-python/


### PR DESCRIPTION
## Intent
No need (or desire) to save metadata artifacts created by deployment process of sample content.

## Type of Change
- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Files excluded w/ a `.gitignore` file. None had made it into the repo yet.

NOTES: 

As part of getting ready for the publish button to do something, I performed these deployments:
```
./bin/darwin-amd64/connect-client publish \
test/sample-content/fastapi-simple \
 --account-name=dogfood \
 --title="First Connect-Client Test"
```

and using rsconnect-python:

```
rsconnect deploy api \     
 --name=dogfood \
test/sample-content/fastapi-simple
```

## Automated Tests
Not applicable

## Directions for Reviewers

After attempting to deploy the FastAPI sample, this is what my repo looks like. The `.gitignore` file ignores these files recursively below the `test/sample-content` subdirectory.

![2023-08-03 at 1 41 PM](https://github.com/rstudio/publishing-client/assets/17675905/f3729c92-0932-42b0-a31c-28033f0b2e42)
