### PR TITLE
Listen on localhost by default

### DIFF
--- a/internal/cli_types/base.go
+++ b/internal/cli_types/base.go
@@ -37,7 +37,7 @@ type UIArgs struct {
 	Interactive            bool   `short:"i" help:"Launch a browser to show the UI at the listen address."`
 	OpenBrowserAt          string `help:"Launch a browser to show the UI at specific network address." placeholder:"HOST[:PORT]" hidden:""`
 	SkipBrowserSessionAuth bool   `help:"Skip Browser Token Auth Checks" hidden:""`
-	Listen                 string `help:"Network address to listen on." placeholder:"HOST[:PORT]"`
+	Listen                 string `help:"Network address to listen on." placeholder:"HOST:PORT" default:"localhost:0"`
 	AccessLog              bool   `help:"Log all HTTP requests."`
 	TLSKeyFile             string `help:"Path to TLS private key file for the UI server."`
 	TLSCertFile            string `help:"Path to TLS certificate chain file for the UI server."`


### PR DESCRIPTION
This PR changes the default `--listen` address from empty (binds all interfaces) to `localhost:0` (binds an ephemeral port on localhost only).

## Intent

Even though we have local token auth, it's better to only bind to localhost so that external access is not permitted. This is suitable for local use as well as hosted environments which will proxy inbound requests to the process locally.

Fixes #150 (where the default address doesn't work on Mac if ipv6 is disabled).

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
Change default value for `--listen`.

## Automated Tests
The CLI defaults do not have automated tests, so there isn't a test specifically for this.

## Directions for Reviewers
Build locally and run without specifying `--listen`. You should see localhost (or an equivalent IP address) and an auto-assigned port number, and the UI should be accessible.
