### PR TITLE
Make configurationPath relative

### DIFF
--- a/internal/services/api/get_configurations.go
+++ b/internal/services/api/get_configurations.go
@@ -26,18 +26,25 @@ func readConfigFiles(base util.Path) ([]configDTO, error) {
 	}
 	response := make([]configDTO, 0, len(paths))
 	for _, path := range paths {
+		relPath, err := path.Rel(base)
+		if err != nil {
+			// This error should never happen. But, if it does,
+			// still return as much data as we can.
+			relPath = path
+		}
 		name := strings.TrimSuffix(path.Base(), ".toml")
 		cfg, err := config.FromFile(path)
+
 		if err != nil {
 			response = append(response, configDTO{
 				Name:  name,
-				Path:  path.String(),
+				Path:  relPath.String(),
 				Error: err.Error(),
 			})
 		} else {
 			response = append(response, configDTO{
 				Name:          name,
-				Path:          path.String(),
+				Path:          relPath.String(),
 				Configuration: cfg,
 			})
 		}

--- a/internal/services/api/get_configurations_test.go
+++ b/internal/services/api/get_configurations_test.go
@@ -62,10 +62,7 @@ func (s *GetConfigurationsSuite) TestGetConfigurations() {
 	s.NoError(dec.Decode(&res))
 	s.Len(res, 1)
 
-	actualPath, err := util.NewPath(res[0].Path, s.cwd.Fs()).Rel(s.cwd)
-	s.NoError(err)
-	s.Equal(".posit/publish/myConfig.toml", actualPath.String())
-
+	s.Equal(".posit/publish/myConfig.toml", res[0].Path)
 	s.Equal("myConfig", res[0].Name)
 	s.Equal("", res[0].Error)
 	s.Equal(cfg, res[0].Configuration)
@@ -99,19 +96,13 @@ func (s *GetConfigurationsSuite) TestGetConfigurationsError() {
 	s.NoError(dec.Decode(&res))
 	s.Len(res, 2)
 
-	actualPath, err := util.NewPath(res[0].Path, s.cwd.Fs()).Rel(s.cwd)
-	s.NoError(err)
-	s.Equal(".posit/publish/config1.toml", actualPath.String())
-
+	s.Equal(".posit/publish/config1.toml", res[0].Path)
 	s.Equal("config1", res[0].Name)
 	s.Equal("", res[0].Error)
 	s.Equal(cfg, res[0].Configuration)
 
 	var nilConfiguration *config.Config
-	actualPath, err = util.NewPath(res[1].Path, s.cwd.Fs()).Rel(s.cwd)
-	s.NoError(err)
-	s.Equal(".posit/publish/config2.toml", actualPath.String())
-
+	s.Equal(".posit/publish/config2.toml", res[1].Path)
 	s.Equal("config2", res[1].Name)
 	s.NotEqual("", res[1].Error)
 	s.Equal(nilConfiguration, res[1].Configuration)

--- a/internal/services/api/get_deployment.go
+++ b/internal/services/api/get_deployment.go
@@ -28,8 +28,15 @@ func readLatestDeploymentFile(base util.Path, id string) (*deploymentDTO, error)
 			Error: err.Error(),
 		}, nil
 	} else {
+		configPath := config.GetConfigPath(base, d.ConfigName)
+		relPath, err := configPath.Rel(base)
+		if err != nil {
+			// This error should never happen. But, if it does,
+			// still return as much data as we can.
+			relPath = configPath
+		}
 		return &deploymentDTO{
-			ConfigPath: config.GetConfigPath(base, d.ConfigName).String(),
+			ConfigPath: relPath.String(),
 			Deployment: d,
 		}, nil
 	}

--- a/internal/services/api/get_deployment_test.go
+++ b/internal/services/api/get_deployment_test.go
@@ -47,6 +47,7 @@ func (s *GetDeploymentSuite) TestGetDeployment() {
 	d := deployment.New()
 	d.Id = "myTargetName"
 	d.ServerType = accounts.ServerTypeConnect
+	d.ConfigName = "myConfig"
 	cfg := config.New()
 	cfg.Type = config.ContentTypePythonDash
 	cfg.Entrypoint = "app.py"
@@ -73,6 +74,7 @@ func (s *GetDeploymentSuite) TestGetDeployment() {
 	s.NotNil(res.Deployment)
 	s.Equal("", res.Error)
 	s.Equal(d, res.Deployment)
+	s.Equal(".posit/publish/myConfig.toml", res.ConfigPath)
 	s.Equal(types.ContentID("myTargetName"), res.Deployment.Id)
 }
 

--- a/internal/services/api/get_deployments.go
+++ b/internal/services/api/get_deployments.go
@@ -31,8 +31,15 @@ func readLatestDeploymentFiles(base util.Path) ([]deploymentDTO, error) {
 				Error: err.Error(),
 			})
 		} else {
+			configPath := config.GetConfigPath(base, d.ConfigName)
+			relPath, err := configPath.Rel(base)
+			if err != nil {
+				// This error should never happen. But, if it does,
+				// still return as much data as we can.
+				relPath = configPath
+			}
 			response = append(response, deploymentDTO{
-				ConfigPath: config.GetConfigPath(base, d.ConfigName).String(),
+				ConfigPath: relPath.String(),
 				Deployment: d,
 			})
 		}

--- a/internal/services/api/get_deployments_test.go
+++ b/internal/services/api/get_deployments_test.go
@@ -46,6 +46,7 @@ func (s *GetDeploymentsSuite) TestGetDeployments() {
 	d := deployment.New()
 	d.Id = "myTargetName"
 	d.ServerType = accounts.ServerTypeConnect
+	d.ConfigName = "myConfig"
 	cfg := config.New()
 	cfg.Type = config.ContentTypePythonDash
 	cfg.Entrypoint = "app.py"
@@ -71,6 +72,7 @@ func (s *GetDeploymentsSuite) TestGetDeployments() {
 	s.Equal("", res[0].Error)
 	s.NotNil(res[0].Deployment)
 	s.Equal(d, res[0].Deployment)
+	s.Equal(".posit/publish/myConfig.toml", res[0].ConfigPath)
 	s.Equal(types.ContentID("myTargetName"), res[0].Deployment.Id)
 }
 


### PR DESCRIPTION
## Intent
This PR makes the `configurationPath` returned by the APIs relative to the project directory. These APIs are affected:
* `GET /api/configurations`
* `GET /api/deployments`
* `GET /api/deployments/{name}`

Fixes #538 

## Type of Change
- [x] Bug Fix           <!-- A change which fixes an existing issue -->
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Automated Tests
Existing tests have been updated to check for a relative path.

## Directions for Reviewers
Run the UI and curl the modified endpoints.
