### PR TITLE
Use no-caps prop on Publish button

### DIFF
--- a/web/src/components/configurePublish/PublishingHeader.vue
+++ b/web/src/components/configurePublish/PublishingHeader.vue
@@ -19,6 +19,7 @@
       label="Publish"
       padding="8px 30px"
       class="q-ml-xs"
+      no-caps
       @click="onPublish"
     />
   </div>


### PR DESCRIPTION
Changes the Publish button from all capitals to only capitalizing the 'P' in 'Publish'.

To do this I'm using the `no-caps` prop for `q-btn` in Quasar. This didn't appear to be documented in the button page, but may be somewhere else. The way I found this was by looking at this example's code: https://quasar.dev/vue-components/button/#custom-ripple.

<details>
  <summary>Preview</summary>
  
![CleanShot 2023-09-26 at 10 52 56](https://github.com/rstudio/publishing-client/assets/19917631/22b87a71-20d4-4fde-a59b-c01b98a6c5d3)

</details> 

## Intent
- Fixes #226 
