### PR TITLE
Add python package file watcher

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -93,6 +93,7 @@ export class HomeViewProvider implements WebviewViewProvider {
   private _webviewConduit: WebviewConduit;
 
   private activeConfigFileWatcher: FileSystemWatcher | undefined;
+  private activePythonPackageFileWatcher: FileSystemWatcher | undefined;
 
   constructor(
     private readonly _context: ExtensionContext,
@@ -118,6 +119,7 @@ export class HomeViewProvider implements WebviewViewProvider {
       this.sendRefreshedFilesLists();
       this._onRefreshPythonPackages();
       this.createActiveConfigFileWatcher(cfg);
+      this.createActivePythonPackageFileWatcher(cfg);
     });
   }
   /**
@@ -926,6 +928,36 @@ export class HomeViewProvider implements WebviewViewProvider {
     }
 
     this.activeConfigFileWatcher = watcher;
+    this._context.subscriptions.push(watcher);
+  }
+
+  private createActivePythonPackageFileWatcher(cfg: Configuration | undefined) {
+    if (this.root === undefined || cfg === undefined) {
+      return;
+    }
+
+    const watcher = workspace.createFileSystemWatcher(
+      new RelativePattern(
+        this.root,
+        cfg.configuration.python?.packageFile || "requirements.txt",
+      ),
+    );
+    watcher.onDidCreate(this._onRefreshPythonPackages, this);
+    watcher.onDidChange(this._onRefreshPythonPackages, this);
+    watcher.onDidDelete(this._onRefreshPythonPackages, this);
+
+    if (this.activePythonPackageFileWatcher) {
+      // Dispose the previous configuration file watcher
+      this.activePythonPackageFileWatcher.dispose();
+      const index = this._context.subscriptions.indexOf(
+        this.activePythonPackageFileWatcher,
+      );
+      if (index !== -1) {
+        this._context.subscriptions.splice(index, 1);
+      }
+    }
+
+    this.activePythonPackageFileWatcher = watcher;
     this._context.subscriptions.push(watcher);
   }
 


### PR DESCRIPTION
This PR adds a Python Package file watcher that either uses the configuration `package_file` setting in the Python section of the selected Configuration or defaults to `requirements.txt` - much in the same way our API does.

It then sends updated packages information to our webview when the file is updated, deleted, or created.

## Intent

Resolves #1513 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here is the exact same as our active configuration file watcher.

## Directions for Reviewers

There are several things to try here:
- change the configuration's `package_file` to:
  - a requirements file that exists
  - a requirements file that doesn't exist
- use the scan command to create a new requirements file
- update the sourced `package_file`
- delete the sourced `package_file` and have a `requirements.txt`
- delete the sourced `package_file` and don't have a `requirements.txt`