### PR TITLE
Configures editor title to show 'Open Assistant" button.

### DIFF
--- a/extensions/positron/package.json
+++ b/extensions/positron/package.json
@@ -17,9 +17,19 @@
     "commands": [
       {
         "command": "positron.publish.assistant.open",
-        "title": "Publisher: Open Assistant"
+        "title": "Open Assistant",
+        "category": "Publisher"
       }
-    ]
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "when": "resourceLangId == python",
+          "command": "positron.publish.assistant.open",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/extensions/positron/src/extension.ts
+++ b/extensions/positron/src/extension.ts
@@ -8,7 +8,7 @@ import * as ports from './ports';
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
-	let assistant = vscode.commands.registerCommand('positron.publish.assistant.open', async () => {
+	vscode.commands.registerCommand('positron.publish.assistant.open', async () => {
 		const port = await ports.acquire();
 		const path = vscode.workspace.workspaceFolders?.at(0)?.uri.path;
 		if (path === undefined) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

https://github.com/rstudio/publishing-client/assets/6015574/46ab613a-bdeb-4d31-bbca-510ef80a624f

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Adds "Open Assistant" button to the editor title menu.

Resolves #329 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

This change was implemented using the following documentation: https://code.visualstudio.com/api/references/contribution-points#contributes.menus

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

None

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

Verify that the button only appears when viewing Python content.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
