### PR TITLE
Rename post configurations endpoint

### DIFF
--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -80,8 +80,8 @@ func RouterHandlerFunc(base util.Path, lister accounts.AccountList, log logging.
 	r.Handle(ToPath("configurations"), GetConfigurationsHandlerFunc(base, log)).
 		Methods(http.MethodGet)
 
-	// POST /api/configurations
-	r.Handle(ToPath("configurations"), PostConfigurationsHandlerFunc(base, log)).
+	// POST /api/initialize
+	r.Handle(ToPath("initialize"), PostInitializeHandlerFunc(base, log)).
 		Methods(http.MethodPost)
 
 	// GET /api/deployments

--- a/internal/services/api/post_initialize.go
+++ b/internal/services/api/post_initialize.go
@@ -12,15 +12,15 @@ import (
 	"github.com/rstudio/connect-client/internal/util"
 )
 
-type PostConfigurationsRequestBody struct {
+type PostInitializeRequestBody struct {
 	ConfigName string `json:"configurationName"`
 }
 
-func PostConfigurationsHandlerFunc(base util.Path, log logging.Logger) http.HandlerFunc {
+func PostInitializeHandlerFunc(base util.Path, log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		dec := json.NewDecoder(req.Body)
 		dec.DisallowUnknownFields()
-		var b PostConfigurationsRequestBody
+		var b PostInitializeRequestBody
 		err := dec.Decode(&b)
 		if err != nil {
 			BadRequest(w, req, log, err)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR renames and re-paths the `POST /api/configurations` endpoint to be `POST /api/initialize`. This is in preparation for other upcoming changes, such as an endpoint that returns all possible (detected) configurations and a new `POST /api/configurations/$NAME` endpoint to create a new configuration given the name and config details.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [x] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->


## Automated Tests
Existing tests should pass.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
