### PR TITLE
Unify missing Configuration and Credential messages

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -672,14 +672,14 @@ export class HomeViewProvider implements WebviewViewProvider {
       let configName = config?.configurationName;
       if (!configName) {
         configName = deployment.configurationName
-          ? `${deployment.configurationName} - ERROR: Config Not Found!`
+          ? `Missing Configuration ${deployment.configurationName}`
           : `ERROR: No Config Entry in Deployment file - ${deployment.saveName}`;
         problem = true;
       }
 
       let credentialName = credential?.name;
       if (!credentialName) {
-        credentialName = `${deployment.serverUrl} - ERROR: No Matching Credential!`;
+        credentialName = `Missing Credential for ${deployment.serverUrl}`;
         problem = true;
       }
 

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -23,9 +23,14 @@
         <QuickPickItem
           v-if="home.selectedDeployment"
           :label="home.selectedDeployment.saveName"
-          :description="home.selectedDeployment.configurationName"
+          :description="
+            isConfigMissing
+              ? `Missing Configuration ${home.selectedDeployment.configurationName}`
+              : home.selectedDeployment.configurationName
+          "
           :detail="
-            home.serverCredential?.name || 'No matching Credential found'
+            home.serverCredential?.name ||
+            `Missing Credential for ${home.selectedDeployment.serverUrl}`
           "
         />
 
@@ -42,12 +47,12 @@
         />
       </div>
 
-      <p v-if="home.selectedDeployment && !home.selectedConfiguration">
+      <p v-if="isConfigMissing">
         The last Configuration used for this Destination was not found. Choose a
         new Configuration.
       </p>
 
-      <p v-if="home.selectedDeployment && !home.serverCredential">
+      <p v-if="isCredentialMissing">
         A Credential for the Destination's server URL was not found.
         <a href="" role="button" @click="newCredential"
           >Create a new Credential</a
@@ -169,6 +174,14 @@ const onAddDestination = () => {
     kind: WebviewToHostMessageType.NEW_DESTINATION,
   });
 };
+
+const isConfigMissing = computed((): boolean => {
+  return Boolean(home.selectedDeployment && !home.selectedConfiguration);
+});
+
+const isCredentialMissing = computed((): boolean => {
+  return Boolean(home.selectedDeployment && !home.serverCredential);
+});
 
 const lastStatusDescription = computed(() => {
   if (!home.selectedDeployment) {


### PR DESCRIPTION
This PR unifies the Destination VSCode Select and the selection text when the Destination is missing the `configuration_name` or a Credential for the `server_url`

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-05-14 at 13 43 57@2x](https://github.com/posit-dev/publisher/assets/19917631/eed15ce5-8f5a-422c-b1a4-4951c4d31465)

</details> 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
