### PR TITLE
Add error message to publish stage failure events

### DIFF
--- a/internal/events/capturing_emitter.go
+++ b/internal/events/capturing_emitter.go
@@ -1,0 +1,18 @@
+package events
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+type capturingEmitter struct {
+	Events []*Event
+}
+
+func NewCapturingEmitter() *capturingEmitter {
+	return &capturingEmitter{
+		Events: make([]*Event, 0),
+	}
+}
+
+func (c *capturingEmitter) Emit(event *Event) error {
+	c.Events = append(c.Events, event)
+	return nil
+}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -47,6 +47,10 @@ type publishSuccessData struct {
 }
 
 type publishFailureData struct {
+	Message string `mapstructure:"message"`
+}
+
+type publishDeployedFailureData struct {
 	DashboardURL string `mapstructure:"dashboardUrl"`
 	DirectURL    string `mapstructure:"url"`
 }
@@ -129,6 +133,10 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 
 	var data events.EventData
 
+	mapstructure.Decode(publishFailureData{
+		Message: agentErr.Error(),
+	}, &data)
+
 	// Record the error in the deployment record
 	if p.Target != nil {
 		p.Target.Error = agentErr
@@ -140,9 +148,8 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 			// Provide URL in the event, if we got far enough in the deployment.
 			dashboardURL = getDashboardURL(p.Account.URL, p.Target.ID)
 			directURL = getDirectURL(p.Account.URL, p.Target.ID)
-			agentErr.Data["dashboard_url"] = dashboardURL
 
-			mapstructure.Decode(publishFailureData{
+			mapstructure.Decode(publishDeployedFailureData{
 				DashboardURL: dashboardURL,
 				DirectURL:    directURL,
 			}, &data)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR adds a `message` field to the failure events that are emitted when a publishing stage fails.

Part of #1063 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The new field is added to the event data in `emitErrorEvents`, which is called whenever any publishing stage fails.

## Automated Tests
Added tests for `emitErrorEvents`, which previously lacked tests.

## Directions for Reviewers
Make publishing fail, and check the `data` field of the failure events in the event stream.
