### PR TITLE
Add anchor to fix missing credential state

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -15,6 +15,7 @@ import { formatURL } from "src/utils/url";
 import { validateApiKey } from "src/utils/apiKeys";
 
 export async function newCredential(
+  startingServerUrl?: string,
   viewId?: string,
 ): Promise<string | undefined> {
   // ***************************************************************
@@ -75,7 +76,7 @@ export async function newCredential(
       data: {
         // each attribute is initialized to undefined
         // to be returned when it has not been cancelled
-        url: undefined, // eventual type is string
+        url: startingServerUrl, // eventual type is string
         name: <string | undefined>undefined, // eventual type is string
         apiKey: <string | undefined>undefined, // eventual type is string
       },

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -20,6 +20,7 @@ export enum WebviewToHostMessageType {
   SCAN_PYTHON_PACKAGE_REQUIREMENTS = "ScanPythonPackageRequirementsMsg",
   SELECT_DESTINATION = "selectDestination",
   NEW_DESTINATION = "newDestination",
+  NEW_CREDENTIAL = "newCredential",
 }
 
 export type AnyWebviewToHostMessage<
@@ -48,7 +49,8 @@ export type WebviewToHostMessage =
   | VSCodeOpenRelativeMsg
   | ScanPythonPackageRequirementsMsg
   | SelectDestinationMsg
-  | NewDestinationMsg;
+  | NewDestinationMsg
+  | NewCredentialMsg;
 
 export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
   return (
@@ -67,7 +69,8 @@ export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
     msg.kind === WebviewToHostMessageType.VSCODE_OPEN_RELATIVE ||
     msg.kind === WebviewToHostMessageType.SCAN_PYTHON_PACKAGE_REQUIREMENTS ||
     msg.kind === WebviewToHostMessageType.SELECT_DESTINATION ||
-    msg.kind === WebviewToHostMessageType.NEW_DESTINATION
+    msg.kind === WebviewToHostMessageType.NEW_DESTINATION ||
+    msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL
   );
 }
 
@@ -152,3 +155,6 @@ export type SelectDestinationMsg =
 
 export type NewDestinationMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.NEW_DESTINATION>;
+
+export type NewCredentialMsg =
+  AnyWebviewToHostMessage<WebviewToHostMessageType.NEW_CREDENTIAL>;

--- a/extensions/vscode/src/views/credentials.ts
+++ b/extensions/vscode/src/views/credentials.ts
@@ -106,8 +106,8 @@ export class CredentialsTreeDataProvider
    *
    * @returns
    */
-  public add = async () => {
-    const credential = await newCredential();
+  public add = async (startingServerUrl?: string) => {
+    const credential = await newCredential(startingServerUrl);
     if (credential) {
       // refresh the credentials view
       this.triggerRefresh();

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -164,6 +164,8 @@ export class HomeViewProvider implements WebviewViewProvider {
         return this.showDestinationQuickPick();
       case WebviewToHostMessageType.NEW_DESTINATION:
         return this.showNewDestinationMultiStep(viewName);
+      case WebviewToHostMessageType.NEW_CREDENTIAL:
+        return this.showNewCredential();
       default:
         throw new Error(
           `Error: _onConduitMessage unhandled msg: ${JSON.stringify(msg)}`,
@@ -620,6 +622,15 @@ export class HomeViewProvider implements WebviewViewProvider {
       };
     }
     return undefined;
+  }
+
+  private showNewCredential() {
+    const deployment = this._getActiveDeployment();
+
+    return commands.executeCommand(
+      "posit.publisher.credentials.add",
+      deployment?.serverUrl,
+    );
   }
 
   private async showDestinationQuickPick(): Promise<

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -41,8 +41,9 @@
     </p>
 
     <p v-if="home.selectedDeployment && !home.serverCredential">
-      A Credential for the Destination's server URL was not found. Create a new
-      Credential.
+      A Credential for the Destination's server URL was not found.
+      <a href="" role="button" @click="newCredential">Create a new Credential</a
+      >.
     </p>
 
     <DeployButton class="w-full" />
@@ -172,6 +173,12 @@ const navigateToUrl = (url: string) => {
     content: {
       uriPath: url,
     },
+  });
+};
+
+const newCredential = () => {
+  hostConduit.sendMsg({
+    kind: WebviewToHostMessageType.NEW_CREDENTIAL,
   });
 };
 </script>


### PR DESCRIPTION
This PR adds an anchor that, when clicked, will initiate adding a Credential. In addition to this feature I've used the selected Deployment's `server-url` as the initial value in the New Credential VSCode input to make it easier for users to fix their state.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-05-13 at 17 03 50@2x](https://github.com/posit-dev/publisher/assets/19917631/ecff0160-ae4f-4e24-b13f-64b30c543804)

</details> 

## Intent

Resolves #1526

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->