### PR TITLE
Use saveName for redeployment update event store

### DIFF
--- a/web/src/stores/events.ts
+++ b/web/src/stores/events.ts
@@ -216,20 +216,20 @@ export const useEventStore = defineStore('event', () => {
 
   type CurrentPublishStatus = {
     localId: string,
-    contentId: string,
+    target: string,
     status: PublishStatus,
   };
 
   const currentPublishStatus = ref<CurrentPublishStatus>({
     localId: '',
-    contentId: '',
+    target: '',
     status: newPublishStatus(),
   });
 
   const doesPublishStatusApply = ((id: string) => {
     return (
       currentPublishStatus.value.localId === id ||
-      currentPublishStatus.value.contentId === id
+      currentPublishStatus.value.target === id
     );
   });
 
@@ -437,7 +437,7 @@ export const useEventStore = defineStore('event', () => {
     if (currentPublishStatus.value.localId === localId) {
       const publishStatus = currentPublishStatus.value.status;
       publishStatus.steps.createDeployment.completion = 'success';
-      currentPublishStatus.value.contentId = msg.data.contentId;
+      currentPublishStatus.value.target = msg.data.contentId;
       publishStatus.steps.createDeployment.allMsgs.push(msg);
     }
   };
@@ -722,7 +722,7 @@ export const useEventStore = defineStore('event', () => {
 
   const initiatePublishProcessWithEvents = async(
     accountName : string,
-    contentId?: string,
+    target?: string,
     saveName?: string,
   ) : Promise<string | Error> => {
     if (publishInProgess.value) {
@@ -732,12 +732,12 @@ export const useEventStore = defineStore('event', () => {
     try {
       publishInProgess.value = true;
       currentPublishStatus.value.localId = '';
-      currentPublishStatus.value.contentId = contentId || '';
+      currentPublishStatus.value.target = target || '';
       currentPublishStatus.value.status = newPublishStatus();
 
       const response = await api.deployments.publish(
         accountName,
-        contentId,
+        target,
         saveName,
       );
       const localId = <string>response.data.localId;

--- a/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationHeader.vue
+++ b/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationHeader.vue
@@ -65,11 +65,12 @@
 <script setup lang="ts">
 
 import { ref, watch } from 'vue';
-import { Account, useApi } from 'src/api';
+import { Account, Deployment, useApi } from 'src/api';
 
 import SelectAccount from 'src/components/SelectAccount.vue';
 import PublishProgressSummary from 'src/components/PublishProgressSummary.vue';
 import { useEventStore } from 'src/stores/events';
+import { PropType } from 'vue';
 
 const api = useApi();
 const eventStore = useEventStore();
@@ -85,6 +86,7 @@ const emit = defineEmits(['publish']);
 const props = defineProps({
   contentId: { type: String, required: true },
   url: { type: String, required: true },
+  deployment: { type: Object as PropType<Deployment>, required: true }
 });
 
 const onChange = (account: Account) => {
@@ -102,7 +104,7 @@ const initiatePublishProcess = async() => {
 
   const result = await eventStore.initiatePublishProcessWithEvents(
     accountName,
-    props.contentId,
+    props.deployment.saveName,
   );
   if (result instanceof Error) {
     return result;

--- a/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationPage.vue
+++ b/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationPage.vue
@@ -5,6 +5,7 @@
     v-if="deployment"
     :content-id="deployment.id"
     :url="deploymentUrl"
+    :deployment="deployment"
   />
 
   <DeploymentSection


### PR DESCRIPTION
This is a bug fix that addresses the inability to republish in the UI. This was caused by using the `deployment.id` to republish rather than the `deployment.saveName` which was affecting named deployments where the `id != saveName`.

This cased this error in the backend:

```
time=2023-12-13T10:54:46.019-08:00 level=ERROR msg="Bad Request" method=POST url=/api/deployments 
error="can't find deployment at 'test/sample-content/fastapi-simple/.posit/publish/deployments/1cc86a7b-2f82-
4ebe-be18-282c13fb00e9.toml': open test/sample-content/fastapi-simple/.posit/publish/deployments/1cc86a7b-
2f82-4ebe-be18-282c13fb00e9.toml: no such file or directory"
```

I updated the event store to use `target` instead of `contentId`.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue -->
