### PR TITLE
Enforce typescript naming-conventions with ESLint

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -98,6 +98,12 @@ module.exports = {
     // in plain CommonJS modules, you can't use `import foo = require('foo')` to pass this rule, so it has to be disabled
     '@typescript-eslint/no-var-requires': 'off',
 
+    '@typescript-eslint/naming-convention': [
+      'error',
+      { selector: ['variableLike', 'classProperty', 'typeProperty'], format: ['camelCase'] },
+      { selector: 'variable', modifiers: ['const'], format: ['camelCase', 'UPPER_CASE'] }
+    ],
+
     // The core 'no-unused-vars' rules (in the eslint:recommended ruleset)
     // does not work with type definitions
     'no-unused-vars': 'off',


### PR DESCRIPTION
This PR adds the [`@typescript-eslint/naming-convention`](https://typescript-eslint.io/rules/naming-convention/) rule to enforce `camelCase` and `UPPER_CASE` naming.

` selector: ['variableLike', 'classProperty', 'typeProperty'], format: ['camelCase'] },`

Enforces `camelCase` on variables, parameters, functions, class properties, and type properties. `property` wasn't used generally since it affects properties of all kinds including the ESLint rules which don't follow `camelCase` along with several other files. This mainly targets actual TypeScript code and types.

`{ selector: 'variable', modifiers: ['const'], format: ['camelCase', 'UPPER_CASE'] }`

Allows us to use `UPPER_CASE` for more global style constants.

## Intent
- Extension of #153 and #74

## Directions for Reviewers
- Take a look at the rule configuration to see if you agree with it.
