### PR TITLE
Initialize Project multi stepper

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -524,7 +524,7 @@
       },
       {
         "view": "posit.publisher.project",
-        "contents": "Before deploying using Posit Publisher, you need to initialize your project by creating a deployment configuration and a project configuration.\n[Initialize Project](command:posit.publisher.init-project)",
+        "contents": "Initialization of the Posit Publishing VSCode Extension is required for this project.\nThis initialization involves adding a Posit Publisher subdirectory within your workspace folder and creating two files within it.\n Click the Initialize Project button below to create:\n- a new subdirectory called .posit/publish\n- a default deployment file (Untitled-1.toml)\n- a default configuration file (default.toml)\n[Initialize Project](command:posit.publisher.init-project)",
         "when": "workbenchState == folder && posit.publish.initialization.credentialCheck == 'succeeded' && posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.inProgress === 'false'"
       },
       {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Initialize Project flow should create both a deployment file and a configuration file. 

If no credentials are available, then the welcome page should display a hard stop until there is at least one available.

resolves #1270 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

There is now a "hard-stop" welcome page which indicates when there are no credentials available on the system from either RSConnect or RSConnect-Python:
![2024-04-08 at 3 52 PM](https://github.com/posit-dev/publisher/assets/17675905/1d31967b-540c-4e8c-969b-e2a45335381d)

Once the user has defined credentials, they can click refresh on that page and we'll re-quesry credentials, and if the project has not been initialized with our `.posit/publish` subdirectory, they'll see this page:
![2024-04-08 at 3 55 PM](https://github.com/posit-dev/publisher/assets/17675905/7ed07e40-c890-4818-bd58-02d55ba486b3)

NOTE: The steps below are shown only if there are more than one choice to pick from. If you have only one credential or only one entry point, then those steps will be skipped.

Clicking `Initialize Project` button, will kick off the new init multi-stepper, which will update the welcome page and start the multi-step prompts:
![2024-04-08 at 3 56 PM](https://github.com/posit-dev/publisher/assets/17675905/730087ad-2542-4717-9a3e-e48cc1a67c30)
![2024-04-08 at 3 57 PM](https://github.com/posit-dev/publisher/assets/17675905/aa340402-ccf1-45ec-a4b6-c285cd53cff8)
![2024-04-08 at 3 57 PM](https://github.com/posit-dev/publisher/assets/17675905/e5236737-1d5e-4ffe-83e0-b08e3f05cf41)
![2024-04-08 at 3 57 PM](https://github.com/posit-dev/publisher/assets/17675905/9035056b-cd7e-4c11-8792-30586fd4bf24)

Pressing enter on the last step shown above, will transition to the Home View, where the button should now be enabled, since we have guaranteed there are credentials, a configuration and a deployment file.
![2024-04-08 at 3 58 PM](https://github.com/posit-dev/publisher/assets/17675905/81a645aa-d3e4-49d2-94fc-561f3aad04c1)

Like all of our multi-steppers, clicking away or hitting the ESC key, will abort the mutli-step process.

NOTE: The initialization multi-step flow is only activated if there is no `.posit/publish` subdirectory. The credentials requirement page is always displayed if there are no credentials on the system. We have chosen not to handle the scenarios where you are missing one of the files or if your credentials do not match the deployments. That will be handled in a future issue.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
You'll want to verify by:
1. remove the `.posit/publish` subdirectory as well as all of your credentials from RSConnect and RSConnect-Python.
2. Remove the `.posit/publish` subdirectory but only have one credential
3. With a `.posit/publish` subdirectory, but with no credentials
4. With an existing project, with credentials, deployments and configurations

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
