### PR TITLE
Progress Page should work for pre-deployments

### DIFF
--- a/web/src/views/deploy-progress/DeployProgressPage.vue
+++ b/web/src/views/deploy-progress/DeployProgressPage.vue
@@ -56,19 +56,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed } from 'vue';
 import { useEventStore } from 'src/stores/events';
 
 import DeployStepper from 'src/views/deploy-progress/DeployStepper.vue';
 import PLink from 'src/components/PLink.vue';
 import { useDeploymentStore } from 'src/stores/deployments';
-import { isDeployment, isDeploymentError, isPreDeployment } from 'src/api';
-import { useRouter } from 'vue-router';
-import { newFatalErrorRouteLocation } from 'src/utils/errors';
+import { isDeployment, isDeploymentError } from 'src/api';
 
 const eventStore = useEventStore();
 const deployments = useDeploymentStore();
-const router = useRouter();
 
 const props = defineProps({
   name: {
@@ -82,19 +79,6 @@ const id = computed(() => {
 });
 
 const deployment = deployments.getDeploymentRef(props.name);
-
-watch(
-  deployment,
-  () => {
-    if (isPreDeployment(deployment.value)) {
-      router.push(newFatalErrorRouteLocation(
-        new Error('Attempting to show progress of PreDeployment object'),
-        'DeployProgressPage: watch deployment'
-      ));
-    }
-  },
-  { immediate: true },
-);
 
 const operation = computed(() => {
   if (!deployment.value) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes #901 
Fixes #905 
Fixes #907 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Removed watch guard which checked if deployment was of a `PreDeployment` type. This allows the deployment progress page to be shown. Following the reproduction, you now can see at the progress page:

![2024-01-29 at 12 05 PM](https://github.com/posit-dev/publisher/assets/17675905/ca5608b8-0149-4603-90c7-8434f198c345)

NOTE that error formatting and display is a separate issue, which may be addressed by PR #765. If not, then we'll need to address it in a new issue.

This also fixed several other bugs, in which we were trying to view the logs for a pre-deployment.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->
Reproduce the error (I went through YETI, but did not bring up one of my servers which I had credentials for.), and navigate to the progress page.

Also to verify the other two bugs, simply initiate a new deployment (not a re-deployment) and then click to view summarized logs. The fatal error previously seen was for the same reason as solved within this PR, we were guarding against pre-deployment objects from coming into the progress page.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
