### PR TITLE
Detect when R Markdown content is run

### DIFF
--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -275,7 +275,7 @@ func (c *ConnectClient) getTask(taskID types.TaskID, previous *taskDTO, log logg
 
 var buildRPattern = regexp.MustCompile("Building (Shiny application|Plumber API|R Markdown document).*")
 var buildPythonPattern = regexp.MustCompile("Building (.* application|.* API|Jupyter notebook).*")
-var launchPattern = regexp.MustCompile("Launching .*(Quarto|application|API|notebook)")
+var launchPattern = regexp.MustCompile("Launching .*(Quarto|R Markdown|application|API|notebook)")
 var staticPattern = regexp.MustCompile("(Building|Launching) static content")
 
 func eventOpFromLogLine(currentOp events.Operation, line string) events.Operation {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

In #1723, when deploying Rmd content, log lines from the execution of the Rmd are lumped into the new `Restore R Environment` log phase. They should be under `Run Content`.

This PR adds detection for the log line that indicates the start of Rmd execution.

Part of #1660 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Directions for Reviewers

Deploy Rmd content. Verify that the knitr execution logs are under the Run Content heading, and not the Restore R Environment heading.
