### PR TITLE
Fix refreshRPackages typo

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -145,15 +145,15 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       );
 
       this.configWatchers.rPackageFile?.onDidCreate(
-        this._onRefreshPythonPackages,
+        this._onRefreshRPackages,
         this,
       );
       this.configWatchers.rPackageFile?.onDidChange(
-        this._onRefreshPythonPackages,
+        this._onRefreshRPackages,
         this,
       );
       this.configWatchers.rPackageFile?.onDidDelete(
-        this._onRefreshPythonPackages,
+        this._onRefreshRPackages,
         this,
       );
     });


### PR DESCRIPTION
Fix a typo and correctly point the `rPackageFile` watcher `onDid` methods to the `_onRefreshRPackages` method.