### PR TITLE
remove extraneous error from init

### DIFF
--- a/cmd/publisher/commands/init.go
+++ b/cmd/publisher/commands/init.go
@@ -3,7 +3,6 @@ package commands
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -20,14 +19,12 @@ type InitCommand struct {
 	ConfigName string    `name:"config" short:"c" help:"Configuration name to create (in .posit/publish/)"`
 }
 
-const contentTypeDetectionFailed = " Could not determine content type and entrypoint.\n\n" +
+const contentTypeDetectionFailed = "Could not determine content type and entrypoint.\n\n" +
 	"Edit the configuration file (%s) \n" +
 	"and set the 'type' to a valid deployment type. Valid types are: \n%s\n\n" +
 	"Set 'entrypoint' to the main file being deployed. For apps and APIs\n" +
 	"this is usually app.py, api.py, app.R, or plumber.R; for reports,\n" +
-	"it is your .qmd, .Rmd, or .ipynb file"
-
-var errDetectionFailed = errors.New("could not determine content type and entrypoint")
+	"it is your .qmd, .Rmd, or .ipynb file.\n"
 
 func formatValidTypes() string {
 	t := config.AllValidContentTypeNames()
@@ -56,7 +53,7 @@ func (cmd *InitCommand) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContex
 	configPath := config.GetConfigPath(cmd.Path, cmd.ConfigName)
 	if cfg.Type == config.ContentTypeUnknown {
 		fmt.Printf(contentTypeDetectionFailed, configPath, formatValidTypes())
-		return errDetectionFailed
+		return nil
 	} else {
 		fmt.Printf("Created config file %q\n", configPath.String())
 		if args.Verbose >= 2 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes some formatting and removes an extraneous error message in the `init` command.

Fixes #584

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
There aren't changes for the CLI layer yet.

## Directions for Reviewers
Run init on an empty directory. The error message should make sense and now have an extraneous log messages or other cruft at the end.
