### PR TITLE
Expand top level directory in file tree

### DIFF
--- a/web/src/panels/FilesToPublish.vue
+++ b/web/src/panels/FilesToPublish.vue
@@ -19,6 +19,7 @@
       <q-card-section>
         <q-tree
           v-model:ticked="filesStore.filesToPublish"
+          v-model:expanded="expanded"
           :nodes="files"
           :node-key="NODE_KEY"
           tick-strategy="leaf"
@@ -43,6 +44,7 @@ const api = useApi();
 const filesStore = useFilesStore();
 
 const files = ref<QTreeNode[]>([]);
+const expanded = ref<string[]>([]);
 
 function fileToTreeNode(file: DeploymentFile): QTreeNode {
   const node: QTreeNode = {
@@ -56,7 +58,14 @@ function fileToTreeNode(file: DeploymentFile): QTreeNode {
 
 async function getFiles() {
   const response = await api.files.get({ pathname: 'web/src/api' });
-  files.value = [fileToTreeNode(response.data)];
+  const file = response.data;
+
+  files.value = [fileToTreeNode(file)];
+
+  if (file.is_dir) {
+    // start with the top level directory expanded
+    expanded.value = [file.pathname];
+  }
 }
 
 getFiles();


### PR DESCRIPTION
This PR adds the `expanded` prop to the `QTree` in the `FilesToPublish` Vue component to manage the default expanded directories in the file tree. 

<details>
  <summary>Before</summary>

https://github.com/rstudio/publishing-client/assets/19917631/dedc9eec-0312-4e72-be1b-050ea360484e

</details> 

<details>
  <summary>After</summary>

https://github.com/rstudio/publishing-client/assets/19917631/7d96767f-a823-4cfc-94a8-c7208d245d53


</details>

## Intent
- Part of #84 

## Type of Change

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
- This adds only the top level directory, if the `DeploymentFile` in the `GET /api/files` API response is a directory in the first place
  - It technically works just fine if the `pathname` points to a regular file, but it felt incorrect to make a non-expandable `QTreeNode` key sit in `expanded`
