### PR TITLE
Clear logs view on `publish/start` event

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -30,10 +30,10 @@ export class LogsTreeDataProvider implements vscode.TreeDataProvider<LogsTreeIte
       }
     });
 
-    // example of how to register a callback for a specific message type
-    // stream.register('agent/log', (message: EventStreamMessage) => {
-    //   console.error(message);
-    // });
+    // Reset events when a new publish starts
+    stream.register('publish/start', (_: EventStreamMessage) => {
+      this.events = [];
+    });
   };
 
   /**


### PR DESCRIPTION
Stepping stone to make the logs a bit easier to view. This PR makes the VSCode logs view clear itself when a `publish/start` event occurs.

## Intent
Part of #1041

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->