### PR TITLE
Show newly added included files in ProjectFiles

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
@@ -41,7 +41,11 @@
                 }),
             },
           ]"
-        />
+        >
+          <template #postDecor v-if="!lastDeployedFiles.has(file.rel)">
+            <PostDecor class="text-git-added">A</PostDecor>
+          </template>
+        </TreeItem>
       </template>
     </TreeItem>
 
@@ -87,9 +91,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
-import { DeploymentFile, FileMatchSource } from "../../../../../src/api";
+import {
+  DeploymentFile,
+  DeploymentState,
+  FileMatchSource,
+} from "../../../../../src/api";
 import { WebviewToHostMessageType } from "../../../../../src/types/messages/webviewToHostMessages";
 
 import TreeItem from "src/components/TreeItem.vue";
@@ -102,6 +110,14 @@ const { sendMsg } = useHostConduitService();
 
 const includedExpanded = ref(true);
 const excludedExpanded = ref(true);
+
+const lastDeployedFiles = computed(() => {
+  if (home.selectedDeployment?.state === DeploymentState.NEW) {
+    return new Set();
+  }
+
+  return new Set(home.selectedDeployment?.files);
+});
 
 const fileDescription = (file: DeploymentFile) => {
   if (file.relDir === ".") {


### PR DESCRIPTION
A really quick feature addition that shows newly added files that will be included in the next deploy that isn't part of the last deploy.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-05-03 at 12 34 06@2x](https://github.com/posit-dev/publisher/assets/19917631/fdf76aba-c5ff-494f-9760-df1974ea0214)

</details> 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->