### PR TITLE
Always save configuration in deployment record

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -216,6 +216,8 @@ func (p *defaultPublisher) writeDeploymentRecord(log logging.Logger) error {
 
 	now := time.Now().Format(time.RFC3339)
 	p.Target.DeployedAt = now
+	p.Target.ConfigName = p.ConfigName
+	p.Target.Configuration = p.Config
 
 	recordPath := deployment.GetDeploymentPath(p.Dir, p.SaveName)
 	return p.Target.WriteFile(recordPath)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -233,6 +233,7 @@ func (s *PublishSuite) publishWithClient(
 			URL: "https://connect.example.com",
 		},
 		Config:     cfg,
+		ConfigName: "myConfig",
 		Target:     target,
 		TargetName: targetName,
 		SaveName:   saveName,
@@ -268,9 +269,12 @@ func (s *PublishSuite) publishWithClient(
 		recordPath := deployment.GetDeploymentPath(stateStore.Dir, recordName)
 		record, err := deployment.FromFile(recordPath)
 		s.NoError(err)
+
 		s.Equal(myContentID, record.ID)
 		s.Equal(project.Version, record.ClientVersion)
 		s.NotEqual("", record.DeployedAt)
+		s.Equal("myConfig", record.ConfigName)
+		s.NotNil(record.Configuration)
 
 		if couldCreateDeployment {
 			logs := s.logBuffer.String()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR ensures that ConfigName and Configuration are populated in failed deployment records.

Fixes #1308 


## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Updated an existing unit test to verify this is happening in all cases.

## Directions for Reviewers

Start with a predeployment or existing deployment. Create a new configuration that will cause an error during deployment, and deploy using that configuration. Verify that the deployment record contains the name and contents of the new (bad) configuration.
