### PR TITLE
Show publish/failure message in error notification

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -123,6 +123,8 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
           stage.status = LogStageStatus.neverStarted;
         }
       });
+
+      window.showErrorMessage(`Publish failed. ${msg.data.message}`);
       this.refresh();
     });
 


### PR DESCRIPTION
This PR shows a failure notification whenever a `publish/failure` event is received in the logs view.

![CleanShot 2024-03-18 at 14 12 57@2x](https://github.com/posit-dev/publisher/assets/19917631/dcf3af90-d5c8-43a6-986d-059abab71551)

## Intent
Resolves #1157 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->