### PR TITLE
Remove TypeScript Vue extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,5 @@
     "recommendations": [
         "dbaeumer.vscode-eslint",
         "vue.volar",
-        "vue.vscode-typescript-vue-plugin",
     ]
 }


### PR DESCRIPTION
Removes the TypeScript Vue plugin recommendation since it is now deprecated: https://github.com/vuejs/language-tools/releases/tag/v2.0.0

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [x] Tooling           <!-- Build, CI, or release scripts and configuration -->
