### PR TITLE
Add delete to Deployments api resource

### DIFF
--- a/web/src/api/resources/Deployments.ts
+++ b/web/src/api/resources/Deployments.ts
@@ -70,4 +70,15 @@ export class Deployments {
       params,
     );
   }
+
+  // Returns:
+  // 204 - no content
+  // 404 - not found
+  // 500 - internal server error
+  delete(saveName: string) {
+    const encodedSaveName = encodeURIComponent(saveName);
+    return this.client.delete(
+      `deployments/${encodedSaveName}`
+    );
+  }
 }


### PR DESCRIPTION
This is a follow-up to #806 that adds the frontend side of the `DELETE /api/deployments/:name` API endpoint.

It adds a `api.deployments.delete(saveName)` function.