### PR TITLE
Update URL from failure event

### DIFF
--- a/web/src/api/types/events.ts
+++ b/web/src/api/types/events.ts
@@ -850,9 +850,16 @@ export function isPublishSuccess(arg: Events): arg is PublishSuccess {
 
 export interface PublishFailure extends EventStreamMessage {
   type: 'publish/failure',
+  data: {
+    // "level": "ERROR", "message": "unexpected response from the server", "method": "GET", "status": 500, "url": "https://connect.localtest.me/rsc/dev-password/content/c565c960-7cdd-45da-be71-073531971409/", "dashboardUrl": "https://connect.localtest.me/rsc/dev-password/connect/#/apps/c565c960-7cdd-45da-be71-073531971409", "localId": "uqANWSJTNK7K0eWf"
+    level: string,
+    message: string,
+    dashboardUrl: string,
+    url: string,
+    // and other non-defined attributes
+  },
   error: string, // translated internally
-  // structured data not guaranteed, use selective or generic queries
-  // from data map
+
 }
 export type OnPublishFailureCallback = (msg: PublishFailure) => void;
 export function isPublishFailure(arg: Events):

--- a/web/src/stores/events.ts
+++ b/web/src/stores/events.ts
@@ -334,6 +334,8 @@ export const useEventStore = defineStore('event', () => {
       const publishStatus = currentPublishStatus.value.status;
       publishStatus.completion = 'error';
       publishStatus.error = splitMsgIntoKeyValuePairs(msg.data);
+      publishStatus.dashboardURL = msg.data.dashboardUrl;
+      publishStatus.directURL = msg.data.url;
     }
     publishInProgess.value = false;
     if (currentPublishStatus.value.saveName) {

--- a/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
+++ b/web/src/views/deploy-progress/steps/WrappingUpDeployment.vue
@@ -12,22 +12,27 @@
         <template v-if="eventStore.currentPublishStatus.status.completion === 'success'">
           Your project has been successfully deployed and is
           available via the
+          <a
+            :href="eventStore.currentPublishStatus.status.dashboardURL"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Connect Dashboard</a>
+          or
+          <a
+            :href="eventStore.currentPublishStatus.status.directURL"
+            target="_blank"
+            rel="noopener noreferrer"
+          >directly</a>.
         </template>
         <template v-if="eventStore.currentPublishStatus.status.completion === 'error'">
           Your project has encountered an error while being deployed.
           To diagnose it further, you can access it via the
+          <a
+            :href="eventStore.currentPublishStatus.status.dashboardURL"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Connect Dashboard</a>
         </template>
-        <a
-          :href="eventStore.currentPublishStatus.status.dashboardURL"
-          target="_blank"
-          rel="noopener noreferrer"
-        >Connect Dashboard</a>
-        or
-        <a
-          :href="eventStore.currentPublishStatus.status.directURL"
-          target="_blank"
-          rel="noopener noreferrer"
-        >directly</a>.
       </template>
       <template v-else>
         Your project is still being deployed...


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #914 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Diagnostics of the bug showed that the `href` assigned to both of these anchors was empty, and was not being updated on failure.

`publish/failure` event already contained the URL and direct URL of a failed deployment. We were not updating the status of the last publishing operation in the `events` store with these values. 

I also realized that providing the direct URL in a failure scenario is not useful, so I've modified it to only be provided when the deployment operation is successful.

Changes result in:

![2024-01-30 at 11 08 AM](https://github.com/posit-dev/publisher/assets/17675905/a9cf143b-4024-43bc-91a8-828d76d991de)

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

Deploy w/ a failure scenario, switch to the summarized log view and. you should see the new link, which will be the dashboard URL.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
