### PR TITLE
Add error field to pre-deployment API

### DIFF
--- a/internal/services/api/deployment_dto.go
+++ b/internal/services/api/deployment_dto.go
@@ -31,6 +31,7 @@ type preDeploymentDTO struct {
 	ServerURL  string              `json:"serverUrl"`
 	SaveName   string              `json:"saveName"`
 	CreatedAt  string              `json:"createdAt"`
+	Error      *types.AgentError   `json:"error,omitempty"`
 }
 
 type fullDeploymentDTO struct {
@@ -90,6 +91,7 @@ func deploymentAsDTO(d *deployment.Deployment, err error, base util.Path, path u
 			ServerURL:  d.ServerURL,
 			SaveName:   d.SaveName,
 			CreatedAt:  d.CreatedAt,
+			Error:      d.Error,
 		}
 	}
 }


### PR DESCRIPTION
## Intent
This PR adds the `error` field to the `GET /api/deployments` and `GET /api/deployment/:name` endpoints. It was removed in the DTO restructuring in #785.

Fixes #854

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
Added a test for the predeployment case, specifically with an error.

## Directions for Reviewers
Create a pre-deployment, add an error to it (e.g. by editing the deployment record file), and hit the endpoint. See the error in the returned object.
