### PR TITLE
Conditionally use router-link destination in PButton for vscode links

### DIFF
--- a/web/src/components/PButton.vue
+++ b/web/src/components/PButton.vue
@@ -6,6 +6,9 @@
     no-caps
     unelevated
     :outline="props.hierarchy === 'secondary'"
+    :to="vscode ? undefined : to"
+    @click="vscode ? router.push(to) : undefined"
+    @keyup.enter="vscode ? router.push(to) : undefined"
   >
     <template
       v-for="(_, slot) of $slots"
@@ -23,9 +26,14 @@
 <script setup lang="ts">
 import { QBtn, QBtnProps, useQuasar } from 'quasar';
 import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+
+import { vscode } from 'src/vscode';
 
 type Hierarchy = 'primary' | 'secondary';
 type QBtnPassthroughProps = Omit<QBtnProps, 'color' | 'textColor' | 'noCaps' | 'unelevated'>;
+
+const router = useRouter();
 
 const $q = useQuasar();
 const props = defineProps<{
@@ -45,7 +53,7 @@ const colors = computed(() => {
 
 const qBtnPassthroughProps = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { hierarchy, ...rest } = props;
+  const { hierarchy, to, ...rest } = props;
   return rest;
 });
 </script>


### PR DESCRIPTION
This PR extends the `PButton` component to handle the `to` prop (the location to navigate to using Vue Router) differently depending on whether we are in VSCode or not.

When in VSCode we navigate ourselves and don't render a `<a>` instead using a `<button>` element.

When in the UI we render a `<a>` as normal which behaves as we would expect from a `RouterLink`. 

## Intent
- Part of #759 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The approach here is to conditionally pass props to `QBtn` which accepts a `to` prop. When in VSCode we don't want to have `QBtn` handle the `to` prop and create a `RouterLink` rendering a `<a>`. Instead we want to use a click and enter listener so VSCode's click listener doesn't intercept the link click and open in a new window.

When we aren't in VSCode however we pass the `to` prop and don't add the listeners at all. 

## Reviewer Instructions
Run the UI and the VSCode extension testing the "New Destination" link. It should navigate in both without issue.

Note this does not fix the breadcrumbs. Those will be addressed in another PR.
