### PR TITLE
Remove the concept of a selected credential

### DIFF
--- a/extensions/vscode/src/bus.ts
+++ b/extensions/vscode/src/bus.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import { Omnibus, args } from "@hypersphere/omnibus";
-import { Credential, Configuration, Deployment, PreDeployment } from "src/api";
+import { Configuration, Deployment, PreDeployment } from "src/api";
 
 export const bus = Omnibus.builder()
   // activeDeploymentChanged: triggered if deployment name or value has changed
@@ -11,12 +11,9 @@ export const bus = Omnibus.builder()
   )
   // activeConfigurationChanged: triggered if configuration name or value has changed
   .register("activeConfigChanged", args<Configuration | undefined>())
-  // activeCredentialChanged: triggered if credential name or value has changed
-  .register("activeCredentialChanged", args<Credential | undefined>())
   // requestActive*: simple events which will cause an Active*Change event to be sent back out.
   .register("requestActiveConfig", args<undefined>())
   .register("requestActiveDeployment", args<undefined>())
-  .register("requestActiveCredential", args<undefined>())
 
   .build();
 
@@ -29,17 +26,11 @@ bus.on("activeDeploymentChanged", (msg) => {
 bus.on("activeConfigChanged", (msg) => {
   console.debug(`\nbus trace: activeConfigChanged: ${JSON.stringify(msg)}\n`);
 });
-bus.on("activeCredentialChanged", (msg) => {
-  console.debug(`\nbus trace: activeCredentialChanged: ${JSON.stringify(msg)}`);
-});
 bus.on("requestActiveConfig", (msg) => {
   console.debug(`\nbus trace: requestActiveConfig: ${JSON.stringify(msg)}`);
 });
 bus.on("requestActiveDeployment", (msg) => {
   console.debug(`\nbus trace: requestActiveDeployment: ${JSON.stringify(msg)}`);
-});
-bus.on("requestActiveCredential", (msg) => {
-  console.debug(`\nbus trace: requestActiveCredential: ${JSON.stringify(msg)}`);
 });
 
 export const useBus = () => {

--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -89,7 +89,6 @@ export type RefreshCredentialDataMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.REFRESH_CREDENTIAL_DATA,
   {
     credentials: Credential[];
-    selectedCredentialName?: string | null;
   }
 >;
 export type PublishStartMsg =

--- a/extensions/vscode/src/types/quickPicks.ts
+++ b/extensions/vscode/src/types/quickPicks.ts
@@ -1,17 +1,10 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import {
-  Credential,
-  Configuration,
-  Deployment,
-  PreDeploymentWithConfig,
-} from "src/api";
+import { Configuration, Deployment, PreDeploymentWithConfig } from "src/api";
 import { QuickPickItem } from "vscode";
 
 export interface DestinationQuickPick extends QuickPickItem {
   deployment: Deployment | PreDeploymentWithConfig;
   config?: Configuration;
-  credential?: Credential;
-  credentialName: string;
   lastMatch: boolean;
 }

--- a/extensions/vscode/src/types/shared.ts
+++ b/extensions/vscode/src/types/shared.ts
@@ -3,11 +3,9 @@
 export type HomeViewState = {
   deploymentName?: string;
   configurationName?: string;
-  credentialName?: string;
 };
 
 export type Destination = {
   deploymentName: string;
   configurationName?: string;
-  credentialName?: string;
 };

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -114,9 +114,6 @@ export class HomeViewProvider implements WebviewViewProvider {
     useBus().on("requestActiveDeployment", () => {
       useBus().trigger("activeDeploymentChanged", this._getActiveDeployment());
     });
-    useBus().on("requestActiveCredential", () => {
-      useBus().trigger("activeCredentialChanged", this._getActiveCredential());
-    });
 
     useBus().on("activeConfigChanged", (cfg: Configuration | undefined) => {
       this.sendRefreshedFilesLists();
@@ -385,14 +382,11 @@ export class HomeViewProvider implements WebviewViewProvider {
     });
   }
 
-  private _updateWebViewViewCredentials(
-    selectedCredentialName?: string | null,
-  ) {
+  private _updateWebViewViewCredentials() {
     this._webviewConduit.sendMsg({
       kind: HostToWebviewMessageType.REFRESH_CREDENTIAL_DATA,
       content: {
         credentials: this._credentials,
-        selectedCredentialName,
       },
     });
   }
@@ -447,7 +441,6 @@ export class HomeViewProvider implements WebviewViewProvider {
       {
         deploymentName: undefined,
         configurationName: undefined,
-        credentialName: undefined,
       },
     );
     return state;
@@ -463,11 +456,6 @@ export class HomeViewProvider implements WebviewViewProvider {
     return this.getDeploymentByName(savedState.deploymentName);
   }
 
-  private _getActiveCredential(): Credential | undefined {
-    const savedState = this._getSelectionState();
-    return this.getCredentialByName(savedState.credentialName);
-  }
-
   private getDeploymentByName(name: string | undefined) {
     return this._deployments.find((d) => d.deploymentName === name);
   }
@@ -476,16 +464,11 @@ export class HomeViewProvider implements WebviewViewProvider {
     return this._configs.find((c) => c.configurationName === name);
   }
 
-  private getCredentialByName(name: string | undefined) {
-    return this._credentials.find((c) => c.name === name);
-  }
-
   private async _saveSelectionState(state: HomeViewState): Promise<void> {
     await this._context.workspaceState.update(lastSelectionState, state);
 
     useBus().trigger("activeDeploymentChanged", this._getActiveDeployment());
     useBus().trigger("activeConfigChanged", this._getActiveConfig());
-    useBus().trigger("activeCredentialChanged", this._getActiveCredential());
   }
 
   private _saveExpansionState(expanded: boolean) {
@@ -593,7 +576,6 @@ export class HomeViewProvider implements WebviewViewProvider {
     const destinations: DestinationQuickPick[] = [];
     const lastDeploymentName = this._getActiveDeployment()?.saveName;
     const lastConfigName = this._getActiveConfig()?.configurationName;
-    const lastCredentialName = this._getActiveCredential()?.name;
 
     this._deployments.forEach((deployment) => {
       if (
@@ -637,8 +619,7 @@ export class HomeViewProvider implements WebviewViewProvider {
 
       let lastMatch =
         lastDeploymentName === deployment.saveName &&
-        lastConfigName === configName &&
-        lastCredentialName === credentialName;
+        lastConfigName === configName;
 
       const destination: DestinationQuickPick = {
         label: title,
@@ -649,8 +630,6 @@ export class HomeViewProvider implements WebviewViewProvider {
           : new ThemeIcon("cloud-upload"),
         deployment,
         config,
-        credential,
-        credentialName,
         lastMatch,
       };
       // Should we not push destinations with no config or matching credentials?
@@ -696,9 +675,8 @@ export class HomeViewProvider implements WebviewViewProvider {
       result = {
         deploymentName: destination.deployment.saveName,
         configurationName: destination.deployment.configurationName,
-        credentialName: destination.credentialName,
       };
-      this._updateWebViewViewCredentials(result.credentialName);
+      this._updateWebViewViewCredentials();
       this._updateWebViewViewConfigurations(result.configurationName);
       this._updateWebViewViewDeployments(result.deploymentName);
       this._requestWebviewSaveSelection();
@@ -824,7 +802,7 @@ export class HomeViewProvider implements WebviewViewProvider {
     const selectionState = includeSavedState
       ? this._getSelectionState()
       : undefined;
-    this._updateWebViewViewCredentials(selectionState?.credentialName || null);
+    this._updateWebViewViewCredentials();
     this._updateWebViewViewConfigurations(
       selectionState?.configurationName || null,
     );
@@ -833,7 +811,6 @@ export class HomeViewProvider implements WebviewViewProvider {
     if (includeSavedState && selectionState) {
       useBus().trigger("activeDeploymentChanged", this._getActiveDeployment());
       useBus().trigger("activeConfigChanged", this._getActiveConfig());
-      useBus().trigger("activeCredentialChanged", this._getActiveCredential());
     }
   };
 

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -107,10 +107,9 @@ const onRefreshDeploymentDataMsg = (msg: RefreshDeploymentDataMsg) => {
     }
   }
 
-  // If no deployment is selected, unset the selected configuration and credential
+  // If no deployment is selected, unset the selected configuration
   if (home.selectedDeployment === undefined) {
     home.selectedConfiguration = undefined;
-    home.selectedCredential = undefined;
   }
 };
 
@@ -155,15 +154,6 @@ const onRefreshConfigDataMsg = (msg: RefreshConfigDataMsg) => {
 const onRefreshCredentialDataMsg = (msg: RefreshCredentialDataMsg) => {
   const home = useHomeStore();
   home.credentials = msg.content.credentials;
-
-  const name = msg.content.selectedCredentialName;
-  if (name) {
-    home.updateSelectedCredentialByName(name);
-  } else if (name === null) {
-    home.selectedCredential = undefined;
-  } else if (home.selectedCredential) {
-    home.updateSelectedCredentialByName(home.selectedCredential.name);
-  }
 };
 const onPublishStartMsg = () => {
   const home = useHomeStore();

--- a/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EasyDeploy.vue
@@ -81,12 +81,9 @@
         />
       </div>
       <label for="credentials-selector">Credentials:</label>
-      <PSelect
-        v-model="home.selectedCredential"
-        :options="home.filteredCredentials"
-        :get-key="(c: Credential) => c.name"
-        class="dropdowns"
-      />
+      <p>
+        {{ home.serverCredential?.name }}
+      </p>
     </div>
     <div v-if="home.selectedDeployment && home.selectedDeployment.serverType">
       <vscode-divider />
@@ -172,7 +169,7 @@ const disableDeployment = computed(() => {
   const result =
     !Boolean(home.selectedDeployment) ||
     !Boolean(home.selectedConfiguration) ||
-    !Boolean(home.selectedCredential);
+    !Boolean(home.serverCredential);
   return result;
 });
 
@@ -184,7 +181,7 @@ const onClickDeploy = () => {
   if (
     !home.selectedDeployment ||
     !home.selectedConfiguration ||
-    !home.selectedCredential
+    !home.serverCredential
   ) {
     throw new Error(
       "EasyDeploy::onClickDeploy trying to send message with undefined values",
@@ -195,7 +192,7 @@ const onClickDeploy = () => {
     content: {
       deploymentName: home.selectedDeployment.saveName,
       configurationName: home.selectedConfiguration.configurationName,
-      credentialName: home.selectedCredential.name,
+      credentialName: home.serverCredential.name,
     },
   });
 };
@@ -241,7 +238,6 @@ const onUpdateModelValueSelectedDeployment = () => {
 };
 
 const updateCredentialsAndConfigurationForDeployment = () => {
-  home.filterCredentialsToDeployment();
   if (home.selectedDeployment?.configurationName) {
     home.updateSelectedConfigurationByName(
       home.selectedDeployment.configurationName,

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -18,10 +18,10 @@
       v-on="home.deployments.length ? { click: onSelectDestination } : {}"
     >
       <QuickPickItem
-        v-if="home.selectedDeployment && home.selectedCredential"
+        v-if="home.selectedDeployment"
         :label="home.selectedDeployment.saveName"
         :description="home.selectedDeployment.configurationName"
-        :detail="home.selectedCredential.name"
+        :detail="home.serverCredential?.name || 'No matching Credential found'"
       />
       <QuickPickItem
         v-else
@@ -40,12 +40,17 @@
     <p>
       Config: {{ home.selectedConfiguration?.configurationName || "undefined" }}
     </p>
-    <p>Cred: {{ home.selectedCredential?.name || " undefined" }}</p>
+    <p>Cred: {{ home.serverCredential?.name || " undefined" }}</p>
     <!-- Remove this later -->
 
     <p v-if="home.selectedDeployment && !home.selectedConfiguration">
       The last Configuration used for this Destination was not found. Choose a
       new Configuration.
+    </p>
+
+    <p v-if="home.selectedDeployment && !home.serverCredential">
+      A Credential for the Destination's server URL was not found. Create a new
+      Credential.
     </p>
   </div>
 </template>


### PR DESCRIPTION
With the change to make Credentials unique on `server-url` we no longer need to have the concept of a selected Credential. Instead we can just compute the selected credential based on the `server_url` in the Destination.

## Intent

Part of #1526

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to change all of the types related to selected Credentials and fix errors that sprouted up from TypeScript.