### PR TITLE
Add implicit newlines between notebook code cells

### DIFF
--- a/internal/inspect/dependencies/pydeps/notebook_contents.go
+++ b/internal/inspect/dependencies/pydeps/notebook_contents.go
@@ -57,5 +57,5 @@ func GetNotebookInputs(r io.Reader) (string, error) {
 			}
 		}
 	}
-	return strings.Join(combinedSource, ""), nil
+	return strings.Join(combinedSource, "\n"), nil
 }

--- a/internal/inspect/dependencies/pydeps/notebook_contents_test.go
+++ b/internal/inspect/dependencies/pydeps/notebook_contents_test.go
@@ -32,7 +32,7 @@ func (s *NotebookContentsSuite) TestGetNotebookFileInputs() {
 
 	inputs, err := GetNotebookFileInputs(path)
 	s.Nil(err)
-	s.Equal("import sys\nprint(sys.executable)\nprint('Summing')\n123 + 456\n", inputs)
+	s.Equal("import sys\n\nprint(sys.executable)\n\nprint('Summing')\n\n123 + 456\n", inputs)
 }
 
 func (s *NotebookContentsSuite) TestGetNotebookFileInputsErr() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR fixes a bug in how we extract Python code from notebook cells.

Fixes #1769 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

There is an implied newline between notebook code cells; this PR introduces it explicitly when extracting the code.

## Automated Tests

Updated existing unit tests.

## Directions for Reviewers

Verify this fixes the linked issue.
