### PR TITLE
Fix deployment typo in new header

### DIFF
--- a/web/src/views/new-deployment/NewDeploymentHeader.vue
+++ b/web/src/views/new-deployment/NewDeploymentHeader.vue
@@ -73,7 +73,7 @@
                 :current-tense="showDeployStatusAsCurrent"
               />
               <RouterLink :to="{ name: 'progress' }">
-                View summarized deploment logs
+                View summarized deployment logs
               </RouterLink>
             </div>
           </div>


### PR DESCRIPTION
A simple typo fix `deploment` to `deployment`