### PR TITLE
Fix duplicate contextual titles

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -89,37 +89,37 @@
         {
           "id": "posit.publisher.project",
           "name": "Project",
-          "contextualTitle": "Project"
+          "contextualTitle": "Publisher"
         },
         {
           "id": "posit.publisher.files",
           "name": "Files",
-          "contextualTitle": "Files"
+          "contextualTitle": "Publisher"
         },
         {
           "id": "posit.publisher.dependencies",
           "name": "Dependencies",
-          "contextualTitle": "Dependencies"
+          "contextualTitle": "Publisher"
         },
         {
           "id": "posit.publisher.configurations",
           "name": "Configurations",
-          "contextualTitle": "Configurations"
+          "contextualTitle": "Publisher"
         },
         {
           "id": "posit.publisher.credentials",
           "name": "Credentials",
-          "contextualTitle": "Credentials"
+          "contextualTitle": "Publisher"
         },
         {
           "id": "posit.publisher.deployments",
           "name": "Deployments",
-          "contextualTitle": "Deployments"
+          "contextualTitle": "Publisher"
         },
         {
           "id": "posit.publisher.helpAndFeedback",
           "name": "Help And Feedback",
-          "contextualTitle": "Help And Feedback"
+          "contextualTitle": "Publisher"
         }
       ]
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes the `contextualTitle`s for the views so that if you drag them to another viewContainer, they don't have duplicative names.

Currently, dragging `Project` to another panel gives it a name of `Project: Project`. With this PR, it will say `Publisher: Project` which gives you the context you need.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->


## Automated Tests
N/A

## Directions for Reviewers
Drag one of our views to another container such as the File tree.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
