### PR TITLE
Read .python-version file during init

### DIFF
--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -41,7 +41,7 @@ func inspectProject(base util.Path, python util.Path, log logging.Logger) (*conf
 	}
 	if needPython {
 		inspector := PythonInspectorFactory(python, log)
-		pyConfig, err := inspector.InspectPython()
+		pyConfig, err := inspector.InspectPython(base)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rstudio/connect-client/internal/util"
 	"github.com/rstudio/connect-client/internal/util/utiltest"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -109,7 +110,7 @@ var expectedPyConfig = &config.Python{
 
 func makeMockPythonInspector(util.Path, logging.Logger) inspect.PythonInspector {
 	pyInspector := inspect.NewMockPythonInspector()
-	pyInspector.On("InspectPython").Return(expectedPyConfig, nil)
+	pyInspector.On("InspectPython", mock.Anything).Return(expectedPyConfig, nil)
 	return pyInspector
 }
 

--- a/internal/inspect/python_mock.go
+++ b/internal/inspect/python_mock.go
@@ -16,8 +16,8 @@ func NewMockPythonInspector() *MockPythonInspector {
 	return &MockPythonInspector{}
 }
 
-func (m *MockPythonInspector) InspectPython() (*config.Python, error) {
-	args := m.Called()
+func (m *MockPythonInspector) InspectPython(base util.Path) (*config.Python, error) {
+	args := m.Called(base)
 	cfg := args.Get(0)
 	if cfg == nil {
 		return nil, args.Error(1)

--- a/internal/services/api/post_configurations_test.go
+++ b/internal/services/api/post_configurations_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rstudio/connect-client/internal/util"
 	"github.com/rstudio/connect-client/internal/util/utiltest"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -38,7 +39,7 @@ var expectedPyConfig = &config.Python{
 
 func makeMockPythonInspector(util.Path, logging.Logger) inspect.PythonInspector {
 	pyInspector := inspect.NewMockPythonInspector()
-	pyInspector.On("InspectPython").Return(expectedPyConfig, nil)
+	pyInspector.On("InspectPython", mock.Anything).Return(expectedPyConfig, nil)
 	return pyInspector
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
`init` should honor a `.python-version` file, if present, as an alternative to running Python to get the version. This is written by `pyenv` if you are using project-local python versions.

Fixes #971 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Read the file, looking in parent directories as described in [the pyenv docs](https://realpython.com/intro-to-pyenv/#specifying-your-python-version).

## Automated Tests
Added unit tests.

## Directions for Reviewers
Run `init` on content with and without a local `.python-version` file, or with one in a parent directory. If present, the python version in the file should be honored. (The contents must start with a valid numeric version).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
