### PR TITLE
Update Title input field to reference Pinia deployment store

### DIFF
--- a/web/src/api/types/connect.ts
+++ b/web/src/api/types/connect.ts
@@ -13,6 +13,6 @@ export type ConnectEnvironmentVariable = {
 }
 
 export type ConnectDeployment = {
-    connect: ConnectContent;
+    content: ConnectContent;
     environment: ConnectEnvironmentVariable[];
 }

--- a/web/src/components/configurePublish/PublishingHeader.vue
+++ b/web/src/components/configurePublish/PublishingHeader.vue
@@ -26,13 +26,33 @@
 
 <script setup lang="ts">
 
-import { ref } from 'vue';
 import { useApi } from 'src/api';
+import { useDeploymentStore } from 'src/stores/deployment';
+import { computed } from 'vue';
 
 const emit = defineEmits(['publish']);
 
 const api = useApi();
-const title = ref('');
+const deploymentStore = useDeploymentStore();
+
+// Unable to use storeToRefs from pinia because deployment is not
+// always defined. We might want to revisit this and instead define it
+// initially with an empty definition.
+const title = computed({
+  get() {
+    if (deploymentStore.deployment) {
+      return deploymentStore.deployment.connect.content.title;
+    }
+    return '';
+  },
+  set(val) {
+    if (deploymentStore.deployment) {
+      deploymentStore.deployment.connect.content.title = val;
+    } else {
+      console.log('Error setting title into empty deployment object!');
+    }
+  }
+});
 
 const onPublish = async() => {
   emit('publish');

--- a/web/tests/unit/components/configurePublish/FilesToPublish.test.ts
+++ b/web/tests/unit/components/configurePublish/FilesToPublish.test.ts
@@ -168,7 +168,7 @@ describe('description', () => {
         }
       },
       connect: {
-        connect: {
+        content: {
           name: '',
         },
         environment: [


### PR DESCRIPTION
## Intent

The GET `api/deployment` API call returns the initial title value at the object path of `connect.content.title` and stores it within the `deployment` pinia store.

The Title input field should be wired to display the value and update it upon change within the store.

Solves: #275 

## Type of Change

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [X] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Since the deployment object is possibly undefined, we are unable to use Pinia's `storeToRefs` functionality to directly hook up the title to the v-model of the input field. Instead, we need to use a computed wrapper and provide getters/setters to allow the checking against the undefined object path. (Unfortunately, optional chaining will not work with Vue's `v-model`.) 

I also discovered that the types file was incorrect for the `content` object.

## Automated Tests
Unit test was updated with the corrected object spec.

## Directions for Reviewers
By using the `--title` CLI parameter, you can specify an initial value for title. If you do this, the value you pass in should be displayed within the Title field. If you pass in nothing, then the field should be blank. Updating the field should update the pinia store value (confirmable via developer tools as well as observing that the value typed in stays there).

Sample command for specifying a title:
```
./bin/darwin-amd64/connect-client publish-ui \
test/sample-content/fastapi-simple \
--listen=127.0.0.1:9001 \
--open-browser-at="http://127.0.0.1:9000" \
--skip-browser-session-auth \
--account-name=dogfood \
--title=abc
```