### PR TITLE
Style FileTree file exclusion tooltip

### DIFF
--- a/web/src/components/FileTree.vue
+++ b/web/src/components/FileTree.vue
@@ -22,7 +22,7 @@
           self="center left"
           :offset="[10, 10]"
         >
-          {{ node.exclusion }}
+          {{ exclusionDisplay(node.exclusion) }}
         </q-tooltip>
       </div>
     </template>
@@ -34,7 +34,7 @@ import { QTreeNode } from 'quasar';
 import { ref } from 'vue';
 
 import { useApi } from 'src/api';
-import { DeploymentFile } from 'src/api/types/files';
+import { DeploymentFile, ExclusionMatch, ExclusionMatchSource } from 'src/api/types/files';
 
 const NODE_KEY = 'key';
 
@@ -64,6 +64,17 @@ async function getFiles() {
   if (file.isDir) {
     // start with the top level directory expanded
     expanded.value = [file.rel];
+  }
+}
+
+function exclusionDisplay(match: ExclusionMatch): string {
+  switch (match.source) {
+    case ExclusionMatchSource.BUILT_IN:
+      return 'Automatically ignored by Posit Publisher';
+    case ExclusionMatchSource.FILE:
+      return `Ignored by "${match.filePath}" on line ${match.line} with pattern "${match.pattern}"`;
+    case ExclusionMatchSource.USER:
+      return 'Ignored by user';
   }
 }
 


### PR DESCRIPTION
This PR takes the `ExclusionMatch` and instead of just throwing the JSON into the hover tooltip formats a string based on the `ExclusionMatch.source`.

<details>
  <summary>Preview</summary>
  
![CleanShot 2023-12-13 at 14 34 19](https://github.com/rstudio/publishing-client/assets/19917631/7d2eca7d-2687-4da3-a9b0-2f8c9120f179)

![CleanShot 2023-12-13 at 14 34 27](https://github.com/rstudio/publishing-client/assets/19917631/54dbdaae-b79b-418d-9984-4875eedc87af)

</details> 

I'm open to suggestions for the strings. I was trying to keep them as short as possible - while still being helpful.

Opened issue #567 to address the relative file path shown in the screenshots above.

## Intent
Resolves #527 

## Type of Change

- [x] New Feature       <!-- A change which adds additional functionality -->

## Approach
Used a switch to cover all of the different `ExclusionMatch.source` options. This felt like the best way to delineate the different ignores since the user doesn't need to know the pattern or line for built in ignores.

For `.positignore` (`ExclusionMatchSource.FILE` source) I gave as much information as we had supplying the file that is ignoring the file, the line number and pattern.

I was unsure how user ignores were done. Looking through the Go code I wasn't able to answer the question. Perhaps @mmarchetti can supply some insight so I can best format that string.
