### PR TITLE
Update for new Connect server_settings API structure

### DIFF
--- a/internal/clients/connect/capabilities.go
+++ b/internal/clients/connect/capabilities.go
@@ -100,7 +100,7 @@ func (a *allSettings) checkKubernetes(cfg *config.Config) error {
 		// No kubernetes config present
 		return nil
 	}
-	if !a.general.License.LauncherEnabled.IsTrue {
+	if !a.general.License.LauncherEnabled {
 		return errKubernetesNotLicensed
 	}
 	if a.general.ExecutionType != server_settings.ExecutionTypeKubernetes {
@@ -180,7 +180,7 @@ func (a *allSettings) checkAccess(cfg *config.Config) error {
 	}
 	racu := cfg.Connect.Access.RunAsCurrentUser
 	if racu != nil && *racu {
-		if !a.general.License.CurrentUserExecution.IsTrue {
+		if !a.general.License.CurrentUserExecution {
 			return errCurrentUserExecutionNotLicensed
 		}
 		if !a.application.RunAsCurrentUser {
@@ -201,8 +201,10 @@ func (a *allSettings) checkAccess(cfg *config.Config) error {
 }
 
 func (a *allSettings) checkConfig(cfg *config.Config) error {
-	if cfg.Type.IsAPIContent() && !a.general.License.AllowAPIs.IsTrue {
-		return errAPIsNotLicensed
+	if cfg.Type.IsAPIContent() {
+		if !a.general.License.AllowAPIs {
+			return errAPIsNotLicensed
+		}
 	}
 	if len(cfg.Description) > 4096 {
 		return errDescriptionTooLong

--- a/internal/clients/connect/capabilities_test.go
+++ b/internal/clients/connect/capabilities_test.go
@@ -12,9 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var flexiBoolTrue = server_settings.FlexiBool{IsTrue: true}
-var flexiBoolFalse = server_settings.FlexiBool{IsTrue: false}
-
 type CapabilitiesSuite struct {
 	utiltest.Suite
 }
@@ -108,7 +105,7 @@ func (s *CapabilitiesSuite) TestRunAsCurrentUser() {
 		},
 		general: server_settings.ServerSettings{
 			License: server_settings.LicenseStatus{
-				CurrentUserExecution: flexiBoolTrue,
+				CurrentUserExecution: true,
 			},
 		},
 		application: server_settings.ApplicationSettings{
@@ -127,7 +124,7 @@ func (s *CapabilitiesSuite) TestRunAsCurrentUser() {
 	s.NoError(goodSettings.checkConfig(&cfg))
 
 	noLicense := goodSettings
-	noLicense.general.License.CurrentUserExecution = flexiBoolFalse
+	noLicense.general.License.CurrentUserExecution = false
 	s.ErrorIs(noLicense.checkConfig(&cfg), errCurrentUserExecutionNotLicensed)
 
 	noConfig := goodSettings
@@ -147,14 +144,14 @@ func (s *CapabilitiesSuite) TestAPILicense() {
 	allowed := allSettings{
 		general: server_settings.ServerSettings{
 			License: server_settings.LicenseStatus{
-				AllowAPIs: flexiBoolTrue,
+				AllowAPIs: true,
 			},
 		},
 	}
 	notAllowed := allSettings{
 		general: server_settings.ServerSettings{
 			License: server_settings.LicenseStatus{
-				AllowAPIs: flexiBoolFalse,
+				AllowAPIs: false,
 			},
 		},
 	}
@@ -185,7 +182,7 @@ func (s *CapabilitiesSuite) TestKubernetesEnablement() {
 			ExecutionType:                server_settings.ExecutionTypeKubernetes,
 			DefaultImageSelectionEnabled: true,
 			License: server_settings.LicenseStatus{
-				LauncherEnabled: flexiBoolTrue,
+				LauncherEnabled: true,
 			},
 		},
 	}
@@ -201,7 +198,7 @@ func (s *CapabilitiesSuite) TestKubernetesEnablement() {
 	s.NoError(goodSettings.checkConfig(&cfg))
 
 	noLicense := goodSettings
-	noLicense.general.License.LauncherEnabled = flexiBoolFalse
+	noLicense.general.License.LauncherEnabled = false
 	s.ErrorIs(noLicense.checkConfig(&cfg), errKubernetesNotLicensed)
 
 	noConfig := goodSettings
@@ -254,7 +251,7 @@ var kubernetesEnabledSettings = allSettings{
 	general: server_settings.ServerSettings{
 		ExecutionType: server_settings.ExecutionTypeKubernetes,
 		License: server_settings.LicenseStatus{
-			LauncherEnabled: flexiBoolTrue,
+			LauncherEnabled: true,
 		},
 	},
 }

--- a/internal/clients/connect/server_settings/server_settings.go
+++ b/internal/clients/connect/server_settings/server_settings.go
@@ -136,19 +136,17 @@ type ProviderGroupAttributes struct {
 	ExternalGroupOwner   bool `json:"external_group_owner"`
 }
 
-type FlexiBool struct {
-	IsTrue bool
-}
+type FlexiBool bool
 
 var errInvalidFlexiBool = errors.New("invalid value for flex boolean")
 
 func (b *FlexiBool) UnmarshalJSON(data []byte) error {
-	b.IsTrue = false
+	*b = false
 	s := string(data)
 	switch s {
-	case "true", "1":
-		b.IsTrue = true
-	case "false", "0":
+	case "true", `"1"`:
+		*b = true
+	case "false", `"0"`:
 		break
 	default:
 		return fmt.Errorf("%q: %w", s, errInvalidFlexiBool)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR adapts to recent changes in Connect's (internal) `server_settings` API. Booleans are now encoded as strings "0" or "1". The client handles these as well as the older JSON booleans.

Fixes #593

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
We don't use that field, and sometimes the JSON we get back cannot be decoded into it, so remove it.

## Automated Tests
There isn't a test for the Connect payload decoding; this needs an integration test eventually.

## Directions for Reviewers
Test deploying to a k8s-configured Connect.
