### PR TITLE
Provide options to access logs on failure

### DIFF
--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -1,12 +1,8 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { ProgressLocation, Uri, commands, env, window } from "vscode";
+import { ProgressLocation, Uri, env, window } from "vscode";
 import { eventTypeToString } from "../api";
 import { EventStream, EventStreamMessage, UnregisterCallback } from "../events";
-
-const showPublisherLogsCommand =
-  "workbench.action.output.show.extension-output-posit.publisher-#1-Posit Publisher";
-const showDeploymentLogsCommand = "posit.publisher.logs.focus";
 
 export function deployProject(localID: string, stream: EventStream) {
   window.withProgress(
@@ -420,29 +416,13 @@ export function deployProject(localID: string, stream: EventStream) {
       );
 
       registrations.push(
-        stream.register("publish/failure", async (msg: EventStreamMessage) => {
+        stream.register("publish/failure", (msg: EventStreamMessage) => {
           if (localID === msg.data.localId) {
             unregiserAll();
             progress.report({
               message: "Deployment process encountered an error",
             });
             rejectCB("Error Encountered!");
-
-            let deploymentLogsOption = "Deployment Logs";
-            let debugLogsOption = "Debug Logs";
-            const selection = await window.showInformationMessage(
-              "Deployment process encountered an error",
-              deploymentLogsOption,
-              debugLogsOption,
-            );
-            switch (selection) {
-              case deploymentLogsOption:
-                await commands.executeCommand(showDeploymentLogsCommand);
-                break;
-              case debugLogsOption:
-                await commands.executeCommand(showPublisherLogsCommand);
-                break;
-            }
           }
         }),
       );

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -57,6 +57,7 @@ const createLogStage = (
 
 const viewName = "posit.publisher.logs";
 const visitCommand = viewName + ".visit";
+const showDeploymentLogsCommand = "posit.publisher.logs.focus";
 
 /**
  * Tree data provider for the Logs view.
@@ -123,7 +124,7 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       this.refresh();
     });
 
-    stream.register("publish/failure", (msg: EventStreamMessage) => {
+    stream.register("publish/failure", async (msg: EventStreamMessage) => {
       this.publishingStage.status = LogStageStatus.failed;
       this.publishingStage.events.push(msg);
 
@@ -133,7 +134,14 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
         }
       });
 
-      window.showErrorMessage(`Publish failed. ${msg.data.message}`);
+      let showLogsOption = "Show Logs";
+      const selection = await window.showErrorMessage(
+        `Publish failed. ${msg.data.message}`,
+        showLogsOption,
+      );
+      if (selection === showLogsOption) {
+        await commands.executeCommand(showDeploymentLogsCommand);
+      }
       this.refresh();
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR provides notification on deployment failure, similar to what we do for success with the "Visit" button. The info notification window provides buttons to show the deployment (summarized) logs or the Publisher debug logs in the output panel.

Fixes #1202

<img width="542" alt="image" src="https://github.com/posit-dev/publisher/assets/2903390/21427b99-3107-4f18-8db9-7300b4ffeea3">


## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [x] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
Similar to the success notification - pass options to `window.showInformationMessage` and see which one is selected.

## Directions for Reviewers
Fail some deployments (request Python 3.99.99?) and see the notification message.

Note: Right now there isn't a way to click both buttons, and the window is dismissed once the first button is pressed.
