### PR TITLE
Hide files and packages when no selected config

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -3,8 +3,10 @@
 <template>
   <main>
     <EasyDeploy class="easy-deploy-container" />
-    <ProjectFiles v-model:expanded="projectFilesExpanded" />
-    <PythonPackages />
+    <template v-if="home.selectedConfiguration">
+      <ProjectFiles v-model:expanded="projectFilesExpanded" />
+      <PythonPackages />
+    </template>
   </main>
 </template>
 
@@ -16,8 +18,11 @@ import ProjectFiles from "src/components/views/ProjectFiles.vue";
 import PythonPackages from "src/components/views/PythonPackages.vue";
 
 import { useHostConduitService } from "src/HostConduitService";
+import { useHomeStore } from "./stores/home";
 
 useHostConduitService();
+
+const home = useHomeStore();
 
 const projectFilesExpanded = ref(true);
 </script>


### PR DESCRIPTION
Simple PR that hides the Project Files and Python Packages views if there isn't a selected configuration.

## Intent

Resolves #1524 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->