### PR TITLE
Sort deployment cards by `deployedAt` time

### DIFF
--- a/web/src/utils/date.ts
+++ b/web/src/utils/date.ts
@@ -8,3 +8,7 @@ export function formatDateString(dateString: string) {
   });
 }
 
+export function sortByDateString(a: string, b: string) {
+  return Date.parse(a) > Date.parse(b) ? -1 : 1;
+}
+

--- a/web/src/views/project-page/ProjectPage.vue
+++ b/web/src/views/project-page/ProjectPage.vue
@@ -25,7 +25,7 @@
       class="card-grid"
     >
       <DeploymentCard
-        v-for="deployment in deployments"
+        v-for="deployment in sortedDeployments"
         :key="deployment.id"
         :deployment="deployment"
       />
@@ -81,6 +81,7 @@ import DeploymentCard from './DeploymentCard.vue';
 import FileTree from 'src/components/FileTree.vue';
 import PButton from 'src/components/PButton.vue';
 import PCard from 'src/components/PCard.vue';
+import { sortByDateString } from 'src/utils/date';
 
 const api = useApi();
 const deployments = ref<Deployment[]>([]);
@@ -88,6 +89,12 @@ const configurations = ref<Array<Configuration | ConfigurationError>>([]);
 
 const hasDeployments = computed(() => {
   return deployments.value.length > 0;
+});
+
+const sortedDeployments = computed(() => {
+  return [...deployments.value].sort((a, b) => {
+    return sortByDateString(a.deployedAt, b.deployedAt);
+  });
 });
 
 async function getDeployments() {


### PR DESCRIPTION
This PR introduces sorting by the last published datetime for the Deployments listed on the Project page.

<details>
  <summary>Preview</summary>
  
![CleanShot 2023-12-15 at 13 02 39](https://github.com/rstudio/publishing-client/assets/19917631/7f3d671a-a9b6-4443-920b-e116c218e5f2)

</details> 

## Intent
Resolves #611 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Created a simple `sortByDateString` utility that takes in datetime strings, uses `Date.parse()` to turn them into milliseconds, and checks which is larger. Then I used a computed property on the `ProjectPage` to sort the deployments we get back from the API.

## References

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description
