### PR TITLE
Register missing python commands to Home View

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -144,19 +144,19 @@
       },
       {
         "command": "posit.publisher.pythonPackages.edit",
-        "title": "Edit Requirements File",
+        "title": "Edit Python Package File",
         "icon": "$(edit)",
         "category": "Posit Publisher"
       },
       {
         "command": "posit.publisher.pythonPackages.refresh",
-        "title": "Refresh Requirements",
+        "title": "Refresh Python Packages",
         "icon": "$(refresh)",
         "category": "Posit Publisher"
       },
       {
         "command": "posit.publisher.pythonPackages.scan",
-        "title": "Scan Requirements",
+        "title": "Scan for Python Packages",
         "icon": "$(eye)",
         "category": "Posit Publisher"
       },

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1153,6 +1153,32 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           await env.openExternal(Uri.parse(logUrl));
         }
       }),
+      commands.registerCommand(
+        Commands.PythonPackages.Edit,
+        async () => {
+          if (this.root === undefined) {
+            return;
+          }
+          const cfg = this._getActiveConfig();
+          const packageFile = cfg?.configuration.python?.packageFile;
+          if (packageFile === undefined) {
+            return;
+          }
+          const fileUri = Uri.joinPath(this.root.uri, packageFile);
+          await commands.executeCommand("vscode.open", fileUri);
+        },
+        this,
+      ),
+      commands.registerCommand(
+        Commands.PythonPackages.Refresh,
+        this._onRefreshPythonPackages,
+        this,
+      ),
+      commands.registerCommand(
+        Commands.PythonPackages.Scan,
+        this._onScanForPythonPackageRequirements,
+        this,
+      ),
     );
 
     watchers.positDir?.onDidDelete(() => {


### PR DESCRIPTION
With the move of the Python Packages view into the Home View we lost the registered functions for the `pythonPackages` commands.

This PR re-adds them using the home view, and changes the text to match the new view name.

## Intent

Part of #1766

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->