### PR TITLE
Exclude debug log messages from deploy steps

### DIFF
--- a/web/src/views/deploy-progress/DeployStep.vue
+++ b/web/src/views/deploy-progress/DeployStep.vue
@@ -21,60 +21,64 @@
       dense
       class="logClass"
     >
-      <q-item
+      <template
         v-for="(msg, index) in messages"
-        :key="index"
       >
-        <q-item-section>
-          <!-- {{ JSON.stringify(msg) }} -->
-          <template v-if="isErrorEventStreamMessage(msg)">
-            <span class="text-error text-weight-medium">
-              {{ formatMsg(msg) }}
-            </span>
-            <ul>
-              <li
-                v-for="(nameValue, i) in splitErrorLog(msg)"
-                :key="i"
-                class="text-caption q-ml-md"
-              >
-                <span class="text-weight-medium">
-                  {{ nameValue.name }}:
+        <q-item
+          v-if="!shouldSkipMessage(msg)"
+          :key="index"
+        >
+          <q-item-section>
+            <!-- {{ JSON.stringify(msg) }} -->
+            <template v-if="isErrorEventStreamMessage(msg)">
+              <span class="text-error text-weight-medium">
+                {{ formatMsg(msg) }}
+              </span>
+              <ul>
+                <li
+                  v-for="(nameValue, i) in splitErrorLog(msg)"
+                  :key="i"
+                  class="text-caption q-ml-md"
+                >
+                  <span class="text-weight-medium">
+                    {{ nameValue.name }}:
+                  </span>
+                  <span>
+                    {{ nameValue.value }}<br>
+                  </span>
+                </li>
+              </ul>
+            </template>
+            <template v-else>
+              <template v-if="msg.type.endsWith('/start')">
+                <span class="text-weight-medium  text-caption">
+                  {{ formatMsg(msg) }}
                 </span>
-                <span>
-                  {{ nameValue.value }}<br>
+              </template>
+              <template v-if="msg.type.endsWith('/success')">
+                <span class="text-caption">
+                  {{ formatMsg(msg) }}
                 </span>
-              </li>
-            </ul>
-          </template>
-          <template v-else>
-            <template v-if="msg.type.endsWith('/start')">
-              <span class="text-weight-medium  text-caption">
-                {{ formatMsg(msg) }}
-              </span>
+              </template>
+              <template v-if="msg.type.endsWith('/status')">
+                <span class="text-weight-medium text-caption">
+                  {{ formatMsg(msg) }}
+                </span>
+              </template>
+              <template v-if="msg.type.endsWith('/log')">
+                <span class="text-caption">
+                  {{ formatMsg(msg) }}
+                </span>
+              </template>
+              <template v-if="msg.type.endsWith('/progress')">
+                <span class="text-caption">
+                  {{ formatMsg(msg) }}
+                </span>
+              </template>
             </template>
-            <template v-if="msg.type.endsWith('/success')">
-              <span class="text-caption">
-                {{ formatMsg(msg) }}
-              </span>
-            </template>
-            <template v-if="msg.type.endsWith('/status')">
-              <span class="text-weight-medium text-caption">
-                {{ formatMsg(msg) }}
-              </span>
-            </template>
-            <template v-if="msg.type.endsWith('/log')">
-              <span class="text-caption">
-                {{ formatMsg(msg) }}
-              </span>
-            </template>
-            <template v-if="msg.type.endsWith('/progress')">
-              <span class="text-caption">
-                {{ formatMsg(msg) }}
-              </span>
-            </template>
-          </template>
-        </q-item-section>
-      </q-item>
+          </q-item-section>
+        </q-item>
+      </template>
     </q-list>
   </q-step>
 </template>
@@ -107,6 +111,10 @@ const props = defineProps({
 });
 
 const hasError = computed(() => props.messages.some(msg => isErrorEventStreamMessage(msg)));
+
+const shouldSkipMessage = (msg: EventStreamMessage): boolean => {
+  return msg.type.endsWith('/log') && msg.data.level === 'DEBUG';
+};
 
 const formatMsg = (msg: EventStreamMessage): string => {
   if (isPublishCreateNewDeploymentStart(msg) || isPublishCreateNewDeploymentSuccess(msg)) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
The PR filters frontend event display in the Summarized Log panel so that it excludes debug log messages.

Fixes #871 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Filtered this in the frontend, at the view level. We wanted to keep those events from the backend for a potential log display panel.

## Directions for Reviewers
Review PR with diff whitespace turned off.

Deploy, and see that the "API request" debug messages are no longer present in the summary log view (for example, expand the preflight step which had several in a row).
