### PR TITLE
Use `deployment.saveName` for existing deployments

### DIFF
--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -13,7 +13,7 @@ const routes = [
   { name: 'project', path: '/project', component: ProjectPage },
   { name: 'addNewDeployment', path: '/add-new-deployment', component: AddNewDeployment },
   { name: 'newDeployment', path: '/new-deployment/:account/:contentId?', component: NewDeploymentDestinationPage },
-  { name: 'deployments', path: '/deployments/:id', component: ExistingDeploymentDestinationPage },
+  { name: 'deployments', path: '/deployments/:name', component: ExistingDeploymentDestinationPage },
   { name: 'progress', path: '/progress', component: PublishProgressPage },
   { name: 'default', path: '/:pathMatch(.*)*', redirect: '/' },
 ];

--- a/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationPage.vue
+++ b/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationPage.vue
@@ -2,7 +2,8 @@
 
 <template>
   <ExistingDeploymentDestinationHeader
-    :content-id="contentID"
+    v-if="deployment"
+    :content-id="deployment.id"
     :url="deploymentUrl"
   />
 
@@ -32,35 +33,28 @@ const api = useApi();
 
 const deployment = ref<Deployment>();
 
-const deploymentID = computed(():string => {
+const deploymentName = computed(():string => {
   // route param can be either string | string[]
-  if (Array.isArray(route.params.id)) {
-    return route.params.id[0];
+  if (Array.isArray(route.params.name)) {
+    return route.params.name[0];
   }
-  return route.params.id;
+  return route.params.name;
 });
 
 const deploymentUrl = computed<string>(() => {
   return deployment.value?.serverUrl || '';
 });
 
-const contentID = computed(():string => {
-  if (Array.isArray(route.params.id)) {
-    return route.params.id[0];
-  }
-  return route.params.id;
-});
-
 const getDeployment = async() => {
   try {
-    if (!deploymentID.value) {
+    if (!deploymentName.value) {
       deployment.value = undefined;
       return;
     }
-    const response = await api.deployments.get(deploymentID.value);
+    const response = await api.deployments.get(deploymentName.value);
     const d = response.data;
     if (isDeploymentError(d)) {
-      throw new Error(`API Error /deployment/${deploymentID.value}: ${d}`);
+      throw new Error(`API Error /deployment/${deploymentName.value}: ${d}`);
     }
     deployment.value = d;
   } catch (err) {

--- a/web/src/views/project-page/DeploymentCard.vue
+++ b/web/src/views/project-page/DeploymentCard.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div class="deployment-card focus-shadow">
-    <RouterLink :to="{ name: 'deployments', params: { id: `${deployment.id}` }}">
+    <RouterLink :to="{ name: 'deployments', params: { name: `${deployment.saveName}` }}">
       <span
         class="link-fill"
         aria-hidden="true"


### PR DESCRIPTION
Simple PR that uses the `deployment.saveName` for the Existing Deployments route and components instead of the `deployment.id` since that will return a 404 if the deployment is named when doing a request to `GET api/deployment/{id}`

## Intent
Fixes #505 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
