### PR TITLE
Create watcher manager to handle file watching

### DIFF
--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -1,0 +1,6 @@
+export const POSIT_FOLDER = ".posit";
+export const PUBLISH_FOLDER = ".posit/publish";
+export const PUBLISH_DEPLOYMENTS_FOLDER = ".posit/publish/deployments";
+
+export const CONFIGURATIONS_PATTERN = ".posit/publish/*.toml";
+export const DEPLOYMENTS_PATTERN = ".posit/publish/deployments/*.toml";

--- a/extensions/vscode/src/watchers.ts
+++ b/extensions/vscode/src/watchers.ts
@@ -1,0 +1,77 @@
+import {
+  Disposable,
+  RelativePattern,
+  WorkspaceFolder,
+  FileSystemWatcher,
+  workspace,
+} from "vscode";
+
+import {
+  PUBLISH_DEPLOYMENTS_FOLDER,
+  POSIT_FOLDER,
+  PUBLISH_FOLDER,
+  CONFIGURATIONS_PATTERN,
+  DEPLOYMENTS_PATTERN,
+} from "src/constants";
+
+/**
+ * Manages all the file system watchers for the extension.
+ *
+ * The directory watchers only watch for onDidDelete events.
+ */
+export class WatcherManager implements Disposable {
+  positDir: FileSystemWatcher | undefined;
+  publishDir: FileSystemWatcher | undefined;
+  configurations: FileSystemWatcher | undefined;
+  deploymentsDir: FileSystemWatcher | undefined;
+  deployments: FileSystemWatcher | undefined;
+  allFiles: FileSystemWatcher | undefined;
+
+  constructor(root?: WorkspaceFolder) {
+    if (root === undefined) {
+      return;
+    }
+
+    this.positDir = workspace.createFileSystemWatcher(
+      new RelativePattern(root, POSIT_FOLDER),
+      true,
+      true,
+      false,
+    );
+
+    this.publishDir = workspace.createFileSystemWatcher(
+      new RelativePattern(root, PUBLISH_FOLDER),
+      true,
+      true,
+      false,
+    );
+
+    this.configurations = workspace.createFileSystemWatcher(
+      new RelativePattern(root, CONFIGURATIONS_PATTERN),
+    );
+
+    this.deploymentsDir = workspace.createFileSystemWatcher(
+      new RelativePattern(root, PUBLISH_DEPLOYMENTS_FOLDER),
+      true,
+      true,
+      false,
+    );
+
+    this.deployments = workspace.createFileSystemWatcher(
+      new RelativePattern(root, DEPLOYMENTS_PATTERN),
+    );
+
+    this.allFiles = workspace.createFileSystemWatcher(
+      new RelativePattern(root, "**"),
+    );
+  }
+
+  dispose() {
+    this.positDir?.dispose();
+    this.publishDir?.dispose();
+    this.configurations?.dispose();
+    this.deploymentsDir?.dispose();
+    this.deployments?.dispose();
+    this.allFiles?.dispose();
+  }
+}


### PR DESCRIPTION
This PR takes the file watchers we create for the various files and directories in the extension (that do not change) and unifies them under a `WatcherManager` class that is created by the extension and passed down to views that require it. 

## Intent

Part of #1673

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
