### PR TITLE
Fill out VSCode changelog add release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,10 @@ Execute `eval "$(just configure)"` to configure the executable on your current `
 
 ### Before Releasing
 
-- Ensure that all relevant changes are documented in the [CHANGELOG.md](CHANGELOG.md).
+- Ensure that all relevant changes are documented in:
+  - the [CHANGELOG.md](CHANGELOG.md) for the repository
+  - the [VSCode Extension CHANGELOG.md](extensions/vscode/CHANGELOG.md)
+    that is bundled with the extension
 - Update the license docs in case any new dependencies have been added, by running
 
 ```

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,9 +1,11 @@
-# Change Log
+# Changelog
 
-All notable changes to the "Publisher" extension will be documented in this file.
+All notable changes to the Posit Publisher extension are documented in this
+file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Initial release
+- Initial beta release


### PR DESCRIPTION
This PR fills out a bit of the VSCode Extension `CHANGELOG.md` that is bundled with the extension, and adds instructions to the `CONTRIBUTING.md` guide to update it.

When we do the next release we can change the `Unreleased` header to `1.1.9`

## Intent

Resolves #1783

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->