### PR TITLE
Use es2021 as target, lib, and env across configs

### DIFF
--- a/web/cypress/tsconfig.json
+++ b/web/cypress/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2021",
         "lib": [
-            "es5",
+            "es2021",
             "dom"
         ],
         "types": [

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "ES2020",
+    "target": "es2021",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["es2021", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
This PR is a follow-up to #189 that unifies our TypeScript config `target` and `lib`, and our ESLint `env` across the frontend to use `es2021`. 

### Reference
- https://h3manth.com/ES2021/
- https://caniuse.com/?search=es2021
