### PR TITLE
Add `TreeSection` actions container styling

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="pane" :class="{ expanded: expanded }">
-    <div class="pane-header" tabindex="0" :class="{ expanded: expanded }">
+    <div
+      class="pane-header"
+      tabindex="0"
+      :class="{ expanded: expanded }"
+      @keydown.enter.self="toggleExpanded"
+    >
       <div class="pane-header-title-container" @click="toggleExpanded">
         <div
           class="twisty-container codicon"


### PR DESCRIPTION
This PR adds more functionality and styling to the `TreeSection`:
- Adds an `actions` container to place icons (currently hardcoded with one)
- Actions are only visible if the pane is hovered or focused just like other views
- Moves `@click` handling to the title only so clicking on an action doesn't cause `expanded` to be toggled
- Adds focus and hover styling to the actions and header
- Adds the ability to expand the `TreeSection` when it is focused, and `enter` is pressed

<details>
  <summary>Preview Video</summary>
  
  https://github.com/posit-dev/publisher/assets/19917631/35c1cba4-052a-4483-8e61-bd8feaaa59c3
</details> 

## Intent

Part of #1333 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
