### PR TITLE
Add docs update step to release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,11 @@ This command will trigger the [Release GitHub Action](https://github.com/rstudio
 
 Once complete the action has completed, the release will be available on the [Releases page](https://github.com/rstudio/publishing-client/releases).
 
+**Step 4**
+
+Update the Installation instructions in [installation.md](docs/installation.md)
+for the new release, using the links to the `.vsix` files uploaded to the CDN.
+
 ### Pre-Releases
 
 Any tags denoted as a pre-release as defined by the [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) specification will be marked as such in GitHub. For example, the `v0.0.dev0` is a pre-release. Tag `v0.0.0` is a standard-release. Please consult the specification for additional information.


### PR DESCRIPTION
This PR adds an additional step to the CONTRIBUTING guide for release instructions that outlines updating the installation docs for the new `.vsix` files.