### PR TITLE
Allow setting the base URL for api module client

### DIFF
--- a/web/src/api/README.md
+++ b/web/src/api/README.md
@@ -17,6 +17,14 @@ try {
 }
 ```
 
+If you need to set the URL and or Port for the base API endpoint you can do so
+using `setBaseUrl`. This changes the client so all requests will use the new
+base URL. This will need to be done before any requests are made.
+
+```typescript
+api.setBaseUrl('http://localhost:9000/api');
+```
+
 ## Organization
 
 ### `client.ts`

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,22 +19,28 @@ const camelCaseInterceptor = (response: AxiosResponse): AxiosResponse => {
 };
 
 class PublishingClientApi {
+  private client;
+
   accounts: Accounts;
   configurations: Configurations;
   deployments: Deployments;
   files: Files;
 
   constructor() {
-    const client = axios.create({
+    this.client = axios.create({
       baseURL: '/api',
     });
 
-    client.interceptors.response.use(camelCaseInterceptor);
+    this.client.interceptors.response.use(camelCaseInterceptor);
 
-    this.accounts = new Accounts(client);
-    this.configurations = new Configurations(client);
-    this.deployments = new Deployments(client);
-    this.files = new Files(client);
+    this.accounts = new Accounts(this.client);
+    this.configurations = new Configurations(this.client);
+    this.deployments = new Deployments(this.client);
+    this.files = new Files(this.client);
+  }
+
+  setBaseUrl(url: string) {
+    this.client.defaults.baseURL = url;
   }
 }
 


### PR DESCRIPTION
This PR adds a new method to the `PublishingClientApi` class - `setBaseUlr()` - that allows changing the default `baseURL` for the internal Axios client.

## Intent
- Resolves #985 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Since the client needs to be accessed in the method I made the `client` an `private` attribute on `PublishingClientApi` so it can be used, but still not accessed outside of the class.

Instructions for its usage are added to the `README`
