### PR TITLE
update hint and add logic for default name

### DIFF
--- a/web/src/views/add-new-deployment/AddNewDeployment.vue
+++ b/web/src/views/add-new-deployment/AddNewDeployment.vue
@@ -127,7 +127,7 @@ const generateDefaultName = () => {
   let defaultName = '';
   do {
     id += 1;
-    const trialName = `Untitled #${id}`;
+    const trialName = `Untitled-${id}`;
     if (!deployments.value.find((deployment) => deployment.saveName === trialName)) {
       defaultName = trialName;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

When adding a new deployment, the description of a name field has led to some confusion. This PR enhances the hint and provides for a default name based on credential selection.

It also auto-selects the first credential in the list.

Closes #707 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The name is generated from the template of `Untitled #X` where X increments from 1+ and is set on the first deployment not named the same. So if `Untitled #1` exists, the name will be `Untitled #2` (or which ever number has not been used in the deployment save-names). Get deployments is queried for the beginning of the form, so that any manual file renaming is accounted for.

This PR also auto-selects the first credential.

Example screenshot of and selection:
![2023-12-20 at 11 38 AM](https://github.com/rstudio/publishing-client/assets/17675905/96765616-80aa-433b-a787-7d52c2f6a079)


## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
