### PR TITLE
Add title attributes to actions with icons

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/ActionToolbar.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ActionToolbar.vue
@@ -14,6 +14,7 @@
           class="action-label codicon"
           :class="action.codicon"
           role="button"
+          :title="action.label"
           :aria-label="action.label"
           tabindex="0"
           @click.stop="action.fn"

--- a/extensions/vscode/webviews/homeView/src/components/ButtonDropdown.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ButtonDropdown.vue
@@ -11,6 +11,7 @@
       <div class="separator-line" />
     </div>
     <vscode-button
+      :title="dropdownLabel"
       :aria-label="dropdownLabel"
       class="dropdown-button"
       @click="emit('dropdownClick')"

--- a/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
@@ -27,6 +27,7 @@
           <vscode-button
             appearance="icon"
             class="action-icons"
+            title="Add Deployment"
             aria-label="Add Deployment"
           >
             <span
@@ -51,6 +52,7 @@
               v-if="home.selectedConfiguration"
               appearance="icon"
               class="action-icons"
+              title="Edit Selected Configuration"
               aria-label="Edit Selected Configuration"
             >
               <span
@@ -61,6 +63,7 @@
             <vscode-button
               appearance="icon"
               class="action-icons"
+              title="Add Configuration"
               aria-label="Add Configuration"
             >
               <span


### PR DESCRIPTION
This PR adds the `title` attribute to elements that are actions / button with only icons. This includes:
- actions in the `ActionToolbar` component
- the `ButtonDropdown` component, specifically the `>` button
- the `vscode-button`s in `EasyDeploy` with `appearance="icon"`

The `aria-label` is re-used exactly.

## Intent

Part of [#1434](https://github.com/posit-dev/publisher/issues/1434)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
