### PR TITLE
Create `ConfigWatcherManager` disposable

### DIFF
--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -4,3 +4,6 @@ export const PUBLISH_DEPLOYMENTS_FOLDER = ".posit/publish/deployments";
 
 export const CONFIGURATIONS_PATTERN = ".posit/publish/*.toml";
 export const DEPLOYMENTS_PATTERN = ".posit/publish/deployments/*.toml";
+
+export const DEFAULT_PYTHON_PACKAGE_FILE = "requirements.txt";
+export const DEFAULT_R_PACKAGE_FILE = "renv.lock";

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { ExtensionContext, commands, workspace } from "vscode";
+import { ExtensionContext, commands } from "vscode";
 
 import * as ports from "src/ports";
 import { Service } from "src/services";
@@ -51,7 +51,7 @@ export async function activate(context: ExtensionContext) {
 
   service = new Service(context, port);
 
-  const watchers = new WatcherManager(workspace.workspaceFolders?.[0]);
+  const watchers = new WatcherManager();
   context.subscriptions.push(watchers);
 
   // First the construction of the data providers
@@ -75,6 +75,7 @@ export async function activate(context: ExtensionContext) {
   const logsTreeDataProvider = new LogsTreeDataProvider(context, stream);
 
   const homeViewProvider = new HomeViewProvider(context, stream);
+  context.subscriptions.push(homeViewProvider);
 
   // Then the registration of the data providers with the VSCode framework
   projectTreeDataProvider.register();


### PR DESCRIPTION
This PR consolidates Configuration watchers into a `ConfigWatcherManager` for the Home view to utilize.

It is a disposable. This PR also fixes the Home View to correctly dispose with the extension.

## Intent

Resolves #1673

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to create a new watcher manager specific to configurations. I didn't incorporate it into the bus since the file watchers were only used in the Home View, but that is something we can do in the future if needed.
