### PR TITLE
Provide `unregister()` closure when registering event callback

### DIFF
--- a/extensions/vscode/src/events.ts
+++ b/extensions/vscode/src/events.ts
@@ -99,6 +99,7 @@ export class EventStream extends Readable {
    * Registers a callback function for a specific event type.
    * @param type The event type to register the callback for.
    * @param callback The callback function to be invoked when the event occurs.
+   * @returns An object with an `unregister` method that can be used to remove the callback.
    */
   public register(type: string, callback: EventStreamMessageCallback): { unregister: () => void } {
     if (!this.callbacks.has(type)) {


### PR DESCRIPTION
This PR introduces a return to the `register` method in the VSCode `events.ts` file. That return is an object that contains an `unregister` function which, when called, will remove the registered callback from the callbacks array associated with the type passed.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The approach here is to return a method which has the context of the `register` call. So we can access `type` and `callback` still without needing them to be passed to `unregister`.

I tested this on #1054 by unregistering the listener that reset the stages status.

Usage looks like this:

```typescript
const registration = stream.register('publish/start', (_: EventStreamMessage) => {
  this.events = [];
  this.resetStages();
});
registration.unregister();
```
