### PR TITLE
Fill VSCode Credentials view with accounts from the API

### DIFF
--- a/extensions/vscode/src/views/credentials.ts
+++ b/extensions/vscode/src/views/credentials.ts
@@ -5,7 +5,7 @@ import {
   window,
 } from 'vscode';
 
-import api from '../api';
+import api, { Account } from '../api';
 
 const viewName = 'posit.publisher.credentials';
 
@@ -25,7 +25,7 @@ export class CredentialsTreeDataProvider implements TreeDataProvider<Credentials
     const response = await api.accounts.getAll();
     const accounts = response.data.accounts;
     return accounts.map(account => {
-      return new CredentialsTreeItem(account.name);
+      return new CredentialsTreeItem(account);
     });
   }
 
@@ -37,11 +37,25 @@ export class CredentialsTreeDataProvider implements TreeDataProvider<Credentials
   }
 }
 export class CredentialsTreeItem extends TreeItem {
+  contextValue = 'posit.publisher.credentials.tree.item';
 
-  constructor(itemString: string) {
-    super(itemString);
+  constructor(account: Account) {
+    super(account.name);
+    this.tooltip = this.getTooltip(account);
   }
 
-  contextValue = 'posit.publisher.credentials.tree.item';
-  tooltip = 'This is a \nCredentials Tree Item';
+  getTooltip(account: Account): string {
+    let result = '';
+
+    if (account.authType === 'token-key') {
+      result += `Account: ${account.accountName}\n`;
+    } else if (account.authType === 'api-key') {
+      result += 'Account: Using API Key\n';
+    }
+
+    result += `URL: ${account.url}\n`;
+    result += `Managed by: ${account.source}`;
+
+    return result;
+  }
 }


### PR DESCRIPTION
This adds the credentials we receive from `/api/accounts` to the Credentials view in VSCode.

## Intent
Part of #1003 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Really simple approach here. The accounts are retrieved from the API, and turned into tree items which have a tooltip that matches the formatting we have in the standalone UI.
