### PR TITLE
Add configuration-dependent requirements endpoint

### DIFF
--- a/extensions/vscode/src/api/resources/Requirements.ts
+++ b/extensions/vscode/src/api/resources/Requirements.ts
@@ -14,8 +14,19 @@ export class Requirements {
   // 200 - success
   // 404 - no requirements file found
   // 500 - internal server error
-  getAll() {
+  get() {
     return this.client.get<RequirementsResponse>("requirements");
+  }
+
+  // Returns:
+  // 200 - success
+  // 404 - configuration or requirements file not found
+  // 500 - internal server error
+  getByConfiguration(configName: string) {
+    const encodedName = encodeURIComponent(configName);
+    return this.client.get<RequirementsResponse>(
+      `/configurations/${encodedName}/requirements`,
+    );
   }
 
   // Returns:

--- a/extensions/vscode/src/views/requirements.ts
+++ b/extensions/vscode/src/views/requirements.ts
@@ -68,7 +68,7 @@ export class RequirementsTreeDataProvider
     }
     try {
       const api = await useApi();
-      const response = await api.requirements.getAll();
+      const response = await api.requirements.get();
       await this.setContextIsEmpty(false);
       return response.data.requirements.map(
         (line) => new RequirementsTreeItem(line),

--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -100,6 +100,10 @@ func RouterHandlerFunc(base util.AbsolutePath, lister accounts.AccountList, log 
 	r.Handle(ToPath("configurations", "{name}", "files"), GetConfigFilesHandlerFunc(base, filesService, log)).
 		Methods(http.MethodGet)
 
+	// GET /api/configurations/$NAME/requirements
+	r.Handle(ToPath("configurations", "{name}", "requirements"), NewGetConfigRequirementsHandler(base, log)).
+		Methods(http.MethodGet)
+
 	// GET /api/deployments
 	r.Handle(ToPath("deployments"), GetDeploymentsHandlerFunc(base, log)).
 		Methods(http.MethodGet)

--- a/internal/services/api/get_config_requirements.go
+++ b/internal/services/api/get_config_requirements.go
@@ -1,0 +1,65 @@
+package api
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rstudio/connect-client/internal/config"
+	"github.com/rstudio/connect-client/internal/inspect"
+	"github.com/rstudio/connect-client/internal/logging"
+	"github.com/rstudio/connect-client/internal/util"
+)
+
+type GetConfigRequirementsHandler struct {
+	base      util.AbsolutePath
+	log       logging.Logger
+	inspector inspect.PythonInspector
+}
+
+func NewGetConfigRequirementsHandler(base util.AbsolutePath, log logging.Logger) *GetConfigRequirementsHandler {
+	return &GetConfigRequirementsHandler{
+		base:      base,
+		log:       log,
+		inspector: inspect.NewPythonInspector(base, util.Path{}, log),
+	}
+}
+
+func (h *GetConfigRequirementsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	name := mux.Vars(req)["name"]
+	configPath := config.GetConfigPath(h.base, name)
+	cfg, err := config.FromFile(configPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			NotFound(w, h.log, err)
+		} else {
+			InternalError(w, req, h.log, err)
+		}
+		return
+	}
+
+	requirementsFilename := cfg.Python.PackageFile
+	if requirementsFilename == "" {
+		requirementsFilename = inspect.PythonRequirementsFilename
+	}
+
+	path := h.base.Join(requirementsFilename)
+	reqs, err := h.inspector.ReadRequirementsFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			NotFound(w, h.log, err)
+		} else {
+			InternalError(w, req, h.log, err)
+		}
+		return
+	}
+	response := requirementsDTO{
+		Requirements: reqs,
+	}
+	w.Header().Set("content-type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/internal/services/api/get_config_requirements_test.go
+++ b/internal/services/api/get_config_requirements_test.go
@@ -1,0 +1,110 @@
+package api
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/rstudio/connect-client/internal/config"
+	"github.com/rstudio/connect-client/internal/logging"
+	"github.com/rstudio/connect-client/internal/util"
+	"github.com/rstudio/connect-client/internal/util/utiltest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+)
+
+type GetConfigRequirementsSuite struct {
+	utiltest.Suite
+	log logging.Logger
+	cwd util.AbsolutePath
+}
+
+func TestGetConfigRequirementsSuite(t *testing.T) {
+	suite.Run(t, new(GetConfigRequirementsSuite))
+}
+
+func (s *GetConfigRequirementsSuite) SetupSuite() {
+	s.log = logging.New()
+}
+
+func (s *GetConfigRequirementsSuite) SetupTest() {
+	fs := afero.NewMemMapFs()
+	cwd, err := util.Getwd(fs)
+	s.Nil(err)
+	s.cwd = cwd
+	s.cwd.MkdirAll(0700)
+}
+
+func (s *GetConfigRequirementsSuite) TestGetConfigRequirements() {
+	reqs := []byte("numpy\npandas\n")
+	s.cwd.Join("requirements-dev.txt").WriteFile(reqs, 0666)
+
+	cfg := config.New()
+	cfg.Type = config.ContentTypeHTML
+	cfg.Python = &config.Python{
+		Version:        "3.11.3",
+		PackageManager: "pip",
+		PackageFile:    "requirements-dev.txt",
+	}
+	err := cfg.WriteFile(config.GetConfigPath(s.cwd, "myConfig"))
+	s.NoError(err)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/configurations/myConfig/requirements", nil)
+	s.NoError(err)
+	req = mux.SetURLVars(req, map[string]string{"name": "myConfig"})
+
+	h := NewGetConfigRequirementsHandler(s.cwd, s.log)
+	h.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	res := requirementsDTO{}
+	dec := json.NewDecoder(rec.Body)
+	dec.DisallowUnknownFields()
+	s.NoError(dec.Decode(&res))
+	s.NotNil(res.Requirements)
+	s.Equal([]string{
+		"numpy",
+		"pandas",
+	}, res.Requirements)
+}
+
+func (s *GetConfigRequirementsSuite) TestGetConfigRequirementsNotFound() {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/configurations/myConfig/requirements", nil)
+	s.NoError(err)
+	req = mux.SetURLVars(req, map[string]string{"name": "myConfig"})
+
+	h := NewGetConfigRequirementsHandler(s.cwd, s.log)
+	h.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusNotFound, rec.Result().StatusCode)
+}
+
+func (s *GetConfigRequirementsSuite) TestGetConfigRequirementsNoRequirementsFile() {
+	cfg := config.New()
+	cfg.Type = config.ContentTypeHTML
+	cfg.Python = &config.Python{
+		Version:        "3.11.3",
+		PackageManager: "pip",
+		PackageFile:    "requirements-dev.txt",
+	}
+	err := cfg.WriteFile(config.GetConfigPath(s.cwd, "myConfig"))
+	s.NoError(err)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/configurations/myConfig/requirements", nil)
+	s.NoError(err)
+	req = mux.SetURLVars(req, map[string]string{"name": "myConfig"})
+
+	h := NewGetConfigRequirementsHandler(s.cwd, s.log)
+	h.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusNotFound, rec.Result().StatusCode)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds a new `GET /api/configurations/$NAME/requirements` endpoint that reads the requirements from the file specified in the configuration's `python.package-file` key.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

Added tests for the new endpoint.

## Directions for Reviewers

Create a config with python.package-file being something other than `requirements.txt`. Access the endpoint. If the file doesn't exist, you'll get a 404. Create the file; then you should get a response listing the requirements from that file.
