### PR TITLE
Handle internal exception when python.interpreterPath not defined

### DIFF
--- a/extensions/vscode/src/utils/config.ts
+++ b/extensions/vscode/src/utils/config.ts
@@ -9,10 +9,13 @@ export async function getPythonInterpreterPath(): Promise<string | undefined> {
   if (workspaceFolder === undefined) {
     return undefined;
   }
-  const configuredPython = await commands.executeCommand<string>(
-    "python.interpreterPath",
-    { workspaceFolder: workspaceFolder },
-  );
+  let configuredPython: string | undefined;
+  try {
+    configuredPython = await commands.executeCommand<string>(
+      "python.interpreterPath",
+      { workspaceFolder: workspaceFolder },
+    );
+  } catch {}
   if (configuredPython === undefined) {
     return undefined;
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Python inspection fails when the mentioned command is not defined within VSCode. I was able to reproduce it by creating a new destination, but it exists in common code which would be traversed by other workflow as well.

resolves #1737 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The `commands.executeCommand` command throws an exception when the command is not found, so I simply reworked the code with an empty try/catch block, with the existing logic check for an `undefined` return;

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

For some reason, I don't have this command defined. All of my Python extensions are disabled, so perhaps doing that will reproduce this scenario.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
