### PR TITLE
Use commands instead of onDidChangeSelection

### DIFF
--- a/extensions/vscode/src/views/configurations.ts
+++ b/extensions/vscode/src/views/configurations.ts
@@ -90,12 +90,6 @@ export class ConfigurationsTreeDataProvider implements TreeDataProvider<Configur
   public register(context: ExtensionContext) {
     context.subscriptions.push(window.registerTreeDataProvider(viewName, this));
     const treeView = window.createTreeView(viewName, { treeDataProvider: this });
-    treeView.onDidChangeSelection(async e => {
-      if (e.selection.length > 0) {
-        const item = e.selection.at(0);
-        await commands.executeCommand(editCommand, item);
-      }
-    });
 
     context.subscriptions.push(
       treeView,
@@ -252,6 +246,11 @@ export class ConfigurationTreeItem extends TreeItem {
       this.iconPath = new ThemeIcon('warning');
     }
     this.tooltip = this.getTooltip();
+    this.command = {
+      title: 'Open',
+      command: 'vscode.open',
+      arguments: [this.fileUri]
+    };
   }
 
   getTooltip(): string {

--- a/extensions/vscode/src/views/deployments.ts
+++ b/extensions/vscode/src/views/deployments.ts
@@ -104,13 +104,6 @@ export class DeploymentsTreeDataProvider implements TreeDataProvider<Deployments
 
   public register(context: ExtensionContext) {
     const treeView = window.createTreeView(viewName, { treeDataProvider: this });
-    treeView.onDidChangeSelection(e => {
-      console.log(e);
-      if (e.selection.length > 0) {
-        const item = e.selection.at(0);
-        commands.executeCommand(editCommand, item);
-      }
-    });
     context.subscriptions.push(treeView);
 
     context.subscriptions.push(
@@ -172,6 +165,11 @@ export class DeploymentsTreeItem extends TreeItem {
     } else {
       this.initializeDeploymentError(this.deployment);
     }
+    this.command = {
+      title: 'Open',
+      command: 'vscode.open',
+      arguments: [this.fileUri]
+    };
   }
 
   private initializeDeployment(deployment: Deployment) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
Some of our treeviews use `onDidChangeSelection` to detect when the current item changes, and use that as a kind of "on click" handler which isn't really the same. This PR binds commands to the items instead.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers
Verify click behavior for the Configurations and Deployments tree views.