### PR TITLE
WIP Rough example of using vscode API in web view

### DIFF
--- a/web/src/views/project-page/ProjectPage.vue
+++ b/web/src/views/project-page/ProjectPage.vue
@@ -104,6 +104,9 @@ async function getConfigurations() {
 
 getDeployments();
 getConfigurations();
+
+console.log('Sending window parent the message', window.parent);
+window.parent.postMessage({ command: 'alert', text: 'it worked' }, '*');
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
**DO NOT MERGE** this is for example and discussion purposes.

This is a rough example that needs to be refined where the VSCode web view iframe can call the VSCode API.

### Things I ran into

- `script` has to be above the `iframe` or it doesn't load at all
- `'*'` was required in `window.parent.postMessage` or the event was received by the VSCode web view

### What is next?

Refining this so we don't need to use `'*'`. We will want to use a specific `targetOrigin` ideally.

We need to find a way in the Vue APP to determine what we are open in. We will want differing behavior in VSCode vs the `publisher ui` view since they have different restrictions.