### PR TITLE
Show dashboard URL on successful publish

### DIFF
--- a/web/src/components/PublishProgressSummary.vue
+++ b/web/src/components/PublishProgressSummary.vue
@@ -65,7 +65,7 @@
         <div>
           Access through Dashboard:
           <span>
-            eventStore.currentPublishStatus.status.dashboardURL
+            {{ eventStore.currentPublishStatus.status.dashboardURL }}
           </span>
         </div>
       </div>


### PR DESCRIPTION
Quick fix that adds necessary `{{ }}` to show the Dashboard URL.

Fix from a mistake I made in #623 