### PR TITLE
Update github workflows to use Node 20

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "20"
       - uses: actions/download-artifact@v4
         with:
           name: dist

--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: "20"
       - id: get-date
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
Now that VSCode is on Node 20 due its bump to Electron 29, we should use Node 20 in our Github Workflows.

## Intent

Part of #1206 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->
