### PR TITLE
Encode URL params for API requests

### DIFF
--- a/web/src/api/resources/Accounts.ts
+++ b/web/src/api/resources/Accounts.ts
@@ -25,8 +25,9 @@ export class Accounts {
   // 404 - account not found
   // 500 - internal server error
   get(accountName: string) {
+    const encodedAccountName = encodeURIComponent(accountName);
     return this.client.get<Account>(
-      `/accounts/${accountName}`,
+      `/accounts/${encodedAccountName}`,
     );
   }
 }

--- a/web/src/api/resources/Deployments.ts
+++ b/web/src/api/resources/Deployments.ts
@@ -25,8 +25,9 @@ export class Deployments {
   // 404 - not found
   // 500 - internal server error
   get(id: string) {
+    const encodedId = encodeURIComponent(id);
     return this.client.get<Deployment | DeploymentError>(
-      `deployments/${id}`,
+      `deployments/${encodedId}`,
     );
   }
 


### PR DESCRIPTION
Simple PR that calls [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) for the params we pass to API client methods that are used in the URL we pass to Axios.

This will make API requests to `GET /api/accounts/{name}` and `GET /api/deployments/{name}` work if the names are not URL safe. It will encode them before making the request.

For example:
`http://localhost:9000/api/deployments/a%b@c!` will become `http://localhost:9000/api/deployments/a%25b%40c!`