### PR TITLE
Update Deployment and Configuration selection handling for Destinations

### DIFF
--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -69,7 +69,7 @@ export type RefreshDeploymentDataMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.REFRESH_DEPLOYMENT_DATA,
   {
     deployments: (Deployment | PreDeployment)[];
-    selectedDeploymentName?: string;
+    selectedDeploymentName?: string | null;
   }
 >;
 export type UpdateExpansionFromStorageMsg = AnyHostToWebviewMessage<
@@ -82,14 +82,14 @@ export type RefreshConfigDataMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.REFRESH_CONFIG_DATA,
   {
     configurations: Configuration[];
-    selectedConfigurationName?: string;
+    selectedConfigurationName?: string | null;
   }
 >;
 export type RefreshCredentialDataMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.REFRESH_CREDENTIAL_DATA,
   {
     credentials: Credential[];
-    selectedCredentialName?: string;
+    selectedCredentialName?: string | null;
   }
 >;
 export type PublishStartMsg =

--- a/extensions/vscode/src/types/quickPicks.ts
+++ b/extensions/vscode/src/types/quickPicks.ts
@@ -12,5 +12,6 @@ export interface DestinationQuickPick extends QuickPickItem {
   deployment: Deployment | PreDeploymentWithConfig;
   config?: Configuration;
   credential?: Credential;
+  credentialName: string;
   lastMatch: boolean;
 }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -361,7 +361,9 @@ export class HomeViewProvider implements WebviewViewProvider {
     }
   }
 
