### PR TITLE
Fix preflight for static and report content types

### DIFF
--- a/internal/clients/connect/capabilities_test.go
+++ b/internal/clients/connect/capabilities_test.go
@@ -85,7 +85,7 @@ func (s *CapabilitiesSuite) TestRuntimeNonWorker() {
 		},
 	}
 	a := allSettings{}
-	s.ErrorIs(a.checkConfig(cfg), errRuntimeSettingsForNonWorker)
+	s.ErrorIs(a.checkConfig(cfg), errRuntimeSettingsForStaticContent)
 }
 
 func (s *CapabilitiesSuite) TestRunAs() {


### PR DESCRIPTION
## Intent
This PR fixes a Connect API call error that occurs during preflight on static content and reports.

Fixes #730

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
For static content and reports, don't fetch the content-type-specific scheduler defaults from Connect (that caused the error). Preflight should enforce that the `connect.runtime` configuration section not be present unless the content is one that uses worker processes.

## Automated Tests
Added a test for the new preflight condition.

## Directions for Reviewers
Publish static HTML content; it should pass preflight (unless you specify a connect.runtime configuration, then it should fail).
