### PR TITLE
Catch "Launching Quarto" logs for run content step

### DIFF
--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -275,7 +275,7 @@ func (c *ConnectClient) getTask(taskID types.TaskID, previous *taskDTO, log logg
 
 var buildRPattern = regexp.MustCompile("Building (Shiny application|Plumber API|R Markdown document).*")
 var buildPythonPattern = regexp.MustCompile("Building (.* application|.* API|Jupyter notebook).*")
-var launchPattern = regexp.MustCompile("Launching .* (application|API|notebook)")
+var launchPattern = regexp.MustCompile("Launching .*(Quarto|application|API|notebook)")
 var staticPattern = regexp.MustCompile("(Building|Launching) static content")
 
 func eventOpFromLogLine(currentOp events.Operation, line string) events.Operation {


### PR DESCRIPTION
This PR changes the regex for the `launchPattern` so that the line "Launching Quarto document..." is captured.

It removes the extra space since `.*` captures that already and was preventing "Launching Quarto" from being caught since there is only one space character.

## Intent
Resolves #1139 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->