### PR TITLE
Make init set the title from the dirname

### DIFF
--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -78,6 +78,11 @@ func Init(path util.Path, configName string, python util.Path, log logging.Logge
 	cfg := config.New()
 	cfg.Type = contentType.Type
 	cfg.Entrypoint = contentType.Entrypoint
+	absPath, err := path.Abs()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Title = absPath.Base()
 
 	requiresPython, err := requiresPython(contentType.Type, path, python)
 	if err != nil {

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -39,9 +39,13 @@ func (s *InitializeSuite) SetupTest() {
 
 func (s *InitializeSuite) TestInitEmpty() {
 	log := logging.New()
-	cfg, err := Init(s.cwd, "", util.Path{}, log)
+	path := s.cwd.Join("My App")
+	err := path.Mkdir(0777)
+	s.NoError(err)
+	cfg, err := Init(path, "", util.Path{}, log)
 	s.Nil(err)
 	s.Equal(config.ContentTypeUnknown, cfg.Type)
+	s.Equal("My App", cfg.Title)
 }
 
 func (s *InitializeSuite) createAppPy() {
@@ -86,7 +90,7 @@ func (s *InitializeSuite) TestInitInferredType() {
 	configPath := config.GetConfigPath(s.cwd, configName)
 	cfg2, err := config.FromFile(configPath)
 	s.NoError(err)
-	s.Equal(cfg.Type, config.ContentTypePythonFlask)
+	s.Equal(config.ContentTypePythonFlask, cfg.Type)
 	s.Equal("3.4.5", cfg.Python.Version)
 	s.Equal(cfg, cfg2)
 }

--- a/internal/services/api/post_configurations_test.go
+++ b/internal/services/api/post_configurations_test.go
@@ -143,5 +143,7 @@ func (s *PostConfigurationsSuite) TestPostConfigurationsInspectionFails() {
 	s.NoError(err)
 	s.Equal("default", res.Name)
 	s.Equal(filepath.Join(".posit", "publish", "default.toml"), actualPath.String())
-	s.Equal(config.New(), res.Configuration)
+	expected := config.New()
+	expected.Title = s.cwd.Base()
+	s.Equal(expected, res.Configuration)
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR sets a default (on `init`) based on the project directory name.

Fixes #607 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
Updated an existing test to check this.

## Directions for Reviewers
Run `init`. Verify the config file has a proper title. Deploy content and see the title in Connect.
