### PR TITLE
Make all items in input credential a single line

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDestination.ts
+++ b/extensions/vscode/src/multiStepInputs/newDestination.ts
@@ -369,7 +369,6 @@ export async function newDestination(
       credentialListItems.push({
         iconPath: new ThemeIcon("plus"),
         label: createNewCredentialLabel,
-        detail: "Select this option to create a destination to a new server",
       });
     } catch (error: unknown) {
       const summary = getSummaryStringFromError(


### PR DESCRIPTION
This PR is a design change making all of the options in the `inputCredentialName` step of the New Destination flow a single line.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-05-14 at 13 54 25@2x](https://github.com/posit-dev/publisher/assets/19917631/a0c1d4bb-b4e3-4396-9d50-be073c2ee219)

</details> 