### PR TITLE
Remove all external links

### DIFF
--- a/web/src/components/PublishProgressSummary.vue
+++ b/web/src/components/PublishProgressSummary.vue
@@ -43,24 +43,10 @@
           Publish was successful!
         </div>
         <div>
-          Access Directly:
-          <a
-            :href="eventStore.currentPublishStatus.status.directURL"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            URL
-          </a>
-        </div>
-        <div>
           Access through Dashboard:
-          <a
-            :href="eventStore.currentPublishStatus.status.dashboardURL"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            URL
-          </a>
+          <span>
+            eventStore.currentPublishStatus.status.dashboardURL
+          </span>
         </div>
       </div>
     </div>

--- a/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationHeader.vue
+++ b/web/src/views/existing-deployment-destination/ExistingDeploymentDestinationHeader.vue
@@ -24,7 +24,7 @@
             {{ deployment.saveName }}
           </h1>
           <p>
-            Redeployment to: <a :href="deployment.serverUrl">{{ deployment.serverUrl }}</a>
+            Redeployment to: {{ deployment.serverUrl }}
           </p>
           <p>
             {{ deployment.id }}

--- a/web/src/views/new-deployment-destination/NewDestinationHeader.vue
+++ b/web/src/views/new-deployment-destination/NewDestinationHeader.vue
@@ -23,14 +23,14 @@
           </h1>
           <template v-if="contentId">
             <p>
-              Redeployment to: <a :href="destinationURL">{{ destinationURL }}</a>
+              Redeployment to: {{ destinationURL }}
             </p>
             <p>
               {{ contentId }}
             </p>
           </template>
           <p v-else>
-            New deployment to: <a :href="destinationURL">{{ destinationURL }}</a>
+            New deployment to: {{ destinationURL }}
           </p>
           <p> {{ addingDestinationMessage }}</p>
         </div>


### PR DESCRIPTION
This PR does two things:
- Removes the direct link to the published content
- Removes ALL `<a>` elements in the UI since they point to external links

### Why are all external links being removed?

VSCode doesn't support `target="_blank"` and actively blocks it. More details can be found in references in #609. The links would still work if you used CMD clicking or middle mouse clicks which defaults to opening in a new tab (new window in VSCode), but if you clicked on them normally:
- a `target="blank"` would be blocked and nothing would happen. A console error would be in the devtools that it was blocked
- an external link would take over the iframe and the only way to navigate back is to use keyboard or mouse shortcuts like a normal browser. VSCode has no interface to back or navigate through history.

Neither of these are ideal for Alpha, and could cause problems. When we find a way to address #609 we can re-add link functionality or a fallback option.

## Intent
- Temporarily deals with #609 
- Resolves #615 

## Type of Change

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->