### PR TITLE
Use password input type for API keys

### DIFF
--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -65,6 +65,7 @@ interface InputBoxParameters {
   title: string;
   step: number;
   totalSteps: number;
+  password?: boolean;
   value: string;
   prompt: string;
   validate: (
@@ -199,6 +200,7 @@ export class MultiStepInput {
     ignoreFocusOut,
     placeholder,
     shouldResume,
+    password,
   }: P) {
     const disposables: Disposable[] = [];
     try {
@@ -209,6 +211,11 @@ export class MultiStepInput {
         input.title = title;
         input.step = step;
         input.totalSteps = totalSteps;
+
+        if (password) {
+          input.password = password;
+        }
+
         input.value = value || "";
         input.prompt = prompt;
         input.ignoreFocusOut = ignoreFocusOut ?? false;

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -211,6 +211,7 @@ export async function newCredential(
       title: state.title,
       step: thisStepNumber,
       totalSteps: state.totalSteps,
+      password: true,
       value: currentAPIKey,
       prompt: `The API key to be used to authenticate with Posit Connect.
         See the [User Guide](https://docs.posit.co/connect/user/api-keys/index.html#api-keys-creating)

--- a/extensions/vscode/src/multiStepInputs/newDestination.ts
+++ b/extensions/vscode/src/multiStepInputs/newDestination.ts
@@ -657,6 +657,7 @@ export async function newDestination(
         title: state.title,
         step: step.step,
         totalSteps: step.totalSteps,
+        password: true,
         value: currentAPIKey,
         prompt: "The API key to be used to authenticate with Posit Connect",
         placeholder: "example: v1cKJzUzYnHP1p5WrAINMump4Sjp5pbq",


### PR DESCRIPTION
Changes the input type to `password` for API key inputs to avoid displaying the API key.

## Intent

Resolves #1775 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
