### PR TITLE
Word wrap destination error

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -343,6 +343,8 @@ const newCredential = () => {
 }
 
 .error-message {
+  min-width: 0;
+  word-wrap: break-word;
   margin-left: 5px;
 }
 


### PR DESCRIPTION
This PR word wraps the Destination error. So in the instance a very long word is in a very thin width sidebar it doesn't break out of the box.

<details>
  <summary>Preview</summary>
  
  
![CleanShot 2024-05-17 at 15 00 43@2x](https://github.com/posit-dev/publisher/assets/19917631/2dc482bc-376d-4a3c-a22e-4b3ff77ca26f)

</details> 

## Intent

Resolves #1628

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
