### PR TITLE
Fix tsconfig to use DOM lib with Vue

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -163,7 +163,6 @@ import {
   Deployment,
   PreDeployment,
   isPreDeployment,
-  isDeployment,
 } from "../../../src/api/types/deployments";
 import { formatDateString } from "../../../../../web/src/utils/date";
 import { Account } from "../../../src/api/types/accounts";
@@ -178,10 +177,6 @@ provideVSCodeDesignSystem().register(
   vsCodeProgressRing(),
   vsCodeDivider(),
 );
-
-// need access to the global window variable
-// in order to access addEventListener
-declare var window: any;
 
 let deployments = ref<(Deployment | PreDeployment)[]>([]);
 let deploymentList = ref<string[]>([]);

--- a/extensions/vscode/webviews/homeView/tsconfig.json
+++ b/extensions/vscode/webviews/homeView/tsconfig.json
@@ -1,11 +1,15 @@
 {
-  "extends": ["@tsconfig/node18/tsconfig.json", "@vue/tsconfig/tsconfig.json"],
+  "extends": [
+    "@tsconfig/node18/tsconfig.json",
+    "@vue/tsconfig/tsconfig.dom.json"
+  ],
   "include": ["src/**/*", "src/**/*.vue"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
       "src/*": ["./src/*"]
     },
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "types": ["@types/vscode-webview"]
   }
 }


### PR DESCRIPTION
We can see in our `web` directory that we should have the `DOM` and `DOM.Iterable` in the webview / Vue TSConfig. We can use Vue's `tsconfig.dom.json` for this so we can access the DOM functions without explicitly typing them. 

We can see the `DOM` and `DOM.Iterable` in the `lib` in the [Vue / Vite template too](https://stackblitz.com/edit/vitejs-vite-mtgxmx?file=tsconfig.json&terminal=dev).

However `tsconfig.dom.json` empties the types array

> Set to empty to avoid accidental inclusion of unwanted types

This breaks `acquireVsCodeApi` so we can tell TSConfig that when in Vue components we should have access to it by included its types.