### PR TITLE
Fetch and display configurations on Project page

### DIFF
--- a/web/src/components/ProjectPage.vue
+++ b/web/src/components/ProjectPage.vue
@@ -14,6 +14,19 @@
       </RouterLink>
     </li>
   </ul>
+
+  <h2>Configurations</h2>
+  <ul
+    v-for="config in configurations"
+    :key="config.configurationName"
+  >
+    <li>
+      {{ config.configurationName }}
+      <span v-if="isConfigurationError(config)">
+        {{ config.error }}
+      </span>
+    </li>
+  </ul>
 </template>
 
 <script setup lang="ts">
@@ -22,9 +35,11 @@ import { RouterLink } from 'vue-router';
 
 import { useApi } from 'src/api';
 import { Deployment, isDeploymentError } from 'src/api/types/deployments';
+import { Configuration, ConfigurationError, isConfigurationError } from 'src/api/types/configurations';
 
 const api = useApi();
 const deployments = ref<Deployment[]>([]);
+const configurations = ref<Array<Configuration | ConfigurationError>>([]);
 
 async function getDeployments() {
   const response = (await api.deployments.getAll()).data;
@@ -33,5 +48,11 @@ async function getDeployments() {
   });
 }
 
+async function getConfigurations() {
+  const response = await api.configurations.getAll();
+  configurations.value = response.data;
+}
+
 getDeployments();
+getConfigurations();
 </script>


### PR DESCRIPTION
This PR fetches the Configurations via the `/api/configurations` endpoint. It displays them to the user by name, and if there is an error present the error will be visible to the user (see screenshot).

These are un-styled so the error is pretty gnarly looking. Since the configurations won't have their own page these don't have links or a route. 

<details>
  <summary>Screenshots</summary>
  
![CleanShot 2023-11-29 at 15 02 30](https://github.com/rstudio/publishing-client/assets/19917631/e0d676c3-9236-4d39-bc9b-e9fef603bf9f)

![CleanShot 2023-11-29 at 15 03 18](https://github.com/rstudio/publishing-client/assets/19917631/1c25cced-2985-40d8-8583-9af2056f2467)

</details> 

## Intent
Resolves #379 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
