### PR TITLE
Add codicon prop to TreeItem

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="tree-item">
     <div class="tree-item-container">
+      <div v-if="codicon" class="tree-item-icon codicon" :class="codicon" />
       <div class="tree-item-label-container">
         <span class="tree-item-title">{{ title }}</span>
         <span v-if="description" class="tree-item-description">
@@ -23,6 +24,7 @@ import ActionToolbar, { ActionButton } from "./ActionToolbar.vue";
 defineProps<{
   title: string;
   description?: string;
+  codicon?: string;
   actions?: ActionButton[];
 }>();
 </script>
@@ -38,6 +40,20 @@ defineProps<{
     overflow: hidden;
     padding-left: 16px;
     padding-right: 12px;
+
+    .tree-item-icon {
+      color: var(--vscode-icon-foreground);
+      align-items: center;
+      background-position: 0;
+      background-repeat: no-repeat;
+      background-size: 16px;
+      display: flex;
+      height: 22px;
+      width: 22px;
+      justify-content: center;
+      padding-right: 6px;
+      -webkit-font-smoothing: antialiased;
+    }
 
     .tree-item-label-container {
       flex: 1;


### PR DESCRIPTION
Adds the ability to set a `codicon` for the `TreeItem` component.

Usage looks like:

```
    <TreeItem
      title="long-file-name-goes-here.csv"
      description="short/"
      codicon="codicon-bell"
    >
```

<details>
  <summary>Preview</summary>
  
  
![CleanShot 2024-04-22 at 15 51 54@2x](https://github.com/posit-dev/publisher/assets/19917631/43e990e2-ca43-4ec8-b4f6-c6ae910a4e16)

</details> 

Note the `codicon` is optional, but when using along side other `TreeItem`s with codicons we should use `codicon-blank` so the spacing is still correct.

## Intent

Part of #1334

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
