### PR TITLE
Use 'Create a Configuration' wording when there are no configs to select

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -690,7 +690,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async selectConfigForDestination() {
-    const config = await selectConfig("Select a Configuration", viewName);
+    const label =
+      this._configs.length > 0
+        ? "Select a Configuration"
+        : "Create a Configuration";
+
+    const config = await selectConfig(label, viewName);
     if (config) {
       const activeDeployment = this._getActiveDeployment();
       if (activeDeployment === undefined) {

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -57,14 +57,20 @@
       <p v-if="isConfigEntryMissing">
         No Config Entry in Deployment file -
         {{ home.selectedDeployment?.saveName }}.
-        <a href="" role="button" @click="selectConfiguration"
-          >Select a Configuration</a
+        <a href="" role="button" @click="selectConfiguration">{{
+          home.configurations.length > 0
+            ? "Select a Configuration"
+            : "Create a Configuration"
+        }}</a
         >.
       </p>
       <p v-if="isConfigMissing">
         The last Configuration used for this Destination was not found.
-        <a href="" role="button" @click="selectConfiguration"
-          >Select a Configuration</a
+        <a href="" role="button" @click="selectConfiguration">{{
+          home.configurations.length > 0
+            ? "Select a Configuration"
+            : "Create a Configuration"
+        }}</a
         >.
       </p>
       <p v-if="isConfigInError">


### PR DESCRIPTION
This PR adds additional text depending on the state of the extension. If the user has zero configurations and they encounter an error or label that recommends them to "Select a Configuration" it now says "Create a Configuration" since there are no Configurations to select.

## Intent

Resolves #1752 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
