### PR TITLE
Add `.cache/` to web gitignore

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,3 +1,5 @@
+.cache/
+
 # Logs
 logs
 videos


### PR DESCRIPTION
This is an incredibly small change that adds the `.cache/` ignore from the root `.gitignore` to the `web/.gitignore`. This is so Prettier can read it and avoid formatting the cached Cypress files.

Prettier [uses the gitignore](https://prettier.io/docs/en/ignore.html):

> By default prettier ignores files in version control systems directories (".git", ".sl", ".svn" and ".hg") and node_modules (unless the [--with-node-modules CLI option](https://prettier.io/docs/en/cli#--with-node-modules) is specified). Prettier will also follow rules specified in the ".gitignore" file if it exists in the same directory from which it is run.

## Intent
Part of #1030

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [x] Tooling           <!-- Build, CI, or release scripts and configuration -->
