### PR TITLE
Start project Files tree and subnodes collapsed

### DIFF
--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -24,7 +24,7 @@ useHostConduitService();
 
 const home = useHomeStore();
 
-const projectFilesExpanded = ref(true);
+const projectFilesExpanded = ref(false);
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/ProjectFiles.vue
@@ -108,8 +108,8 @@ import { useHostConduitService } from "src/HostConduitService";
 const home = useHomeStore();
 const { sendMsg } = useHostConduitService();
 
-const includedExpanded = ref(true);
-const excludedExpanded = ref(true);
+const includedExpanded = ref(false);
+const excludedExpanded = ref(false);
 
 const lastDeployedFiles = computed(() => {
   if (home.selectedDeployment?.state === DeploymentState.NEW) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves: #1674 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Simple change, just changed initial value.

Note, that the expanded state will not be restored, but rather will always start out collapsed when the extension is opened up the first time in a project. I think this is acceptable.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Simply load the extension and confirm that the Project Files section is collapsed. Expand it and confirm that the Included Files and Excluded files nodes are also collapsed. Expand them to just confirm they still work.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
