### PR TITLE
Use camelCase for getAccountResponse

### DIFF
--- a/internal/services/api/get_accounts.go
+++ b/internal/services/api/get_accounts.go
@@ -13,14 +13,14 @@ import (
 // getAccountResponse is the format of returned account data.
 // It does not include credentials (ApiKey, Token, Secret, or PrivateKey).
 type getAccountResponse struct {
-	Type        string `json:"type"`         // Which type of API this server provides
-	Source      string `json:"source"`       // Source of the saved server configuration
-	AuthType    string `json:"auth_type"`    // Authentication method (API key, token, etc)
-	Name        string `json:"name"`         // Nickname
-	URL         string `json:"url"`          // Server URL, e.g. https://connect.example.com/rsc
-	Insecure    bool   `json:"insecure"`     // Skip https server verification
-	Certificate string `json:"ca_cert"`      // Root CA certificate, if server cert is signed by a private CA
-	AccountName string `json:"account_name"` // For shinyapps.io and Posit Cloud servers
+	Type        string `json:"type"`        // Which type of API this server provides
+	Source      string `json:"source"`      // Source of the saved server configuration
+	AuthType    string `json:"authType"`    // Authentication method (API key, token, etc)
+	Name        string `json:"name"`        // Nickname
+	URL         string `json:"url"`         // Server URL, e.g. https://connect.example.com/rsc
+	Insecure    bool   `json:"insecure"`    // Skip https server verification
+	Certificate string `json:"caCert"`      // Root CA certificate, if server cert is signed by a private CA
+	AccountName string `json:"accountName"` // For shinyapps.io and Posit Cloud servers
 }
 
 type getAccountsResponse struct {


### PR DESCRIPTION
Nice and simple PR that removes the old snake_case names in `getAccountResponse` for the fetching of accounts API endpoint.

## Intent
Resolves #1012 
Part of #511 
