### PR TITLE
Refactor App Header to group logo

### DIFF
--- a/web/src/components/AppHeader.vue
+++ b/web/src/components/AppHeader.vue
@@ -4,20 +4,20 @@
   <q-header>
     <q-toolbar class="publisher-layout">
       <AppMenu />
-      <router-link
-        :to="{ name: 'root' }"
-        class="header row"
-      >
-        <WhitePositLogo
-          width="70px"
-          height="30px"
-          class="posit-logo"
-          alt="Posit PBC Logo"
-        />
-        <q-toolbar-title class="q-pl-xs">
-          Publisher
-        </q-toolbar-title>
-      </router-link>
+      <q-toolbar-title>
+        <router-link
+          class="posit-logo-link"
+          :to="{ name: 'root' }"
+        >
+          <WhitePositLogo
+            width="70px"
+            height="30px"
+            class="posit-logo"
+            alt="Posit PBC Logo"
+          />
+          <span class="q-pl-xs">Publisher</span>
+        </router-link>
+      </q-toolbar-title>
     </q-toolbar>
   </q-header>
 </template>
@@ -29,17 +29,19 @@ import WhitePositLogo from 'src/components/icons/WhitePositLogo.vue';
 
 </script>
 
-<style lang="scss">
-
+<style scoped lang="scss">
 .posit-logo {
   fill: white;
   stroke: none;
-  cursor: pointer;
 }
 
-.header {
+.posit-logo-link {
   text-decoration: none;
   color: white;
+
+  & > * {
+    vertical-align: middle;
+  }
 }
 
 </style>


### PR DESCRIPTION
This PR is a simple refactor of `AppHeader` to avoid having `router-link` group content across `QToolbar` component slots and overriding Quasar CSS layout templating.

## Type of Change
- Precursor to #581 

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [x] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
`router-link` was using a flex container across the SVG logo and the `q-toolbar-title`. Instead of doing that we can put the logo and the "Publisher" text in the title slot.

To keep the SVG and text looking good next to each other we need to use `vertical-align: middle;`

`cursor: pointer` is handled by the `a` element automatically.

This ultimately prevents the entire full-width toolbar-title slot from being a link which was confusing both from a layout perspective, but also a user perspective. 
