### PR TITLE
Add more Python entrypoint names

### DIFF
--- a/internal/inspect/entrypoint.go
+++ b/internal/inspect/entrypoint.go
@@ -18,7 +18,7 @@ type defaultInferenceHelper struct{}
 // If it's a directory, it specifies the deployment directory.
 // - If preferredFilename exists in the directory, it is the entrypoint.
 // - If there is only one file with the specified suffix, it is the entrypoint.
-func (h defaultInferenceHelper) InferEntrypoint(path util.Path, suffix string, preferredFilename string) (string, util.Path, error) {
+func (h defaultInferenceHelper) InferEntrypoint(path util.Path, suffix string, preferredFilenames ...string) (string, util.Path, error) {
 	isDir, err := path.IsDir()
 	if err != nil {
 		return "", util.Path{}, err
@@ -33,14 +33,16 @@ func (h defaultInferenceHelper) InferEntrypoint(path util.Path, suffix string, p
 			relPath, err := matchingFiles[0].Rel(path)
 			return relPath.Path(), matchingFiles[0], err
 		} else {
-			// Favor preferredFilename as an entrypoint
-			preferredPath := path.Join(preferredFilename)
-			exists, err := preferredPath.Exists()
-			if err != nil {
-				return "", util.Path{}, err
-			}
-			if exists {
-				return preferredFilename, preferredPath, nil
+			for _, preferredFilename := range preferredFilenames {
+				// Favor one of the preferredFilenames as an entrypoint
+				preferredPath := path.Join(preferredFilename)
+				exists, err := preferredPath.Exists()
+				if err != nil {
+					return "", util.Path{}, err
+				}
+				if exists {
+					return preferredFilename, preferredPath, nil
+				}
 			}
 			// else entrypoint is ambiguous
 			return "", util.Path{}, nil

--- a/internal/inspect/entrypoint_test.go
+++ b/internal/inspect/entrypoint_test.go
@@ -48,6 +48,20 @@ func (s *EntrypointSuite) TestInferEntrypointMatchingPreferredFileAndAnother() {
 	s.Equal("app.py", entrypointPath.Base())
 }
 
+func (s *EntrypointSuite) TestInferEntrypointAlternatePreferredFileAndAnother() {
+	path := util.NewPath(".", afero.NewMemMapFs())
+	err := path.Join("main.py").WriteFile([]byte{}, 0600)
+	s.Nil(err)
+	err = path.Join("mylib.py").WriteFile([]byte{}, 0600)
+	s.Nil(err)
+
+	h := defaultInferenceHelper{}
+	entrypoint, entrypointPath, err := h.InferEntrypoint(path, ".py", "app.py", "main.py")
+	s.Nil(err)
+	s.Equal("main.py", entrypoint)
+	s.Equal("main.py", entrypointPath.Base())
+}
+
 func (s *EntrypointSuite) TestInferEntrypointNonMatchingFile() {
 	path := util.NewPath("app.py", afero.NewMemMapFs())
 	err := path.WriteFile([]byte{}, 0600)

--- a/internal/inspect/infer.go
+++ b/internal/inspect/infer.go
@@ -27,7 +27,7 @@ type ContentTypeInferer interface {
 }
 
 type inferenceHelper interface {
-	InferEntrypoint(path util.Path, suffix string, preferredFilename string) (string, util.Path, error)
+	InferEntrypoint(path util.Path, suffix string, preferredFilenames ...string) (string, util.Path, error)
 	HasPythonImports(r io.Reader, packages []string) (bool, error)
 	FileHasPythonImports(path util.Path, packages []string) (bool, error)
 }

--- a/internal/inspect/infer_test.go
+++ b/internal/inspect/infer_test.go
@@ -27,8 +27,8 @@ type MockInferenceHelper struct {
 	mock.Mock
 }
 
-func (m *MockInferenceHelper) InferEntrypoint(path util.Path, suffix string, preferredFilename string) (string, util.Path, error) {
-	args := m.Called(path, suffix, preferredFilename)
+func (m *MockInferenceHelper) InferEntrypoint(path util.Path, suffix string, preferredFilenames ...string) (string, util.Path, error) {
+	args := m.Called(path, suffix, preferredFilenames)
 	return args.String(0), args.Get(1).(util.Path), args.Error(2)
 }
 

--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -65,7 +65,9 @@ func NewPyShinyDetector() *PythonAppDetector {
 }
 
 func (d *PythonAppDetector) InferType(path util.Path) (*ContentType, error) {
-	entrypoint, entrypointPath, err := d.InferEntrypoint(path, ".py", "app.py")
+	entrypoint, entrypointPath, err := d.InferEntrypoint(
+		path, ".py", "main.py", "app.py", "streamlit_app.py", "api.py")
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/inspect/python_test.go
+++ b/internal/inspect/python_test.go
@@ -54,6 +54,29 @@ func (s *PythonSuite) TestInferTypePreferredFilename() {
 	}, t)
 }
 
+func (s *PythonSuite) TestInferTypeAlternatePreferredFilename() {
+	dir := util.NewPath("/", afero.NewMemMapFs())
+	err := dir.MkdirAll(0777)
+	s.NoError(err)
+
+	filename := "main.py"
+	err = dir.Join(filename).WriteFile([]byte("import flask\napp = flask.Flask(__name__)\n"), 0600)
+	s.Nil(err)
+
+	// a distraction
+	err = dir.Join("random.py").WriteFile([]byte("import dash\n"), 0600)
+	s.Nil(err)
+
+	detector := NewFlaskDetector()
+	t, err := detector.InferType(dir)
+	s.Nil(err)
+	s.Equal(&ContentType{
+		Type:           config.ContentTypePythonFlask,
+		Entrypoint:     filename,
+		RequiresPython: true,
+	}, t)
+}
+
 func (s *PythonSuite) TestInferTypeOnlyPythonFile() {
 	filename := "myapp.py"
 	path := util.NewPath(filename, afero.NewMemMapFs())


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR allows the `init` command to detect some other common entrypoints for Python projects. Currently, only "app.py" is recognized as a special filename if there are multiple .py files in the directory. This PR adds "main.py", "streamlit_app.py", and "main.py" since those are also commonly used.

Fixes #485 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
The `InferEntrypoint` routine now accepts multiple preferredFilenames, and the `PythonAppDetector` passes in multiple names.

## Automated Tests
Added new tests to the `InferEntrypoint` and the `PythonAppDetector` suites.

## Directions for Reviewers
run 
```
just run init -c newconfig $(pwd) 
```
in a directory where there are multiple .py files, and the one containing your app is named `main.py` instead of `app.py`.

The config file created (.posit/publish/newconfig.toml) should contain
```
entrypoint = 'main.py'
```

