### PR TITLE
Rename error field in pre-deployment API response

### DIFF
--- a/extensions/vscode/src/api/types/deployments.ts
+++ b/extensions/vscode/src/api/types/deployments.ts
@@ -28,11 +28,11 @@ type DeploymentRecord = {
   saveName: string;
   createdAt: string;
   configurationName: string;
+  deploymentError: AgentError | null;
 } & DeploymentLocation;
 
 export type PreDeployment = {
   state: DeploymentState.NEW;
-  error: AgentError | null;
 } & DeploymentRecord;
 
 export type Deployment = {
@@ -44,7 +44,6 @@ export type Deployment = {
   files: string[];
   deployedAt: string;
   state: DeploymentState.DEPLOYED;
-  deploymentError: AgentError | null;
 } & DeploymentRecord &
   Configuration;
 
@@ -56,10 +55,10 @@ export function isSuccessful(
   if (d === undefined) {
     return undefined;
   }
-  if (isDeployment(d)) {
-    return Boolean(!d.deploymentError);
+  if (isDeploymentError(d)) {
+    return false;
   }
-  return Boolean(!d.error);
+  return Boolean(!d.deploymentError);
 }
 
 export function isUnsuccessful(

--- a/internal/services/api/deployment_dto.go
+++ b/internal/services/api/deployment_dto.go
@@ -31,7 +31,7 @@ type preDeploymentDTO struct {
 	ServerURL  string              `json:"serverUrl"`
 	SaveName   string              `json:"saveName"`
 	CreatedAt  string              `json:"createdAt"`
-	Error      *types.AgentError   `json:"error,omitempty"`
+	Error      *types.AgentError   `json:"deploymentError,omitempty"`
 }
 
 type fullDeploymentDTO struct {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR fixes the usage of the `error` field in the deployments API responses. Front-end types and the `isSuccessful` function on deployments have been updated to match.

Fixes #1247 

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

There are two error-related fields in the deployment API responses:
* `error` is used in an error response, to indicate that the deployment can't be loaded (for example, because it has invalid TOML syntax). There is no deployment record returned.
* `deploymentError` is part of the deployment record and is used to indicate that the last deployment attempt ended with an error. The record itself is valid (no `error`).

Currently, pre-deployments are putting their "last deployment error" in the `error` field. 

## Automated Tests

API tests don't cover DTO field naming; they decode into a DTO object and assert field values. So this is not covered by a test.

## Directions for Reviewers

The deployments part of the UI should show the correct icon if a deployment file includes an error. For example, if your deployment record contains:
```
[deployment-error]
code = 'pythonNotAvailable'
message = "Python 3.99 is not available on the server.\nConsider editing your configuration file to request one of the available versions:\n3.8.1, 3.9.7, 3.10.10, 3.11.3."
operation = 'publish/checkCapabilities'
```

You should see the "deployment failed" icon
<img width="29" alt="image" src="https://github.com/posit-dev/publisher/assets/2903390/f5a35824-63ed-4e17-8bb6-73df8b4effc5">

not the "invalid file" icon
<img width="29" alt="image" src="https://github.com/posit-dev/publisher/assets/2903390/def74ad5-f53c-43a6-a98a-6e5eee407adf">

