### PR TITLE
Remove custom config in Deployments API module

### DIFF
--- a/web/src/api/resources/Deployments.ts
+++ b/web/src/api/resources/Deployments.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
-import { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { AxiosInstance } from 'axios';
 
 import { Deployment, DeploymentError } from 'src/api/types/deployments';
 
@@ -11,24 +11,15 @@ export class Deployments {
     this.client = client;
   }
 
-  private createConfig(config?: AxiosRequestConfig): AxiosRequestConfig {
-    return {
-      ignoreCamelCase: ['files'],
-      ...config,
-    };
-  }
-
   getAll() {
     return this.client.get<Array<Deployment | DeploymentError>>(
-      '/deployments',
-      this.createConfig()
+      '/deployments'
     );
   }
 
   get(id: string) {
     return this.client.get<Deployment | DeploymentError>(
-      `deployments/${id}`,
-      this.createConfig()
+      `deployments/${id}`
     );
   }
 }


### PR DESCRIPTION
This PR is a follow-up to #402 to clean up the custom AxiosRequestConfig used in the Deployments API module. It isn't necessary anymore since the files value in the Deployment object is an array of strings as opposed to what we had before which was a keyed object. Since `camelcase-keys` only effects object keys there is no reason to have this for the `files` structure.