### PR TITLE
Force selection of first destination once created.

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -20,7 +20,6 @@ import { HelpAndFeedbackTreeDataProvider } from "src/views/helpAndFeedback";
 import { LogsTreeDataProvider } from "src/views/logs";
 import { EventStream } from "src/events";
 import { HomeViewProvider } from "src/views/homeView";
-import { newDestination } from "./multiStepInputs/newDestination";
 
 const STATE_CONTEXT = "posit.publish.state";
 const MISSING_CONTEXT = "posit.publish.missing";
@@ -135,7 +134,7 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand(INIT_PROJECT_COMMAND, async (viewId?: string) => {
       setInitializationInProgressContext(InitializationInProgress.true);
-      await newDestination(viewId);
+      await homeViewProvider.showNewDestinationMultiStep(viewId);
       setInitializationInProgressContext(InitializationInProgress.false);
     }),
   );

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -547,13 +547,22 @@ export class HomeViewProvider implements WebviewViewProvider {
     configurationName?: string,
     deploymentName?: string,
   ) {
+    // We have to break our protocol and go ahead and write this into storage,
+    // in case this multi-stepper is actually running ahead of the webview
+    // being brought up.
+    this._saveSelectionState({
+      deploymentName,
+      configurationName,
+    });
+    // Now push down into the webview
     this._updateWebViewViewCredentials();
     this._updateWebViewViewConfigurations(configurationName);
     this._updateWebViewViewDeployments(deploymentName);
+    // And have the webview save what it has selected.
     this._requestWebviewSaveSelection();
   }
 
-  private async showNewDestinationMultiStep(
+  public async showNewDestinationMultiStep(
     viewId?: string,
   ): Promise<DestinationNames | undefined> {
     const destinationObjects = await newDestination(viewId);
@@ -592,6 +601,7 @@ export class HomeViewProvider implements WebviewViewProvider {
         this._credentials.push(destinationObjects.credential);
         refreshCredentials = true;
       }
+
       this.propogateDestinationSelection(
         destinationObjects.configuration.configurationName,
         destinationObjects.deployment.saveName,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This PR will cause the first created destination to be auto-selected after initialization.

The code was already selecting a newly created destination when initiated through the homeview.

Resolves #1598 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

There is a timing issue here since we're asking to select a destination ahead of the webview going through initialization. So the best way for the initial selection to occur, ahead of the home view being visible, is to set the last selection in VSCode storage. I've integrated this logic into the flow, which will work regardless if the webview has been initialized or not.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
Confirm that the initialization of a new project selects the newly created destination on completion.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
