### PR TITLE
Adds GitHub Action cache for VSCode installation

### DIFF
--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -1,6 +1,8 @@
 name: VSCode
 on:
   workflow_call:
+env:
+  VSCODE_VERSION: 1.85.0
 jobs:
   native:
     env:
@@ -18,9 +20,19 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ./extensions/vscode/.vscode-test/vscode-*
+          key: ${{ matrix.runner }}-vscode-${{ env.VSCODE_VERSION }}
       - run: just vscode install
       - run: just vscode lint
       - run: just vscode test
+      - uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ./extensions/vscode/.vscode-test/vscode-*
+          key: ${{ matrix.runner }}-vscode-${{ env.VSCODE_VERSION }}
   docker:
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +40,16 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ./extensions/vscode/.vscode-test/vscode-*
+          key: docker-vscode-${{ env.VSCODE_VERSION }}
       - run: just vscode install
       - run: just vscode lint
       - run: just vscode test
+      - uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ./extensions/vscode/.vscode-test/vscode-*
+          key: docker-vscode-${{ env.VSCODE_VERSION }}

--- a/extensions/vscode/src/test/runTest.ts
+++ b/extensions/vscode/src/test/runTest.ts
@@ -1,9 +1,11 @@
 import * as path from 'path';
 
-import { runTests } from '@vscode/test-electron';
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 
 async function main() {
 	try {
+		const vscodeExecutablePath = await downloadAndUnzipVSCode(process.env.VSCODE_VERSION);
+
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
 		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
@@ -13,7 +15,7 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath });
 	} catch (err) {
 		console.error('Failed to run tests', err);
 		process.exit(1);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Adds a cache layer for VSCode installation. This change prevents runners from requesting the same download multiple times from Microsoft.

Closes #503 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Utilizes the `actions/cache` to restore and save the downloaded VSCode application. Additional logic is added to the test runner to read the environment variable VSCODE_VERSION when supplied. By default, the test runner will continue utilizing the latest available version of VSCode when the environment variable isn't supplied.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
