### PR TITLE
Specifying Python doesn't imply the project uses it

### DIFF
--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -47,7 +47,7 @@ func inspectProject(base util.AbsolutePath, python util.Path, rExecutable util.P
 		cfg.Title = base.Base()
 	}
 
-	needPython, err := requiresPython(cfg, base, python)
+	needPython, err := requiresPython(cfg, base)
 	if err != nil {
 		return nil, err
 	}
@@ -76,12 +76,7 @@ func inspectProject(base util.AbsolutePath, python util.Path, rExecutable util.P
 	return cfg, nil
 }
 
-func requiresPython(cfg *config.Config, base util.AbsolutePath, python util.Path) (bool, error) {
-	if python.String() != "" {
-		// If user provided Python on the command line,
-		// then configure Python for the project.
-		return true, nil
-	}
+func requiresPython(cfg *config.Config, base util.AbsolutePath) (bool, error) {
 	if cfg.Python != nil && cfg.Python.Version == "" {
 		// InferType returned a python configuration for us to fill in.
 		return true, nil
@@ -137,7 +132,7 @@ func GetPossibleConfigs(base util.AbsolutePath, python util.Path, rExecutable ut
 			// Default title is the name of the project directory.
 			cfg.Title = base.Base()
 		}
-		needPython, err := requiresPython(cfg, base, python)
+		needPython, err := requiresPython(cfg, base)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -103,22 +103,6 @@ func (s *InitializeSuite) TestInitInferredType() {
 	s.Equal(cfg, cfg2)
 }
 
-func (s *InitializeSuite) TestInitExplicitPython() {
-	log := logging.New()
-	s.createHTML()
-	PythonInspectorFactory = makeMockPythonInspector
-	configName := ""
-	python := util.NewPath("/usr/bin/python", s.cwd.Fs())
-	cfg, err := Init(s.cwd, configName, python, util.Path{}, log)
-	s.NoError(err)
-	configPath := config.GetConfigPath(s.cwd, configName)
-	cfg2, err := config.FromFile(configPath)
-	s.NoError(err)
-	s.Equal(cfg.Type, config.ContentTypeHTML)
-	s.Equal("3.4.5", cfg.Python.Version)
-	s.Equal(cfg, cfg2)
-}
-
 func (s *InitializeSuite) TestInitRequirementsFile() {
 	log := logging.New()
 	s.createHTML()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR fixes R-only projects being detected as requiring Python, which was introduced in #1727.

Fixes #1760

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Specifying which Python to use when inspecting no longer implies that the project uses Python (the extension now always passes the Python path in via the API).

## Automated Tests

Removed the test that enforced this condition.

## Directions for Reviewers

Deploy R-only, Python, and combination projects.
