### PR TITLE
Omit empty R package fields

### DIFF
--- a/internal/inspect/dependencies/renv/lockfile.go
+++ b/internal/inspect/dependencies/renv/lockfile.go
@@ -33,13 +33,13 @@ type Package struct {
 	Repository        RepoURL       `toml:"repository" json:"repository"`
 	Requirements      []PackageName `toml:"requirements,omitempty" json:"requirements"`
 	Hash              string        `toml:"hash" json:"hash"`
-	RemoteType        string        `toml:"remote_type,omitempty" json:"remoteType"`
-	RemotePkgRef      string        `toml:"remote_pkg_ref,omitempty" json:"remotePkgRef"`
-	RemoteRef         string        `toml:"remote_ref,omitempty" json:"remoteRef"`
-	RemoteRepos       string        `toml:"remote_repos,omitempty" json:"remoteRepos"`
-	RemoteReposName   string        `toml:"remote_repos_name,omitempty" json:"remoteReposName"`
-	RemotePkgPlatform string        `toml:"remote_pkg_platform,omitempty" json:"remotePkgPlatform"`
-	RemoteSha         string        `toml:"remote_sha,omitempty" json:"remoteSha"`
+	RemoteType        string        `toml:"remote_type,omitempty" json:"remoteType,omitempty"`
+	RemotePkgRef      string        `toml:"remote_pkg_ref,omitempty" json:"remotePkgRef,omitempty"`
+	RemoteRef         string        `toml:"remote_ref,omitempty" json:"remoteRef,omitempty"`
+	RemoteRepos       string        `toml:"remote_repos,omitempty" json:"remoteRepos,omitempty"`
+	RemoteReposName   string        `toml:"remote_repos_name,omitempty" json:"remoteReposName,omitempty"`
+	RemotePkgPlatform string        `toml:"remote_pkg_platform,omitempty" json:"remotePkgPlatform,omitempty"`
+	RemoteSha         string        `toml:"remote_sha,omitempty" json:"remoteSha,omitempty"`
 }
 
 func ReadLockfile(path util.AbsolutePath) (*Lockfile, error) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR omits empty Remote fields from the R package data returned from the `GET /api/configurations/$NAME/packages/r` endpoint. They are only populated in the renv.lock file for git-installed packages, which are uncommon, and add a lot to the payload size.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
- - [x] Other

## Directions for Reviewers

R packages in #1671 should still display correctly (the view doesn't use these fields anyway).
