### PR TITLE
Add information message with Visit option on deployment success

### DIFF
--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -1,8 +1,8 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { window, ProgressLocation } from 'vscode';
-import { EventStream, EventStreamMessage, UnregisterCallback } from '../events';
+import { ProgressLocation, Uri, env, window } from 'vscode';
 import { eventTypeToString } from '../api';
+import { EventStream, EventStreamMessage, UnregisterCallback } from '../events';
 
 export function deployProject(localID: string, stream: EventStream) {
   window.withProgress({
@@ -266,11 +266,18 @@ export function deployProject(localID: string, stream: EventStream) {
     );
 
     registrations.push(
-      stream.register('publish/success', (msg: EventStreamMessage) => {
+      stream.register('publish/success', async (msg: EventStreamMessage) => {
         if (localID === msg.data.localId) {
           unregiserAll();
           progress.report({ increment: 100, message: "Deployment was successful" });
           resolveCB('Success!');
+
+          let visitOption = "Visit";
+          const selection = await window.showInformationMessage("Deployment was successful", visitOption);
+          if (selection === visitOption) {
+            const uri = Uri.parse(msg.data.dashboardUrl, true);
+            await env.openExternal(uri);
+          }
         }
       })
     );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR uses `window.showInformationMessage` to show the user a deployment success message with a `Visit` button so they can easily view their content in Connect as soon as it's deployed. This window is shown immediately after the progress window is closed.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers
Deploy, and see the window pop up in the bottom right. Try clicking the Visit button (or just closing the window).
