### PR TITLE
Redeploy command in command palette

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -174,6 +174,12 @@
         "category": "Posit Publisher"
       },
       {
+        "command": "posit.publisher.homeView.redeploy",
+        "title": "Redeploy",
+        "icon": "$(cloud-upload)",
+        "category": "Posit Publisher"
+      },
+      {
         "command": "posit.publisher.homeView.deployWithDiffConfig",
         "title": "Deploy with a Different Configuration",
         "category": "Posit Publisher"
@@ -391,6 +397,10 @@
         {
           "command": "posit.publisher.homeView.refresh",
           "when": "!posit.publish.missing && posit.publish.state == 'initialized'"
+        },
+        {
+          "command": "posit.publisher.homeView.redeploy",
+          "when": "posit.publish.state == 'initialized'"
         },
         {
           "command": "posit.publisher.homeView.selectDestination",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds a `Posit Publisher: Redeploy` command to the command palette that redeploys using the currently selected destination.

Fixes #355

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Register a new command using the existing deployment machinery.
