### PR TITLE
Create expanding `TreeSection`

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="pane" :class="{ expanded: expanded }">
+    <div
+      class="pane-header"
+      :class="{ expanded: expanded }"
+      @click="expanded = !expanded"
+    >
+      <div
+        class="twisty-container codicon"
+        :class="expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'"
+      />
+      <h3 class="title">{{ title }}</h3>
+    </div>
+    <div v-if="expanded" class="pane-body">
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo ad adipisci
+      veniam rerum id dicta quos voluptatum ab voluptatem quibusdam hic totam,
+      voluptate reiciendis odit consequatur iste blanditiis harum error! Lorem
+      ipsum dolor sit amet consectetur adipisicing elit. Autem, veritatis!
+      Quidem sequi reiciendis reprehenderit at, iure blanditiis veritatis quod
+      amet eveniet sed officia accusamus vel enim tempora. Enim, eligendi ipsa.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const expanded = defineModel("expanded", { required: false, default: false });
+
+defineProps<{
+  title: string;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.pane-header {
+  line-height: 22px;
+  color: var(--vscode-sideBarSectionHeader-foreground);
+  background-color: var(--vscode-sideBarSectionHeader-background);
+  border-top: 1px solid var(--vscode-sideBarSectionHeader-border);
+  position: relative;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  font-size: 11px;
+  font-weight: 700;
+  height: 22px;
+  overflow: hidden;
+
+  .twisty-container {
+    margin: 0 2px;
+    font-size: 16px;
+    color: var(--vscode-icon-foreground);
+  }
+}
+
+.pane-body {
+  flex: 1;
+  overflow: hidden;
+}
+
+.title {
+  font-size: 11px;
+  min-width: 3ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+  -webkit-margin-before: 0;
+  -webkit-margin-after: 0;
+}
+</style>


### PR DESCRIPTION
This PR is the very start of the `TreeSection` component. It sets up the `title` prop, and `expanded` model.

![CleanShot 2024-04-17 at 12 29 50](https://github.com/posit-dev/publisher/assets/19917631/a631e92b-ba3a-48cb-ac81-5c816c401cac)


## Intent

Part of #1333

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

- `TreeSection` was the name I came up with to fufill the [Vue Multi-word Component rule](https://v2.vuejs.org/v2/style-guide/?redirect=true#Multi-word-component-names-essential)
- Setup a `model:expanded` to be able to set the initial expanded state, but also communicate / set it bi-directionally

Currently I'm pulling CSS from the Tree Views, but I plan to do a review of all the CSS before #1333 is closed out to remove any unnecessary or duplicate CSS rules / classes to make this easier to maintain.