### PR TITLE
Don't populate empty manifest sections

### DIFF
--- a/internal/bundles/manifest.go
+++ b/internal/bundles/manifest.go
@@ -145,13 +145,9 @@ func ReadManifestFile(path util.Path) (*Manifest, error) {
 
 func NewManifest() *Manifest {
 	return &Manifest{
-		Version:     1,
-		Python:      &Python{},
-		Quarto:      &Quarto{},
-		Jupyter:     &Jupyter{},
-		Environment: &Environment{},
-		Packages:    make(PackageMap),
-		Files:       make(ManifestFileMap),
+		Version:  1,
+		Packages: make(PackageMap),
+		Files:    make(ManifestFileMap),
 	}
 }
 

--- a/internal/bundles/manifest_test.go
+++ b/internal/bundles/manifest_test.go
@@ -60,14 +60,10 @@ func (s *ManifestSuite) TestReadManifest() {
 	manifest, err := ReadManifest(reader)
 	s.Nil(err)
 	s.Equal(&Manifest{
-		Version:     1,
-		Platform:    "4.1.0",
-		Python:      &Python{},
-		Quarto:      &Quarto{},
-		Jupyter:     &Jupyter{},
-		Environment: &Environment{},
-		Packages:    PackageMap{},
-		Files:       ManifestFileMap{},
+		Version:  1,
+		Platform: "4.1.0",
+		Packages: PackageMap{},
+		Files:    ManifestFileMap{},
 	}, manifest)
 }
 
@@ -102,14 +98,10 @@ func (s *ManifestSuite) TestReadManifestFile() {
 	manifest, err := ReadManifestFile(manifestPath)
 	s.Nil(err)
 	s.Equal(&Manifest{
-		Version:     1,
-		Platform:    "4.1.0",
-		Python:      &Python{},
-		Quarto:      &Quarto{},
-		Jupyter:     &Jupyter{},
-		Environment: &Environment{},
-		Packages:    PackageMap{},
-		Files:       ManifestFileMap{},
+		Version:  1,
+		Platform: "4.1.0",
+		Packages: PackageMap{},
+		Files:    ManifestFileMap{},
 	}, manifest)
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR removes the instantiation of empty manifest sections; those were making it into the bundle manifest files.

Fixes #1823

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

Existing tests are updated.

## Directions for Reviewers

Deploy in various scenarios. Download the bundles and make sure there are no empty sections in the manifest (`python`, jupyter`, and `quarto`).
