### PR TITLE
Open files by id with VSCODE_RELATIVE_OPEN

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
@@ -20,8 +20,8 @@
           v-for="file in home.includedFiles"
           @click="
             sendMsg({
-              kind: WebviewToHostMessageType.VSCODE_OPEN,
-              content: { uri: file.id },
+              kind: WebviewToHostMessageType.VSCODE_OPEN_RELATIVE,
+              content: { relativePath: file.id },
             })
           "
           :key="file.id"
@@ -59,8 +59,8 @@
           v-for="file in home.excludedFiles"
           @click="
             sendMsg({
-              kind: WebviewToHostMessageType.VSCODE_OPEN,
-              content: { uri: file.id },
+              kind: WebviewToHostMessageType.VSCODE_OPEN_RELATIVE,
+              content: { relativePath: file.id },
             })
           "
           :key="file.id"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR fixes the Project Files view click-to-open functionality. 

Fixes #1569

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

We are opening files using `file.id` which is a slash-separated (POSIX) path relative to the project root. Perfect for constructing a URI (unlike file.rel and file.abs which are platform-specific paths) but it needs to be appended to the root URI.

## Directions for Reviewers

Click a file in the Included Files or Excluded files list. It should open in the editor. This should also work on Windows.
