### PR TITLE
Fix InternalError capitalization typo

### DIFF
--- a/internal/services/api/files.go
+++ b/internal/services/api/files.go
@@ -105,7 +105,7 @@ func getFile(afs afero.Fs, log rslog.Logger, w http.ResponseWriter, r *http.Requ
 
 	ok, err := p.IsSafe()
 	if err != nil {
-		internalError(w, log, err)
+		InternalError(w, log, err)
 		return
 	}
 


### PR DESCRIPTION
Fixes a typo that was causing the build to fail:
```
❯ just build-agent-dev
rm -rf ./bin/**/connect-client

Generating a development build of connect-client.
Building darwin/arm64
# github.com/rstudio/connect-client/internal/services/api
internal/services/api/files.go:108:3: undefined: internalError
```
