### PR TITLE
Add aria-labels to icon only buttons

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -21,6 +21,11 @@
             border-top-left-radius: unset;
             border-bottom-left-radius: unset;
           "
+          :aria-label="
+            showDetails
+              ? 'Collapse Deployment Selection Details'
+              : 'Expand Deployment Selection Details'
+          "
         >
           <span :class="buttonIconClass"></span>
         </vscode-button>
@@ -31,7 +36,11 @@
       <div>
         <div class="label-and-icons">
           <label for="deployment-selector">Deployment:</label>
-          <vscode-button appearance="icon" class="action-icons">
+          <vscode-button
+            appearance="icon"
+            class="action-icons"
+            aria-label="Add Deployment"
+          >
             <span
               class="codicon codicon-add"
               @click="onClickAddDeployment"
@@ -57,13 +66,21 @@
         <div class="label-and-icons">
           <label for="config-selector">Configuration:</label>
           <div class="action-icons-container">
-            <vscode-button appearance="icon" class="action-icons">
+            <vscode-button
+              appearance="icon"
+              class="action-icons"
+              aria-label="Edit Selected Configuration"
+            >
               <span
                 class="codicon codicon-edit"
                 @click="onClickEditConfiguration"
               ></span>
             </vscode-button>
-            <vscode-button appearance="icon" class="action-icons">
+            <vscode-button
+              appearance="icon"
+              class="action-icons"
+              aria-label="Add Configuration"
+            >
               <span
                 class="codicon codicon-add"
                 @click="onClickAddConfiguration"


### PR DESCRIPTION
Adds `aria-label`s to all of the icon-only buttons in the webview.

## Intent

Resolves #1279

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
