### PR TITLE
Register tree data providers before awaiting server startup

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -83,20 +83,22 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   const port = await ports.acquire();
-  service = new Service(context, port);
-  await service.start();
-
   const stream = new EventStream(port);
   context.subscriptions.push(stream);
 
+  service = new Service(context, port);
+  const apiReady = service.isUp();
+
   new ProjectTreeDataProvider().register(context);
-  new DeploymentsTreeDataProvider(stream).register(context);
-  new ConfigurationsTreeDataProvider().register(context);
-  new FilesTreeDataProvider().register(context);
-  new RequirementsTreeDataProvider().register(context);
-  new CredentialsTreeDataProvider().register(context);
+  new DeploymentsTreeDataProvider(stream, apiReady).register(context);
+  new ConfigurationsTreeDataProvider(apiReady).register(context);
+  new FilesTreeDataProvider(apiReady).register(context);
+  new RequirementsTreeDataProvider(apiReady).register(context);
+  new CredentialsTreeDataProvider(apiReady).register(context);
   new HelpAndFeedbackTreeDataProvider().register(context);
   new LogsTreeDataProvider(stream).register(context);
+
+  await service.start();
 
   setStateContext(PositPublishState.initialized);
 }

--- a/extensions/vscode/src/servers.ts
+++ b/extensions/vscode/src/servers.ts
@@ -92,7 +92,7 @@ export class Server implements vscode.Disposable {
    * @returns {Promise<boolean>} A Promise that resolves to `true` if the server is up, and rejects if all attempts fail.
    * @throws {Error} Will throw an error if the connection check encounters an error or reaches the maximum number of retries.
    */
-  private async isUp(): Promise<boolean> {
+  async isUp(): Promise<boolean> {
     const operation = retry.operation();
     return new Promise(async (resolve, reject) => {
       // Attempt the operation with exponential backoff
@@ -122,7 +122,7 @@ export class Server implements vscode.Disposable {
    * @returns {Promise<boolean>} A Promise that resolves to `true` if the server is down, and rejects if all attempts fail.
    * @throws {Error} Will throw an error if the connection check encounters an error (excluding ECONNREFUSED) or reaches the maximum number of retries.
    */
-  private async isDown(): Promise<boolean> {
+  async isDown(): Promise<boolean> {
     const operation = retry.operation();
     return new Promise(async (resolve, reject) => {
       // Attempt the operation with exponential backoff

--- a/extensions/vscode/src/services.ts
+++ b/extensions/vscode/src/services.ts
@@ -25,6 +25,10 @@ export class Service implements vscode.Disposable {
     await this.server.start(this.context);
   };
 
+  isUp = () => {
+    return this.server.isUp();
+  };
+
   open = async () => {
     // re-run the start sequence in case the server has stopped.
     await this.server.start(this.context);

--- a/extensions/vscode/src/views/configurations.ts
+++ b/extensions/vscode/src/views/configurations.ts
@@ -53,7 +53,7 @@ export class ConfigurationsTreeDataProvider
   readonly onDidChangeTreeData: ConfigurationEvent =
     this._onDidChangeTreeData.event;
 
-  constructor() {
+  constructor(private apiReady: Promise<boolean>) {
     const workspaceFolders = workspace.workspaceFolders;
     if (workspaceFolders !== undefined) {
       this.root = workspaceFolders[0];
@@ -78,6 +78,7 @@ export class ConfigurationsTreeDataProvider
     }
 
     try {
+      await this.apiReady;
       const response = await api.configurations.getAll();
       const configurations = response.data;
       await this.setContextIsEmpty(configurations.length === 0);

--- a/extensions/vscode/src/views/credentials.ts
+++ b/extensions/vscode/src/views/credentials.ts
@@ -30,7 +30,7 @@ export class CredentialsTreeDataProvider
   readonly onDidChangeTreeData: CredentialEvent =
     this._onDidChangeTreeData.event;
 
-  constructor() {}
+  constructor(private apiReady: Promise<boolean>) {}
 
   getTreeItem(element: CredentialsTreeItem): TreeItem | Thenable<TreeItem> {
     return element;
@@ -44,6 +44,7 @@ export class CredentialsTreeDataProvider
     }
 
     try {
+      await this.apiReady;
       const response = await api.accounts.getAll();
       const result = response.data.map((account) => {
         return new CredentialsTreeItem(account);

--- a/extensions/vscode/src/views/deployments.ts
+++ b/extensions/vscode/src/views/deployments.ts
@@ -60,7 +60,10 @@ export class DeploymentsTreeDataProvider
 
   private api = useApi();
 
-  constructor(private stream: EventStream) {
+  constructor(
+    private stream: EventStream,
+    private apiReady: Promise<boolean>,
+  ) {
     const workspaceFolders = workspace.workspaceFolders;
     if (workspaceFolders !== undefined) {
       this.root = workspaceFolders[0];
@@ -93,6 +96,7 @@ export class DeploymentsTreeDataProvider
       // API Returns:
       // 200 - success
       // 500 - internal server error
+      await this.apiReady;
       const response = await this.api.deployments.getAll();
       const deployments = response.data;
       commands.executeCommand(

--- a/extensions/vscode/src/views/files.ts
+++ b/extensions/vscode/src/views/files.ts
@@ -60,7 +60,7 @@ export class FilesTreeDataProvider implements TreeDataProvider<TreeEntries> {
 
   private api = useApi();
 
-  constructor() {
+  constructor(private apiReady: Promise<boolean>) {
     const workspaceFolders = workspace.workspaceFolders;
     this.root = Uri.parse("positPublisherFiles://unknown");
     if (workspaceFolders !== undefined) {
@@ -80,6 +80,7 @@ export class FilesTreeDataProvider implements TreeDataProvider<TreeEntries> {
     if (element === undefined) {
       // first call.
       try {
+        await this.apiReady;
         const response = await this.api.files.get();
         const file = response.data;
 

--- a/extensions/vscode/src/views/requirements.ts
+++ b/extensions/vscode/src/views/requirements.ts
@@ -43,7 +43,7 @@ export class RequirementsTreeDataProvider
   readonly onDidChangeTreeData: RequirementsEvent =
     this._onDidChangeTreeData.event;
 
-  constructor() {
+  constructor(private apiReady: Promise<boolean>) {
     const workspaceFolders = workspace.workspaceFolders;
     if (workspaceFolders !== undefined) {
       this.root = workspaceFolders[0];
@@ -67,6 +67,7 @@ export class RequirementsTreeDataProvider
       return [];
     }
     try {
+      await this.apiReady;
       const response = await api.requirements.getAll();
       await this.setContextIsEmpty(false);
       return response.data.requirements.map(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR moves the API server startup to after the tree data providers are registered. This eliminates the time period where the views are visible, and VSCode shows a placeholder message stating that there's no data provider for the view.

Fixes #1090

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [x] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [ ] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
The providers that need the API accept a promise (created from `server.isUp` which they await in `getChildren`.

## Directions for Reviewers
Try to look at the extension views during startup. Reload window if needed You should never see a message that there is no data provider for the view. 
