### PR TITLE
Disable Deploy button while deploy is in progress

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -1,5 +1,8 @@
 <template>
-  <vscode-button :disabled="!haveResources" @click="deploy">
+  <vscode-button
+    :disabled="!haveResources || home.publishInProgress"
+    @click="deploy"
+  >
     Deploy Your Project
   </vscode-button>
 </template>


### PR DESCRIPTION
This prevents users from triggering multiple deployments at once by disabling the deploy button while there is currently a deployment running.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
