### PR TITLE
Detect R Shiny content

### DIFF
--- a/internal/inspect/detectors/all.go
+++ b/internal/inspect/detectors/all.go
@@ -19,6 +19,7 @@ func NewContentTypeDetector() *ContentTypeDetector {
 			// ContentType will determine the result.
 			NewQuartoDetector(),
 			NewNotebookDetector(),
+			NewRShinyDetector(),
 			NewPyShinyDetector(),
 			NewFastAPIDetector(),
 			NewFlaskDetector(),

--- a/internal/inspect/detectors/rshiny.go
+++ b/internal/inspect/detectors/rshiny.go
@@ -1,0 +1,55 @@
+package detectors
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"github.com/rstudio/connect-client/internal/config"
+	"github.com/rstudio/connect-client/internal/executor"
+	"github.com/rstudio/connect-client/internal/util"
+)
+
+type RShinyDetector struct {
+	inferenceHelper
+	executor executor.Executor
+}
+
+func NewRShinyDetector() *RShinyDetector {
+	return &RShinyDetector{
+		inferenceHelper: defaultInferenceHelper{},
+		executor:        executor.NewExecutor(),
+	}
+}
+
+func (d *RShinyDetector) InferType(base util.AbsolutePath) (*config.Config, error) {
+	// rsconnect looks for these two specific entrypoint filenames.
+	// Note that this has to happen after rmd-shiny and quarto-shiny detection,
+	// since server.R might contain server code referenced from a shiny-document.
+	entrypoint := base.Join("app.R")
+	exists, err := entrypoint.Exists()
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		entrypoint = base.Join("server.R")
+		exists, err = entrypoint.Exists()
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			// Not a Shiny project
+			return nil, nil
+		}
+	}
+
+	cfg := config.New()
+	cfg.Type = config.ContentTypeRShiny
+	relPath, err := entrypoint.Rel(base)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Entrypoint = relPath.String()
+
+	// Indicate that R inspection is needed.
+	cfg.R = &config.R{}
+	return cfg, nil
+}

--- a/internal/inspect/detectors/rshiny_test.go
+++ b/internal/inspect/detectors/rshiny_test.go
@@ -1,0 +1,81 @@
+package detectors
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"testing"
+
+	"github.com/rstudio/connect-client/internal/config"
+	"github.com/rstudio/connect-client/internal/schema"
+	"github.com/rstudio/connect-client/internal/util"
+	"github.com/rstudio/connect-client/internal/util/utiltest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+)
+
+type ShinySuite struct {
+	utiltest.Suite
+}
+
+func TestShinySuite(t *testing.T) {
+	suite.Run(t, new(ShinySuite))
+}
+
+func (s *ShinySuite) TestInferTypeAppR() {
+	base := util.NewAbsolutePath("/project", afero.NewMemMapFs())
+	err := base.MkdirAll(0777)
+	s.NoError(err)
+
+	filename := "app.R"
+	path := base.Join(filename)
+	err = path.WriteFile(nil, 0600)
+	s.Nil(err)
+
+	detector := NewRShinyDetector()
+	t, err := detector.InferType(base)
+	s.Nil(err)
+	s.Equal(&config.Config{
+		Schema:     schema.ConfigSchemaURL,
+		Type:       config.ContentTypeRShiny,
+		Title:      "",
+		Entrypoint: filename,
+		Validate:   true,
+		Files:      []string{"*"},
+		R:          &config.R{},
+	}, t)
+}
+
+func (s *ShinySuite) TestInferTypeServerR() {
+	base := util.NewAbsolutePath("/project", afero.NewMemMapFs())
+	err := base.MkdirAll(0777)
+	s.NoError(err)
+
+	filename := "server.R"
+	path := base.Join(filename)
+	err = path.WriteFile(nil, 0600)
+	s.Nil(err)
+
+	detector := NewRShinyDetector()
+	t, err := detector.InferType(base)
+	s.Nil(err)
+	s.Equal(&config.Config{
+		Schema:     schema.ConfigSchemaURL,
+		Type:       config.ContentTypeRShiny,
+		Title:      "",
+		Entrypoint: filename,
+		Validate:   true,
+		Files:      []string{"*"},
+		R:          &config.R{},
+	}, t)
+}
+
+func (s *ShinySuite) TestInferTypeNone() {
+	base := util.NewAbsolutePath("/project", afero.NewMemMapFs())
+	err := base.MkdirAll(0777)
+	s.NoError(err)
+
+	detector := NewRShinyDetector()
+	t, err := detector.InferType(base)
+	s.Nil(err)
+	s.Nil(t)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds a detector for R Shiny content.

Fixes #1468

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Uses the same approach as the rsconnect R package: a project is a Shiny app if it contains a file named "app.R" or "server.R" (and it isn't an rmd-shiny or quarto-shiny project).

## Automated Tests

Added tests for the new detector.

## Directions for Reviewers

Inspect n R Shiny project, for example from the `connect-content` repo. The generated configuration should contain `type = 'r-shiny'`.

Note that the `[r]` configuration section will be empty, unless you have the change in https://github.com/posit-dev/publisher/pull/1455.