### PR TITLE
Make homeView `_refreshData` fully async

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -216,39 +216,27 @@ export class HomeViewProvider implements WebviewViewProvider {
 
   private async _refreshData() {
     try {
-      // API Returns:
-      // 200 - success
-      // 500 - internal server error
-      const response = await this.api.deployments.getAll();
-      const deployments = response.data;
+      const [deploymentsResponse, credentialsResponse, configurationsResponse] =
+        await Promise.all([
+          this.api.deployments.getAll(),
+          this.api.accounts.getAll(),
+          this.api.configurations.getAll(),
+        ]);
+
+      // deployments
+      const deployments = deploymentsResponse.data;
       this._deployments = [];
       deployments.forEach((deployment) => {
         if (!isDeploymentError(deployment)) {
           this._deployments.push(deployment);
         }
       });
-    } catch (error: unknown) {
-      const summary = getSummaryStringFromError(
-        "_refreshData::deployments.getAll",
-        error,
-      );
-      window.showInformationMessage(summary);
-    }
 
-    try {
-      const response = await this.api.accounts.getAll();
-      this._credentials = response.data;
-    } catch (error: unknown) {
-      const summary = getSummaryStringFromError(
-        "_refreshData::accounts.getAll",
-        error,
-      );
-      window.showInformationMessage(summary);
-    }
+      // credentials
+      this._credentials = credentialsResponse.data;
 
-    try {
-      const response = await this.api.configurations.getAll();
-      const configurations = response.data;
+      // configurations
+      const configurations = configurationsResponse.data;
       this._configs = [];
       configurations.forEach((config) => {
         if (!isConfigurationError(config)) {
@@ -257,7 +245,7 @@ export class HomeViewProvider implements WebviewViewProvider {
       });
     } catch (error: unknown) {
       const summary = getSummaryStringFromError(
-        "configurations::getChildren",
+        "HomeViewProvider::_refreshData",
         error,
       );
       window.showInformationMessage(summary);


### PR DESCRIPTION
Holding until Alpha 5 releases.

This PR changes up the `_refreshData` function in the `HomeViewProvider` to be fully async without synchronously calling the API.

## Intent

Part of #1276

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

There are a few ways to do this, but the one I went with for this code block was using [`Promise.all()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all). Here are the reasons why:

Promise.all()` waits for each promise to be fulfilled before continuing, but in this case allows all of our API calls to make their requests at once

`Promise.all()` fails with the first rejection
This code block doesn't really care too much about how to handle each failure. They all handle it the same way, the only difference was the code that triggered it. In this case I just changed the string to be more general to this function as opposed to the API call that caused it.