### PR TITLE
Add timestamp to deployment record

### DIFF
--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -5,6 +5,7 @@ package deployment
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rstudio/connect-client/internal/accounts"
@@ -21,6 +22,7 @@ type Deployment struct {
 	ConfigName    string              `toml:"configuration-name" json:"configuration-name"`
 	Configuration config.Config       `toml:"configuration" json:"configuration"`
 	Files         []string            `toml:"files" json:"files"`
+	DeployedAt    time.Time           `toml:"deployed-at" json:"deployed-at"`
 }
 
 const DeploymentSchema config.SchemaURL = "https://github.com/rstudio/publishing-client/blob/main/schemas/posit-publishing-record-schema-v3.json"

--- a/internal/deployment/deployment_test.go
+++ b/internal/deployment/deployment_test.go
@@ -5,6 +5,7 @@ package deployment
 import (
 	"io/fs"
 	"testing"
+	"time"
 
 	"github.com/rstudio/connect-client/internal/accounts"
 	"github.com/rstudio/connect-client/internal/util"
@@ -30,12 +31,14 @@ func (s *DeploymentSuite) SetupTest() {
 	s.cwd.MkdirAll(0700)
 }
 
-func (s *DeploymentSuite) createDeploymentFile(name string) {
-	configFile := GetLatestDeploymentPath(s.cwd, name)
+func (s *DeploymentSuite) createDeploymentFile(name string) *Deployment {
+	path := GetLatestDeploymentPath(s.cwd, name)
 	deployment := New()
 	deployment.ServerType = accounts.ServerTypeConnect
-	err := deployment.WriteFile(configFile)
+	deployment.DeployedAt = time.Now().UTC()
+	err := deployment.WriteFile(path)
 	s.NoError(err)
+	return deployment
 }
 
 func (s *DeploymentSuite) TestNew() {
@@ -65,12 +68,12 @@ func (s *DeploymentSuite) TestGetLatestDeploymentHistoryPath() {
 }
 
 func (s *DeploymentSuite) TestFromFile() {
-	s.createDeploymentFile("myTargetID")
+	expected := s.createDeploymentFile("myTargetID")
 	path := GetLatestDeploymentPath(s.cwd, "myTargetID")
-	deployment, err := FromFile(path)
+	actual, err := FromFile(path)
 	s.NoError(err)
-	s.NotNil(deployment)
-	s.Equal(accounts.ServerTypeConnect, deployment.ServerType)
+	s.NotNil(actual)
+	s.Equal(expected, actual)
 }
 
 func (s *DeploymentSuite) TestFromFileErr() {

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -136,6 +136,7 @@ func (p *defaultPublisher) createDeploymentRecord(
 		ConfigName:    p.ConfigName,
 		Files:         createdManifest.GetFilenames(),
 		Configuration: *p.Config,
+		DeployedAt:    time.Now().UTC(),
 	}
 	// Save current deployment information for this target
 	recordPath := deployment.GetLatestDeploymentPath(p.Dir, string(contentID))

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -4,6 +4,7 @@ package publish
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/rstudio/connect-client/internal/accounts"
 	"github.com/rstudio/connect-client/internal/api_client/clients/clienttest"
@@ -145,5 +146,7 @@ func (s *PublishSuite) publishWithClient(target *deployment.Deployment, createEr
 		s.Equal(myContentID, record.Id)
 		s.Contains(record.Files, "app.py")
 		s.Contains(record.Files, "requirements.txt")
+		s.NotEqual(time.Time{}, record.DeployedAt)
+		s.True(record.DeployedAt.After(time.Now().UTC().Add(-1 * time.Minute)))
 	}
 }

--- a/schema/draft/posit-publishing-record-schema-v3.json
+++ b/schema/draft/posit-publishing-record-schema-v3.json
@@ -37,6 +37,14 @@
         "de2e7bdb-b085-401e-a65c-443e40009749"
       ]
     },
+    "deployed-at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time the deployment was created.",
+      "examples": [
+        "2023-12-04T19:44:59.937393Z"
+      ]
+    },
     "configuration-name": {
       "type": "string",
       "description": "Name of the configuration that was used during deployment.",

--- a/schema/posit-publishing-record-schema-v3.json
+++ b/schema/posit-publishing-record-schema-v3.json
@@ -37,6 +37,14 @@
         "de2e7bdb-b085-401e-a65c-443e40009749"
       ]
     },
+    "deployed-at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time the deployment was created.",
+      "examples": [
+        "2023-12-04T19:44:59.937393Z"
+      ]
+    },
     "configuration-name": {
       "type": "string",
       "description": "Name of the configuration that was used during deployment.",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
Adds a new `deployed-at` field to the deployment record TOML and API response.

Fixes #449 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
New field, populated on deployment.

## Automated Tests
Unit tests are included in the PR.

## Directions for Reviewers
Deploy a piece of content. Verify the `deployed-at` field in the deployment record (in .posit/publish/deployments). Verify that the list deployments API (GET /api/deployments) returns the new field.
