### PR TITLE
Use fresh exclusion list in Files API

### DIFF
--- a/internal/services/api/files/services_test.go
+++ b/internal/services/api/files/services_test.go
@@ -5,6 +5,7 @@ package files
 import (
 	"testing"
 
+	"github.com/rstudio/connect-client/internal/bundles/gitignore"
 	"github.com/rstudio/connect-client/internal/logging"
 	"github.com/rstudio/connect-client/internal/util"
 	"github.com/rstudio/connect-client/internal/util/utiltest"
@@ -37,8 +38,10 @@ func (s *ServicesSuite) TestGetFile() {
 	base := util.NewPath("", afs)
 	service := CreateFilesService(base, s.log)
 	s.NotNil(service)
-	file, err := service.GetFile(base)
-	s.Nil(err)
+	ignore, err := gitignore.NewIgnoreList(base)
+	s.NoError(err)
+	file, err := service.GetFile(base, ignore)
+	s.NoError(err)
 	s.NotNil(file)
 }
 
@@ -47,8 +50,10 @@ func (s *ServicesSuite) TestGetFileUsingSampleContent() {
 	base := util.NewPath("../../../../test/sample-content/fastapi-simple", afs)
 	service := CreateFilesService(base, s.log)
 	s.NotNil(service)
-	file, err := service.GetFile(base)
-	s.Nil(err)
+	ignore, err := gitignore.NewIgnoreList(base)
+	s.NoError(err)
+	file, err := service.GetFile(base, ignore)
+	s.NoError(err)
 	s.NotNil(file)
 }
 
@@ -57,8 +62,10 @@ func (s *ServicesSuite) TestGetFileUsingSampleContentWithTrailingSlash() {
 	base := util.NewPath("../../../../test/sample-content/fastapi-simple/", afs)
 	service := CreateFilesService(base, s.log)
 	s.NotNil(service)
-	file, err := service.GetFile(base)
-	s.Nil(err)
+	ignore, err := gitignore.NewIgnoreList(base)
+	s.NoError(err)
+	file, err := service.GetFile(base, ignore)
+	s.NoError(err)
 	s.NotNil(file)
 }
 
@@ -84,8 +91,10 @@ func (s *ServicesSuite) TestGetFileWithPositIgnore() {
 
 	service := CreateFilesService(base, s.log)
 	s.NotNil(service)
-	file, err := service.GetFile(base)
-	s.Nil(err)
+	ignore, err := gitignore.NewIgnoreList(base)
+	s.NoError(err)
+	file, err := service.GetFile(base, ignore)
+	s.NoError(err)
 	s.NotNil(file)
 
 	files := file.Files
@@ -140,7 +149,9 @@ func (s *ServicesSuite) TestGetFileWithChangingPositIgnore() {
 
 	service := CreateFilesService(base, s.log)
 	s.NotNil(service)
-	file, err := service.GetFile(base)
+	ignore, err := gitignore.NewIgnoreList(base)
+	s.NoError(err)
+	file, err := service.GetFile(base, ignore)
 	s.Nil(err)
 	s.NotNil(file)
 
@@ -177,7 +188,9 @@ func (s *ServicesSuite) TestGetFileWithChangingPositIgnore() {
 	err = base.Join(".positignore").WriteFile([]byte{}, 0666)
 	s.NoError(err)
 
-	file, err = service.GetFile(base)
+	ignore, err = gitignore.NewIgnoreList(base)
+	s.NoError(err)
+	file, err = service.GetFile(base, ignore)
 	s.Nil(err)
 	s.NotNil(file)
 

--- a/internal/services/api/get_file.go
+++ b/internal/services/api/get_file.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/rstudio/connect-client/internal/bundles/gitignore"
 	"github.com/rstudio/connect-client/internal/logging"
 	"github.com/rstudio/connect-client/internal/services/api/files"
 	"github.com/rstudio/connect-client/internal/services/api/paths"
@@ -34,8 +35,14 @@ func GetFileHandlerFunc(base util.Path, filesService files.FilesService, pathsSe
 			w.Write([]byte(http.StatusText(http.StatusForbidden)))
 			return
 		}
+		ignore, err := gitignore.NewIgnoreList(base)
+		if err != nil {
+			log.Warn("failed to initialize ignore list")
+			InternalError(w, r, log, err)
+			return
+		}
 
-		file, err := filesService.GetFile(p)
+		file, err := filesService.GetFile(p, ignore)
 		if err != nil {
 			InternalError(w, r, log, err)
 			return

--- a/internal/services/api/get_file_test.go
+++ b/internal/services/api/get_file_test.go
@@ -33,7 +33,7 @@ func (s *GetFileHandlerFuncSuite) SetupSuite() {
 
 func (s *GetFileHandlerFuncSuite) TestGetFileHandlerFunc() {
 	files := new(MockFilesService)
-	files.On("GetFile", mock.Anything).Return(nil, nil)
+	files.On("GetFile", mock.Anything, mock.Anything).Return(nil, nil)
 
 	paths := new(MockPathsService)
 	paths.On("IsSafe", mock.Anything).Return(nil, nil)
@@ -51,7 +51,7 @@ func (s *GetFileHandlerFuncSuite) TestHandlerFunc() {
 	src := &files.File{Rel: base.String()}
 
 	filesService := new(MockFilesService)
-	filesService.On("GetFile", mock.Anything).Return(src, nil)
+	filesService.On("GetFile", mock.Anything, mock.Anything).Return(src, nil)
 
 	pathsService := new(MockPathsService)
 	pathsService.On("IsSafe", mock.Anything).Return(true, nil)
@@ -84,7 +84,7 @@ func (s *GetFileHandlerFuncSuite) TestHandlerFuncUsingPathname() {
 	src := &files.File{Rel: pathname}
 
 	filesService := new(MockFilesService)
-	filesService.On("GetFile", mock.Anything).Return(src, nil)
+	filesService.On("GetFile", mock.Anything, mock.Anything).Return(src, nil)
 
 	pathsService := new(MockPathsService)
 	pathsService.On("IsSafe", mock.Anything).Return(true, nil)
@@ -157,7 +157,7 @@ func (s *GetFileHandlerFuncSuite) TestHandlerFuncGetFileReturnsError() {
 	src := &files.File{Rel: base.String()}
 
 	filesService := new(MockFilesService)
-	filesService.On("GetFile", mock.Anything).Return(src, errors.New(""))
+	filesService.On("GetFile", mock.Anything, mock.Anything).Return(src, errors.New(""))
 
 	pathsService := new(MockPathsService)
 	pathsService.On("IsSafe", mock.Anything).Return(true, nil)

--- a/internal/services/api/test.go
+++ b/internal/services/api/test.go
@@ -3,6 +3,7 @@ package api
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"github.com/rstudio/connect-client/internal/bundles/gitignore"
 	"github.com/rstudio/connect-client/internal/services/api/files"
 	"github.com/rstudio/connect-client/internal/services/api/paths"
 	"github.com/rstudio/connect-client/internal/util"
@@ -14,8 +15,8 @@ type MockFilesService struct {
 	files.FilesService
 }
 
-func (m *MockFilesService) GetFile(p util.Path) (*files.File, error) {
-	args := m.Called(p)
+func (m *MockFilesService) GetFile(p util.Path, ignore gitignore.IgnoreList) (*files.File, error) {
+	args := m.Called(p, ignore)
 	return args.Get(0).(*files.File), args.Error(1)
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes an issue where the exclusions in a .positignore file persist even when they are removed from the file, or the file is removed.

Fixes #690

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Create a new IgnoreList for each call to the files API. This ensures that the content of previous .positignore reads does not persist across calls.

## Automated Tests
Added a test case for this.

## Directions for Reviewers
Verify fix as described in the linked issue.
