### PR TITLE
Use saved config when updating a deployment

### DIFF
--- a/cmd/connect-client/commands/publish.go
+++ b/cmd/connect-client/commands/publish.go
@@ -28,10 +28,6 @@ type PublishCmd struct {
 var errNoAccounts = errors.New("there are no accounts yet; register an account before publishing")
 
 func (cmd *PublishCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
-	if cmd.ConfigName == "" {
-		cmd.ConfigName = config.DefaultConfigName
-	}
-
 	err := initialize.InitIfNeeded(cmd.Path, cmd.ConfigName, ctx.Logger)
 	if err != nil {
 		return err

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -107,7 +107,12 @@ func New(path util.Path, accountName, configName, targetID string, accountList a
 			}
 			accountName = account.Name
 		}
+	} else {
+		if configName == "" {
+			configName = config.DefaultConfigName
+		}
 	}
+
 	// Use specified account, or default account
 	account, err = loadAccount(accountName, accountList)
 	if err != nil {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -268,7 +268,28 @@ func (s *StateSuite) TestNew() {
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(state.AccountName, "")
-	s.Equal(state.ConfigName, "")
+	s.Equal(state.ConfigName, config.DefaultConfigName)
+	s.Equal(state.TargetID, "")
+	s.Nil(state.Account, "")
+	s.Equal(cfg, state.Config)
+	s.Nil(state.Target)
+}
+
+func (s *StateSuite) TestNewNonDefaultConfig() {
+	accts := &accounts.MockAccountList{}
+	accts.On("GetAllAccounts").Return(nil, nil)
+
+	configName := "staging"
+	configPath := config.GetConfigPath(s.cwd, configName)
+	cfg := config.New()
+	err := cfg.WriteFile(configPath)
+	s.NoError(err)
+
+	state, err := New(s.cwd, "", configName, "", accts)
+	s.NoError(err)
+	s.NotNil(state)
+	s.Equal(state.AccountName, "")
+	s.Equal(state.ConfigName, configName)
 	s.Equal(state.TargetID, "")
 	s.Nil(state.Account, "")
 	s.Equal(cfg, state.Config)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes the handling of the `--update/-u` option. If you don't specify a configuration, it should use the configuration name that was previously used for the deployment. Instead, was using the default name because the default was being applied too soon.

Fixes #460

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
Apply the default config name in `state.New` instead of the publish command.

## Automated Tests
Updated the test for state.New to verify correct handling of an empty config name, and added a test for non-empty config name.

## Directions for Reviewers
Deploy content with a config that is not `default`. Update that configuration using the `-u` option on the CLI. Verify that the correct non-default configuration was used; there should be a log line near the top stating:
```
time=2023-12-05T11:01:52.564-05:00 level=INFO msg=Publish configuration=staging account=dogfood target=57c746c2-051c-4c67-9c4b-2c1e1640e8de
```
