### PR TITLE
Use pathname for parent file in file tree

### DIFF
--- a/web/src/panels/FilesToPublish.vue
+++ b/web/src/panels/FilesToPublish.vue
@@ -46,11 +46,11 @@ const filesStore = useFilesStore();
 const files = ref<QTreeNode[]>([]);
 const expanded = ref<string[]>([]);
 
-function fileToTreeNode(file: DeploymentFile): QTreeNode {
+function fileToTreeNode(file: DeploymentFile, isParent = false): QTreeNode {
   const node: QTreeNode = {
     [NODE_KEY]: file.pathname,
-    label: file.base_name,
-    children: file.files.map(fileToTreeNode),
+    label: isParent ? file.pathname : file.base_name,
+    children: file.files.map(child => fileToTreeNode(child)),
   };
 
   return node;
@@ -60,7 +60,7 @@ async function getFiles() {
   const response = await api.files.get({ pathname: 'web/src/api' });
   const file = response.data;
 
-  files.value = [fileToTreeNode(file)];
+  files.value = [fileToTreeNode(file, true)];
 
   if (file.is_dir) {
     // start with the top level directory expanded


### PR DESCRIPTION
This PR makes it so the top level Directory File uses the full `pathname` as opposed to the `base_name` in the File Tree.

<details>
  <summary>Preview</summary>
  
  ![CleanShot 2023-08-08 at 14 48 06](https://github.com/rstudio/publishing-client/assets/19917631/902a7e4b-a572-4827-b3cd-4957927e33a3)

</details> 

## Intent
- Part of #84 

## Approach
I tried a few different methods like converting only the top level file and then the children different, creating different functions, or more complex parameters. It felt like the easiest was to provide a boolean whether or not we were converting the top level `DeploymentFile` and use the `pathname` based on that.

It does feel a bit less multi-use as a utility function because of this, but we can adjust if something like this is needed in multiple spots in the codebase.

## Directions for Reviewers
Take a look at the changes to `fileToTreeNode` function and see if you agree that is the best path forward for this.

