### PR TITLE
Re-write VSCode docs for Alpha 5

### DIFF
--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -109,17 +109,15 @@ process. :tada:
 The Deployment Files view shows a list of the files in your project directory,
 divided into two lists:
 
-Included Files show the files that will be included in your deployment and
-sent to the server as part of the uploaded content. You can exclude a file by
-clicking the icon to the right of the filename.
-
+- Included Files show the files that will be included in your deployment and
+  sent to the server as part of the uploaded content. You can exclude a file by
+  clicking the icon to the right of the filename.
 - Excluded Files shows the files in your project that will not be included in
   the deployment. The tooltip on an excluded file will indicate the reason it
   was excluded.
 
 Exclusions are managed through a `.positignore` file in the root directory of
-your project. It is in the same format as a [`.gitignore` file](https://git-scm.com/docs/gitignore);
-however, negated patterns are not yet supported.
+your project. It is in the same format as a [`.gitignore` file](https://git-scm.com/docs/gitignore)
 
 ![](https://cdn.posit.co/publisher/assets/img/deployment-files-view.png)
 
@@ -168,7 +166,11 @@ Click the deploy icon next to a deployment, which will prompt you for your crede
 Lists the configurations in your project.
 
 Clicking a configuration will open the configuration file in the editor.
-Additionally, you can right-click on a configuration for more operations.
+Additionally, you can right-click on a configuration for more operations
+
+- Clone
+- Rename
+- Delete
 
 ![](https://cdn.posit.co/publisher/assets/img/configurations.png)
 


### PR DESCRIPTION
This PR re-writes the VSCode docs for Alpha 5.

## Intent

Resolves [#1265](https://github.com/posit-dev/publisher/issues/1265)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to keep the tutorial section and break out the details about each of the views into their own sections.

I also utilized [GitHub's Alerts for markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) where appropriate.

## Directions for Reviewers

Rather than looking at the diff, I'd recommend just looking at [the entire VSCode doc file in the rich preview mode](https://github.com/posit-dev/publisher/blob/7fe9264ed74f0b3978c3d19ad8c1f464b74d3c58/docs/vscode.md).
