### PR TITLE
Omit has_parameters from config if it is false

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,7 +98,7 @@ func (s *ConfigSuite) TestWriteFile() {
 	s.NoError(err)
 }
 
-func (s *ConfigSuite) TestWriteFileEmptyEntrypoing() {
+func (s *ConfigSuite) TestWriteFileEmptyEntrypoint() {
 	configFile := GetConfigPath(s.cwd, "myConfig")
 	cfg := New()
 	cfg.Type = ContentTypeHTML
@@ -114,6 +114,8 @@ func (s *ConfigSuite) TestWriteFileEmptyEntrypoing() {
 	s.NoError(err)
 	lines := strings.Split(string(contents), "\n")
 	s.Contains(lines, "entrypoint = ''")
+
+	s.NotContains(contents, []byte("has_parameters"))
 }
 
 func (s *ConfigSuite) TestWriteFileErr() {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -88,7 +88,7 @@ type Config struct {
 	Type          ContentType `toml:"type" json:"type"`
 	Entrypoint    string      `toml:"entrypoint" json:"entrypoint,omitempty"`
 	Validate      bool        `toml:"validate" json:"validate"`
-	HasParameters bool        `toml:"has_parameters" json:"hasParameters"`
+	HasParameters bool        `toml:"has_parameters,omitempty" json:"hasParameters"`
 	Files         []string    `toml:"files" json:"files"`
 	Title         string      `toml:"title,omitempty" json:"title,omitempty"`
 	Description   string      `toml:"description,multiline,omitempty" json:"description,omitempty"`


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR omits the `has_parameters` field from TOML files we create, if it is false (which it usually is).

Fixes #1788

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

Updated an existing test to cover this.

## Directions for Reviewers

Create a new config, should be no `has_parameters` line.
