### PR TITLE
Add `PCard` menu button and slot

### DIFF
--- a/web/src/components/PCard.vue
+++ b/web/src/components/PCard.vue
@@ -34,10 +34,13 @@
       </div>
 
       <q-btn
+        v-if="$slots.menu"
         padding="xs"
         flat
         icon="more_vert"
-      />
+      >
+        <slot name="menu" />
+      </q-btn>
     </section>
 
     <slot />


### PR DESCRIPTION
This PR adds the ability to pass a [`QMenu`](https://quasar.dev/vue-components/menu) to the named "menu" slot in `PCard` to get a icon button and the menu passed.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-01-26 at 15 15 28](https://github.com/posit-dev/publisher/assets/19917631/da87e30a-07bb-4f77-8245-3de9f0fd2b50)

</details> 

## Intent
- Part of #746 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
To make the menu clickable the same `z-index` trick is used to "lift" buttons above the anchor to be clickable.

To maximize flexibility the `menu` slot is optional. When provided the button appears and will open the `QMenu` passed.

Here is an example of what usage may look like:

```
  <PCard
    :to="toLink"
    :title="deployment.deploymentName"
  >
    ...default slot stuff goes here

    <template #menu>
      <q-menu>
        <q-list style="min-width: 100px">
          <q-item
            v-close-popup
            clickable
          >
            <q-item-section>This is a menu item</q-item-section>
          </q-item>
          <q-item
            v-close-popup
            clickable
          >
            <q-item-section>This is another one</q-item-section>
          </q-item>
        </q-list>
      </q-menu>
    </template>
  </PCard>
```