### PR TITLE
Show current config settings existing deployment

### DIFF
--- a/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationPage.vue
+++ b/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationPage.vue
@@ -14,7 +14,8 @@
     :subtitle="deployment.configurationName"
   >
     <ConfigSettings
-      :config="deployment"
+      v-if="defaultConfig"
+      :config="defaultConfig"
     />
   </DeploymentSection>
   <DeploymentSection
@@ -28,7 +29,7 @@
 import { ref, computed, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
-import { useApi } from 'src/api';
+import { Configuration, ConfigurationError, useApi } from 'src/api';
 import { Deployment, isDeploymentError } from 'src/api/types/deployments';
 
 import ConfigSettings from 'src/components/config/ConfigSettings.vue';
@@ -40,6 +41,8 @@ const route = useRoute();
 const api = useApi();
 
 const deployment = ref<Deployment>();
+
+const configurations = ref<Array<Configuration | ConfigurationError>>([]);
 
 const deploymentName = computed(():string => {
   // route param can be either string | string[]
@@ -69,6 +72,17 @@ const getDeployment = async() => {
     // TODO: handle the API error
   }
 };
+
+const defaultConfig = computed(() => {
+  return configurations.value.find((c) => c.configurationName === 'default');
+});
+
+async function getConfigurations() {
+  const response = await api.configurations.getAll();
+  configurations.value = response.data;
+}
+
+getConfigurations();
 
 watch(
   () => route.params,


### PR DESCRIPTION
When fetching a Deployment its `configuration` is the `configuration` it was last published with. The existing deployment page doesn't want to show what WAS published it wants to show what WILL BE published when the publish button is clicked.

This PR makes the existing deployment destination page fetch the currently selected deployment (hardcoded to the default for now) and displays that.
