### PR TITLE
Omit rendered files in quarto mode

### DIFF
--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -47,6 +47,7 @@ type quartoInspectOutput struct {
 				Title      string   `json:"title"`
 				PreRender  []string `json:"pre-render"`
 				PostRender []string `json:"post-render"`
+				OutputDir  string   `json:"output-dir"`
 			} `json:"project"`
 			Website struct {
 				Title string `json:"title"`
@@ -237,9 +238,13 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath) ([]*config.Config, er
 		if outputFile == "" {
 			outputFile = "*.html"
 		}
-		outputDir := strings.TrimSuffix(outputFile, ".html") + "_files"
+		htmlOutputDir := strings.TrimSuffix(outputFile, ".html") + "_files"
 
-		cfg.Files = append(cfg.Files, "!"+outputFile, "!"+outputDir)
+		cfg.Files = append(cfg.Files, "!"+outputFile, "!"+htmlOutputDir)
+		projectOutputDir := inspectOutput.Project.Config.Project.OutputDir
+		if projectOutputDir != "" {
+			cfg.Files = append(cfg.Files, "!"+projectOutputDir)
+		}
 		configs = append(configs, cfg)
 	}
 	return configs, nil

--- a/internal/inspect/detectors/quarto_test.go
+++ b/internal/inspect/detectors/quarto_test.go
@@ -219,7 +219,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 		Entrypoint: "about.qmd",
 		Title:      "About",
 		Validate:   true,
-		Files:      []string{"*", "!about.html", "!about_files"},
+		Files:      []string{"*", "!about.html", "!about_files", "!_site"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -231,7 +231,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 		Entrypoint: "index.qmd",
 		Title:      "quarto-website-none",
 		Validate:   true,
-		Files:      []string{"*", "!index.html", "!index_files"},
+		Files:      []string{"*", "!index.html", "!index_files", "!_site"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

When inspecting a quarto source project, create a configuration that omits local rendering artifacts. They are not needed since Connect will render the content.

Fixes #1707

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Omit the `output-file` indicated by the `quarto inspect` output, along with its associated assets directory.

## Automated Tests

Existing tests have been updated.

## Directions for Reviewers

Render your Quarto content locally, then deploy in `quarto` mode. The HTML output and directory should not be included. Deploy it again in HTML mode; then it should be included.
