### PR TITLE
Correct args type in SignalFn

### DIFF
--- a/web/src/utils/requestOnce.ts
+++ b/web/src/utils/requestOnce.ts
@@ -1,6 +1,7 @@
 import { debounce } from 'quasar';
 
-type SignalFn = (signal: AbortSignal, ...args: unknown[]) => unknown;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SignalFn = (signal: AbortSignal, ...args: any[]) => unknown;
 type ExcludeSignal<T extends unknown[]> = T extends [AbortSignal, ...infer P] ? P : never;
 
 export function requestOnce<F extends SignalFn>(


### PR DESCRIPTION
This PR corrects the `..args: unknown[]` to `...args: any[]` in the `SignalFn` TypeScript type for `requestOnce`. 

With `unknown` the usage would error saying that the arguments are incompatible with `unknown`. Opening the type to accept any function with any arguments defined allows for each use to be accepted.

A `eslint-disable-next-line @typescript-eslint/no-explicit-any` does need to be used to allow for this, but `any` is the correct usage here since it can be _any_ type. 