### PR TITLE
Add license to VSCode extension

### DIFF
--- a/extensions/vscode/LICENSE
+++ b/extensions/vscode/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2024 Posit, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/extensions/vscode/justfile
+++ b/extensions/vscode/justfile
@@ -133,7 +133,7 @@ package os="$(just ../../os)" arch="$(just ../../arch)":
     echo "info: getting output package name..." 1>&2
     package="$path"/$(just package-name {{ os }} {{ arch }})
     echo "info: packaging..." 1>&2
-    npx --yes @vscode/vsce package -o "$package" --skip-license -t "$target_platform" | sed 's/^/debug: /'
+    npx --yes @vscode/vsce package -o "$package" -t "$target_platform" | sed 's/^/debug: /'
     echo "info: writing package to $package..." 1>&2
 
 package-name os="$(just ../../os)" arch="$(just ../../arch)":


### PR DESCRIPTION
This PR removes the `--skip-license` flag that we use for packaging the VSCode extension(s) and adds a `LICENSE` file at the `extensions/vscode` level to be bundles by `vsce`.

## Intent

Resolves #1773

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
