### PR TITLE
Always pass abs path to gitignore

### DIFF
--- a/internal/bundles/bundle.go
+++ b/internal/bundles/bundle.go
@@ -47,7 +47,7 @@ func NewBundler(path util.Path, manifest *Manifest, pythonRequirements []byte, l
 	if err != nil {
 		return nil, err
 	}
-	excluder, err := gitignore.NewExcludingWalker(dir)
+	excluder, err := gitignore.NewExcludingWalker(absDir)
 	if err != nil {
 		return nil, fmt.Errorf("error loading ignore list: %w", err)
 	}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR changes how we initialize the gitignore object, always giving it the absolute path. This is needed in order to process .positignore files in subdirectories.

Fixes #590 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
Added tests for this case.

## Directions for Reviewers
Deploy with a .positignore at the root level, and in a subdirectory. Ensure that appropriate files are ignored. Also verify the exclusions using the UI.
