### PR TITLE
Remove dark mode setter AppMenu in VSCode

### DIFF
--- a/web/src/components/AppHeader.vue
+++ b/web/src/components/AppHeader.vue
@@ -3,7 +3,7 @@
 <template>
   <q-header>
     <q-toolbar class="publisher-layout">
-      <AppMenu />
+      <AppMenu v-if="!vscode" />
       <q-toolbar-title>
         <PLink
           class="posit-logo-link text-white"
@@ -29,6 +29,7 @@
 </template>
 
 <script setup lang="ts">
+import { vscode } from 'src/vscode';
 import AppMenu from 'src/components/AppMenu.vue';
 import PLink from 'src/components/PLink.vue';
 import WhitePositLogo from 'src/components/icons/WhitePositLogo.vue';


### PR DESCRIPTION
This PR removes the `AppMenu` while in VSCode. The `AppMenu` currently only has the theme mode setting which should not be present in VSCode. With #844 the UI will match the VSCode theme mode automatically.

This prevents the UI from getting out of sync with the VSCode theme mode.

## Intent
- Resolves #804 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->
