### PR TITLE
Error if ESLint discovers warnings

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -505,7 +505,7 @@
     "compile-extension": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
-    "lint": "eslint src --ext ts",
+    "lint": "eslint src --ext ts --max-warnings 0",
     "compile-deploy-selector": "npm run --prefix webviews/homeView compile",
     "test": "node ./out/test/runTest.js"
   },

--- a/test/cy/package.json
+++ b/test/cy/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "lint": "eslint --ext .js,.ts,.cjs .",
+    "lint": "eslint --ext .js,.ts,.cjs --max-warnings 0 .",
     "fix": "eslint --ext .js,.ts,.cjs . --fix",
     "init": "just ../../run init ./test/sample-content/fastapi-simple",
     "start": "just ../../run ui --listen 127.0.0.1:9000 ./test/sample-content/fastapi-simple",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint --ext .js,.ts,.vue,.cjs .",
+    "lint": "eslint --ext .js,.ts,.vue,.cjs --max-warnings 0 .",
     "fix": "eslint --ext .js,.ts,.vue,.cjs . --fix",
     "test": "vitest run",
     "watch": "vitest"


### PR DESCRIPTION
This PR uses [ESLint's `--max-warnings` flag](https://eslint.org/docs/latest/use/command-line-interface#--max-warnings) to exit with an error if any warnings are detected.

Currently we have no warnings so this will pass, but if a warning is ever brought it this will cause our CI to fail.

## Intent

Follow-up to https://github.com/posit-dev/publisher/pull/1324#discussion_r1558206380

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->