### PR TITLE
Add creation date to deployment record

### DIFF
--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rstudio/connect-client/internal/accounts"
@@ -21,6 +22,7 @@ type Deployment struct {
 	ServerType    accounts.ServerType `toml:"server-type" json:"serverType"`
 	ServerURL     string              `toml:"server-url" json:"serverUrl"`
 	ClientVersion string              `toml:"client-version" json:"-"`
+	CreatedAt     string              `toml:"created-at" json:"createdAt"`
 	ID            types.ContentID     `toml:"id" json:"id"`
 	ConfigName    string              `toml:"configuration-name" json:"configurationName"`
 	DeployedAt    string              `toml:"deployed-at" json:"deployedAt"`
@@ -39,6 +41,7 @@ func New() *Deployment {
 		Schema:        schema.DeploymentSchemaURL,
 		ServerType:    accounts.ServerTypeConnect,
 		ClientVersion: project.Version,
+		CreatedAt:     time.Now().Format(time.RFC3339),
 		Configuration: nil,
 		Files:         nil,
 	}

--- a/internal/deployment/deployment_test.go
+++ b/internal/deployment/deployment_test.go
@@ -48,9 +48,11 @@ func (s *DeploymentSuite) createDeploymentFile(name string) *Deployment {
 }
 
 func (s *DeploymentSuite) TestNew() {
-	deployment := New()
-	s.NotNil(deployment)
-	s.Equal(schema.DeploymentSchemaURL, deployment.Schema)
+	d := New()
+	s.NotNil(d)
+	s.Equal(schema.DeploymentSchemaURL, d.Schema)
+	s.NotEmpty(d.CreatedAt)
+	s.Empty(d.DeployedAt)
 }
 
 func (s *DeploymentSuite) TestGetDeploymentPath() {

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -181,16 +181,24 @@ func (p *defaultPublisher) createDeploymentRecord(
 	// bundleID. These will be added after the
 	// bundle upload.
 	cfg := *p.Config
+
+	now := time.Now().Format(time.RFC3339)
+	created := now
+	if p.Target != nil {
+		created = p.Target.CreatedAt
+	}
+
 	p.Target = &deployment.Deployment{
 		Schema:        schema.DeploymentSchemaURL,
 		ServerType:    account.ServerType,
 		ServerURL:     account.URL,
 		ClientVersion: project.Version,
+		CreatedAt:     created,
 		ID:            contentID,
 		ConfigName:    p.ConfigName,
 		Files:         nil,
 		Configuration: &cfg,
-		DeployedAt:    time.Now().UTC().Format(time.RFC3339),
+		DeployedAt:    now,
 		BundleID:      "",
 		DashboardURL:  getDashboardURL(p.Account.URL, contentID),
 		DirectURL:     getDirectURL(p.Account.URL, contentID),

--- a/internal/schema/schemas/draft/posit-publishing-record-schema-v3.json
+++ b/internal/schema/schemas/draft/posit-publishing-record-schema-v3.json
@@ -51,12 +51,20 @@
       "type": "string",
       "description": "Version of the publisher that deployed the content."
     },
-    "deployed-at": {
+    "created-at": {
       "type": "string",
       "format": "date-time",
       "description": "Date and time the deployment was created.",
       "examples": [
-        "2023-12-04T19:44:59.937393Z"
+        "2024-01-19T09:33:33.131481-05:00"
+      ]
+    },
+    "deployed-at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time of the last deployment to the server.",
+      "examples": [
+        "2024-01-19T09:33:33.131481-05:00"
       ]
     },
     "configuration-name": {

--- a/internal/schema/schemas/draft/record.toml
+++ b/internal/schema/schemas/draft/record.toml
@@ -2,7 +2,9 @@
 server-url = "https://connect.example.com"
 id = "de2e7bdb-b085-401e-a65c-443e40009749"
 client-version = '1.0.1'
-configuration-name = "production.json"
+created-at = '2024-01-19T09:33:33.131481-05:00'
+configuration-name = "production"
+deployed-at = '2024-01-19T09:33:33.131481-05:00'
 bundle-id = '123'
 bundle-url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
 dashboard-url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/'

--- a/internal/schema/schemas/posit-publishing-record-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-record-schema-v3.json
@@ -49,12 +49,20 @@
       "type": "string",
       "description": "Version of the publisher that deployed the content."
     },
-    "deployed-at": {
+    "created-at": {
       "type": "string",
       "format": "date-time",
       "description": "Date and time the deployment was created.",
       "examples": [
-        "2023-12-04T19:44:59.937393Z"
+        "2024-01-19T09:33:33.131481-05:00"
+      ]
+    },
+    "deployed-at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time of the last deployment to the server.",
+      "examples": [
+        "2024-01-19T09:33:33.131481-05:00"
       ]
     },
     "configuration-name": {

--- a/internal/schema/schemas/record.toml
+++ b/internal/schema/schemas/record.toml
@@ -2,7 +2,9 @@
 server-url = "https://connect.example.com"
 id = "de2e7bdb-b085-401e-a65c-443e40009749"
 client-version = '1.0.1'
+created-at = '2024-01-19T09:33:33.131481-05:00'
 configuration-name = "production"
+deployed-at = '2024-01-19T09:33:33.131481-05:00'
 bundle-id = '123'
 bundle-url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
 dashboard-url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/'

--- a/internal/services/api/deployment_dto.go
+++ b/internal/services/api/deployment_dto.go
@@ -30,6 +30,7 @@ type preDeploymentDTO struct {
 	ServerType accounts.ServerType `json:"serverType"`
 	ServerURL  string              `json:"serverUrl"`
 	SaveName   string              `json:"saveName"`
+	CreatedAt  string              `json:"createdAt"`
 }
 
 type fullDeploymentDTO struct {
@@ -88,6 +89,7 @@ func deploymentAsDTO(d *deployment.Deployment, err error, base util.Path, path u
 			ServerType: d.ServerType,
 			ServerURL:  d.ServerURL,
 			SaveName:   d.SaveName,
+			CreatedAt:  d.CreatedAt,
 		}
 	}
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -154,15 +154,20 @@ func (s *StateSuite) createTargetFile(name string, bad bool) {
 
 func (s *StateSuite) TestLoadTarget() {
 	s.createTargetFile("myTarget", false)
-	cfg, err := loadTarget(s.cwd, "myTarget")
+	d, err := loadTarget(s.cwd, "myTarget")
 	s.NoError(err)
 	min_procs := int32(1)
+
+	// Since we don't know the exact value of CreatedAt, skip it.
+	s.NotEmpty(d.CreatedAt)
+	d.CreatedAt = ""
 
 	s.Equal(&deployment.Deployment{
 		Schema:     "https://cdn.posit.co/publisher/schemas/posit-publishing-record-schema-v3.json",
 		ServerURL:  "https://connect.example.com",
 		ServerType: "connect",
 		ConfigName: "myConfig",
+		CreatedAt:  "",
 		Files: []string{
 			"app.py",
 			"requirements.txt",
@@ -189,7 +194,7 @@ func (s *StateSuite) TestLoadTarget() {
 				},
 			},
 		},
-	}, cfg)
+	}, d)
 }
 
 func (s *StateSuite) TestLoadTargetNonexistent() {

--- a/web/src/api/types/deployments.ts
+++ b/web/src/api/types/deployments.ts
@@ -26,6 +26,7 @@ type DeploymentRecord = {
   serverType: ServerType,
   serverUrl: string,
   saveName: string,
+  createdAt: string,
 } & DeploymentLocation;
 
 export type PreDeployment = {


### PR DESCRIPTION
## Intent
This PR adds a `created-at` field to the deployment records. It is set once, vs. `deployed-at` which is updated on redeployment.

Fixes #836.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Added this to the deployment object and the corresponding schemas. Also added it to the PreDeployment API response and the front-end API type definition. It is not otherwise used in the frontend yet; see #839.

## Automated Tests
Existing tests have been updated with assertions about the new field.

## Directions for Reviewers
Deploy content. Observe that created-at and deploy-at in the toml file are equal. Redeploy and verify that created-at remains unchanged, and deployed-at has been updated. Load the UI and see that `createdAt` is included in the API response for both pre-deployments and completed deployments.
