### PR TITLE
Improve R error messages

### DIFF
--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -155,8 +155,8 @@ func readPackageDescription(name PackageName, libPaths []util.AbsolutePath) (dcf
 	return nil, fmt.Errorf("%s: %w", name, errPackageNotFound)
 }
 
-var errLockfileLibraryMismatch = errors.New("library and lockfile are out of sync. Use renv::restore() or renv::snapshot() to synchronize")
-var errMissingPackageSource = errors.New("can't re-install packages installed from source; all packages must be installed from a reproducible location")
+var errLockfileLibraryMismatch = errors.New("package versions in library and lockfile are out of sync; use renv::restore() or renv::snapshot() to synchronize")
+var errMissingPackageSource = errors.New("can't re-install packages installed from source; all packages must be installed from a reproducible location such as a repository")
 
 func (m *defaultPackageMapper) GetManifestPackages(
 	base util.AbsolutePath,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Clarify some errors that can be returned by the R package dependency code during deployment.

Follow-up to #1515

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

There are tests for this code, however, they assert the type of the error and not the content of the error message.

## Directions for Reviewers

Create R packaging problems, for example an out of date renv.lock file or trying to deploy from a repo checkout where the renv/library directory is not populated.
