### PR TITLE
Add `PreDeployment` to details page types and fix compile

### DIFF
--- a/web/src/views/existing-deployment/ExistingDeploymentPage.vue
+++ b/web/src/views/existing-deployment/ExistingDeploymentPage.vue
@@ -31,7 +31,7 @@ import { ref, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import { Configuration, ConfigurationError, isConfigurationError, useApi } from 'src/api';
-import { Deployment, isDeploymentRecordError, isPreDeployment } from 'src/api/types/deployments';
+import { Deployment, PreDeployment, isDeploymentRecordError } from 'src/api/types/deployments';
 import {
   newFatalErrorRouteLocation,
 } from 'src/util/errors';
@@ -45,7 +45,7 @@ const route = useRoute();
 const router = useRouter();
 const api = useApi();
 
-const deployment = ref<Deployment>();
+const deployment = ref<Deployment | PreDeployment>();
 
 const configurations = ref<Array<Configuration | ConfigurationError>>([]);
 
@@ -92,10 +92,6 @@ const getDeployment = async() => {
       // let the fatal error page handle this deployment error.
       // we're in a header, they can't fix it here.
       throw new Error(d.error.msg);
-    } else if (isPreDeployment(d)) {
-      // let the fatal error page handle this deployment error.
-      // we're in a header, they can't fix it here.
-      throw new Error('This page doesn\'t support pre-deployments yet.');
     } else {
       deployment.value = d;
     }


### PR DESCRIPTION
This PR adds changes the types that are supported for Deployments in the `ExistingDeploymentPage.vue` component.

Previously it was `Deployment` now it is `Deployment` or `PreDeployment`.

This resolves the issue where opening a details page for a `PreDeployment` gives an error.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-01-16 at 14 27 20](https://github.com/posit-dev/publisher/assets/19917631/13d8e3a6-92c8-40b7-88f4-76bbf1e166a9)

</details> 

## Intent
Resolves #777

This PR does not resolve all `PreDeployment` issues.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The approach here was to get the compiler to pass with the `ExistingDeploymentPage` accepting a `PreDeployment` type.

There are still issues with this:

Deploying will make the UI think another deployment is running since the progress summary and all of the eventing relies on `id` which `PreDeployment` records do not have. I believe that fix work is described in #778 so is not addressed here.

A refresh fixes this once the deployment is successful.

I think this is an acceptable bug for a few reasons:
- the page loads now where it didn't previously
- to address this would require app-wide changes
- this is an iterative step

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
You will need to create a `PreDeployment` record using the API like so (I'm using [HTTPie](https://httpie.io/)):

```
http POST :9000/api/deployments account=rsc.radixu.com saveName=pre-test
```

You will be able to see the `pre-test` deployment on your list of Deployments on the Project page. From there clicking on it will open a details page for it. 