### PR TITLE
Allow all valid Python import identifiers

### DIFF
--- a/internal/inspect/dependencies/pydeps/file_imports_test.go
+++ b/internal/inspect/dependencies/pydeps/file_imports_test.go
@@ -48,3 +48,17 @@ func (s *FileImportsSuite) TestScanImports() {
 		"frobble",
 	}, importNames)
 }
+
+func (s *FileImportsSuite) TestScanImportsUnicode() {
+	code := `
+		import çde
+		import Щ, Σ123
+		from Θ import woo as wow
+	`
+	log := logging.New()
+	scanner := NewImportScanner(log)
+	importNames := scanner.ScanImports(code)
+	s.Equal([]ImportName{
+		"çde", "Θ", "Σ123", "Щ",
+	}, importNames)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes the regex we are using to scan for Python imports to match the Python syntax definition. 

Based on https://github.com/posit-dev/publisher/pull/958#discussion_r1486533026.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Expand the regex to allow all characters per the Python spec. Mostly, the difference is in unicode chars which are rarely used in import names names since pip doesn't allow them in package names.

## Automated Tests
Added tests to cover this case.

## Directions for Reviewers
I think tests passing is sufficient here, however, you could create a project that imports weird package names that don't exist and then use `publisher requirements show` on it.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
