### PR TITLE
Create simplest file tree using files API

### DIFF
--- a/internal/services/api/files.go
+++ b/internal/services/api/files.go
@@ -16,6 +16,7 @@ import (
 
 type file struct {
 	FileType         fileType `json:"file_type"`         // the file type
+	BaseName         string   `json:"base_name"`         // the file name
 	Pathname         string   `json:"pathname"`          // the pathname
 	Size             int64    `json:"size"`              // nullable; length in bytes for regular files; system-dependent
 	ModifiedDatetime string   `json:"modified_datetime"` // the last modified datetime
@@ -39,6 +40,7 @@ func newFile(path util.Path, isExcluded bool) (*file, error) {
 
 	return &file{
 		FileType:         filetype,
+		BaseName:         path.Base(),
 		Pathname:         path.Path(),
 		Size:             info.Size(),
 		ModifiedDatetime: info.ModTime().Format(time.RFC3339),

--- a/internal/services/api/files_test.go
+++ b/internal/services/api/files_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/rstudio/connect-client/internal/util"
@@ -55,6 +56,7 @@ func (s *FilesSuite) Test_getFile() {
 func (s *FilesSuite) Test_getFile_pathname() {
 	fs := afero.NewMemMapFs()
 	pathname, _ := afero.TempDir(fs, "", "")
+	basename := filepath.Base(pathname)
 	req, err := http.NewRequest("GET", "?pathname="+pathname, nil)
 	s.NoError(err)
 
@@ -71,4 +73,5 @@ func (s *FilesSuite) Test_getFile_pathname() {
 	s.NoError(dec.Decode(res))
 
 	s.Equal(pathname, res.Pathname)
+	s.Equal(basename, res.BaseName)
 }

--- a/web/src/api/types/files.ts
+++ b/web/src/api/types/files.ts
@@ -6,6 +6,7 @@ export enum DeploymentFileType {
 export type DeploymentFile = {
     file_type: DeploymentFileType
     pathname: string
+    base_name: string
     size: number
     modified_datetime: string
     is_dir: boolean

--- a/web/src/panels/FilesToPublish.vue
+++ b/web/src/panels/FilesToPublish.vue
@@ -42,7 +42,7 @@ const files = ref<QTreeNode[]>([]);
 function fileToTreeNode(file: DeploymentFile): QTreeNode {
   const node: QTreeNode = {
     key: file.pathname,
-    label: file.pathname,
+    label: file.base_name,
     children: file.files.map(fileToTreeNode),
   };
 


### PR DESCRIPTION
This PR adds the simplest version of the file tree using `QTree` from Quasar and the Files API.

<details>
  <summary>Preview</summary>

![CleanShot 2023-08-08 at 12 27 20](https://github.com/rstudio/publishing-client/assets/19917631/d3e60773-2ea0-4e5f-8243-3eb72d898264)


</details> 

## Intent
- Part of #84 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
- Files are retrieved using the `GET /api/files` API endpoint 
  - This is done when the component is created by calling the async function at the end of the setup script
- `DeploymentFile` objects are simply converted to `QTreeNode`s to use with Quasar's Tree component
- The checkboxes are not "check-able" since no state has been created
- The pathname `web/src/api` is used temporarily to reduce the size of the file tree:
  - With the full `publishing-client` directory the rendering really starts to slow and crashed my Chrome tab once
  - the `GET /api/files` endpoint also doesn't get the whole tree

## Directions for Reviewers
Take a look at the minimal File Tree patterns used here, and determine if it is a good foundation to continue off of. 
