### PR TITLE
Add title to first line of publishing log

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -139,8 +139,8 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     // Reset events when a new publish starts
     this._stream.register("publish/start", (msg: EventStreamMessage) => {
       this.resetStages();
-      this.publishingStage.inactiveLabel = `Publish to ${msg.data.server}`;
-      this.publishingStage.activeLabel = `Publishing to ${msg.data.server}`;
+      this.publishingStage.inactiveLabel = `Publish "${msg.data.title}" to ${msg.data.server}`;
+      this.publishingStage.activeLabel = `Publishing "${msg.data.title}" to ${msg.data.server}`;
       this.publishingStage.status = LogStageStatus.inProgress;
       this.refresh();
     });

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -42,6 +42,7 @@ type baseEventData struct {
 
 type publishStartData struct {
 	Server string `mapstructure:"server"`
+	Title  string `mapstructure:"title"`
 }
 
 type publishSuccessData struct {
@@ -194,6 +195,7 @@ func (p *defaultPublisher) PublishDirectory(log logging.Logger) error {
 	log.Info("Publishing from directory", logging.LogKeyOp, events.AgentOp, "path", p.Dir)
 	p.emitter.Emit(events.New(events.PublishOp, events.StartPhase, events.NoError, publishStartData{
 		Server: p.Account.URL,
+		Title:  p.Config.Title,
 	}))
 	log.Info("Starting deployment to server", "server", p.Account.URL)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds the title to the first entry in the Posit Publisher Logs, so it says
```
Publishing "Fancy Title" to https://rsc.radixu.com
```

instead of

```
Publishing to https://rsc.radixu.com
```

Fixes #1756

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Backend adds the title to the publish/start event payload, and the front end renders it for that message type.

## Directions for Reviewers

Deploy, and look for the title at the start of the Posit Publisher Logs.
