### PR TITLE
Update whole publish icon on `publish/failure`

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -20,6 +20,7 @@ import {
 
 enum LogStageStatus {
   notStarted,
+  neverStarted,
   inProgress,
   completed,
   failed
@@ -123,6 +124,11 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     
     stream.register('publish/failure', (_: EventStreamMessage) => {
       this.publishingStage.status = LogStageStatus.failed;
+      this.stages.forEach((stage) => {
+        if (stage.status === LogStageStatus.notStarted) {
+          stage.status = LogStageStatus.neverStarted;
+        }
+      });
       this.refresh();
     });
   }
@@ -437,7 +443,10 @@ export class LogsTreeStageItem extends TreeItem {
   setIcon(status: LogStageStatus) {
     switch (status) {
       case LogStageStatus.notStarted:
-        this.iconPath = new ThemeIcon('circle-outline');
+        this.iconPath = new ThemeIcon('circle-large-outline');
+        break;
+      case LogStageStatus.neverStarted:
+        this.iconPath = new ThemeIcon('circle-slash');
         break;
       case LogStageStatus.inProgress:
         this.iconPath = new ThemeIcon('loading~spin');


### PR DESCRIPTION
This adds a `publish/failure` listener to the Logs view in the VSCode extension that updates the `LogsTreeStageItem` icon for the entire publish.

![CleanShot 2024-03-12 at 01 01 13@2x](https://github.com/posit-dev/publisher/assets/19917631/8dd7ecf3-7145-4644-b88b-a4b6adc8912e)

## Intent
Resolves #1071

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The approach here is to handle each stage's failures, and the `publishState` using the `publish/success` or `publish/failure` events.

If all stages happen synchronously then we should:
- show errors on the high level publishing stage, and the nested stage that failed
- stages above that succeeded will still show as succeeded  
- stages below will continue to show as not-started
