### PR TITLE
Remove MatchSourceUser

### DIFF
--- a/internal/bundles/bundle.go
+++ b/internal/bundles/bundle.go
@@ -46,7 +46,7 @@ func NewBundler(path util.Path, manifest *Manifest, pythonRequirements []byte, l
 	if err != nil {
 		return nil, err
 	}
-	excluder, err := gitignore.NewExcludingWalker(dir, nil)
+	excluder, err := gitignore.NewExcludingWalker(dir)
 	if err != nil {
 		return nil, fmt.Errorf("error loading ignore list: %w", err)
 	}

--- a/internal/bundles/gitignore/gitignore.go
+++ b/internal/bundles/gitignore/gitignore.go
@@ -28,7 +28,6 @@ type MatchSource string
 
 const MatchSourceFile MatchSource = "file"
 const MatchSourceBuiltIn MatchSource = "built-in"
-const MatchSourceUser MatchSource = "user"
 
 type Match struct {
 	Source   MatchSource `json:"source"`  // type of match, e.g. file or a caller-provided value

--- a/internal/bundles/gitignore/gitignore_test.go
+++ b/internal/bundles/gitignore/gitignore_test.go
@@ -52,7 +52,7 @@ func (s *GitIgnoreSuite) TestMatch() {
 	ign, err := From(ignoreFilePath)
 	s.NoError(err)
 
-	err = ign.AppendGlobs([]string{"*.bak"}, MatchSourceUser)
+	err = ign.AppendGlobs([]string{"*.bak"}, MatchSourceBuiltIn)
 	s.NoError(err)
 
 	// Match returns nil if no match
@@ -73,7 +73,7 @@ func (s *GitIgnoreSuite) TestMatch() {
 	m, err = ign.Match("app.py.bak")
 	s.NoError(err)
 	s.NotNil(m)
-	s.Equal(MatchSourceUser, m.Source)
+	s.Equal(MatchSourceBuiltIn, m.Source)
 	s.Equal("*.bak", m.Pattern)
 	s.Equal("", m.FilePath)
 	s.Equal(0, m.Line)
@@ -81,13 +81,13 @@ func (s *GitIgnoreSuite) TestMatch() {
 	ignoredir := s.cwd.Join("ignoredir")
 	err = ignoredir.MkdirAll(0700)
 	s.NoError(err)
-	err = ign.AppendGlobs([]string{"ignoredir/"}, MatchSourceUser)
+	err = ign.AppendGlobs([]string{"ignoredir/"}, MatchSourceBuiltIn)
 	s.NoError(err)
 
 	m, err = ign.Match(ignoredir.Path())
 	s.NoError(err)
 	s.NotNil(m)
-	s.Equal(MatchSourceUser, m.Source)
+	s.Equal(MatchSourceBuiltIn, m.Source)
 	s.Equal("ignoredir/", m.Pattern)
 	s.Equal("", m.FilePath)
 	s.Equal(0, m.Line)

--- a/internal/bundles/gitignore/walker.go
+++ b/internal/bundles/gitignore/walker.go
@@ -84,8 +84,8 @@ func (i *excludingWalker) Walk(path util.Path, fn util.WalkFunc) error {
 // Exclusions are sourced from the built-in exclusions, gitignore, and the
 // specified ignore list. Python environment directories are also excluded,
 // and .positignore files are processed as they are encountered.
-func NewExcludingWalker(dir util.Path, ignores []string) (util.Walker, error) {
-	gitIgnore, err := NewIgnoreList(dir, ignores)
+func NewExcludingWalker(dir util.Path) (util.Walker, error) {
+	gitIgnore, err := NewIgnoreList(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -96,13 +96,9 @@ func NewExcludingWalker(dir util.Path, ignores []string) (util.Walker, error) {
 
 // NewIgnoreList returns an IgnoreList populated with the built-in
 // exclusions, gitignore contents, and the provided ignore list.
-func NewIgnoreList(dir util.Path, ignores []string) (IgnoreList, error) {
+func NewIgnoreList(dir util.Path) (IgnoreList, error) {
 	gitIgnore := New(dir)
 	err := gitIgnore.AppendGlobs(standardIgnores, MatchSourceBuiltIn)
-	if err != nil {
-		return nil, err
-	}
-	err = gitIgnore.AppendGlobs(ignores, MatchSourceUser)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bundles/gitignore/walker_test.go
+++ b/internal/bundles/gitignore/walker_test.go
@@ -38,7 +38,7 @@ func (s *WalkerSuite) SetupTest() {
 }
 
 func (s *WalkerSuite) TestNewExcludingWalker() {
-	w, err := NewExcludingWalker(s.cwd, []string{"*.log"})
+	w, err := NewExcludingWalker(s.cwd)
 	s.NoError(err)
 	s.NotNil(w)
 }
@@ -50,7 +50,7 @@ func (s *WalkerSuite) TestNewWalkerBadIgnoreFile() {
 	err := giPath.WriteFile(data, 0600)
 	s.NoError(err)
 
-	w, err := NewExcludingWalker(s.cwd, nil)
+	w, err := NewExcludingWalker(s.cwd)
 	s.NoError(err)
 	s.NotNil(w)
 
@@ -60,18 +60,12 @@ func (s *WalkerSuite) TestNewWalkerBadIgnoreFile() {
 	s.NotNil(err)
 }
 
-func (s *WalkerSuite) TestNewWalkerBadIgnore() {
-	w, err := NewExcludingWalker(s.cwd, []string{"[Z-A]"})
-	s.NotNil(err)
-	s.Nil(w)
-}
-
 func (s *WalkerSuite) TestWalkErrorLoadingPositIgnore() {
 	positIgnorePath := s.cwd.Join(".positignore")
 	err := positIgnorePath.WriteFile([]byte("[Z-A]"), 0600)
 	s.NoError(err)
 
-	w, err := NewExcludingWalker(s.cwd, nil)
+	w, err := NewExcludingWalker(s.cwd)
 	s.NoError(err)
 	s.NotNil(w)
 
@@ -118,7 +112,7 @@ func (s *WalkerSuite) TestWalk() {
 		s.NoError(err)
 	}
 
-	w, err := NewExcludingWalker(s.cwd, nil)
+	w, err := NewExcludingWalker(s.cwd)
 	s.NoError(err)
 	s.NotNil(w)
 

--- a/internal/services/api/files/services.go
+++ b/internal/services/api/files/services.go
@@ -16,7 +16,7 @@ type FilesService interface {
 }
 
 func CreateFilesService(base util.Path, log logging.Logger) FilesService {
-	ignore, err := gitignore.NewIgnoreList(base, nil)
+	ignore, err := gitignore.NewIgnoreList(base)
 	if err != nil {
 		log.Warn("failed to load .gitignore file")
 	}

--- a/web/src/api/types/files.ts
+++ b/web/src/api/types/files.ts
@@ -23,7 +23,6 @@ export type DeploymentFile = {
 export enum ExclusionMatchSource {
     FILE = 'file',
     BUILT_IN = 'built-in',
-    USER = 'user',
 }
 
 export type ExclusionMatch = {

--- a/web/src/components/FileTree.vue
+++ b/web/src/components/FileTree.vue
@@ -73,8 +73,6 @@ function exclusionDisplay(match: ExclusionMatch): string {
       return 'Automatically ignored by Posit Publisher';
     case ExclusionMatchSource.FILE:
       return `Ignored by "${match.filePath}" on line ${match.line} with pattern "${match.pattern}"`;
-    case ExclusionMatchSource.USER:
-      return 'Ignored by user';
   }
 }
 


### PR DESCRIPTION
## Intent
This is a small cleanup on top of https://github.com/rstudio/publishing-client/pull/568, removing the obsolete `MatchSourceUser` value which was originally used for exclusions provided on the CLI.

Fixes #569 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [x] Cleanup


## Automated Tests
Existing tests have been updated.

## Directions for Reviewers
File exclusions in the linked PR should still work.
