### PR TITLE
Create summary slot for DeployStep

### DIFF
--- a/web/src/views/deploy-progress/DeployStep.vue
+++ b/web/src/views/deploy-progress/DeployStep.vue
@@ -13,9 +13,9 @@
     error-color="red"
   >
     <div
-      class="text-bold q-pa-sm summaryClass"
+      class="text-bold q-pa-sm"
     >
-      {{ summary }}
+      <slot name="summary" />
     </div>
     <q-list
       dense
@@ -103,7 +103,6 @@ import {
 const props = defineProps({
   name: { type: [String, Number], required: true },
   icon: { type: String, required: true },
-  summary: { type: String, required: true },
   messages: { type: Array as PropType<EventStreamMessage[]>, required: false, default: () => [] },
 });
 
@@ -188,7 +187,3 @@ const splitErrorLog = (msg: EventStreamMessage) => {
 };
 
 </script>
-
-<style scoped>
-
-</style>

--- a/web/src/views/deploy-progress/steps/CheckCapabilities.vue
+++ b/web/src/views/deploy-progress/steps/CheckCapabilities.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Check Capabilities"
     icon="create_new_folder"
-    summary="Checking capabilities and performing pre-deployment checks."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Checking capabilities and performing pre-deployment checks.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/CreateBundle.vue
+++ b/web/src/views/deploy-progress/steps/CreateBundle.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Create Bundle"
     icon="compress"
-    summary="Collecting and bundling up the files included in your project, so that they can be uploaded to the server within a bundle."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Collecting and bundling up the files included in your project, so that they can be uploaded to the server within a bundle.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/CreateDeployment.vue
+++ b/web/src/views/deploy-progress/steps/CreateDeployment.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Create Deployment"
     icon="create_new_folder"
-    summary="Registering the deployment object with the Posit Connect Server."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Registering the deployment object with the Posit Connect Server.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/CreateNewDeployment.vue
+++ b/web/src/views/deploy-progress/steps/CreateNewDeployment.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Create New Deployment"
     icon="create_new_folder"
-    summary="Creating a new deployment file."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Creating a new deployment file.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/DeployBundle.vue
+++ b/web/src/views/deploy-progress/steps/DeployBundle.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Deploy Bundle"
     icon="publish"
-    summary="Associating the uploaded bundle with the deployment object."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Associating the uploaded bundle with the deployment object.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/RestorePythonEnvironment.vue
+++ b/web/src/views/deploy-progress/steps/RestorePythonEnvironment.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Restore Python Environment"
     icon="move_down"
-    summary="Installing the dependent python packages on the server in order to reproduce your runtime environment."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Installing the dependent python packages on the server in order to reproduce your runtime environment.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/RunContent.vue
+++ b/web/src/views/deploy-progress/steps/RunContent.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Run Content"
     icon="sync"
-    summary="Performing execution checks ahead of applying settings."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Performing execution checks ahead of applying settings.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/SetEnvVars.vue
+++ b/web/src/views/deploy-progress/steps/SetEnvVars.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Set Environment Variables"
     icon="sync"
-    summary="Setting Environment Variables on Connect Server."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Setting Environment Variables on Connect Server.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/UploadBundle.vue
+++ b/web/src/views/deploy-progress/steps/UploadBundle.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Upload Bundle"
     icon="login"
-    summary="Transferring the files from your local workstation to the server."
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Transferring the files from your local workstation to the server.
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/ValidateDeployment.vue
+++ b/web/src/views/deploy-progress/steps/ValidateDeployment.vue
@@ -5,10 +5,13 @@
     :name="name"
     title="Validate Deployment"
     icon="sync"
-    summary="Validating your content on the Connect Server"
     :done="done"
     :messages="messages"
-  />
+  >
+    <template #summary>
+      Validating your content on the Connect Server
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">

--- a/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
+++ b/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
@@ -5,13 +5,31 @@
     :name="name"
     title="Wrapping Up Deployment"
     icon="checklist"
-    :summary="summary"
     :done="done"
-  />
+  >
+    <template #summary>
+      <template v-if="done">
+        Your project has been successfully deployed and is
+        available via the <a
+          :href="eventStore.currentPublishStatus.status.dashboardURL"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Connect Dashboard</a>
+        or <a
+          :href="eventStore.currentPublishStatus.status.directURL"
+          target="_blank"
+          rel="noopener noreferrer"
+        >directly</a>.
+      </template>
+      <template v-else>
+        Your project is still being deployed...
+      </template>
+    </template>
+  </DeployStep>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 
 import DeployStep from 'src/views/deploy-progress/DeployStep.vue';
 
@@ -26,15 +44,6 @@ defineProps({
 const emit = defineEmits(['done']);
 
 const done = ref(false);
-
-const summary = computed(() => {
-  if (done.value) {
-    return `Your project has been successfully deployed and is 
-    available via the Connect Dashboard (${eventStore.currentPublishStatus.status.dashboardURL})
-    or directly (${eventStore.currentPublishStatus.status.directURL}).`;
-  }
-  return `Your project is still being deployed...`;
-});
 
 watch(
   () => eventStore.currentPublishStatus.status.completion,


### PR DESCRIPTION
This PR adds a slot in the `DeployStep` component called `summary` rather than using a `summary` prop. This allows us to put whatever HTML we'd like opening up the ability to add links.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-01-12 at 16 54 32](https://github.com/posit-dev/publisher/assets/19917631/88706a19-83e5-4a46-8a0f-c7e6ed89473d)
![CleanShot 2024-01-12 at 16 54 20](https://github.com/posit-dev/publisher/assets/19917631/1be76e6d-4e99-4913-b070-6ad1252693dc)
</details> 

## Intent
- Addresses #589 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers
Most of the components changed in this PR are just removing the props and using the slot. The "Wrapping Up Deployment" component has the only functional change - adding those links.