### PR TITLE
Create separate sub-logger when publishing

### DIFF
--- a/internal/services/api/post_deployments.go
+++ b/internal/services/api/post_deployments.go
@@ -69,7 +69,7 @@ func PostDeploymentsHandlerFunc(
 		publisher := publisherFactory(newState)
 
 		go func() {
-			log = log.WithArgs("local_id", localID)
+			log := log.WithArgs("local_id", localID)
 			err = publisher.PublishDirectory(log)
 			if err != nil {
 				log.Error("Deployment failed", "error", err.Error())


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes logging output that contained multiple `local_id` values after doing multiple deployments.

Fixes #694 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
We create a sub-logger for the deployment. We need to not assign that to a captured variable that persists across deployments.

## Automated Tests
Tests don't cover this code, which executes in a secondary goroutine within the scope of the API handler.

## Directions for Reviewers
Deploy multiple times through the UI. Make the last one fail. Check stderr logs; there should only be one local_id.
