### PR TITLE
Use file.id to build URIs

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
@@ -21,7 +21,7 @@
           @click="
             sendMsg({
               kind: WebviewToHostMessageType.VSCODE_OPEN,
-              content: { uri: file.abs },
+              content: { uri: file.id },
             })
           "
           :key="file.id"
@@ -60,7 +60,7 @@
           @click="
             sendMsg({
               kind: WebviewToHostMessageType.VSCODE_OPEN,
-              content: { uri: file.abs },
+              content: { uri: file.id },
             })
           "
           :key="file.id"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

When opening files in the vscode extension, use `file.id` rather than `file.abs` returned by the files API. `id` is a POSIX path, and `abs` is a platform-specific path. VSCode requires file URIs which use POSIX paths.

Fixes #1512

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

On Windows, click a file in the included files and excluded files views.
