### PR TITLE
Remove unused init-project.refresh command

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -41,12 +41,6 @@
         "category": "Posit Publisher"
       },
       {
-        "command": "posit.publisher.init-project.refresh",
-        "title": "Refresh Project Initialization",
-        "icon": "${refresh)",
-        "category": "Posit Publisher"
-      },
-      {
         "command": "posit.publisher.configurations.refresh",
         "title": "Refresh Configurations",
         "icon": "$(refresh)",
@@ -420,10 +414,6 @@
         {
           "command": "posit.publisher.homeView.newDeployment",
           "when": "posit.publisher.homeView.initialized == 'initialized'"
-        },
-        {
-          "command": "posit.publisher.init-project.refresh",
-          "when": "false"
         },
         {
           "command": "posit.publisher.showOutputChannel",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -12,7 +12,6 @@ export const DEFAULT_R_PACKAGE_FILE = "renv.lock";
 
 const baseCommands = {
   InitProject: "posit.publisher.init-project",
-  // RefreshProjectInitialization = "posit.publisher.init-project.refresh",
   ShowOutputChannel: "posit.publisher.showOutputChannel",
   ShowPublishingLog: "posit.publisher.showPublishingLog",
 } as const;


### PR DESCRIPTION
This PR removes an unused command from the VSCode extension. It was only in the `package.json` and wasn't used or registered anywhere.

## Intent

Part of #1766