### PR TITLE
Remove error code from event type string

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -69,7 +69,7 @@ func New(op Operation, phase Phase, errCode ErrorCode, data any) *Event {
 	}
 	return &Event{
 		Time:    time.Now(),
-		Type:    EventTypeOf(op, phase, errCode),
+		Type:    EventTypeOf(op, phase),
 		Data:    eventData,
 		op:      op,
 		phase:   phase,
@@ -77,10 +77,6 @@ func New(op Operation, phase Phase, errCode ErrorCode, data any) *Event {
 	}
 }
 
-func EventTypeOf(op Operation, phase Phase, errCode ErrorCode) EventType {
-	if phase == FailurePhase && errCode != "" {
-		return fmt.Sprintf("%s/%s/%s", op, phase, errCode)
-	} else {
-		return fmt.Sprintf("%s/%s", op, phase)
-	}
+func EventTypeOf(op Operation, phase Phase) EventType {
+	return fmt.Sprintf("%s/%s", op, phase)
 }

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -5,7 +5,6 @@ package events
 import (
 	"testing"
 
-	"github.com/rstudio/connect-client/internal/types"
 	"github.com/rstudio/connect-client/internal/util/utiltest"
 	"github.com/stretchr/testify/suite"
 )
@@ -20,12 +19,6 @@ func TestEventsSuite(t *testing.T) {
 
 func (s *EventsSuite) TestEventTypeOf() {
 	expected := "publish/createBundle/start"
-	actual := EventTypeOf(PublishCreateBundleOp, StartPhase, types.UnknownErrorCode)
-	s.Equal(expected, actual)
-}
-
-func (s *EventsSuite) TestEventTypeOfFailure() {
-	expected := "publish/createBundle/failure/authFailure"
-	actual := EventTypeOf(PublishCreateBundleOp, FailurePhase, ErrorCode("authFailure"))
+	actual := EventTypeOf(PublishCreateBundleOp, StartPhase)
 	s.Equal(expected, actual)
 }

--- a/internal/events/sse_handler.go
+++ b/internal/events/sse_handler.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 
 	"github.com/rstudio/connect-client/internal/logging"
-	"github.com/rstudio/connect-client/internal/types"
 )
 
 // SSEHandler emits an event for every log message.
@@ -43,14 +42,11 @@ func (h *SSEHandler) recordToEvent(rec slog.Record) *Event {
 	// log.Info("a message", "op", "publish/restore")
 	// will create an SSE event with Type: "publish/restore/log".
 	op := AgentOp
-	errCode := types.UnknownErrorCode
 
 	handleAttr := func(attr slog.Attr) bool {
 		switch attr.Key {
 		case logging.LogKeyOp:
 			op = Operation(attr.Value.String())
-		case logging.LogKeyErrCode:
-			errCode = ErrorCode(attr.Value.String())
 		case "": // skip empty attrs
 		default:
 			event.Data[attr.Key] = attr.Value.Any()
@@ -63,7 +59,7 @@ func (h *SSEHandler) recordToEvent(rec slog.Record) *Event {
 	}
 	// Then the ones from this specific message.
 	rec.Attrs(handleAttr)
-	event.Type = EventTypeOf(op, LogPhase, errCode)
+	event.Type = EventTypeOf(op, LogPhase)
 	return event
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR removes the `errorCode` part of the event type string.

Fixes #1082 
