### PR TITLE
Add optional actions prop to TreeSection

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
@@ -13,7 +13,7 @@
         />
         <h3 class="title">{{ title }}</h3>
       </div>
-      <div class="actions">
+      <div v-if="actions" class="actions">
         <div class="monaco-toolbar">
           <div class="monaco-action-bar">
             <ul
@@ -22,15 +22,18 @@
               :aria-label="`${title} actions`"
             >
               <li
+                v-for="action in actions"
                 class="action-item menu-entry"
                 role="presentation"
-                custom-hover="true"
               >
                 <a
-                  class="action-label codicon codicon-refresh"
+                  class="action-label codicon"
+                  :class="action.codicon"
                   role="button"
-                  aria-label="Refresh Deployment Files"
+                  :aria-label="action.label"
                   tabindex="0"
+                  @click="action.fn"
+                  @keydown.enter="action.fn"
                 ></a>
               </li>
             </ul>
@@ -50,10 +53,17 @@
 </template>
 
 <script setup lang="ts">
+export type TreeAction = {
+  label: string;
+  codicon: string;
+  fn: () => void;
+};
+
 const expanded = defineModel("expanded", { required: false, default: false });
 
 defineProps<{
   title: string;
+  actions?: TreeAction[];
 }>();
 
 const toggleExpanded = () => {


### PR DESCRIPTION
Adds a simple `actions` prop to `TreeSection`. It is optional, and an array.

It requires a label for `aria-label`, a `codicon` string, and a function to call when `enter` is pressed on the button or it is clicked.

The action toolbar is only added to the DOM if `actions` is passed.

## Intent

- Part of #1333

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
