### PR TITLE
Bug: incorrectly retrieving config inspection details

### DIFF
--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -42,6 +42,26 @@ export enum ContentType {
   UNKNOWN = "unknown",
 }
 
+export const contentTypeStrings = {
+  [ContentType.HTML]: "serve pre-rendered HTML",
+  [ContentType.JUPYTER_NOTEBOOK]: "render with Jupyter nbconvert",
+  [ContentType.JUPYTER_VOILA]: "run with Jupyter Voila",
+  [ContentType.PYTHON_BOKEH]: "run with Bokeh",
+  [ContentType.PYTHON_DASH]: "run with Dash",
+  [ContentType.PYTHON_FASTAPI]: "run with FastAPI",
+  [ContentType.PYTHON_FLASK]: "run with Flask",
+  [ContentType.PYTHON_SHINY]: "run with Python Shiny",
+  [ContentType.PYTHON_STREAMLIT]: "run with Streamlit",
+  [ContentType.QUARTO_SHINY]: "render with Quarto and run embedded Shiny app",
+  [ContentType.QUARTO]: "render with Quarto",
+  [ContentType.R_PLUMBER]: "run with Plumber",
+  [ContentType.R_SHINY]: "run with R Shiny",
+  [ContentType.RMD_SHINY]:
+    "render with rmarkdown/knitr and run embedded Shiny app",
+  [ContentType.RMD]: "render with rmarkdown/knitr",
+  [ContentType.UNKNOWN]: "unknown content type; cannot deploy this item",
+};
+
 export type ConfigurationDetails = {
   $schema: SchemaURL;
   type: ContentType;

--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -20,6 +20,14 @@ export function isQuickPickItem(d: QuickPickItem | string): d is QuickPickItem {
   return typeof d !== "string";
 }
 
+export type QuickPickItemWithIndex = QuickPickItem & { index: number };
+
+export function isQuickPickItemWithIndex(
+  d: QuickPickItem | string,
+): d is QuickPickItemWithIndex {
+  return (d as QuickPickItemWithIndex).index !== undefined;
+}
+
 export interface MultiStepState {
   title: string;
   step: number;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1630 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Fix involved associating the index key of the configuration details returned from the API with the QuickPickInput Item (which is a QuickPickInputWithIndex). We had done this for one of the multi-steps, but had not used this same pattern for the other two multi-steps. I have now made them all consistent and removed the incorrect use of the title as a key into a map containing the configuration details (since we set that title to the entrypoint name, but that is not unique since we have multiple ways of rendering some of these entrypoints).

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
This affects the following multi-step flows and operations:
1. New Destination (called by either initial new destination button or plus sign)
2. New Config (called by plus sign on configuration view)
3. Select Config (called by destination - context menu - Select Active Configuration)

Should verify both projects with single entrypoints and multiple.

Perform the operations and confirm that the `type` is set correctly within the new config file.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
