### PR TITLE
Suppress empty bullet when displaying errors

### DIFF
--- a/web/src/components/deploymentStatus/StatusDeploymentFileError.vue
+++ b/web/src/components/deploymentStatus/StatusDeploymentFileError.vue
@@ -42,6 +42,7 @@
 <script setup lang="ts">
 import { DeploymentError } from 'src/api';
 import { PropType, computed } from 'vue';
+import { scrubErrorData } from 'src/utils/errors';
 
 const props = defineProps({
   deployment: {
@@ -51,19 +52,7 @@ const props = defineProps({
 });
 
 const scrubbedErrorData = computed(() => {
-  if (!props.deployment.error?.data) {
-    return {};
-  }
-
-  // remove what we don't want to display
-  // in this unknown list of attributes
-  const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
-    file, method, status, url,
-    ...remainingData
-  } = props.deployment.error?.data as Record<string, string>;
-
-  return remainingData;
+  return scrubErrorData(props.deployment.error?.data);
 });
 
 </script>

--- a/web/src/components/deploymentStatus/StatusErrorDeployment.vue
+++ b/web/src/components/deploymentStatus/StatusErrorDeployment.vue
@@ -65,6 +65,7 @@
 import { Deployment } from 'src/api';
 import { PropType, computed } from 'vue';
 import { formatDateString } from 'src/utils/date';
+import { scrubErrorData } from 'src/utils/errors';
 
 const props = defineProps({
   deployment: {
@@ -79,23 +80,7 @@ const props = defineProps({
 });
 
 const scrubbedErrorData = computed(() => {
-  if (!props.deployment.deploymentError?.data) {
-    return {};
-  }
-
-  // remove what we don't want to display
-  // in this unknown list of attributes
-  const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
-    file, method, status, url,
-    ...remainingData
-  } = props.deployment.deploymentError?.data as Record<string, string>;
-
-  if (Object.keys(remainingData).length === 0) {
-    return undefined;
-  }
-
-  return remainingData;
+  return scrubErrorData(props.deployment.deploymentError?.data);
 });
 
 </script>

--- a/web/src/components/deploymentStatus/StatusErrorPreDeployment.vue
+++ b/web/src/components/deploymentStatus/StatusErrorPreDeployment.vue
@@ -61,6 +61,7 @@
 import { PreDeployment } from 'src/api';
 import { PropType, computed } from 'vue';
 import { formatDateString } from 'src/utils/date';
+import { scrubErrorData } from 'src/utils/errors';
 
 const props = defineProps({
   deployment: {
@@ -75,23 +76,7 @@ const props = defineProps({
 });
 
 const scrubbedErrorData = computed(() => {
-  if (!props.deployment.error?.data) {
-    return {};
-  }
-
-  // remove what we don't want to display
-  // in this unknown list of attributes
-  const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
-    file, method, status, url,
-    ...remainingData
-  } = props.deployment.error?.data as Record<string, string>;
-
-  if (Object.keys(remainingData).length === 0) {
-    return undefined;
-  }
-
-  return remainingData;
+  return scrubErrorData(props.deployment.error?.data);
 });
 
 </script>

--- a/web/src/utils/errors.ts
+++ b/web/src/utils/errors.ts
@@ -84,3 +84,22 @@ export const newFatalErrorRouteLocation =
       },
     };
   };
+
+export const scrubErrorData = (data: Record<string, unknown> | undefined) => {
+  if (!data) {
+    return undefined;
+  }
+  // remove what we don't want to display
+  // in this unknown list of attributes
+  const {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
+    file, method, status, url,
+    ...remainingData
+  } = data;
+
+  if (Object.keys(remainingData).length === 0) {
+    return undefined;
+  }
+
+  return remainingData;
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #912 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Centralized logic and replaced returning an empty object when data was undefined with returning undefined, which then is protected by the existing guard on the unordered list.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

Validate by producing an error which does not have additional data returned in the response from the agent. Examples of this include not being able to access the server or having a pre-check fail (as is used in the original bug).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
