### PR TITLE
Make match file path relative to base directory

### DIFF
--- a/internal/bundles/gitignore/gitignore.go
+++ b/internal/bundles/gitignore/gitignore.go
@@ -45,6 +45,7 @@ type ignoreFile struct {
 
 type GitIgnoreList struct {
 	files []ignoreFile
+	base  util.Path
 	cwd   []string
 	fs    afero.Fs
 }
@@ -67,9 +68,10 @@ func New(cwd util.Path) GitIgnoreList {
 	files[0].abspath = toSplit(absPath.Path())
 
 	return GitIgnoreList{
-		files,
-		toSplit(absPath.Path()),
-		absPath.Fs(),
+		files: files,
+		base:  cwd,
+		cwd:   toSplit(absPath.Path()),
+		fs:    absPath.Fs(),
 	}
 }
 
@@ -195,11 +197,15 @@ func (ign *GitIgnoreList) append(path util.Path, dir []string) error {
 		if err != nil {
 			return err
 		}
+		relPath, err := path.Rel(ign.base)
+		if err != nil {
+			return err
+		}
 		match := &Match{
 			Source:   MatchSourceFile,
 			Pattern:  s,
 			glob:     g,
-			FilePath: path.Path(),
+			FilePath: relPath.Path(),
 			Line:     line,
 		}
 		ignf.matches = append(ignf.matches, match)

--- a/internal/bundles/gitignore/gitignore_test.go
+++ b/internal/bundles/gitignore/gitignore_test.go
@@ -66,7 +66,7 @@ func (s *GitIgnoreSuite) TestMatch() {
 	s.NotNil(m)
 	s.Equal(MatchSourceFile, m.Source)
 	s.Equal(".Rhistory", m.Pattern)
-	s.Equal(ignoreFilePath.Path(), m.FilePath)
+	s.Equal(".positignore", m.FilePath)
 	s.Equal(1, m.Line)
 
 	// Non-file matches don't include file info


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR makes the match file path relative to the project directory.

Fixes #567 

## Type of Change
* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Automated Tests
Existing test has been updated for the new behavior.

## Directions for Reviewers
Make a .positignore file that matches some files. View the files in the UI. Hover over an ignored file. The ignore file path shown should be relative to the project directory. Also test having .positignore in a subdirectory.
