### PR TITLE
Style anchors and hover based on light/dark mode

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -43,11 +43,27 @@ h1, h2, h3, h4, h5, h6, p, dd, dl {
   --focus-shadow-border-color-opacity: 0.2;
 }
 
+.body--light a {
+  color: var(--vscode-textLink-foreground, var(--posit-blue));
+}
+
+.body--light a:hover {
+  color: var(--vscode-textLink-activeForeground, var(--posit-dark-blue-1));
+}
+
 .body--dark {
   --focus-shadow-color: 255, 255, 255;
   --focus-shadow-color-opacity: 0.18;
   --focus-shadow-border-color: 255, 255, 255;
   --focus-shadow-border-color-opacity: 0.25;
+}
+
+.body--dark a {
+  color: var(--vscode-textLink-foreground, var(--posit-light-blue-2));
+}
+
+.body--dark a:hover {
+  color: var(--vscode-textLink-activeForeground, var(--posit-light-blue-1));
 }
 
 .focus-shadow:focus,


### PR DESCRIPTION
This PR changes the anchor styling in the UI and the VSCode extension. It removes the `:visited` styling which makes more sense in an application dashboard, and uses Posit blues when not matching the running VSCode style.

<details>
  <summary>Previews</summary>
  
![CleanShot 2024-01-22 at 15 43 10](https://github.com/posit-dev/publisher/assets/19917631/2c06e2a2-995c-455b-bee1-f030c65e239b)
![CleanShot 2024-01-22 at 15 43 17](https://github.com/posit-dev/publisher/assets/19917631/7713695a-3b97-4dbf-8d65-bab417dced16)
![CleanShot 2024-01-22 at 15 44 04](https://github.com/posit-dev/publisher/assets/19917631/9d205477-6e90-4a14-81d0-405b6bd0e00e)
![CleanShot 2024-01-22 at 15 44 24](https://github.com/posit-dev/publisher/assets/19917631/ffdc5b14-1468-4a81-95cd-9e1997213dbb)

</details> 

## Intent
- Resolves #840 
- Resolves #841 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The blue colors added as CSS variables are from the Posit Brand Guidelines.

To style the `anchors` we needed to independently style them for our light and dark mode which is done by using the body classes `body--light` and `body--dark`. Additionally we need to use VSCode styling when available which can be accomplished with `var()`'s fallback value option.

VSCode introduces hover effects that utilize their CSS variables `--vscode-textLink-foreground` and `--vscode-textLink-activeForeground`. When those aren't utilized we can use our own rather than not providing a `:hover` styling. In both light and dark mode I increased the contrast by going darker in light mode and lighter in dark mode.

#### References
- https://developer.mozilla.org/en-US/docs/Web/CSS/var

## Directions for Reviewers
Test the UI and the VSCode Extension independently. Note that #844 is still not merged so you will need to change the dark/light mode to match your VSCode theme when running the extension.
