### PR TITLE
Update breadcrumb labels and hiearchy

### DIFF
--- a/web/src/views/deploy-progress/DeployProgressPage.vue
+++ b/web/src/views/deploy-progress/DeployProgressPage.vue
@@ -58,13 +58,6 @@ const saveName = computed(() => {
 });
 
 const operation = computed(() => {
-  if (eventStore.currentPublishStatus.deploymentMode === 'deploy') {
-    return `New deployment to: ${eventStore.currentPublishStatus.destinationURL}`;
-  }
-  if (eventStore.currentPublishStatus.deploymentMode === 'redeploy') {
-    return `Redeployment to: ${eventStore.currentPublishStatus.destinationURL}`;
-  }
-  // return something better than just 'unknown'
   return `Deploying to: ${eventStore.currentPublishStatus.destinationURL}`;
 });
 

--- a/web/src/views/existing-deployment/ExistingDeploymentHeader.vue
+++ b/web/src/views/existing-deployment/ExistingDeploymentHeader.vue
@@ -24,7 +24,7 @@
             {{ deployment.saveName }}
           </h1>
           <p>
-            Redeployment to: {{ deployment.serverUrl }}
+            Deploying to: {{ deployment.serverUrl }}
           </p>
           <p>
             {{ deployment.id }}
@@ -69,7 +69,7 @@
                 v-if="showLogsLink"
                 :to="routerLocation"
               >
-                View summarized redeployment logs
+                View summarized deployment logs
               </RouterLink>
             </div>
           </div>
@@ -128,13 +128,6 @@ const routerLocation = computed(() => {
 });
 
 const operationStr = computed(() => {
-  if (eventStore.currentPublishStatus.deploymentMode === 'deploy') {
-    return `New deployment to: ${props.deployment.serverUrl}`;
-  }
-  if (eventStore.currentPublishStatus.deploymentMode === 'redeploy') {
-    return `Redeployment to: ${props.deployment.serverUrl}`;
-  }
-  // return something better than just 'unknown'
   return `Deploying to: ${props.deployment.serverUrl}`;
 });
 

--- a/web/src/views/new-deployment/NewDeploymentHeader.vue
+++ b/web/src/views/new-deployment/NewDeploymentHeader.vue
@@ -33,7 +33,7 @@
           </template>
           <template v-else>
             <p>
-              Redeployment to: {{ deploymentURL }}
+              Deployment to: {{ deploymentURL }}
             </p>
             <p>
               {{ contentId }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Moves the publishing process to be a breadcrumb underneath a deployment/redeployment

closes: #667 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

I have settled on implementing a simple hierarchy rather than trying to complicate it with the deployment name (if there is one) and having a difference between deploy and redeploy.

I actually implemented this more complicated approach first, but after testing and playing around with it, I wasn't happy with the end effect. I believe this more straightforward approach to be superior for the user.

Just to let you know, I have not placed the add deployment panel into the hierarchy per-sa. Since we have to specify the breadcrumbs on each page, it is difficult to know at this time that the path to the log page came through the add deployment flow. So, for now, we'll keep it simple.

Here are screenshots of the updated breadcrumbs in place:

![2023-12-19 at 8 36 PM](https://github.com/rstudio/publishing-client/assets/17675905/e5fc2d86-dec1-436d-a6d9-7fbc28579b1c)

![2023-12-19 at 8 36 PM](https://github.com/rstudio/publishing-client/assets/17675905/fbcdb41d-f5ba-4130-82b1-de4d3bdf90cc)

![2023-12-19 at 8 37 PM](https://github.com/rstudio/publishing-client/assets/17675905/f11ef740-7811-4d8f-b1d9-ce5fb830c0bb)

![2023-12-19 at 8 37 PM](https://github.com/rstudio/publishing-client/assets/17675905/75d03fd7-88b1-46ff-9b31-0097e60985be)

![2023-12-19 at 8 37 PM](https://github.com/rstudio/publishing-client/assets/17675905/56bbde47-6625-421c-8ebe-e536297cf047)

![2023-12-19 at 8 38 PM](https://github.com/rstudio/publishing-client/assets/17675905/43766bd0-8d30-4136-ab9d-b3a3805ae9c6)

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->
Navigate around, including clicking on past links to return to earlier pages and confirm deployment functionality.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
