### PR TITLE
[extension ui] Add view container and empty config/deployment views

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -22,6 +22,29 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "posit-publisher",
+					"title": "Posit Publisher",
+					"icon": "assets/img/color.svg"
+				}
+			]
+		},
+		"views": {
+			"posit-publisher": [
+				{
+					"id": "posit-publisher-config",
+					"name": "Configurations",
+					"contextualTitle": "Configurations"
+				},
+				{
+					"id": "posit-publisher-deployments",
+					"name": "Deployments",
+					"contextualTitle": "Deployments"
+				}
+			]
+		},
     "commands": [
       {
         "command": "posit.publisher.open",


### PR DESCRIPTION
Show the Publish icon in the activity bar, and empty view container for configurations and deployments.

This also establishes a naming scheme for the components.
