### PR TITLE
Update extension publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - "v*.*.*"
-  workflow_call: # TODO: testing
+  workflow_dispatch: # TODO: testing
 jobs:
   build:
     uses: ./.github/workflows/build.yaml


### PR DESCRIPTION
## Intent

This PR enables further testing of the `publish` workflow, by setting up just (which is needed to run one of the steps) and also setting up `workflow_dispatch` so we can invoke it (the original incorrectly had `workflow_call`). We can run manually once this is merged to main.

I've also created a placeholder `OPEN_VSX_TOKEN` secret in the repo so we can dry-run; we cannot publish until we have a real token.

Part of #1786 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->
