### PR TITLE
Add never started icon to logs view

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -20,6 +20,7 @@ import {
 
 enum LogStageStatus {
   notStarted,
+  neverStarted,
   inProgress,
   completed,
   failed
@@ -123,6 +124,11 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     
     stream.register('publish/failure', (_: EventStreamMessage) => {
       this.publishingStage.status = LogStageStatus.failed;
+      this.stages.forEach((stage) => {
+        if (stage.status === LogStageStatus.notStarted) {
+          stage.status = LogStageStatus.neverStarted;
+        }
+      });
       this.refresh();
     });
   }
@@ -437,7 +443,10 @@ export class LogsTreeStageItem extends TreeItem {
   setIcon(status: LogStageStatus) {
     switch (status) {
       case LogStageStatus.notStarted:
-        this.iconPath = new ThemeIcon('circle-outline');
+        this.iconPath = new ThemeIcon('circle-large-outline');
+        break;
+      case LogStageStatus.neverStarted:
+        this.iconPath = new ThemeIcon('circle-slash');
         break;
       case LogStageStatus.inProgress:
         this.iconPath = new ThemeIcon('loading~spin');


### PR DESCRIPTION
This PR does two things:
- updates the logs view `notStarted` icon to `circle-large-outline` to match the sizing of the other icons
- adds a `neverStarted` icon `circle-slash` for stages that never ran in the event of a failure

![CleanShot 2024-03-12 at 01 07 47@2x](https://github.com/posit-dev/publisher/assets/19917631/5e8bf797-73ff-44eb-88b2-f2948ca8bfcd)

![CleanShot 2024-03-12 at 01 07 07@2x](https://github.com/posit-dev/publisher/assets/19917631/6df49986-2d98-4555-88dd-aedee25b77d4)


## Intent
Part of #1071 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The approach here is simple - when we hit a `publish/failure` go through all of the stages in the Logs view and convert any stage with `status === notStarted` to `neverStarted`
