### PR TITLE
Fix deployment error alignment

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
@@ -285,7 +285,6 @@ const updateCredentialsAndConfigurationForDeployment = () => {
   border-color: gray;
   padding: 5px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
 }
 


### PR DESCRIPTION
Removes `justify-content: space-between;` which was causing the deployment error to appear right aligned since the margin-left was maxing out with the `justify-content`.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-05-02 at 15 04 09@2x](https://github.com/posit-dev/publisher/assets/19917631/7ba58978-2c9a-4007-842a-dd737ee90ebd)

</details> 

## Intent

Resolves #1504
