### PR TITLE
Fix continuation line handling in DCF reader

### DIFF
--- a/internal/util/dcf/dcf.go
+++ b/internal/util/dcf/dcf.go
@@ -105,7 +105,10 @@ func (d *decoder) Decode(r io.Reader) (Records, error) {
 			if !slices.Contains(d.keepWhite, currentTag) {
 				line = strings.Trim(line, whitespace)
 			}
-			currentRecord[currentTag] += "\n" + line
+			if currentRecord[currentTag] != "" {
+				currentRecord[currentTag] += "\n"
+			}
+			currentRecord[currentTag] += line
 		} else {
 			// New field in the current record
 			tag, value, ok := strings.Cut(line, ":")

--- a/internal/util/dcf/dcf_test.go
+++ b/internal/util/dcf/dcf_test.go
@@ -91,11 +91,12 @@ func (s *DCFSuite) TestReadFilesErr() {
 }
 
 func (s *DCFSuite) TestDecode() {
-	input := "a: 1\nb: 2\n\na: 3\nb: 4\n\ns: abc\n  def "
+	input := "a: 1\nb: 2\n\na: 3\nb: 4\n\ns: abc\n  def \n\nt: \n  ghi"
 	expectedRecords := Records{
 		{"a": "1", "b": "2"},
 		{"a": "3", "b": "4"},
 		{"s": "abc\ndef"},
+		{"t": "ghi"},
 	}
 	r := bytes.NewReader([]byte(input))
 	decoder := NewDecoder(nil)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR suppresses newlines in DCF fields (which occur with field folding to continuation lines) if they are not preceded by any non-whitespace content.

Fixes #1546

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests

Added a test case for this.

## Directions for Reviewers

@sagerb  should be able to deploy with his original rsconnect accounts.
