### PR TITLE
When rescanning requirements, switch confirmation button from update to overwrite

### DIFF
--- a/extensions/vscode/src/dialogs.ts
+++ b/extensions/vscode/src/dialogs.ts
@@ -14,8 +14,8 @@ const forgetItem: MessageItem = {
   title: l10n.t("Forget"),
 };
 
-const updateItem: MessageItem = {
-  title: l10n.t("Update"),
+const overwriteItem: MessageItem = {
+  title: l10n.t("Overwrite"),
 };
 
 const replaceItem: MessageItem = {
@@ -53,8 +53,8 @@ export async function confirmReplace(message: string): Promise<boolean> {
   return confirm(message, replaceItem);
 }
 
-export async function confirmUpdate(message: string): Promise<boolean> {
-  return confirm(message, updateItem);
+export async function confirmOverwrite(message: string): Promise<boolean> {
+  return confirm(message, overwriteItem);
 }
 
 export async function alert(message: string): Promise<void> {

--- a/extensions/vscode/src/views/requirements.ts
+++ b/extensions/vscode/src/views/requirements.ts
@@ -18,7 +18,7 @@ import {
 
 import { isAxiosError } from 'axios';
 import api from '../api';
-import { confirmUpdate } from '../dialogs';
+import { confirmOverwrite } from '../dialogs';
 import { getSummaryStringFromError } from '../utils/errors';
 import { fileExists } from '../utils/files';
 
@@ -63,7 +63,7 @@ export class RequirementsTreeDataProvider implements TreeDataProvider<Requiremen
       const response = await api.requirements.getAll();
       await this.setContextIsEmpty(false);
       return response.data.requirements.map(line => new RequirementsTreeItem(line));
-    } catch(error: unknown) {
+    } catch (error: unknown) {
       if (isAxiosError(error) && error.response?.status === 404) {
         // No requirements file; show the welcome view.
         await this.setContextIsEmpty(true);
@@ -76,7 +76,7 @@ export class RequirementsTreeDataProvider implements TreeDataProvider<Requiremen
     }
   }
 
-  private async setContextIsEmpty(isEmpty: boolean): Promise<void>{
+  private async setContextIsEmpty(isEmpty: boolean): Promise<void> {
     await commands.executeCommand('setContext', contextIsEmpty, isEmpty ? "empty" : "notEmpty");
   }
 
@@ -114,7 +114,7 @@ export class RequirementsTreeDataProvider implements TreeDataProvider<Requiremen
     }
 
     if (await fileExists(this.fileUri)) {
-      const ok = await confirmUpdate('Are you sure you want to overwrite your existing requirements.txt file?');
+      const ok = await confirmOverwrite('Are you sure you want to overwrite your existing requirements.txt file?');
       if (!ok) {
         return;
       }
@@ -123,7 +123,7 @@ export class RequirementsTreeDataProvider implements TreeDataProvider<Requiremen
     try {
       await api.requirements.create("requirements.txt");
       await this.edit();
-    } catch(error: unknown) {
+    } catch (error: unknown) {
       const summary = getSummaryStringFromError('dependencies::scan', error);
       window.showInformationMessage(summary);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1129 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Was only usage of common dialog, so changed it to be overwrite button.

Example of dialog after change:

![2024-03-13 at 2 55 PM](https://github.com/posit-dev/publisher/assets/17675905/4050b6f6-993b-409e-a5f4-8be7b8b950f9)

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

Confirm clicking eyeball to rescan requirements displays dialog w/ overwrite button.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
