### PR TITLE
Create `ButtonDropdown` component for re-use

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/ButtonDropdown.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ButtonDropdown.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="button-dropdown">
+    <vscode-button
+      v-bind="$attrs"
+      @click="emit('click')"
+      class="primary-button"
+    >
+      <slot />
+    </vscode-button>
+    <div class="dropdown-separator">
+      <div class="separator-line" />
+    </div>
+    <vscode-button
+      :aria-label="dropdownLabel"
+      class="dropdown-button"
+      @click="emit('dropdownClick')"
+    >
+      <span class="codicon" :class="dropdownCodicon" />
+    </vscode-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+
+const emit = defineEmits(["click", "dropdownClick"]);
+
+interface Props {
+  dropdownCodicon?: string;
+  dropdownLabel: string;
+}
+
+withDefaults(defineProps<Props>(), {
+  dropdownCodicon: "codicon-chevron-down",
+});
+</script>
+
+<style lang="scss" scoped>
+.button-dropdown {
+  display: flex;
+
+  .primary-button {
+    border-right-width: 0 !important;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .dropdown-separator {
+    border-top: 1px solid var(--vscode-button-border);
+    border-bottom: 1px solid var(--vscode-button-border);
+    background-color: var(--vscode-button-background);
+    cursor: default;
+    padding: 4px 0;
+
+    .separator-line {
+      background-color: var(--vscode-button-separator);
+      height: 100%;
+      width: 1px;
+    }
+  }
+
+  .dropdown-button {
+    border-left-width: 0 !important;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+
+    &::part(control) {
+      padding: 0 4px;
+    }
+  }
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
@@ -1,33 +1,24 @@
 <template>
   <div>
     <div class="roomy">
-      <div class="deploy-combo-button">
-        <vscode-button
-          :disabled="disableDeployment"
-          @click="onClickDeploy"
-          style="
-            flex: 2;
-            border-top-right-radius: unset;
-            border-bottom-right-radius: unset;
-          "
-        >
-          Deploy Your Project
-        </vscode-button>
-        <vscode-button
-          @click="onClickDeployExpand"
-          style="
-            border-top-left-radius: unset;
-            border-bottom-left-radius: unset;
-          "
-          :aria-label="
-            showDetails
-              ? 'Collapse Deployment Selection Details'
-              : 'Expand Deployment Selection Details'
-          "
-        >
-          <span :class="buttonIconClass"></span>
-        </vscode-button>
-      </div>
+      <ButtonDropdown
+        class="deploy-button"
+        :disabled="disableDeployment"
+        :dropdown-label="
+          showDetails
+            ? 'Collapse Deployment Selection Details'
+            : 'Expand Deployment Selection Details'
+        "
+        :dropdown-codicon="
+          showDetails
+            ? 'codicon codicon-chevron-down'
+            : 'codicon codicon-chevron-right'
+        "
+        @click="onClickDeploy"
+        @dropdown-click="onClickDeployExpand"
+      >
+        Deploy Your Project
+      </ButtonDropdown>
     </div>
     <div v-if="showDetails">
       <div>
@@ -154,6 +145,7 @@ import { Account } from "../../../../src/api/types/accounts";
 import { Configuration } from "../../../../src/api/types/configurations";
 import { useHomeStore } from "../stores/home";
 
+import ButtonDropdown from "./ButtonDropdown.vue";
 import PSelect from "./PSelect.vue";
 
 const home = useHomeStore();
@@ -176,12 +168,6 @@ const lastStatusDescription = computed(() => {
     return "Not Yet Deployed";
   }
   return "Last Deployment Successful";
-});
-
-const buttonIconClass = computed(() => {
-  return showDetails.value
-    ? "codicon codicon-chevron-down"
-    : "codicon codicon-chevron-right";
 });
 
 const disableDeployment = computed(() => {
@@ -455,9 +441,8 @@ const onMessageFromProvider = (event: any) => {
   margin-left: 5px;
 }
 
-.deploy-combo-button {
-  display: flex;
-  min-width: 100%;
+:deep(.deploy-button) {
+  flex: 1;
 }
 
 .progress-container {


### PR DESCRIPTION
This PR takes the button dropdown we have in `EasyDeploy` and componentizes it, and adds a bit of extra styling so it looks a bit closer to the Source Control button dropdown in VSCode.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
