### PR TITLE
Disable checkbox in file tree for excluded files

### DIFF
--- a/web/src/panels/FilesToPublish.vue
+++ b/web/src/panels/FilesToPublish.vue
@@ -51,6 +51,7 @@ function fileToTreeNode(file: DeploymentFile): QTreeNode {
     [NODE_KEY]: file.pathname,
     label: file.base_name,
     children: file.files.map(fileToTreeNode),
+    tickable: !file.exclusion,
   };
 
   return node;


### PR DESCRIPTION
Nice and simple PR. This one makes files that are `is_excluded: true` not "tickable" in the File Tree.

What that means is:
- they cannot be checked or unchecked - clicking on the checkbox will not change the state of the `ticked` prop
- files can still be in the `filesToPublish` store property and be disabled if we would like different behavior based on what `GET /api/deployment/files` returns we will need to adjust this

<details>
  <summary>Preview</summary>

https://github.com/rstudio/publishing-client/assets/19917631/44838109-37e6-40d2-b3c6-6356151f9e0b

</details> 

## Intent
Resolves #122 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
This uses `QTree`'s Node's model structure when converting `DeploymentFile`s to `QTreeNode`s and sets `tickable` based on `file.is_excluded`.

There is another option ([discussed here in Slack](https://positpbc.slack.com/archives/C05D7NZD52S/p1691697562897719)) called `disabled` that does three things:
- override `tickable`
- prevents the checkbox from being checked
- prevents the collapsing / uncollapsing click action from happening if the file has children

I opted not to use that for the `excluded` for now, but definitely voice your opinions if you believe we should use the other property. We can revisit when dealing with soft and hard exclusions.

## Directions for Reviewers
- Take a look at the logic
- Determine if `tickable` or `disabled` is the right way to go
