### PR TITLE
Add a Visit Deployment command to the deployment list

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -78,6 +78,12 @@
         "category": "Posit Publisher"
       },
       {
+        "command": "posit.publisher.deployments.visit",
+        "title": "View this deployment in Connect",
+        "icon": "$(link-external)",
+        "category": "Posit Publisher"
+      },
+      {
         "command": "posit.publisher.deployments.refresh",
         "title": "Refresh Deployments",
         "icon": "$(refresh)",
@@ -230,6 +236,11 @@
           "when": "view == posit.publisher.deployments"
         },
         {
+          "command": "posit.publisher.deployments.visit",
+          "when": "viewItem == posit.publisher.deployments.tree.item.deployment",
+          "group": "inline"
+        },
+          {
           "command": "posit.publisher.files.addExclusion",
           "when": "viewItem == posit.publisher.files.isIncludedFile",
           "group": "inline"

--- a/extensions/vscode/src/views/deployments.ts
+++ b/extensions/vscode/src/views/deployments.ts
@@ -2,41 +2,43 @@
 
 import {
   Event,
-  TreeDataProvider,
-  TreeItem,
-  ExtensionContext,
-  window,
-  WorkspaceFolder,
   EventEmitter,
-  workspace,
+  ExtensionContext,
   RelativePattern,
   ThemeIcon,
-  commands,
+  TreeDataProvider,
+  TreeItem,
   Uri,
+  WorkspaceFolder,
+  commands,
+  env,
+  window,
+  workspace,
 } from 'vscode';
 
 import {
-  useApi,
+  AllDeploymentTypes,
   Deployment,
   DeploymentError,
-  isDeployment,
   PreDeployment,
-  isPreDeployment,
-  AllDeploymentTypes,
+  isDeployment,
   isDeploymentError,
+  isPreDeployment,
+  useApi,
 } from '../api';
 
-import { getSummaryStringFromError } from '../utils/errors';
-import { formatDateString } from '../utils/date';
 import { confirmForget } from '../dialogs';
+import { EventStream } from '../events';
 import { addDeployment } from '../multiStepInputs/addDeployment';
 import { publishDeployment } from '../multiStepInputs/deployProject';
-import { EventStream } from '../events';
+import { formatDateString } from '../utils/date';
+import { getSummaryStringFromError } from '../utils/errors';
 
 const viewName = 'posit.publisher.deployments';
 const refreshCommand = viewName + '.refresh';
 const editCommand = viewName + '.edit';
 const forgetCommand = viewName + '.forget';
+const visitCommand = viewName + '.visit';
 const addCommand = viewName + '.add';
 const deployCommand = viewName + '.deploy';
 const isEmptyContext = viewName + '.isEmpty';
@@ -136,8 +138,16 @@ export class DeploymentsTreeDataProvider implements TreeDataProvider<Deployments
         if (ok) {
           await this.api.deployments.delete(item.deployment.deploymentName);
         }
+      }),
+      commands.registerCommand(visitCommand, async (item: DeploymentsTreeItem) => {
+        // This command is only registered for Deployments
+        if (isDeployment(item.deployment)) {
+          const uri = Uri.parse(item.deployment.dashboardUrl, true);
+          await env.openExternal(uri);
+        }
       })
     );
+
 
     if (this.root !== undefined) {
       const watcher = workspace.createFileSystemWatcher(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR adds a "Visit" command to the items in the Deployments tree view.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

I also ran "organize imports"; the imports are sorted which appears in the diff. Importing `env` from VSCode is the only new import.

## Directions for Reviewers
Try visiting a deployment using the new treeview item icon (the "external link" icon next to the Deploy symbol).

![image](https://github.com/posit-dev/publisher/assets/2903390/2849e8cf-7a7e-42ac-8797-667b55a2a6e1)
