### PR TITLE
Remove an errant $ in `upload.bash`

### DIFF
--- a/scripts/upload.bash
+++ b/scripts/upload.bash
@@ -73,7 +73,7 @@ do
     else
       if [ $release_type == "nightly" ]; 
       then
-        object="$object_path/v$$today/$(basename $(./scripts/get-vscode-extension-path.bash "$name" "$today" "$os" "$arch"))"
+        object="$object_path/v$today/$(basename $(./scripts/get-vscode-extension-path.bash "$name" "$today" "$os" "$arch"))"
       else
         object="$object_path/$(basename "$extension")"
       fi 


### PR DESCRIPTION
There was one extra `$`, leading to uploads like `s3://posit-publisher/publisher/releases/nightly/v1today/publisher-2024-03-27-darwin-amd64.vsix`

## Intent
Remove the exra `$`

## Type of Change
* - [X] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
␡

## Automated Tests
None, though I wonder if this might be a sign that moving some of the finicky bits into something more easily testable would be a good thing?

## Directions for Reviewers

## Checklist
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
