### PR TITLE
Run typescript compiler before esbuild

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -558,7 +558,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "tsc --noEmit && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "lint": "eslint src --ext ts --max-warnings 0",


### PR DESCRIPTION
This PR adds `tsc --noEmit` to `esbuild-base`. This will run the TypeScript compiler with no emitted JavaScript before running our base `esbuild` command. That includes when we run `vscode:prepublish` (runs automatically with `npx @vscode/vsce package`).

This will cause our base `just` command and CI to fail when there is a TypeScript error.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

