### PR TITLE
Use border-box box-sizing in webview

### DIFF
--- a/extensions/vscode/webviews/homeView/src/main.ts
+++ b/extensions/vscode/webviews/homeView/src/main.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { createApp, inject } from "vue";
+import { createApp } from "vue";
 import App from "./App.vue";
 import {
   provideVSCodeDesignSystem,
@@ -10,6 +10,8 @@ import {
   vsCodeProgressRing,
   vsCodeDivider,
 } from "@vscode/webview-ui-toolkit";
+
+import "./style.css";
 
 // In order to use the Webview UI Toolkit web components they
 // must be registered with the browser (i.e. webview) using the

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -1,0 +1,5 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
This PR changes all elements in the webview to use [`box-sizing: border-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing#border-box). After inspection it doesn't look like this affected any of our current CSS and the webview looks exactly the same.

## Intent

- Resolves #1278 
