### PR TITLE
Add `TreeItem` tooltip prop using title

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
@@ -8,6 +8,7 @@
   >
     <div
       class="tree-item-container"
+      :title="tooltip"
       v-on="{
         click: $slots.default ? toggleExpanded : undefined,
       }"
@@ -55,6 +56,7 @@ const expanded = defineModel("expanded", { required: false, default: false });
 interface Props {
   title: string;
   description?: string;
+  tooltip?: string;
   alignIconWithTwisty?: boolean;
   codicon?: string;
   actions?: ActionButton[];

--- a/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
@@ -74,6 +74,7 @@
       <template #default="{ indentLevel }">
         <TreeItem
           title=".DS_Store"
+          :tooltip="`.DS_Store will be excluded from the next deployment.\nThis is a built-in exclusion for the pattern: '!.DS_Store' and cannot be overridden.`"
           codicon="codicon-debug-stackframe-dot"
           :indentLevel="indentLevel"
         />


### PR DESCRIPTION
This PR adds an optional `tooltip` prop, mimicking the `.tooltip` of `FileTreeItem`, that uses `title` to add hover-showing text to `TreeItem`s.

This PR includes an example in the currently-hardcoded `ProjectFiles.vue` component.

## Intent

Resolves #1434 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
