### PR TITLE
Set initial visibility of extension sections to collapsed

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -352,6 +352,7 @@
           "name": "Deployment Files",
           "contextualTitle": "Publisher",
           "icon": "$(symbol-file)",
+          "visibility": "collapsed",
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized'"
         },
         {
@@ -359,6 +360,7 @@
           "name": "Requirements",
           "contextualTitle": "Publisher",
           "icon": "$(package)",
+          "visibility": "collapsed",
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized'"
         },
         {
@@ -366,6 +368,7 @@
           "name": "Configurations",
           "contextualTitle": "Publisher",
           "icon": "$(gear)",
+          "visibility": "collapsed",
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized'"
         },
         {
@@ -373,6 +376,7 @@
           "name": "Credentials",
           "contextualTitle": "Publisher",
           "icon": "$(key)",
+          "visibility": "collapsed",
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized'"
         },
         {
@@ -380,6 +384,7 @@
           "name": "Deployments",
           "contextualTitle": "Publisher",
           "icon": "$(cloud-upload)",
+          "visibility": "collapsed",
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized'"
         },
         {
@@ -387,6 +392,7 @@
           "name": "Help And Feedback",
           "contextualTitle": "Publisher",
           "icon": "$(info)",
+          "visibility": "collapsed",
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized'"
         }
       ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves: #1196 

For the FIRST time a user opens a particular folder project, VSCode will use the initial settings to show the publisher views as collapsed:
![2024-03-29 at 10 51 AM](https://github.com/posit-dev/publisher/assets/17675905/774a379e-e346-4334-9a03-10cd3ac875e6)

If they have opened the project earlier, then it will not use the initial settings, but be instead left at the state where they last interacted with them.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

* - [ ] Bug Fix           <!-- A change which fixes an existing issue -->
* - [ ] New Feature       <!-- A change which adds additional functionality -->
* - [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
* - [ ] Documentation     <!-- User or developer documentation -->
* - [x] Refactor          <!-- Code restructuring -->
* - [ ] Tooling           <!-- Build, CI, or release scripts and configuration -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Initial viewing state of Publisher Views all set to Collapsed for the initial viewing of a project.

Please note that VSCode makes it EXTREMELY difficult to reset views of a project that you have opened back to the same initial state as you first opened them. The change contained within this PR only affects that initial state and is instantly (and permanently) overridden by user actions.

To verify this, you must create a new project (I suggest copying one of our sample content projects in `/test/sample-content/`) and open that folder with the extension. If you do this, you should then see all of the sections collapsed as was shown above.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
