### PR TITLE
Add external links that open in new tab

### DIFF
--- a/web/src/components/DeployProgressSummary.vue
+++ b/web/src/components/DeployProgressSummary.vue
@@ -65,9 +65,13 @@
         </div>
         <div>
           Access through Dashboard:
-          <span>
+          <a
+            :href="eventStore.currentPublishStatus.status.dashboardURL"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             {{ eventStore.currentPublishStatus.status.dashboardURL }}
-          </span>
+          </a>
         </div>
       </div>
     </div>
@@ -101,10 +105,10 @@
 </template>
 
 <script setup lang="ts">
-
-import { useEventStore } from 'src/stores/events';
 import { computed } from 'vue';
 import { useQuasar } from 'quasar';
+
+import { useEventStore } from 'src/stores/events';
 
 const eventStore = useEventStore();
 const $q = useQuasar();

--- a/web/src/views/existing-deployment/ExistingDeploymentHeader.vue
+++ b/web/src/views/existing-deployment/ExistingDeploymentHeader.vue
@@ -24,7 +24,13 @@
             {{ deployment.saveName }}
           </h1>
           <p>
-            Deploying to: {{ deployment.serverUrl }}
+            Deploying to: <a
+              :href="deployment.serverUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ deployment.serverUrl }}
+            </a>
           </p>
           <p>
             {{ deployment.id }}

--- a/web/src/views/new-deployment/NewDeploymentHeader.vue
+++ b/web/src/views/new-deployment/NewDeploymentHeader.vue
@@ -25,7 +25,13 @@
           </h1>
           <template v-if="deployAsNew">
             <p>
-              New deployment to: {{ deploymentURL }}
+              New deployment to: <a
+                :href="deploymentURL"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ deploymentURL }}
+              </a>
             </p>
             <p>
               {{ addingDeploymentMessage }}
@@ -33,7 +39,13 @@
           </template>
           <template v-else>
             <p>
-              Deployment to: {{ deploymentURL }}
+              Deployment to: <a
+                :href="deploymentURL"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ deploymentURL }}
+              </a>
             </p>
             <p>
               {{ contentId }}


### PR DESCRIPTION
This PR re-adds all of the external links that were removed in #623 and makes them open in a new tab. By default VSCode will open these in a new browser window.

## Intent
- Resolves #609 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers
- Open the links in the UI - they will open in a new tab
- Open the links in VSCode and they will open in a browser window in a new tab
