### PR TITLE
Return callback when adding event stream callback

### DIFF
--- a/web/src/api/resources/EventStream.ts
+++ b/web/src/api/resources/EventStream.ts
@@ -233,11 +233,11 @@ export class EventStream {
   public addEventMonitorCallback<T extends EventSubscriptionTarget>(
     target: T,
     cb: EventSubscriptionTargetCallbackMap[T]
-  ): void;
+  ): EventSubscriptionTargetCallbackMap[T];
   public addEventMonitorCallback(
     target: EventSubscriptionTarget | EventSubscriptionTarget[],
     cb: OnMessageEventSourceCallback
-  ): void {
+  ): OnMessageEventSourceCallback {
     if (Array.isArray(target)) {
       target.forEach(t => this.addEventMonitorCallback(t, cb));
     } else {
@@ -246,6 +246,7 @@ export class EventStream {
         callback: cb,
       });
     }
+    return cb;
   }
 
   /**


### PR DESCRIPTION
This PR changes the `EventStream.addEventMonitorCallback()` method from not returning anything to returning the callback passed to it.

This is a slight improvement for development that makes it easier to use `addEventMonitorCallback` and `delEventFilterCallback` together with arrow functions like so:

```
const cb = eventStream.addEventMonitorCallback('target', () => {
 // this is a callback
});
eventStream.delEventFilterCallback(cb);
```

## Intent
Small improvement to the `EventStream` to make it easier to use in #233 and further work.
