### PR TITLE
Don't rename deployment records during deployment

### DIFF
--- a/cmd/publisher/commands/deploy.go
+++ b/cmd/publisher/commands/deploy.go
@@ -56,7 +56,6 @@ func (cmd *DeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext)
 	if err != nil {
 		return err
 	}
-	stateStore.TargetName = cmd.SaveName
 	fmt.Printf("Deploy to server %s using account %s and configuration %s, creating deployment %s\n",
 		stateStore.Account.URL,
 		stateStore.Account.Name,

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -132,7 +132,7 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 		p.Target.Error = agentErr
 		writeErr := p.writeDeploymentRecord(log)
 		if writeErr != nil {
-			log.Warn("failed to write updated deployment record", "name", p.TargetName, "err", err)
+			log.Warn("failed to write updated deployment record", "name", p.TargetName, "err", writeErr)
 		}
 		if p.isDeployed() {
 			// Provide URL in the event, if we got far enough in the deployment.
@@ -237,12 +237,6 @@ func (p *defaultPublisher) createDeploymentRecord(
 
 	// Save current deployment information for this target
 	if p.SaveName != "" {
-		if p.TargetName != "" {
-			err := deployment.RenameDeployment(p.Dir, p.TargetName, p.SaveName)
-			if err != nil {
-				return err
-			}
-		}
 		p.TargetName = p.SaveName
 	}
 	return p.writeDeploymentRecord(log)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
Fixes rename error introduced in #968

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Removed the code that renames deployment records during deployment, and reverted the change to the `deploy` command that sets the target name early.

## Automated Tests
The command layer lacks tests (boo).

## Directions for Reviewers
Deploy and redeploy from the CLI and UI.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
