### PR TITLE
Fix deployment name in GET /api/deployments reponse

### DIFF
--- a/internal/services/api/get_deployment_test.go
+++ b/internal/services/api/get_deployment_test.go
@@ -75,6 +75,7 @@ func (s *GetDeploymentSuite) TestGetDeployment() {
 	s.NotNil(res.Deployment)
 	s.Nil(res.Error)
 	s.Equal(d, res.Deployment)
+	s.Equal("myTargetName", res.Name)
 	s.Equal(filepath.Join(".posit", "publish", "myConfig.toml"), res.ConfigPath)
 	s.Equal(types.ContentID("myTargetName"), res.Deployment.ID)
 }

--- a/internal/services/api/get_deployments.go
+++ b/internal/services/api/get_deployments.go
@@ -31,7 +31,7 @@ func readLatestDeploymentFiles(base util.Path) ([]deploymentDTO, error) {
 		d, err := deployment.FromFile(path)
 		if err != nil {
 			response = append(response, deploymentDTO{
-				Name:  path.Base(),
+				Name:  deployment.SaveNameFromPath(path),
 				Path:  path.String(),
 				Error: types.AsAgentError(err),
 			})
@@ -44,7 +44,7 @@ func readLatestDeploymentFiles(base util.Path) ([]deploymentDTO, error) {
 				relPath = configPath
 			}
 			response = append(response, deploymentDTO{
-				Name:       path.Base(),
+				Name:       deployment.SaveNameFromPath(path),
 				Path:       path.String(),
 				ConfigPath: relPath.String(),
 				Deployment: d,

--- a/internal/services/api/get_deployments_test.go
+++ b/internal/services/api/get_deployments_test.go
@@ -110,10 +110,12 @@ func (s *GetDeploymentsSuite) TestGetDeploymentsError() {
 	s.Len(res, 2)
 	s.Nil(res[0].Error)
 	s.NotNil(res[0].Deployment)
+	s.Equal("target1", res[0].Name)
 	s.Equal(d, res[0].Deployment)
 	s.Equal(types.ContentID("target1"), res[0].Deployment.ID)
 
 	var nilDeployment *deployment.Deployment
 	s.Equal(nilDeployment, res[1].Deployment)
+	s.Equal("target2", res[1].Name)
 	s.NotNil(res[1].Error)
 }


### PR DESCRIPTION
## Intent
This PR fixes the GET /api/deployments reponse `deploymentName` field so that it is only the deployment name, without the .toml suffix.

Fixes #792

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Use the existing helper to get the name from the file path as we iterate the files.

## Automated Tests
Added assertions to existing tests for both endpoints (GET /api/deployments and GET /api/deployments/:name).

## Directions for Reviewers
Verify reponse from the GET /api/deployments does not have .toml suffix on the `deploymentName`.
