### PR TITLE
Set inner PSelect selection to computed ref

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/PSelect.vue
+++ b/extensions/vscode/webviews/homeView/src/components/PSelect.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts" generic="T">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 const model = defineModel<T>();
 
@@ -23,13 +23,12 @@ const props = defineProps<{
   disabled?: T[];
 }>();
 
-const _selection = ref<string | undefined>(
-  model.value !== undefined ? props.getKey(model.value) : undefined,
-);
+const _selection = computed<string | undefined>(() => {
+  return model.value !== undefined ? props.getKey(model.value) : undefined;
+});
 
 const onInnerSelectionChange = (event: Event) => {
   const el = event.target as HTMLSelectElement;
-  _selection.value = el.value;
 
   model.value = props.options.find(
     (option) => props.getKey(option) === el.value,


### PR DESCRIPTION
The `PSelect` was working great when using the `vscode-dropdown` but when the `v-model` ref was updated programmatically by the parent it wasn't reflecting in the inner `_selection` ref in `PSelect`.

To fix this I changed `_selection` to a `computed` ref so it was always based on the `model.value` instead of maintaining its own value.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->