### PR TITLE
Use `v-show` for Tree component slots to remember state

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    <div v-if="$slots.default && expanded" class="tree-item-children">
+    <div v-show="$slots.default && expanded" class="tree-item-children">
       <slot :indent-level="indentLevel + 1" />
     </div>
   </div>

--- a/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
@@ -23,7 +23,7 @@
         <ActionToolbar :title="title" :actions="actions" />
       </div>
     </div>
-    <div v-if="expanded" class="pane-body">
+    <div v-show="expanded" class="pane-body">
       <slot />
     </div>
   </div>


### PR DESCRIPTION
This changes the default slot for the `TreeItem` and `TreeSection` components to use `v-show` instead of `v-if`. This will ensure that the components are always in the DOM so the expanded state is remembered when sections or items are collapsed like the VSCode behavior.

Reference: https://vuejs.org/guide/essentials/conditional.html#v-if-vs-v-show

## Intent

Part of #1335

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
