### PR TITLE
Enable copyright header checks as part of linting

### DIFF
--- a/internal/clients/connect/server_settings/server_settings.go
+++ b/internal/clients/connect/server_settings/server_settings.go
@@ -1,5 +1,7 @@
 package server_settings
 
+// Copyright (C) 2023 by Posit Software, PBC.
+
 import (
 	"errors"
 	"fmt"

--- a/internal/events/cli_logger.go
+++ b/internal/events/cli_logger.go
@@ -1,5 +1,7 @@
 package events
 
+// Copyright (C) 2023 by Posit Software, PBC.
+
 import (
 	"context"
 	"fmt"

--- a/internal/util/toml.go
+++ b/internal/util/toml.go
@@ -1,5 +1,7 @@
 package util
 
+// Copyright (C) 2023 by Posit Software, PBC.
+
 import (
 	"fmt"
 	"io"

--- a/justfile
+++ b/justfile
@@ -195,7 +195,7 @@ lint: stub
     set -eou pipefail
     {{ _with_debug }}
 
-    # ./scripts/ccheck.py ./scripts/ccheck.config
+    ./scripts/ccheck.py ./scripts/ccheck.config
     just _with_docker staticcheck ./...
     just _with_docker go vet -all ./...
     just _with_docker ./scripts/fmt-check.bash


### PR DESCRIPTION
## Intent
Re-enable the copyright header check as part of `just lint`, and fix some files that were added without headers.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [x] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
This adds a check to linting.

## Directions for Reviewers
CI should pass, and linting can be run locally.
