### PR TITLE
Make Python inspection work better with pyenv

### DIFF
--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -54,6 +54,15 @@ func NewPythonInspector(base util.Path, pythonPath util.Path, log logging.Logger
 // be determined by the specified pythonExecutable,
 // or by `python3` or `python` on $PATH.
 func (i *defaultPythonInspector) InspectPython() (*config.Python, error) {
+	// Change into the project dir because the user might have
+	// .python-version there or in a parent directory, which will
+	// determine which Python version is run by pyenv.
+	oldWD, err := util.Chdir(i.base.String())
+	if err != nil {
+		return nil, err
+	}
+	defer util.Chdir(oldWD)
+
 	pythonVersion, err := i.getPythonVersion()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR has the Python config inspection cd into the project directory, matching how we scan for package requirements. This ensures that the configuration and the package list are both using the same Python when using pyenv and a `.python-version` file. Previously, this code assumed that the Python that runs only depends on `PATH`.

Fixes #1162 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
There isn't a unit test included here because we don't have pyenv available when unit testing. We should consider adding an integration test that uses pyenv.

## Directions for Reviewers
Validate the fix for #1162, and ensure that Python deployments not using pyenv also work as before.
