### PR TITLE
Add DeploymentFile ExclusionMatch types

### DIFF
--- a/web/src/api/types/files.ts
+++ b/web/src/api/types/files.ts
@@ -27,7 +27,6 @@ export type DeploymentFile = {
     is_dir: boolean
     is_entrypoint: boolean
     is_file: boolean
-    is_excluded: boolean
     files: DeploymentFile[]
     exclusion: ExclusionMatch | null
 }


### PR DESCRIPTION
This is a follow-up to #105 that incorporates the type changes seen in #89.

## Intent
- Part of #83 

## Approach
- This takes the type `file` struct in `internal/services/api/files.go` and incorporates it into the frontend types

## Directions for Reviewers
- Check the added types and see if they match the Go struct in `internal/services/api/files.go`

If you'd like to verify the usage you can add the following to a frontend Vue component:

```
import { useApi } from 'src/api/client';

const api = useApi();

const files = async() => {
  const response = await api.files.get({ pathname: 'web/src/api' });
  console.log(response);
};

files();
```
