### PR TITLE
Use prettier as recommended vscode formatter

### DIFF
--- a/.vscode/recommended.settings.json
+++ b/.vscode/recommended.settings.json
@@ -1,12 +1,3 @@
 {
-  "eslint.format.enable": true,
-  "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[vue]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  }
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
A small change to use Prettier as our formatter in our recommended VSCode settings.