### PR TITLE
Remove npm peerDependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -47,12 +47,6 @@
         "node": "^18 || ^16 || ^14.19",
         "npm": ">= 6.13.4",
         "yarn": ">= 1.21.1"
-      },
-      "peerDependencies": {
-        "eslint-plugin-import": "^2.27.5",
-        "quasar": "^2.12.0",
-        "vue": "^3.3.4",
-        "vue-router": "^4.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/web/package.json
+++ b/web/package.json
@@ -45,11 +45,5 @@
     "node": "^18 || ^16 || ^14.19",
     "npm": ">= 6.13.4",
     "yarn": ">= 1.21.1"
-  },
-  "peerDependencies": {
-    "eslint-plugin-import": "^2.27.5",
-    "quasar": "^2.12.0",
-    "vue": "^3.3.4",
-    "vue-router": "^4.2.2"
   }
 }


### PR DESCRIPTION
While cleaning up our packages in #170 I noticed we had a few `peerDepedencies` that were already in our dependency list. None of these are [`peerDepedencies` in the way that npm describes them](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies).

I believe these came from the Qausar template for setting up a project. For comparison I started up a Quasar project from scratch and it no longer has any `peerDependencies` listed.

## Intent
- Part of #167 work