### PR TITLE
Fix diffType prop typing to String

### DIFF
--- a/web/src/components/DiffTag.vue
+++ b/web/src/components/DiffTag.vue
@@ -16,7 +16,7 @@ export type DiffType = 'inserted' | 'removed';
 
 const props = defineProps({
   diffType: {
-    type: Object as PropType<DiffType>,
+    type: String as PropType<DiffType>,
     required: true,
   },
   value: {


### PR DESCRIPTION
Small bug fix that changes the expected prop type for `diffType` from `Object` to `String`. This avoids a console error and potential rendering issues.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->