### PR TITLE
Convert add Config command to use multistep framework

### DIFF
--- a/extensions/vscode/src/multiStepInputs/initWorkspace.ts
+++ b/extensions/vscode/src/multiStepInputs/initWorkspace.ts
@@ -138,7 +138,7 @@ export async function initWorkspace(
     };
     // determine number of total steps, as each step
     let totalSteps = 4;
-    if (configs.length === 1) {
+    if (entryPointListItems.length === 1) {
       totalSteps -= 1;
     }
     if (fixedDeploymentName) {
@@ -351,5 +351,4 @@ export async function initWorkspace(
     window.showErrorMessage(`Failed to create pre-deployment file. ${summary}`);
     return;
   }
-  return state.data.configFileName;
 }

--- a/extensions/vscode/src/multiStepInputs/newConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/newConfig.ts
@@ -1,0 +1,210 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import {
+  MultiStepInput,
+  MultiStepState,
+  isQuickPickItem,
+} from "./multiStepHelper";
+
+import {
+  InputBoxValidationSeverity,
+  QuickPickItem,
+  ThemeIcon,
+  Uri,
+  commands,
+  window,
+} from "vscode";
+
+import { useApi, ConfigurationDetails, Configuration } from "../api";
+import { getSummaryStringFromError } from "../utils/errors";
+import { untitledConfigurationName } from "../utils/names";
+import { isValidFilename } from "../utils/files";
+
+export async function newConfig(title: string) {
+  // ***************************************************************
+  // API Calls and results
+  // ***************************************************************
+  const api = await useApi();
+
+  let entryPointLabels: string[] = [];
+  let entryPointListItems: QuickPickItem[] = [];
+  const entryPointLabelMap = new Map<string, ConfigurationDetails>();
+  let configs: ConfigurationDetails[] = [];
+  try {
+    const inspectResponse = await api.configurations.inspect();
+    configs = inspectResponse.data;
+    entryPointLabels = configs.map((config) => `${config.entrypoint}`);
+    configs.forEach((config) => {
+      if (config.entrypoint) {
+        entryPointListItems.push({
+          iconPath: new ThemeIcon("file"),
+          label: config.entrypoint,
+          description: `(type ${config.type})`,
+        });
+      }
+    });
+    for (let i = 0; i < configs.length; i++) {
+      entryPointLabelMap.set(entryPointLabels[i], configs[i]);
+    }
+  } catch (error: unknown) {
+    const summary = getSummaryStringFromError(
+      "initWorkspace, configurations.inspect",
+      error,
+    );
+    window.showErrorMessage(
+      `Unable to continue with project inspection failure. ${summary}`,
+    );
+    return;
+  }
+  if (!entryPointListItems.length) {
+    window.showErrorMessage(
+      `Unable to continue with no project entrypoints found during inspection`,
+    );
+    return;
+  }
+
+  // ***************************************************************
+  // Order of all steps
+  // NOTE: This multi-stepper is used for multiple commands
+  // ***************************************************************
+
+  // Name the config file to use - if a fixedConfigurationName has not been supplied
+  // Return the name of the config file, so it can be opened.
+
+  // ***************************************************************
+  // Method which kicks off the multi-step.
+  // Initialize the state data
+  // Display the first input panel
+  // ***************************************************************
+  async function collectInputs() {
+    const state: MultiStepState = {
+      title: title,
+      step: -1,
+      lastStep: 0,
+      totalSteps: -1,
+      data: {
+        // each attribute is initialized to undefined
+        // to be returned when it has not been cancelled to assist type guards
+        entryPoint: undefined, /// eventual type is QuickPickItem
+        configFileName: undefined, // eventual type is string
+      },
+    };
+    // determine number of total steps, as each step
+    let totalSteps = 2;
+    if (entryPointListItems.length === 1) {
+      totalSteps -= 1;
+    }
+    state.totalSteps = totalSteps;
+
+    // start the progression through the steps
+
+    await MultiStepInput.run((input) => inputEntryPointSelection(input, state));
+    return state as MultiStepState;
+  }
+  // ***************************************************************
+  // Step #1:
+  // Select the config to be used w/ the deployment
+  // ***************************************************************
+  async function inputEntryPointSelection(
+    input: MultiStepInput,
+    state: MultiStepState,
+  ) {
+    // skip if we only have one choice.
+    if (entryPointListItems.length > 1) {
+      const thisStepNumber = state.lastStep + 1;
+      const pick = await input.showQuickPick({
+        title: state.title,
+        step: thisStepNumber,
+        totalSteps: state.totalSteps,
+        placeholder: "Select main file and type",
+        items: entryPointListItems,
+        buttons: [],
+        shouldResume: () => Promise.resolve(false),
+      });
+
+      state.data.entryPoint = pick;
+      state.lastStep = thisStepNumber;
+    } else {
+      state.data.entryPoint = entryPointListItems[0];
+    }
+    return (input: MultiStepInput) => inputConfigurationName(input, state);
+  }
+
+  // ***************************************************************
+  // Step #2:
+  // Name the configuration
+  // ***************************************************************
+  async function inputConfigurationName(
+    input: MultiStepInput,
+    state: MultiStepState,
+  ) {
+    const thisStepNumber = state.lastStep + 1;
+    const configFileName = await input.showInputBox({
+      title: state.title,
+      step: thisStepNumber,
+      totalSteps: state.totalSteps,
+      value: await untitledConfigurationName(),
+      prompt: "Choose a unique name for the configuration",
+      validate: (value) => {
+        if (value.length < 3 || !isValidFilename(value)) {
+          return Promise.resolve({
+            message: `Invalid Name: Value must be longer than 3 characters, cannot be '.' or contain '..' or any of these characters: /:*?"<>|\\`,
+            severity: InputBoxValidationSeverity.Error,
+          });
+        }
+        return Promise.resolve(undefined);
+      },
+      shouldResume: () => Promise.resolve(false),
+    });
+
+    state.data.configFileName = configFileName;
+    state.lastStep = thisStepNumber;
+  }
+
+  // ***************************************************************
+  // Kick off the input collection
+  // and await until it completes.
+  // This is a promise which returns the state data used to
+  // collect the info.
+  // ***************************************************************
+  const state = await collectInputs();
+
+  // make sure user has not hit escape or moved away from the window
+  // before completing the steps. This also serves as a type guard on
+  // our state data vars down to the actual type desired
+  if (
+    state.data.entryPoint === undefined ||
+    state.data.configFileName === undefined ||
+    // have to add type guards here to eliminate the variability
+    !isQuickPickItem(state.data.entryPoint) ||
+    typeof state.data.configFileName !== "string"
+  ) {
+    return;
+  }
+  // Create the Config File
+  let newConfig: Configuration | undefined = undefined;
+  try {
+    const selectedConfig = entryPointLabelMap.get(state.data.entryPoint.label);
+    if (!selectedConfig) {
+      window.showErrorMessage(
+        `Unable to proceed creating configuration. Error retrieving config for ${state.data.entryPoint.label}`,
+      );
+      return;
+    }
+    const createResponse = await api.configurations.createOrUpdate(
+      state.data.configFileName,
+      selectedConfig,
+    );
+    newConfig = createResponse.data;
+    const fileUri = Uri.file(newConfig.configurationPath);
+    await commands.executeCommand("vscode.open", fileUri);
+  } catch (error: unknown) {
+    const summary = getSummaryStringFromError(
+      "initWorkspace, configurations.createOrUpdate",
+      error,
+    );
+    window.showErrorMessage(`Failed to create config file. ${summary}`);
+    return;
+  }
+  return newConfig;
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Resolves #1319 

This PR refactors the code to leverage our multi-step infrastructure rather than the earlier code. This achieves consistency and a better UX experience. It should also reduce the maintenance burden of the code.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

I had already ported the add configuration code from the configuration view provider into a multi-step for the project initialization. This made it a straightforward process to simply strip back a few steps out of the initialization multi-step to create the newConfig multistep.

Existing functionality should be maintained. I did address one small bug as part of this (I'll add a comment to the code for clarity).

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
Please verify that you can add a configuration for both a simple project and the multi-type project. You should always see the name prompt, but the number of steps will vary along with the ability to select the entrypoint only being presented if there are valid multiple choices (such as within the multi-type sample project).

Be sure to verify adding a configuration from the home view (and confirm that the the new config is selected automatically within the dropdown) as well as from the advanced view of configurations.

Like all other multi-steppers, hitting escape or switching away from the VSCode window should close the prompts and not create a new configuration file.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
