### PR TITLE
Fix AddNewDeployment form submit

### DIFF
--- a/web/src/views/add-new-deployment/AddNewDeployment.vue
+++ b/web/src/views/add-new-deployment/AddNewDeployment.vue
@@ -38,7 +38,6 @@
       <div class="flex row reverse">
         <PButton
           hierarchy="primary"
-          :to="destinationPage"
           :disable="disableToDestinationPage"
           type="submit"
         >


### PR DESCRIPTION
Adjusts the "Continue to Publish" button from being a link to the "New Destination Page" to a `type="submit"` button.

This allows the `<form>` to work as a normal web form where the "Enter" key submits the form. The `AddNewDeployment.vue` component captures that submit even with `@submit.prevent="navigateToNewDestinationPage"`. As it says it navigates to the `NewDestinationPage`.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->
