### PR TITLE
Add `TreeSection` description prop and slot

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
@@ -12,7 +12,12 @@
           :class="expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'"
         />
         <h3 class="title">{{ title }}</h3>
-        <p v-if="description" class="description">{{ description }}</p>
+        <span v-if="$slots.description" class="description">
+          <slot name="description" />
+        </span>
+        <span v-else-if="description" class="description">
+          {{ description }}
+        </span>
       </div>
       <div v-if="actions" class="actions">
         <div class="monaco-toolbar">
@@ -180,6 +185,7 @@ const toggleExpanded = () => {
     }
 
     .description {
+      display: block;
       color: var(--vscode-sideBarSectionHeader-foreground);
       flex-shrink: 100000;
       font-weight: 400;


### PR DESCRIPTION
This is the last PR needed for the features outlined in #1333. It adds:

- A default slot for the `pane-body` contents
- An optional `description` prop that adds small text to the header
- An optional `description` slot that overrides the prop (if passed) so we can pass fully featured HTML for styling

<details>
  <summary>Preview</summary>

With the Slot
  
![CleanShot 2024-04-18 at 16 25 14@2x](https://github.com/posit-dev/publisher/assets/19917631/957ef09e-67f2-4fdd-84ba-cdad3937006d)

With just text in a prop

![CleanShot 2024-04-18 at 16 25 53@2x](https://github.com/posit-dev/publisher/assets/19917631/c1b2ab17-586d-4e08-b8b4-cf7767b0accf)


</details> 

## Intent

Resolves #1333 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