-  private _updateWebViewViewDeployments(selectedDeploymentName?: string) {
+  private _updateWebViewViewDeployments(
+    selectedDeploymentName?: string | null,
+  ) {
     this._webviewConduit.sendMsg({
       kind: HostToWebviewMessageType.REFRESH_DEPLOYMENT_DATA,
       content: {
@@ -371,7 +373,9 @@ export class HomeViewProvider implements WebviewViewProvider {
     });
   }
 
-  private _updateWebViewViewConfigurations(selectedConfigurationName?: string) {
+  private _updateWebViewViewConfigurations(
+    selectedConfigurationName?: string | null,
+  ) {
     this._webviewConduit.sendMsg({
       kind: HostToWebviewMessageType.REFRESH_CONFIG_DATA,
       content: {
@@ -381,7 +385,9 @@ export class HomeViewProvider implements WebviewViewProvider {
     });
   }
 
-  private _updateWebViewViewCredentials(selectedCredentialName?: string) {
+  private _updateWebViewViewCredentials(
+    selectedCredentialName?: string | null,
+  ) {
     this._webviewConduit.sendMsg({
       kind: HostToWebviewMessageType.REFRESH_CREDENTIAL_DATA,
       content: {
@@ -644,6 +650,7 @@ export class HomeViewProvider implements WebviewViewProvider {
         deployment,
         config,
         credential,
+        credentialName,
         lastMatch,
       };
       // Should we not push destinations with no config or matching credentials?
@@ -688,8 +695,8 @@ export class HomeViewProvider implements WebviewViewProvider {
     if (destination) {
       result = {
         deploymentName: destination.deployment.saveName,
-        configurationName: destination.config?.configurationName,
-        credentialName: destination.credential?.name,
+        configurationName: destination.deployment.configurationName,
+        credentialName: destination.credentialName,
       };
       this._updateWebViewViewCredentials(result.credentialName);
       this._updateWebViewViewConfigurations(result.configurationName);
@@ -817,9 +824,11 @@ export class HomeViewProvider implements WebviewViewProvider {
     const selectionState = includeSavedState
       ? this._getSelectionState()
       : undefined;
-    this._updateWebViewViewCredentials(selectionState?.credentialName);
-    this._updateWebViewViewConfigurations(selectionState?.configurationName);
-    this._updateWebViewViewDeployments(selectionState?.deploymentName);
+    this._updateWebViewViewCredentials(selectionState?.credentialName || null);
+    this._updateWebViewViewConfigurations(
+      selectionState?.configurationName || null,
+    );
+    this._updateWebViewViewDeployments(selectionState?.deploymentName || null);
     this._updateWebViewViewExpansionState();
     if (includeSavedState && selectionState) {
       useBus().trigger("activeDeploymentChanged", this._getActiveDeployment());

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -82,48 +82,87 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
   }
 };
 
+/**
+ * When getting new deployments set the new name if given one,
+ * unset the deployment if told to do so with null,
+ * or keep the selected deployment with updated data.
+ */
 const onRefreshDeploymentDataMsg = (msg: RefreshDeploymentDataMsg) => {
   const home = useHomeStore();
   home.deployments = msg.content.deployments;
-  if (msg.content.selectedDeploymentName) {
-    home.updateSelectedDeploymentByName(msg.content.selectedDeploymentName);
-  } else {
+
+  const name = msg.content.selectedDeploymentName;
+  if (name) {
+    home.updateSelectedDeploymentByName(name);
+  } else if (name === null) {
+    home.selectedDeployment = undefined;
+  } else if (home.selectedDeployment) {
     if (
       !home.updateSelectedDeploymentByName(
-        home.selectedDeployment?.deploymentName,
+        home.selectedDeployment.deploymentName,
       )
     ) {
-      // Always cause the re-calculation even if selected deployment didn't change
+      // Recalculate if the deployment object changed with new data
       home.updateCredentialsAndConfigurationForDeployment();
     }
   }
+
+  // If no deployment is selected, unset the selected configuration and credential
+  if (home.selectedDeployment === undefined) {
+    home.selectedConfiguration = undefined;
+    home.selectedCredential = undefined;
+  }
 };
+
 const onUpdateExpansionFromStorageMsg = (
   msg: UpdateExpansionFromStorageMsg,
 ) => {
   const home = useHomeStore();
   home.easyDeployExpanded = msg.content.expansionState;
 };
+
+/**
+ * When getting new configurations set the new name if given one,
+ * unset the configuration if told to do so with null,
+ * keep the selected configuration with updated data,
+ * or set the selected configuration to the one from the selected deployment.
+ */
 const onRefreshConfigDataMsg = (msg: RefreshConfigDataMsg) => {
   const home = useHomeStore();
   home.configurations = msg.content.configurations;
-  if (msg.content.selectedConfigurationName) {
+
+  const name = msg.content.selectedConfigurationName;
+  if (name) {
+    home.updateSelectedConfigurationByName(name);
+  } else if (name === null) {
+    home.selectedConfiguration = undefined;
+  } else if (home.selectedConfiguration) {
     home.updateSelectedConfigurationByName(
-      msg.content.selectedConfigurationName,
+      home.selectedConfiguration.configurationName,
     );
-  } else {
+  } else if (home.selectedDeployment?.configurationName) {
     home.updateSelectedConfigurationByName(
-      home.selectedConfiguration?.configurationName,
+      home.selectedDeployment.configurationName,
     );
   }
 };
+
+/**
+ * When getting new credentials set the new name if given one,
+ * unset the credential if told to do so with null,
+ * or keep the selected credential with updated data.
+ */
 const onRefreshCredentialDataMsg = (msg: RefreshCredentialDataMsg) => {
   const home = useHomeStore();
   home.credentials = msg.content.credentials;
-  if (msg.content.selectedCredentialName) {
-    home.updateSelectedCredentialByName(msg.content.selectedCredentialName);
-  } else {
-    home.updateSelectedCredentialByName(home.selectedCredential?.name);
+
+  const name = msg.content.selectedCredentialName;
+  if (name) {
+    home.updateSelectedCredentialByName(name);
+  } else if (name === null) {
+    home.selectedCredential = undefined;
+  } else if (home.selectedCredential) {
+    home.updateSelectedCredentialByName(home.selectedCredential.name);
   }
 };
 const onPublishStartMsg = () => {

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -18,13 +18,9 @@
       v-on="home.deployments.length ? { click: onSelectDestination } : {}"
     >
       <QuickPickItem
-        v-if="
-          home.selectedDeployment &&
-          home.selectedConfiguration &&
-          home.selectedCredential
-        "
+        v-if="home.selectedDeployment && home.selectedCredential"
         :label="home.selectedDeployment.saveName"
-        :description="home.selectedConfiguration.configurationName"
+        :description="home.selectedDeployment.configurationName"
         :detail="home.selectedCredential.name"
       />
       <QuickPickItem
@@ -38,6 +34,19 @@
         aria-hidden="true"
       />
     </div>
+
+    <!-- Temporary Section -->
+    <p>Deployment: {{ home.selectedDeployment?.saveName || "undefined" }}</p>
+    <p>
+      Config: {{ home.selectedConfiguration?.configurationName || "undefined" }}
+    </p>
+    <p>Cred: {{ home.selectedCredential?.name || " undefined" }}</p>
+    <!-- Remove this later -->
+
+    <p v-if="home.selectedDeployment && !home.selectedConfiguration">
+      The last Configuration used for this Destination was not found. Choose a
+      new Configuration.
+    </p>
   </div>
 </template>
 

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -43,19 +43,19 @@ export const useHomeStore = defineStore("home", () => {
     });
   });
 
-  function updateSelectedDeploymentByName(name?: string) {
+  /**
+   * Updates the selected deployment to one with the given name.
+   * If the named deployment is not found, the selected deployment is set to undefined.
+   *
+   * @param name the name of the new deployment to select
+   * @returns true if the selected deployment was the same, false if not
+   */
+  function updateSelectedDeploymentByName(name: string) {
     const previousSelectedDeployment = selectedDeployment.value;
-    let selectedDeploymentTarget: Deployment | PreDeployment | undefined =
-      undefined;
-    if (name) {
-      selectedDeploymentTarget = deployments.value.find(
-        (d) => d.deploymentName === name,
-      );
-    }
-    if (!selectedDeploymentTarget && deployments.value.length) {
-      selectedDeploymentTarget = deployments.value[0];
-    }
-    selectedDeployment.value = selectedDeploymentTarget;
+
+    const deployment = deployments.value.find((d) => d.deploymentName === name);
+
+    selectedDeployment.value = deployment;
     return previousSelectedDeployment === selectedDeployment.value;
   }
 
@@ -66,18 +66,21 @@ export const useHomeStore = defineStore("home", () => {
     selectedDeployment.value = deployment;
   }
 
-  function updateSelectedConfigurationByName(name?: string) {
+  /**
+   * Updates the selected configuration to the one with the given name.
+   * If the named configuration is not found, the selected deployment is set to undefined.
+   *
+   * @param name the name of the new configuration to select
+   * @returns true if the selected deployment was the same, false if not
+   */
+  function updateSelectedConfigurationByName(name: string) {
     const previousSelectedConfig = selectedConfiguration.value;
-    let selectedConfigTarget: Configuration | undefined = undefined;
-    if (name) {
-      selectedConfigTarget = configurations.value.find(
-        (c) => c.configurationName === name,
-      );
-    }
-    if (!selectedConfigTarget && configurations.value.length) {
-      selectedConfigTarget = configurations.value[0];
-    }
-    selectedConfiguration.value = selectedConfigTarget;
+
+    const config = configurations.value.find(
+      (c) => c.configurationName === name,
+    );
+
+    selectedConfiguration.value = config;
     return previousSelectedConfig === selectedConfiguration.value;
   }
 
@@ -86,16 +89,19 @@ export const useHomeStore = defineStore("home", () => {
     selectedConfiguration.value = config;
   }
 
-  function updateSelectedCredentialByName(name?: string) {
+  /**
+   * Updates the selected credential to the one with the given name.
+   * If the named credential is not found, the selected credential is set to undefined.
+   *
+   * @param name the name of the new credential to select
+   * @returns true if the selected credential was the same, false if not
+   */
+  function updateSelectedCredentialByName(name: string) {
     const previousSelectedAccount = selectedCredential.value;
-    let selectedCredentialTarget: Credential | undefined = undefined;
-    if (name) {
-      selectedCredentialTarget = credentials.value.find((c) => c.name === name);
-    }
-    if (!selectedCredentialTarget && credentials.value.length) {
-      selectedCredentialTarget = credentials.value[0];
-    }
-    selectedCredential.value = selectedCredentialTarget;
+
+    const credential = credentials.value.find((c) => c.name === name);
+
+    selectedCredential.value = credential;
     return previousSelectedAccount === selectedCredential.value;
   }
 


### PR DESCRIPTION
This PR pretty drastically changes the selection state of the webview based on the file watchers, selection updates, and more.

## Intent

- Resolves #1523 
- Part of #1525 (doesn't include the actionable link, but does have the error message)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

I changed the refresh resource messages to allow for the selected name to be `null` which is how I specifically told the webview to unselect its selection for the related resource.

I used the `credentialName` instead of the credential itself in the `showDestinationQuickPick` so the state was better handled if the credential no longer existed.

I added JSDoc comments and forced the `updateSelectedDeploymentByName` and similar functions to require a string for the name rather than `undefined`. This made it much easier to follow the logical paths in the message handlers.

I added a temporary section to the `EvenEasierDeploy` component to see the selections for our Deployment, Configuration, and Credential since the previous selectors don't handle `undefined` well. This makes it easier to test, and can be removed when we remove the `EasyDeploy` component.

## Directions for Reviewers

This is majorly about state handling with Deployment and Configuration changes.

Some things to try:
- see that VSCode state still works recovering your last selection
- change your last selection between VSCode runs (delete a Configuration or Deployment)
- rename or delete a selected Destination's Configuration or Deployment and watch VSCode unselect those
- rename or delete a selected Destination's Configuration then re-create or rename it back to the same `configuration-name` and the Destination will auto-update to use the Destination's `configuration-name`

The Destination's Deployment going away should unset everything. The Configuration going away will show the error described in #1525 calling for user action.