### PR TITLE
Send failure event for top-level publishing operation

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -90,6 +90,13 @@ func (p *defaultPublisher) publish(
 	err = p.publishWithClient(bundler, p.Account, client, log)
 	if err != nil {
 		log.Failure(err)
+
+		// Also fail the overall operation
+		agentErr, ok := err.(*types.AgentError)
+		if ok {
+			agentErr.SetOperation(events.PublishOp)
+			log.Failure(agentErr)
+		}
 	}
 	return nil
 }
@@ -186,7 +193,7 @@ func (p *defaultPublisher) publishWithClient(
 	}
 	err = p.createDeploymentRecord(bundler, contentID, account, log)
 	if err != nil {
-		return err
+		return types.ErrToAgentError(events.PublishCreateDeploymentOp, err)
 	}
 
 	bundleFile, err := os.CreateTemp("", "bundle-*.tar.gz")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR ensures that the agent emits a Failure event for the top level publishing operation when any of the steps fails.

Fixes #461

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Automated Tests
The outer `publish` function does not have a test at this time.

## Directions for Reviewers
Create a failure during deployment (or validation). You should see the error in the logs twice, once for the step (e.g. `event_op=publish/validateDeployment`) and then for the top level operation (`event_op=publish`).
