### PR TITLE
Set homeView body padding to 0 for Trees

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -475,6 +475,10 @@ const onMessageFromProvider = (event: any) => {
 </script>
 
 <style lang="scss" scoped>
+main {
+  padding: 0 20px;
+}
+
 .roomy {
   margin: 0.5rem 0;
 }

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -3,3 +3,7 @@
 *::after {
   box-sizing: border-box;
 }
+
+body {
+  padding: 0;
+}


### PR DESCRIPTION
Really small PR that sets the padding for the home view's body to `0` so the Tree webview components can be full-width.

To get the same styling we have now I moved the default padding styling to the `main` element in the home view's `App.vue`.

## Intent

Part of #1333
