### PR TITLE
fix: creates ephemeral keyring when dbus unavaiable

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -178,7 +178,8 @@ func (cs *CredentialsService) save(table CredentialTable) error {
 		return fmt.Errorf("failed to serialize credentials: %v", err)
 	}
 
-	err = keyring.Set(ServiceName, "credentials", string(data))
+	ks := KeyringService{}
+	err = ks.Set(ServiceName, "credentials", string(data))
 	if err != nil {
 		return fmt.Errorf("failed to set credentials: %v", err)
 	}
@@ -187,7 +188,8 @@ func (cs *CredentialsService) save(table CredentialTable) error {
 
 // Loads the CredentialTable
 func (cs *CredentialsService) load() (CredentialTable, error) {
-	data, err := keyring.Get(ServiceName, "credentials")
+	ks := KeyringService{}
+	data, err := ks.Get(ServiceName, "credentials")
 	if err != nil {
 		if err == keyring.ErrNotFound {
 			return make(map[string]CredentialRecord), nil

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -1,0 +1,44 @@
+package credentials
+
+import (
+	"strings"
+
+	"github.com/zalando/go-keyring"
+)
+
+type KeyringService struct {
+	keyring.Keyring
+}
+
+func (ks *KeyringService) Set(service, user, password string) error {
+	err := keyring.Set(service, user, password)
+	if err != nil {
+		if strings.HasSuffix(err.Error(), "exec: \"dbus-launch\": executable file not found in $PATH") {
+			keyring.MockInit()
+			return keyring.Set(service, user, password)
+		}
+	}
+	return err
+}
+
+func (ks *KeyringService) Get(service, user string) (string, error) {
+	v, err := keyring.Get(service, user)
+	if err != nil {
+		if strings.HasSuffix(err.Error(), "exec: \"dbus-launch\": executable file not found in $PATH") {
+			keyring.MockInit()
+			return keyring.Get(service, user)
+		}
+	}
+	return v, err
+}
+
+func (ks *KeyringService) Delete(service, user string) error {
+	err := keyring.Delete(service, user)
+	if err != nil {
+		if strings.HasSuffix(err.Error(), "exec: \"dbus-launch\": executable file not found in $PATH") {
+			keyring.MockInit()
+			return keyring.Delete(service, user)
+		}
+	}
+	return err
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

When running in Posit Workbench, the dbus-launcher executable is not installed. This executable is a dependency of Gnome Keyring. This change creates an ephemeral solution using the keyring.MockInit() function. Generally, this is used for unit testing, but it works for this situation.

In the future, we could implement a persistent on-disk solution.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
