### PR TITLE
Show file exclusions on file hover

### DIFF
--- a/web/src/components/FileTree.vue
+++ b/web/src/components/FileTree.vue
@@ -6,7 +6,27 @@
     :nodes="files"
     :node-key="NODE_KEY"
     dense
-  />
+  >
+    <template #default-header="{ node }">
+      <q-icon
+        v-if="node.icon"
+        class="q-mr-sm"
+        :name="node.icon"
+      />
+      <div :class="{ 'excluded-file': node.exclusion }">
+        {{ node.label }}
+        <q-tooltip
+          v-if="node.exclusion"
+          class="text-body2"
+          anchor="center right"
+          self="center left"
+          :offset="[10, 10]"
+        >
+          {{ node.exclusion }}
+        </q-tooltip>
+      </div>
+    </template>
+  </q-tree>
 </template>
 
 <script setup lang="ts">
@@ -28,8 +48,8 @@ function fileToTreeNode(file: DeploymentFile): QTreeNode {
     [NODE_KEY]: file.id,
     label: file.base,
     children: file.files.map(fileToTreeNode),
-    disabled: Boolean(file.exclusion),
     icon: file.isDir ? 'folder' : undefined,
+    exclusion: file.exclusion,
   };
 
   return node;
@@ -49,4 +69,10 @@ async function getFiles() {
 
 getFiles();
 </script>
+
+<style scoped lang="scss">
+.excluded-file {
+  opacity: 60%;
+}
+</style>
 


### PR DESCRIPTION
This PR uses the custom slot for the `q-tree` to show a tooltip, on hover, when the file has an exclusion.

<details>
  <summary>Preview</summary>
  
![CleanShot 2023-12-11 at 19 18 37](https://github.com/rstudio/publishing-client/assets/19917631/83078458-b24f-4b50-b105-855ff7a03c81)

</details> 

## Type of Change
- [x] New Feature       <!-- A change which adds additional functionality -->

## Approach
Quasar exposes a `default-header` slot in its `q-tree`. Using that we can customize our own label and use `q-tooltip` along side it.

1. At the start I created a `template` that matched the Quasar's `q-tree` exactly with the optional icon and label.
2. After that I removed the `node.disabled` since that removes pointer events which makes it so `q-tooltip` never appears. 
3. I created a custom CSS class to bring back the opacity that disabled used
4. I created a `q-tooltip` with larger text (for accessibility), and custom positioning to go to the right
  - This avoids overlapping with other files when hovering to some degree
  
The exclusion is not styled, but that can be an easy follow-up PR now that the tooltip and `exclusion` object is accessible.