### PR TITLE
Fix error serialization

### DIFF
--- a/internal/clients/http_client/http_client.go
+++ b/internal/clients/http_client/http_client.go
@@ -82,7 +82,7 @@ func (c *defaultHTTPClient) do(method string, path string, body io.Reader, bodyT
 		if e, ok := err.(net.Error); ok && e.Timeout() {
 			return nil, types.NewAgentError(events.OperationTimedOutCode, err, nil)
 		}
-		return nil, err
+		return nil, types.NewAgentError(events.ConnectionFailedCode, err, nil)
 	}
 	defer resp.Body.Close()
 

--- a/internal/events/error_codes.go
+++ b/internal/events/error_codes.go
@@ -11,6 +11,7 @@ const (
 	AuthenticationFailedCode  ErrorCode = "authFailedErr"            // Couldn't authenticate to publishing server
 	PermissionsCode           ErrorCode = "permissionErr"            // Server responded with 403 forbidden
 	OperationTimedOutCode     ErrorCode = "timeoutErr"               // HTTP request to publishing server timed out
+	ConnectionFailedCode      ErrorCode = "connectionFailed"         // Couldn't connect to Connect
 	ServerErrorCode           ErrorCode = "serverErr"                // HTTP 5xx code from publishing server
 	VanityURLNotAvailableCode ErrorCode = "vanityURLNotAvailableErr" // Vanity URL already in use
 	DeploymentNotFoundCode    ErrorCode = "deploymentNotFoundErr"    // Could not find deployment to update

--- a/internal/events/errors_test.go
+++ b/internal/events/errors_test.go
@@ -5,7 +5,6 @@ package events
 import (
 	"errors"
 	"os"
-	"syscall"
 	"testing"
 	"time"
 
@@ -42,8 +41,6 @@ func (s *ErrorsSuite) TestGoErrorWithAttrs() {
 
 	s.NotEqual(time.Time{}, event.Time)
 	s.Equal("publish/restoreREnv/failure/unknown", event.Type)
-	s.Equal(syscall.Errno(2), event.Data["Err"])
-	s.Equal("/nonexistent", event.Data["Path"])
 }
 
 type testErrorDetails struct {
@@ -80,7 +77,5 @@ func (s *ErrorsSuite) TestErrorObjectAndDetails() {
 
 	s.NotEqual(time.Time{}, event.Time)
 	s.Equal("publish/restorePythonEnv/failure/serverErr", event.Type)
-	s.Equal(syscall.Errno(2), event.Data["Err"])
-	s.Equal("/nonexistent", event.Data["Path"])
 	s.Equal(500, event.Data["Status"])
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -127,6 +127,8 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 	dashboardURL := ""
 	directURL := ""
 
+	var data events.EventData
+
 	// Record the error in the deployment record
 	if p.Target != nil {
 		p.Target.Error = agentErr
@@ -139,14 +141,14 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 			dashboardURL = getDashboardURL(p.Account.URL, p.Target.ID)
 			directURL = getDirectURL(p.Account.URL, p.Target.ID)
 			agentErr.Data["dashboard_url"] = dashboardURL
+
+			mapstructure.Decode(publishFailureData{
+				DashboardURL: dashboardURL,
+				DirectURL:    directURL,
+			}, &data)
 		}
 	}
 
-	var data events.EventData
-	mapstructure.Decode(publishFailureData{
-		DashboardURL: dashboardURL,
-		DirectURL:    directURL,
-	}, &data)
 	maps.Copy(data, agentErr.GetData())
 
 	// Fail the phase

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -44,7 +44,6 @@ func NewAgentError(code ErrorCode, err error, details any) *AgentError {
 	msg := ""
 	if err != nil {
 		msg = err.Error()
-		mapstructure.Decode(err, &data)
 	}
 	if details != nil {
 		detailMap := make(ErrorData)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
When we serialize errors in the backend, `data` field currently includes any provided `details` from the agent code as well as any public fields in the `error` itself. This PR removes the public `error` fields since there is no guarantee that they are serializable.

Fixes #1048

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
* No longer serialize the `error` fields.
* Add a specific error code that is more descriptive for the error in #1048 
* Don't include dashboardUrl in error detailed for a deployment that fails before there is a contentID created.
* As a side note, linting should not check for copyright headers in `node_modules` when running lint locally. In CI this was fine because we don't run `npm install` before linting the agent.

## Automated Tests
Updated existing tests.

## Directions for Reviewers
Validate #1048.
