### PR TITLE
Use lowercase in add new deployment form

### DIFF
--- a/web/src/views/add-new-deployment/AddNewDeployment.vue
+++ b/web/src/views/add-new-deployment/AddNewDeployment.vue
@@ -106,7 +106,11 @@ const deploymentNameError = computed(() => {
   if (!deploymentName.value) {
     return 'A unique deployment name must be provided.';
   }
-  if (deployments.value.find((deployment) => deployment.saveName === deploymentName.value)) {
+  if (
+    deployments.value.find(
+      (deployment) => deployment.saveName.toLowerCase() === deploymentName.value.toLowerCase()
+    )
+  ) {
     return 'Deployment name already in use. Please supply a unique name.';
   }
   return undefined;


### PR DESCRIPTION
This fixes a strange behavior in the UI. For context:

A deployment named `One` and `one` are the same to the API.

Deploying a deployment named `one` and deploying another named `One` ends with a single `one.toml` deployment record, and a confusing experience in the UI.

To address this we can check for save name collision using `toLowerCase()`

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->
