### PR TITLE
wrap python error

### DIFF
--- a/internal/environment/python.go
+++ b/internal/environment/python.go
@@ -58,7 +58,10 @@ func NewPythonInspector(projectDir util.Path, pythonPath util.Path, log logging.
 func (i *defaultPythonInspector) validatePythonExecutable(pythonExecutable string) error {
 	args := []string{"--version"}
 	_, err := i.executor.runPythonCommand(pythonExecutable, args)
-	return err
+	if err != nil {
+		return fmt.Errorf("could not run python executable '%s': %w", pythonExecutable, err)
+	}
+	return nil
 }
 
 func (i *defaultPythonInspector) getPythonExecutable(exec util.PathLooker) (string, error) {

--- a/internal/environment/python_test.go
+++ b/internal/environment/python_test.go
@@ -201,6 +201,8 @@ func (s *PythonSuite) TestGetPythonExecutableNoRunnablePython() {
 	exec.On("LookPath", "python").Return("/some/python", nil)
 	executable, err := inspector.getPythonExecutable(exec)
 	s.NotNil(err)
+	s.ErrorIs(err, testError)
+	s.ErrorContains(err, "could not run python executable")
 	s.Equal("", executable)
 }
 


### PR DESCRIPTION


## Intent
This PR provides better error messaging when the detected Python is not runnable. This can happen when pyenv doesn't have an active Python, or with Windows execution aliases. Current, it fails with an uninformative exit code error.

Fixes #723 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Wrap the error in a more descriptive one.

## Automated Tests
Updated tests to assert the new behavior.

## Directions for Reviewers
Have the Python on PATH be one that exits nonzero, and run 
```
just build && echo && $(just executable-path) init
```
