### PR TITLE
Set Prettier as default Vue formatter in VSCode

### DIFF
--- a/extensions/vscode/.vscode/settings.json
+++ b/extensions/vscode/.vscode/settings.json
@@ -14,5 +14,8 @@
   "editor.formatOnSave": true,
   "editor.detectIndentation": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnPaste": true
+  "editor.formatOnPaste": true,
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }


### PR DESCRIPTION
Super simple PR that just sets Prettier as the default formatter for Vue files.