### PR TITLE
Set missing context on extension activate

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -79,7 +79,9 @@ export async function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(watcher);
 
-    // set our initial mode
+    setMissingContext(await isMissingPublishDirs(folder));
+
+    // set our initial mode for the home view
     commands.executeCommand(
       "setContext",
       "posit.publisher.homeView.deploymentActiveMode",


### PR DESCRIPTION
Looks like https://github.com/posit-dev/publisher/pull/1250 removed the `setMissingContext` call in the extension activation. This PR re-adds it to avoid skipping the initialization welcome view if the opened workspace folder isn't initiatlized.

## Intent

- Resolves #1290 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

Open up a un-initialized project (doesn't have `.posit` or `.posit/publish`). The initialization welcome view should be shown.

If those folders are not present ever the welcome view should be shown again.