### PR TITLE
Use src import alias in homeView app

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -9,11 +9,11 @@
 </template>
 
 <script setup lang="ts">
-import EasyDeploy from "./components/EasyDeploy.vue";
-import ProjectFiles from "./components/views/ProjectFiles.vue";
-import PythonPackages from "./components/views/PythonPackages.vue";
+import EasyDeploy from "src/components/EasyDeploy.vue";
+import ProjectFiles from "src/components/views/ProjectFiles.vue";
+import PythonPackages from "src/components/views/PythonPackages.vue";
 
-import { useHostConduitService } from "./HostConduitService";
+import { useHostConduitService } from "src/HostConduitService";
 
 useHostConduitService();
 </script>

--- a/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
@@ -138,18 +138,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeMount, onBeforeUnmount, ref } from "vue";
+import { computed } from "vue";
 
 import { formatDateString } from "../../../../../../web/src/utils/date";
 import { isPreDeployment } from "../../../../src/api/types/deployments";
 import { Account } from "../../../../src/api/types/accounts";
 import { Configuration } from "../../../../src/api/types/configurations";
-import { useHomeStore } from "../stores/home";
-
-import ButtonDropdown from "./ButtonDropdown.vue";
-import PSelect from "./PSelect.vue";
-import { useHostConduitService } from "../HostConduitService";
 import { WebviewToHostMessageType } from "../../../../src/types/messages/webviewToHostMessages";
+
+import { useHomeStore } from "src/stores/home";
+import ButtonDropdown from "src/components/ButtonDropdown.vue";
+import PSelect from "src/components/PSelect.vue";
+
+import { useHostConduitService } from "src/HostConduitService";
 
 const home = useHomeStore();
 const hostConduit = useHostConduitService();

--- a/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeItem.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup lang="ts">
-import ActionToolbar, { ActionButton } from "./ActionToolbar.vue";
+import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 

--- a/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/TreeSection.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import ActionToolbar, { ActionButton } from "./ActionToolbar.vue";
+import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 

--- a/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
@@ -103,8 +103,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-import TreeItem from "../TreeItem.vue";
-import TreeSection from "../TreeSection.vue";
+import TreeItem from "src/components/TreeItem.vue";
+import TreeSection from "src/components/TreeSection.vue";
 
 const includedExpanded = ref(true);
 const excludedExpanded = ref(true);

--- a/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
@@ -24,6 +24,6 @@
 </template>
 
 <script setup lang="ts">
-import TreeItem from "../TreeItem.vue";
-import TreeSection from "../TreeSection.vue";
+import TreeItem from "src/components/TreeItem.vue";
+import TreeSection from "src/components/TreeSection.vue";
 </script>

--- a/extensions/vscode/webviews/homeView/src/main.ts
+++ b/extensions/vscode/webviews/homeView/src/main.ts
@@ -2,7 +2,6 @@
 
 import { createApp } from "vue";
 import { createPinia } from "pinia";
-import App from "./App.vue";
 import {
   provideVSCodeDesignSystem,
   vsCodeButton,
@@ -12,7 +11,9 @@ import {
   vsCodeDivider,
 } from "@vscode/webview-ui-toolkit";
 
-import "./style.css";
+import App from "src/App.vue";
+
+import "src/style.css";
 
 // In order to use the Webview UI Toolkit web components they
 // must be registered with the browser (i.e. webview) using the


### PR DESCRIPTION
This PR switches us over to use the `src` import alias for the `webviews/homeView` Vite/Vue app.

The imports that raise up to the `vscode` level still have to be relative, but the imports local to `homeView` can use the `src` alias without errors.

`esbuild` is not necessary for this part to work.

## Intent

Part of #1470

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->
