### PR TITLE
VSCode Extension - adjust new project visibility and grow factor

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -412,6 +412,8 @@
           "id": "posit.publisher.project",
           "name": "Project",
           "contextualTitle": "Publisher",
+          "visibility": "visible",
+          "initialSize": 0,
           "when": "workbenchState == empty || workbenchState == workspace || posit.publish.missing || posit.publish.state == 'uninitialized'"
         },
         {
@@ -420,6 +422,8 @@
           "name": "Home",
           "contextualTitle": "Publisher",
           "icon": "$(symbol-file)",
+          "visibility": "visible",
+          "initialSize": 1,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded'"
         },
         {
@@ -427,6 +431,8 @@
           "name": "Deployment Files",
           "contextualTitle": "Publisher",
           "icon": "$(symbol-file)",
+          "visibility": "collapsed",
+          "initialSize": 0,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded' && posit.publisher.homeView.deploymentActiveMode == 'basic-mode'"
         },
         {
@@ -434,6 +440,8 @@
           "name": "Requirements",
           "contextualTitle": "Publisher",
           "icon": "$(package)",
+          "visibility": "collapsed",
+          "initialSize": 0,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded' && posit.publisher.homeView.deploymentActiveMode == 'basic-mode'"
         },
         {
@@ -441,6 +449,8 @@
           "name": "Configurations",
           "contextualTitle": "Publisher",
           "icon": "$(gear)",
+          "visibility": "collapsed",
+          "initialSize": 0,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded' && posit.publisher.homeView.deploymentActiveMode == 'advanced-mode'"
         },
         {
@@ -448,6 +458,8 @@
           "name": "Credentials",
           "contextualTitle": "Publisher",
           "icon": "$(key)",
+          "visibility": "collapsed",
+          "initialSize": 0,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded' && posit.publisher.homeView.deploymentActiveMode == 'advanced-mode'"
         },
         {
@@ -455,6 +467,8 @@
           "name": "Deployments",
           "contextualTitle": "Publisher",
           "icon": "$(cloud-upload)",
+          "visibility": "collapsed",
+          "initialSize": 0,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded' && posit.publisher.homeView.deploymentActiveMode == 'advanced-mode'"
         },
         {
@@ -463,6 +477,7 @@
           "contextualTitle": "Publisher",
           "icon": "$(info)",
           "visibility": "collapsed",
+          "initialSize": 0,
           "when": "workbenchState == folder && !posit.publish.missing && posit.publish.state == 'initialized' && posit.publish.initialization.credentialCheck == 'succeeded'"
         }
       ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1197 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Made sure each of the views had an explicit collapse/expanded state as well as the initial size grow factor that was indicated in the original issue where only the home view would get a 1 (others got a 0).

Since VSCode remembers the user's last view states for every project that the user opens, the following screenshots show the initial states for a newly created project:

![basic-view](https://github.com/posit-dev/publisher/assets/17675905/67a88ffe-8b65-425a-b6bb-51f4452db56c)

![advanced-view](https://github.com/posit-dev/publisher/assets/17675905/3cb12b44-7e91-4bf0-865b-44ed0ca3097e)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

I do not have a good method of resetting VSCode's knowledge of a previously opened project, so in order to verify this, you will need to create a new project and open it prior to activating the extension. 

I would suggest simply duplicating one of the sample projects in your repo directory and then removing the existing .posit/publish subdirectory. Then activate the extension, complete the initialization and then verify the initial window states. I don't have a good suggestion on how to verify the grow factor.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
