### PR TITLE
Use `PLink`s in breadcrumb elements

### DIFF
--- a/web/src/views/add-new-deployment/AddNewDeployment.vue
+++ b/web/src/views/add-new-deployment/AddNewDeployment.vue
@@ -3,10 +3,11 @@
 <template>
   <div class="publisher-layout q-pt-md q-pb-xl">
     <q-breadcrumbs>
-      <q-breadcrumbs-el
-        label="Project"
-        :to="{ name: 'project' }"
-      />
+      <q-breadcrumbs-el>
+        <PLink :to="{ name: 'project' }">
+          Project
+        </PLink>
+      </q-breadcrumbs-el>
       <q-breadcrumbs-el label="New Deployment" />
     </q-breadcrumbs>
 
@@ -64,6 +65,7 @@ import { Deployment, isDeploymentRecordError } from 'src/api/types/deployments';
 import AccountRadio from 'src/views/add-new-deployment/AccountRadio.vue';
 import { newFatalErrorRouteLocation } from 'src/util/errors';
 import PButton from 'src/components/PButton.vue';
+import PLink from 'src/components/PLink.vue';
 
 const accounts = ref<Account[]>([]);
 const selectedAccountName = ref<string>('');

--- a/web/src/views/deploy-progress/DeployProgressPage.vue
+++ b/web/src/views/deploy-progress/DeployProgressPage.vue
@@ -3,13 +3,11 @@
 <template>
   <div class="publisher-layout q-pt-md q-pb-xl">
     <q-breadcrumbs>
-      <q-breadcrumbs-el
-        label="Project"
-        :to="{
-          name:
-            'project'
-        }"
-      />
+      <q-breadcrumbs-el>
+        <PLink :to="{ name: 'project' }">
+          Project
+        </PLink>
+      </q-breadcrumbs-el>
       <q-breadcrumbs-el
         label="Deploy"
         class="click-target"
@@ -49,6 +47,7 @@ import { useEventStore } from 'src/stores/events';
 import { useRouter } from 'vue-router';
 
 import DeployStepper from 'src/views/deploy-progress/DeployStepper.vue';
+import PLink from 'src/components/PLink.vue';
 
 const eventStore = useEventStore();
 const router = useRouter();

--- a/web/src/views/existing-deployment/ExistingDeploymentHeader.vue
+++ b/web/src/views/existing-deployment/ExistingDeploymentHeader.vue
@@ -4,13 +4,11 @@
   <div class="deployment-header">
     <div class="publisher-layout q-py-md">
       <q-breadcrumbs>
-        <q-breadcrumbs-el
-          label="Project"
-          :to="{
-            name:
-              'project'
-          }"
-        />
+        <q-breadcrumbs-el>
+          <PLink :to="{ name: 'project' }">
+            Project
+          </PLink>
+        </q-breadcrumbs-el>
         <q-breadcrumbs-el
           label="Deploy"
         />

--- a/web/src/views/new-deployment/NewDeploymentHeader.vue
+++ b/web/src/views/new-deployment/NewDeploymentHeader.vue
@@ -4,10 +4,11 @@
   <div class="deployment-header">
     <div class="publisher-layout q-py-md">
       <q-breadcrumbs>
-        <q-breadcrumbs-el
-          label="Project"
-          :to="{ name: 'project' }"
-        />
+        <q-breadcrumbs-el>
+          <PLink :to="{ name: 'project' }">
+            Project
+          </PLink>
+        </q-breadcrumbs-el>
         <q-breadcrumbs-el
           label="Deploy"
         />


### PR DESCRIPTION
This PR updates the breadcrumbs to use the `PLink` if they are intended to be links.

## Intent
- Part of #759 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Instead of creating a custom Breadcrumb Element or Breadcrumbs component instead I used the custom slot provided by Quasar. I think leaves a pretty gross gotcha in the codebase where the `:to` prop is still readily available to use but will cause an error. I'd like to eventually tackle this, but this felt like an easy way to get this bug fixed for a fairly low bit of technical debt.

## Directions for Reviewers
This will need to be tested in the web and in the VSCode extension.
