### PR TITLE
Change publish -> (re)deploy in Vue components

### DIFF
--- a/web/src/components/DeployProgressLine.vue
+++ b/web/src/components/DeployProgressLine.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div
-    v-if="publishInProgess"
+    v-if="deployInProgress"
     class="flex items-center"
     :class="textClass"
   >
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div
-    v-if="showPublishError"
+    v-if="showDeployError"
     class="flex items-center"
     :class="textClass"
   >
@@ -25,7 +25,7 @@
       size="1rem"
     />
     <div class="q-ml-sm text-left text-bold">
-      Publishing Operation has failed.
+      Deploying Operation has failed.
     </div>
   </div>
 </template>
@@ -47,11 +47,11 @@ const completion = computed(() => {
   return eventStore.currentPublishStatus.status.completion;
 });
 
-const publishInProgess = computed(() => {
+const deployInProgress = computed(() => {
   return eventStore.isPublishActiveByID(props.id);
 });
 
-const showPublishError = computed(() => {
+const showDeployError = computed(() => {
   return (
     eventStore.doesPublishStatusApply(props.id)
     &&

--- a/web/src/components/DeployProgressSummary.vue
+++ b/web/src/components/DeployProgressSummary.vue
@@ -5,7 +5,7 @@
     style="min-width:100%; min-height: 5rem;"
   >
     <div
-      v-if="showOtherPublishOperationInProgress"
+      v-if="showOtherDeployOperationInProgress"
       class="summary row items-center"
       :class="textClass"
     >
@@ -25,7 +25,7 @@
       </div>
     </div>
     <div
-      v-if="showPublishInProgress"
+      v-if="showDeployInProgress"
       class="summary row items-center"
       :class="textClass"
     >
@@ -37,7 +37,7 @@
       </div>
       <div class="col-10 text-left">
         <div class="text-bold">
-          Publishing project...
+          Deploying project...
         </div>
         <div>
           {{ eventStore.summaryOfCurrentPublishingProcess.operation }}
@@ -48,7 +48,7 @@
       </div>
     </div>
     <div
-      v-if="showPublishSuccessSummary"
+      v-if="showDeploySuccessSummary"
       class="summary row text-left items-center"
       :class="textClass"
     >
@@ -60,7 +60,7 @@
       </div>
       <div class="col-10 text-caption">
         <div class="text-bold">
-          {{ pastTenseModifier }} Publish was successful!
+          {{ pastTenseModifier }} Deploy was successful!
         </div>
         <div>
           Access through Dashboard:
@@ -71,7 +71,7 @@
       </div>
     </div>
     <div
-      v-if="showPublishError"
+      v-if="showDeployError"
       class="error row text-left items-center"
       :class="textClass"
     >
@@ -83,7 +83,7 @@
       </div>
       <div class="col-10 text-caption">
         <div class="text-bold">
-          {{ pastTenseModifier }} Publishing Operation has failed.
+          {{ pastTenseModifier }} Deploying Operation has failed.
         </div>
         <div
           v-for="keyValuePair in eventStore.currentPublishStatus.status.error"
@@ -117,21 +117,21 @@ const completion = computed(() => {
   return eventStore.currentPublishStatus.status.completion;
 });
 
-const showOtherPublishOperationInProgress = computed(() => {
+const showOtherDeployOperationInProgress = computed(() => {
   return (
     eventStore.publishInProgess &&
     !eventStore.doesPublishStatusApply(props.id)
   );
 });
 
-const showPublishInProgress = computed(() => {
+const showDeployInProgress = computed(() => {
   return (
     eventStore.isPublishActiveByID(props.id) &&
     eventStore.currentPublishStatus.status.currentStep // Make sure it has started
   );
 });
 
-const showPublishSuccessSummary = computed(() => {
+const showDeploySuccessSummary = computed(() => {
   return (
     eventStore.doesPublishStatusApply(props.id)
     &&
@@ -139,7 +139,7 @@ const showPublishSuccessSummary = computed(() => {
   );
 });
 
-const showPublishError = computed(() => {
+const showDeployError = computed(() => {
   return (
     eventStore.doesPublishStatusApply(props.id)
     &&

--- a/web/src/views/deploy-progress/DeployProgressPage.vue
+++ b/web/src/views/deploy-progress/DeployProgressPage.vue
@@ -11,7 +11,7 @@
         }"
       />
       <q-breadcrumbs-el
-        label="Publish Process"
+        label="Deploy Progress"
       />
     </q-breadcrumbs>
 

--- a/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
+++ b/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
@@ -29,11 +29,11 @@ const done = ref(false);
 
 const summary = computed(() => {
   if (done.value) {
-    return `Your project has been successfully published and is 
+    return `Your project has been successfully deployed and is 
     available via the Connect Dashboard (${eventStore.currentPublishStatus.status.dashboardURL})
     or directly (${eventStore.currentPublishStatus.status.directURL}).`;
   }
-  return `Your project is still being published...`;
+  return `Your project is still being deployed...`;
 });
 
 watch(

--- a/web/src/views/new-deployment/NewDeploymentPage.vue
+++ b/web/src/views/new-deployment/NewDeploymentPage.vue
@@ -4,13 +4,13 @@
   <NewDeploymentHeader
     :account-name="accountName"
     :deployment-name="deploymentName"
-    @publish="hasPublished = true"
+    @deploy="hasDeployed = true"
   />
 
   <DeploymentSection
     title="Configuration"
     :subtitle="defaultConfig?.configurationName ||
-      'No default configuration found. One will be created automatically on publish'"
+      'No default configuration found. One will be created automatically on deploy'"
   >
     <ConfigSettings
       v-if="defaultConfig"
@@ -38,7 +38,7 @@ import DeploymentSection from 'src/components/DeploymentSection.vue';
 
 const route = useRoute();
 const router = useRouter();
-const hasPublished = ref(false);
+const hasDeployed = ref(false);
 const api = useApi();
 const $q = useQuasar();
 
@@ -73,7 +73,7 @@ const defaultConfig = computed(() => {
 });
 
 onBeforeRouteLeave((_to, _from, next) => {
-  if (hasPublished.value) {
+  if (hasDeployed.value) {
     return next();
   }
   $q.dialog({

--- a/web/src/views/project-page/DeploymentCard.vue
+++ b/web/src/views/project-page/DeploymentCard.vue
@@ -13,7 +13,7 @@
         :id="deployment.id"
       />
       <p v-else>
-        Last Published on {{ formatDateString(deployment.deployedAt) }}
+        Last Deployed on {{ formatDateString(deployment.deployedAt) }}
       </p>
     </div>
   </PCard>


### PR DESCRIPTION
This PR changes all of the variables, refs, computed props, props, and text in Vue components to use (re)deploy instead of Publish where applicable.

This PR doesn't touch the eventing code since that is a larger scale refactor for Alpha 1. Instead a new issue was created to refactor this: #678

## Intent
Resolves #597

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [x] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

