### PR TITLE
Force re-render of PSelect when props change

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/PSelect.vue
+++ b/extensions/vscode/webviews/homeView/src/components/PSelect.vue
@@ -1,5 +1,9 @@
 <template>
-  <vscode-dropdown :value="_selection" @change="onInnerSelectionChange">
+  <vscode-dropdown
+    :key="renderKey"
+    :value="_selection"
+    @change="onInnerSelectionChange"
+  >
     <vscode-option
       v-for="option in stringifiedOptions"
       :key="option"
@@ -13,7 +17,7 @@
 </template>
 
 <script setup lang="ts" generic="T">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 const model = defineModel<T>();
 
@@ -22,6 +26,16 @@ const props = defineProps<{
   getKey: (o: T) => string;
   disabled?: T[];
 }>();
+
+const renderKey = ref(0);
+
+const forceRerender = () => {
+  renderKey.value += 1;
+};
+
+// Force a re-render when props change to avoid showing incorrect selection
+// https://github.com/microsoft/fast/issues/5773
+watch(props, forceRerender);
 
 const _selection = computed<string | undefined>(() => {
   return model.value !== undefined ? props.getKey(model.value) : undefined;


### PR DESCRIPTION
Force re-render of `PSelect` when props change to avoid `vscode-dropdown` the index selection visual bug.

## Intent

Resolves #1349

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was after attempts to create our own dropdown detailed in #1349.

What gets this to work is [`:key`](https://vuejs.org/api/built-in-special-attributes.html#key).

> It can also be used to force replacement of an element/component instead of reusing it. This can be useful when you want to:
> - Properly trigger lifecycle hooks of a component
> - Trigger transitions

So when `:key` changes on the `vscode-dropdown` Vue will completely replace it. When props change we change the key causing a full re-render avoiding [the bug causing this](https://github.com/microsoft/fast/issues/5773) entirely.

Iterating from `0` can be done because:

> Children of the same common parent must have unique keys. Duplicate keys will cause render errors.

Meaning as long as the number is unique in `PSelect` we are good.

## Directions for Reviewers

This one is tough to review. I recommend adding the below to `App.vue` when testing this locally:

```vue
 {{ selectedDeployment?.saveName || "Nothing Selected" }}
```

That way you can see the true value of `selectedDeployment` and see if the `PSelect` is showing the right value.

To reproduce the bug that this fixes you can:

1. Have a single Deployment named `quarto`
2. Open the Home View ensuring `quarto` is selected
3. Open the Deployments view and create a `python` deployment

Because `python` is before `quarto` alphabetically the `vscode-dropdown` would visually change the selection (but only visually) to `python`. With this PR it will show the correct value.
