### PR TITLE
Listen to localhost by default

### DIFF
--- a/internal/cli_types/base.go
+++ b/internal/cli_types/base.go
@@ -41,7 +41,7 @@ type UIArgs struct {
 	Interactive            bool   `short:"i" help:"Launch a browser to show the UI at the listen address."`
 	OpenBrowserAt          string `help:"Launch a browser to show the UI at specific network address." placeholder:"HOST[:PORT]" hidden:""`
 	SkipBrowserSessionAuth bool   `help:"Skip Browser Token Auth Checks" hidden:""`
-	Listen                 string `help:"Network address to listen on." placeholder:"HOST[:PORT]"`
+	Listen                 string `help:"Network address to listen on." placeholder:"HOST[:PORT]" default:"localhost:0"`
 	AccessLog              bool   `help:"Log all HTTP requests."`
 	TLSKeyFile             string `help:"Path to TLS private key file for the UI server."`
 	TLSCertFile            string `help:"Path to TLS certificate chain file for the UI server."`


### PR DESCRIPTION
This PR sets the default Listen address to `localhost:0`. This will avoid the issue where we were generating an ipv6 address like `http://[::]:54744/?token=...` even if ipv6 wasn't enabled. Using port 0 causes the go network code to dynamically allocate a port.

## Intent
Fixes #210 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Automated Tests
We don't have automated tests for the Kong binding struct tags.

## Directions for Reviewers
Build the agent and run `publish-ui` without including `--listen`. You should see a localhost URL like `http://127.0.0.1:54748/?token=...` rather than the ipv6 address. Also run with `--listen` to ensure that you can still select a port.
