### PR TITLE
Add minimal PATCH deployment endpoint for configuration name changes

### DIFF
--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -138,6 +138,10 @@ func RouterHandlerFunc(base util.AbsolutePath, lister accounts.AccountList, log 
 	r.Handle(ToPath("deployments"), PostDeploymentsHandlerFunc(base, log, lister)).
 		Methods(http.MethodPost)
 
+	// PATCH /api/deployments/$NAME updates a deployment record
+	r.Handle(ToPath("deployments", "{name}"), PatchDeploymentHandlerFunc(base, log)).
+		Methods(http.MethodPatch)
+
 	// GET /api/deployments/$NAME
 	r.Handle(ToPath("deployments", "{name}"), GetDeploymentHandlerFunc(base, log)).
 		Methods(http.MethodGet)

--- a/internal/services/api/patch_deployment.go
+++ b/internal/services/api/patch_deployment.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rstudio/connect-client/internal/config"
+	"github.com/rstudio/connect-client/internal/deployment"
+	"github.com/rstudio/connect-client/internal/logging"
+	"github.com/rstudio/connect-client/internal/util"
+)
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+type PatchDeploymentRequestBody struct {
+	ConfigName string `json:"configurationName"`
+}
+
+func PatchDeploymentHandlerFunc(
+	base util.AbsolutePath,
+	log logging.Logger) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		name := mux.Vars(req)["name"]
+		dec := json.NewDecoder(req.Body)
+		dec.DisallowUnknownFields()
+		var b PatchDeploymentRequestBody
+		err := dec.Decode(&b)
+		if err != nil {
+			BadRequest(w, req, log, err)
+			return
+		}
+
+		// Deployment must exist
+		path := deployment.GetDeploymentPath(base, name)
+		exists, err := path.Exists()
+		if err != nil {
+			InternalError(w, req, log, err)
+			return
+		}
+		if !exists {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Config must exist
+		configPath := config.GetConfigPath(base, b.ConfigName)
+		exists, err = configPath.Exists()
+		if err != nil {
+			InternalError(w, req, log, err)
+			return
+		}
+		if !exists {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(fmt.Sprintf("configuration %s not found", b.ConfigName)))
+			return
+		}
+
+		d, err := deployment.FromFile(path)
+		if err != nil {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(fmt.Sprintf("failed to load deployment %s", name)))
+			return
+		}
+
+		d.ConfigName = b.ConfigName
+
+		err = d.WriteFile(path)
+		if err != nil {
+			InternalError(w, req, log, err)
+			return
+		}
+		response := deploymentAsDTO(d, err, base, path)
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

We need a way to change the configuration name for an existing deployment.

Part of #1525

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

New PATCH /api/deployments/$NAME endpoint that only accepts `configurationName` in the request body.

## Automated Tests

We need them; will create a task on the board.

## Directions for Reviewers

```
curl -s http://localhost:9001/api/deployments/$DEPLOYMENT_NAME -XPATCH -d '{"configurationName":"$CONFIG_NAME"}'
```
