### PR TITLE
Fix display when error encountered during "Wrapping up Deployment" step

### DIFF
--- a/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
+++ b/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
@@ -9,8 +9,14 @@
   >
     <template #summary>
       <template v-if="done">
-        Your project has been successfully deployed and is
-        available via the
+        <template v-if="eventStore.currentPublishStatus.status.completion === 'success'">
+          Your project has been successfully deployed and is
+          available via the
+        </template>
+        <template v-if="eventStore.currentPublishStatus.status.completion === 'error'">
+          Your project has encountered an error while being deployed.
+          To diagnose it further, you can access it via the
+        </template>
         <a
           :href="eventStore.currentPublishStatus.status.dashboardURL"
           target="_blank"
@@ -50,7 +56,7 @@ const done = ref(false);
 watch(
   () => eventStore.currentPublishStatus.status.completion,
   (value) => {
-    if (value === 'success') {
+    if (value === 'success' || value === 'error') {
       done.value = true;
       emit('done');
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #867 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

We weren't watching for the error case within the deployment step, so upon completion, since it wasn't successful, we continued to show the step as in progress.

With the changes included here, we now see this:

![2024-01-29 at 11 43 AM](https://github.com/posit-dev/publisher/assets/17675905/5be5eed2-b990-4a50-8a53-c55b7b2a06d6)

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->
To reproduce this particular error, update your `default.toml` file to specify an invalid entrypoint, such as `entrypoint = 'blue.py'`, then deploy to the server.

On the deployment page you'll see an error:
![2024-01-29 at 11 45 AM](https://github.com/posit-dev/publisher/assets/17675905/c0473254-2cb1-4dda-9b2d-7402a4540940)

And on the progress page, you'll see:
![2024-01-29 at 11 46 AM](https://github.com/posit-dev/publisher/assets/17675905/0d8a408c-5808-44b4-ace5-9e94c2085993)

For proper verification, be sure you navigate to the progress page while the deployment is in progress, so that you'll see the stepper reactively change with the proper detection. (This is done by clicking on the `View summarized deployment logs` link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
