### PR TITLE
Add failure messages to staged logs view

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -122,8 +122,10 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       this.refresh();
     });
     
-    stream.register('publish/failure', (_: EventStreamMessage) => {
+    stream.register('publish/failure', (msg: EventStreamMessage) => {
       this.publishingStage.status = LogStageStatus.failed;
+      this.publishingStage.events.push(msg);
+    
       this.stages.forEach((stage) => {
         if (stage.status === LogStageStatus.notStarted) {
           stage.status = LogStageStatus.neverStarted;


### PR DESCRIPTION
This PR adds the new messages we get in `/failure` event payloads (#1142) and uses them in the staged logs view.

One thing to note is if the event is long, or contains new lines it will not be formatted and the Tree Item will continue being a single line. [This is intentional, and TreeItems do not wrap to avoid layout issues in VSCode](https://github.com/microsoft/vscode/issues/103403).

![CleanShot 2024-03-13 at 15 20 18@2x](https://github.com/posit-dev/publisher/assets/19917631/5da5a1c8-1e99-4016-9ecb-ec223a580ded)

## Intent
Resolves #1063 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->