### PR TITLE
Add R packages commands similar to python commands

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -161,6 +161,24 @@
         "category": "Posit Publisher"
       },
       {
+        "command": "posit.publisher.rPackages.edit",
+        "title": "Edit R Package File",
+        "icon": "$(edit)",
+        "category": "Posit Publisher"
+      },
+      {
+        "command": "posit.publisher.rPackages.refresh",
+        "title": "Refresh R Packages",
+        "icon": "$(refresh)",
+        "category": "Posit Publisher"
+      },
+      {
+        "command": "posit.publisher.rPackages.scan",
+        "title": "Scan for R Packages",
+        "icon": "$(eye)",
+        "category": "Posit Publisher"
+      },
+      {
         "command": "posit.publisher.homeView.refresh",
         "title": "Refresh Home View",
         "icon": "$(refresh)",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -58,6 +58,12 @@ const pythonPackagesCommands = {
   Scan: "posit.publisher.pythonPackages.scan",
 } as const;
 
+const rPackagesCommands = {
+  Edit: "posit.publisher.rPackages.edit",
+  Refresh: "posit.publisher.rPackages.refresh",
+  Scan: "posit.publisher.rPackages.scan",
+} as const;
+
 const homeViewCommands = {
   Refresh: "posit.publisher.homeView.refresh",
   SelectConfigForDeployment:
@@ -86,6 +92,7 @@ export const Commands = {
   Logs: logsCommands,
   Files: filesCommands,
   PythonPackages: pythonPackagesCommands,
+  RPackages: rPackagesCommands,
   HomeView: homeViewCommands,
   HelpAndFeedback: helpAndFeedbackCommands,
 } as const;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1179,6 +1179,32 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         this._onScanForPythonPackageRequirements,
         this,
       ),
+      commands.registerCommand(
+        Commands.RPackages.Edit,
+        async () => {
+          if (this.root === undefined) {
+            return;
+          }
+          const cfg = this._getActiveConfig();
+          const packageFile = cfg?.configuration.r?.packageFile;
+          if (packageFile === undefined) {
+            return;
+          }
+          const fileUri = Uri.joinPath(this.root.uri, packageFile);
+          await commands.executeCommand("vscode.open", fileUri);
+        },
+        this,
+      ),
+      commands.registerCommand(
+        Commands.RPackages.Refresh,
+        this._onRefreshRPackages,
+        this,
+      ),
+      commands.registerCommand(
+        Commands.RPackages.Scan,
+        this._onScanForRPackageRequirements,
+        this,
+      ),
     );
 
     watchers.positDir?.onDidDelete(() => {


### PR DESCRIPTION
This PR adds similar command palette commands to `pythonPackages` but for R:
- `posit.publisher.rPackages.edit`
- `posit.publisher.rPackages.refresh`
- `posit.publisher.rPackages.scan`

## Intent

Part of #1766

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->