### PR TITLE
Only show config edit if config selected

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -65,8 +65,9 @@
       <div>
         <div class="label-and-icons">
           <label for="config-selector">Configuration:</label>
-          <div class="action-icons-container">
+          <div>
             <vscode-button
+              v-if="selectedConfig"
               appearance="icon"
               class="action-icons"
               aria-label="Edit Selected Configuration"


### PR DESCRIPTION
Removes the Configuration edit button in the Home view when there is no Configuration selected.

## Intent

Resolves #1316

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

There isn't a way to unselect a configuration other than deleting all potential options.
