### PR TITLE
Add reload instructions to UI docs

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -36,3 +36,8 @@ Click the **Project** link at the top of the page to return to the starting page
 Click the deployment to see details and or to re-deploy, which applies any updates you've made to your project source code or configuration file. Configuration changes since your last deployment are highlighted:
 
 <p><img width="400px" src="images/ui-redeploy-diff.png"/></p>
+
+Currently a reload is needed if any changes have been made to your
+configuration or deployment files while the UI is running. If running in a
+browser, reload the window. If using VSCode, open the Command Palette
+(Ctrl+Shift+P or Cmd+Shift+P) and run  "Developer: Reload Webviews".


### PR DESCRIPTION
This PR is an addition to #889 that adds instructions to the docs for reloading the web view either in the browser or the VSCode extension

## Intent
- Part of #674 and #791

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [x] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->
