### PR TITLE
Use NODE_KEY const in FilesToPublish

### DIFF
--- a/web/src/panels/FilesToPublish.vue
+++ b/web/src/panels/FilesToPublish.vue
@@ -20,7 +20,7 @@
         <q-tree
           v-model:ticked="filesStore.filesToPublish"
           :nodes="files"
-          node-key="key"
+          :node-key="NODE_KEY"
           tick-strategy="leaf"
           dark
           dense
@@ -37,6 +37,8 @@ import { ref } from 'vue';
 import { useApi, DeploymentFile } from 'src/api';
 import { useFilesStore } from 'src/stores/files';
 
+const NODE_KEY = 'key';
+
 const api = useApi();
 const filesStore = useFilesStore();
 
@@ -44,7 +46,7 @@ const files = ref<QTreeNode[]>([]);
 
 function fileToTreeNode(file: DeploymentFile): QTreeNode {
   const node: QTreeNode = {
-    key: file.pathname,
+    [NODE_KEY]: file.pathname,
     label: file.base_name,
     children: file.files.map(fileToTreeNode),
   };


### PR DESCRIPTION
Super small PR that adds a const `NODE_KEY` to `FilesToPublish.vue`. The reason for this is `QTree` takes a [`nodes-key` prop](https://quasar.dev/vue-components/tree#qtree-api) that represents "The property name of each node object that holds a unique node id".

`node-key` is a required Prop, but there is nothing that prevents us from de-syncing what is in the template and what property key we use in our construction of the `QTreeNode`s.

Adding this const gives a stronger connection to the two.

## Intent
- Part of #84 
