### PR TITLE
Use provide / inject for EventStream

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -71,7 +71,7 @@ const eventStream = new EventStream();
 // Temporary storage of events
 const allEvents = ref<EventStreamMessage[]>([]);
 
-provide<SSE>(sseKey, {
+provide(sseKey, {
   stream: eventStream,
   events: allEvents
 });

--- a/web/src/components/publishProcess/PublishProcess.vue
+++ b/web/src/components/publishProcess/PublishProcess.vue
@@ -34,10 +34,10 @@
 import { PublishSuccess } from 'src/api/types/events';
 import { inject, onBeforeUnmount, ref, watch } from 'vue';
 import { scroll as qScroll } from 'quasar';
-import { SSE, sseKey } from 'src/utils/inject';
+import { sseKey } from 'src/utils/inject';
 const { getScrollTarget, setVerticalScrollPosition } = qScroll;
 
-const sse = inject<SSE>(sseKey);
+const sse = inject(sseKey);
 
 const agentLogEnd = ref<HTMLDivElement | null>(null);
 

--- a/web/src/utils/inject.ts
+++ b/web/src/utils/inject.ts
@@ -1,13 +1,13 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
-import { Ref } from 'vue';
+import { Ref, InjectionKey } from 'vue';
 
 import { EventStream } from 'src/api/resources/EventStream';
 import { EventStreamMessage } from 'src/api/types/events';
-
-export const sseKey = Symbol('Key for Server Side Events Vue Provide / Inject');
 
 export type SSE = {
   stream: EventStream,
   events: Ref<EventStreamMessage[]>
 }
+
+export const sseKey = Symbol('Key for Server Side Events Vue Provide / Inject') as InjectionKey<SSE>;


### PR DESCRIPTION
This PR changes our App level `eventStream` and `allEvents` from being passed down using props to being provided to children (grandchildren etc) components using Vue 3's [Provide / Inject](https://vuejs.org/guide/components/provide-inject.html#provide-inject).

## Intent
To provide a way for further components to access our Event Stream while avoiding establishing several connections, and prop-drilling too far down.
