### PR TITLE
Only support `workbenchState == folder` for deploy

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -195,50 +195,51 @@
           "id": "posit.publisher.project",
           "name": "Project",
           "contextualTitle": "Publisher",
-          "when": "workbenchState == empty"
+          "when": "workbenchState == empty || workbenchState == workspace"
         },
         {
           "id": "posit.publisher.files",
           "name": "Files",
           "contextualTitle": "Publisher",
-          "when": "workbenchState != empty"
+          "when": "workbenchState == folder"
         },
         {
           "id": "posit.publisher.dependencies",
           "name": "Dependencies",
           "contextualTitle": "Publisher",
-          "when": "workbenchState != empty"
+          "when": "workbenchState == folder"
         },
         {
           "id": "posit.publisher.configurations",
           "name": "Configurations",
           "contextualTitle": "Publisher",
-          "when": "workbenchState != empty"
+          "when": "workbenchState == folder"
         },
         {
           "id": "posit.publisher.credentials",
           "name": "Credentials",
           "contextualTitle": "Publisher",
-          "when": "workbenchState != empty"
+          "when": "workbenchState == folder"
         },
         {
           "id": "posit.publisher.deployments",
           "name": "Deployments",
           "contextualTitle": "Publisher",
-          "when": "workbenchState != empty"
+          "when": "workbenchState == folder"
         },
         {
           "id": "posit.publisher.helpAndFeedback",
           "name": "Help And Feedback",
           "contextualTitle": "Publisher",
-          "when": "workbenchState != empty"
+          "when": "workbenchState == folder"
         }
       ],
       "posit-publisher-logs": [
         {
           "id": "posit.publisher.logs",
           "name": "Logs",
-          "contextualTitle": "Logs"
+          "contextualTitle": "Logs",
+          "when": "workbenchState == folder"
         }
       ]
     },
@@ -257,6 +258,11 @@
         "view": "posit.publisher.project",
         "contents": "In order to deploy using Posit Publisher, you can open a folder initialized as a Posit project or initialize a new project.\n[Open Folder](command:vscode.openFolder)",
         "when": "workbenchState == empty"
+      },
+      {
+        "view": "posit.publisher.project",
+        "contents": "Posit Publisher currently only supports single folder workspaces, open a folder initialized as a Posit project or initialize a new project.\n[Open Folder](command:vscode.openFolder)",
+        "when": "workbenchState == workspace"
       }
     ]
   },


### PR DESCRIPTION
This PR reinforces our support of only single-folder workspaces by only showing our non-welcome views when `workbenchState == folder`.

It also adds a `workbenchState == workspace` welcome view.

<details>
  <summary>Preview</summary>
  
  ![CleanShot 2024-03-06 at 18 11 52](https://github.com/posit-dev/publisher/assets/19917631/fd4bb541-44de-4132-8338-d20b1eb103bd)
![CleanShot 2024-03-06 at 18 11 53](https://github.com/posit-dev/publisher/assets/19917631/bdfd3e3e-e254-4a0c-8b94-1c03c80bb637)

</details> 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
`workbenchState` "Can be `empty`, `folder` (1 folder), or `workspace`." We currently only support `folder` so instead of only basing our views of `!= empty` we should only show them when `== folder`.

## Directions for Reviewers
1. Open up the extension
2. Add two+ folders to the workspace to make the `workbenchState` context `== workspace`.
3. See the new welcome view
