### PR TITLE
Switch deployment progress bar from discrete progress to general progress

### DIFF
--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -26,21 +26,15 @@ export function deployProject(localID: string, stream: EventStream) {
     registrations.push(
       stream.register('publish/start', (msg: EventStreamMessage) => {
         if (localID === msg.data.localId) {
-          progress.report({ increment: 0 });
           progress.report({ message: "Starting to Deploy..." });
         }
       })
     );
 
-    let progressCount = 0;
     const handleProgressMessages = (msg: EventStreamMessage) => {
       if (localID === msg.data.localId) {
         const progressStr = eventTypeToString(msg.type);
-        if (progressCount < 90) {
-          progressCount += 1;
-        }
         progress.report({
-          increment: progressCount,
           message: progressStr,
         });
         console.log(progressStr);
@@ -272,7 +266,9 @@ export function deployProject(localID: string, stream: EventStream) {
       stream.register('publish/success', async (msg: EventStreamMessage) => {
         if (localID === msg.data.localId) {
           unregiserAll();
-          progress.report({ increment: 100, message: "Deployment was successful" });
+          progress.report({
+            message: "Deployment was successful",
+          });
           resolveCB('Success!');
 
           let visitOption = "Visit";
@@ -289,7 +285,9 @@ export function deployProject(localID: string, stream: EventStream) {
       stream.register('publish/failure', (msg: EventStreamMessage) => {
         if (localID === msg.data.localId) {
           unregiserAll();
-          progress.report({ increment: 100, message: "Deployment process encountered an error " });
+          progress.report({
+            message: "Deployment process encountered an error",
+          });
           rejectCB('Error Encountered!');
         }
       })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

resolves #1172 

This PR changes from the incremental progress bar to the pulsating progress status that VSCode suggests using when you do not know the actual status of a long-running operation.

This is a quicker alternative than making the deployment steps known to the UX, so that progress can be correctly calculated.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

Just deploy.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
