### PR TITLE
Escape lockfile path

### DIFF
--- a/internal/inspect/r.go
+++ b/internal/inspect/r.go
@@ -110,7 +110,8 @@ func (i *defaultRInspector) CreateLockfile(lockfilePath util.AbsolutePath) error
 		return err
 	}
 
-	code := fmt.Sprintf(`renv::snapshot(lockfile="%s")`, lockfilePath.String())
+	escaped := strings.ReplaceAll(lockfilePath.String(), `\`, `\\`)
+	code := fmt.Sprintf(`renv::snapshot(lockfile="%s")`, escaped)
 	args := []string{"-s", "-e", code}
 	stdout, stderr, err := i.executor.RunCommand(rExecutable, args, i.base, i.log)
 	i.log.Debug("renv::snapshot()", "out", string(stdout), "err", string(stderr))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Backslashes in the lockfile path must be escaped before invoking R.

Fixes #1746

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

Scan R dependencies on Windows.

