### PR TITLE
Register refresh files in home view

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1154,6 +1154,11 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         }
       }),
       commands.registerCommand(
+        Commands.Files.Refresh,
+        this.sendRefreshedFilesLists,
+        this,
+      ),
+      commands.registerCommand(
         Commands.PythonPackages.Edit,
         async () => {
           if (this.root === undefined) {


### PR DESCRIPTION
This PR registers the `posit.publisher.files.refresh` command function in the Home View.

I didn't do:
- `posit.publisher.files.exclude`
- `posit.publisher.files.include`

Since both of those do not show up in the command palette and it is unclear how they would work.

## Intent

Final PR for #1766

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->