### PR TITLE
Make getting R package information a separate log phase

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -89,6 +89,13 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
   private resetStages() {
     this.stages = new Map([
       [
+        "publish/getRPackageDescriptions",
+        createLogStage(
+          "Get Package Descriptions",
+          "Getting Package Descriptions",
+        ),
+      ],
+      [
         "publish/checkCapabilities",
         createLogStage("Check Capabilities", "Checking Capabilities"),
       ],

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -44,19 +44,20 @@ const (
 const (
 	AgentOp Operation = "agent"
 
-	PublishCheckCapabilitiesOp   Operation = "publish/checkCapabilities"
-	PublishCreateNewDeploymentOp Operation = "publish/createNewDeployment"
-	PublishSetEnvVarsOp          Operation = "publish/setEnvVars"
-	PublishCreateBundleOp        Operation = "publish/createBundle"
-	PublishUpdateDeploymentOp    Operation = "publish/createDeployment"
-	PublishUploadBundleOp        Operation = "publish/uploadBundle"
-	PublishDeployBundleOp        Operation = "publish/deployBundle"
-	PublishRestorePythonEnvOp    Operation = "publish/restorePythonEnv"
-	PublishRestoreREnvOp         Operation = "publish/restoreREnv"
-	PublishRunContentOp          Operation = "publish/runContent"
-	PublishSetVanityUrlOp        Operation = "publish/setVanityURL"
-	PublishValidateDeploymentOp  Operation = "publish/validateDeployment"
-	PublishOp                    Operation = "publish"
+	PublishCheckCapabilitiesOp       Operation = "publish/checkCapabilities"
+	PublishGetRPackageDescriptionsOp Operation = "publish/getRPackageDescriptions"
+	PublishCreateNewDeploymentOp     Operation = "publish/createNewDeployment"
+	PublishSetEnvVarsOp              Operation = "publish/setEnvVars"
+	PublishCreateBundleOp            Operation = "publish/createBundle"
+	PublishUpdateDeploymentOp        Operation = "publish/createDeployment"
+	PublishUploadBundleOp            Operation = "publish/uploadBundle"
+	PublishDeployBundleOp            Operation = "publish/deployBundle"
+	PublishRestorePythonEnvOp        Operation = "publish/restorePythonEnv"
+	PublishRestoreREnvOp             Operation = "publish/restoreREnv"
+	PublishRunContentOp              Operation = "publish/runContent"
+	PublishSetVanityUrlOp            Operation = "publish/setVanityURL"
+	PublishValidateDeploymentOp      Operation = "publish/validateDeployment"
+	PublishOp                        Operation = "publish"
 )
 
 func New(op Operation, phase Phase, errCode ErrorCode, data any) *Event {

--- a/internal/inspect/dependencies/renv/available_packages_test.go
+++ b/internal/inspect/dependencies/renv/available_packages_test.go
@@ -33,7 +33,7 @@ func (s *AvailablePackagesSuite) SetupTest() {
 }
 
 func (s *AvailablePackagesSuite) TestListAvailablePackages() {
-	lister := NewAvailablePackageLister(s.base, util.Path{}, logging.New())
+	lister := NewAvailablePackageLister(s.base, util.Path{})
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", "R", mock.Anything, s.base, mock.Anything).Return([]byte(
 		"pkg1 1.0 https://cran.rstudio.com/src/contrib \npkg2 2.0 https://cran.rstudio.com/src/contrib \n"), []byte{}, nil)
@@ -41,7 +41,7 @@ func (s *AvailablePackagesSuite) TestListAvailablePackages() {
 
 	pkgs, err := lister.ListAvailablePackages([]Repository{
 		{Name: "cran", URL: "https://cran.rstudio.com"},
-	})
+	}, logging.New())
 	s.NoError(err)
 	s.Equal([]AvailablePackage{
 		{Name: "pkg1", Version: "1.0", Repository: "https://cran.rstudio.com"},
@@ -57,12 +57,12 @@ BioCbooks https://bioconductor.org/packages/3.18/books
 `
 
 func (s *AvailablePackagesSuite) TestGetBioconductorRepos() {
-	lister := NewAvailablePackageLister(s.base, util.Path{}, logging.New())
+	lister := NewAvailablePackageLister(s.base, util.Path{})
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", "R", mock.Anything, s.base, mock.Anything).Return([]byte(biocReposOutput), []byte{}, nil)
 	lister.rExecutor = executor
 
-	repos, err := lister.GetBioconductorRepos(s.base)
+	repos, err := lister.GetBioconductorRepos(s.base, logging.New())
 	s.NoError(err)
 	s.Equal([]Repository{
 		{Name: "BioCsoft", URL: "https://bioconductor.org/packages/3.18/bioc"},
@@ -81,12 +81,12 @@ func (s *AvailablePackagesSuite) TestGetLibPaths() {
 	if runtime.GOOS == "windows" {
 		s.T().Skip()
 	}
-	lister := NewAvailablePackageLister(s.base, util.Path{}, logging.New())
+	lister := NewAvailablePackageLister(s.base, util.Path{})
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", "R", mock.Anything, s.base, mock.Anything).Return([]byte(libPathsOutput), []byte{}, nil)
 	lister.rExecutor = executor
 
-	repos, err := lister.GetLibPaths()
+	repos, err := lister.GetLibPaths(logging.New())
 	s.NoError(err)
 	s.Len(repos, 2)
 	s.Equal("/project/renv/library/R-4.3/x86_64-apple-darwin20", repos[0].String())
@@ -101,12 +101,12 @@ func (s *AvailablePackagesSuite) TestGetLibPathsWindows() {
 	if runtime.GOOS != "windows" {
 		s.T().Skip()
 	}
-	lister := NewAvailablePackageLister(s.base, util.Path{}, logging.New())
+	lister := NewAvailablePackageLister(s.base, util.Path{})
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", "R", mock.Anything, s.base, mock.Anything).Return([]byte(windowsLibPathsOutput), []byte{}, nil)
 	lister.rExecutor = executor
 
-	repos, err := lister.GetLibPaths()
+	repos, err := lister.GetLibPaths(logging.New())
 	s.NoError(err)
 	s.Len(repos, 2)
 	s.Equal(`D:\project\renv\library\R-4.3\x86_64-apple-darwin20`, repos[0].String())

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -16,7 +16,6 @@ import (
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/deployment"
 	"github.com/posit-dev/publisher/internal/events"
-	"github.com/posit-dev/publisher/internal/inspect"
 	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/project"
@@ -76,7 +75,7 @@ func NewFromState(s *state.State, emitter events.Emitter, log logging.Logger) (P
 	return &defaultPublisher{
 		State:          s,
 		emitter:        emitter,
-		rPackageMapper: renv.NewPackageMapper(s.Dir, util.Path{}, log),
+		rPackageMapper: renv.NewPackageMapper(s.Dir, util.Path{}),
 	}, nil
 }
 
@@ -118,23 +117,6 @@ func logAppInfo(w io.Writer, accountURL string, contentID types.ContentID, log l
 		fmt.Fprintln(w, "Dashboard URL: ", dashboardURL)
 		fmt.Fprintln(w, "Direct URL:    ", directURL)
 	}
-}
-
-func (p *defaultPublisher) getRPackages(log logging.Logger) (bundles.PackageMap, error) {
-	log.Info("Collecting R package descriptions")
-
-	lockfileString := p.Config.R.PackageFile
-	if lockfileString == "" {
-		lockfileString = inspect.DefaultRenvLockfile
-	}
-	lockfilePath := p.Dir.Join(lockfileString)
-
-	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath)
-	if err != nil {
-		return nil, err
-	}
-	log.Info("Done collecting R package descriptions")
-	return rPackages, nil
 }
 
 func (p *defaultPublisher) isDeployed() bool {

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -40,7 +40,7 @@ type mockPackageMapper struct {
 	mock.Mock
 }
 
-func (m *mockPackageMapper) GetManifestPackages(base util.AbsolutePath, lockfilePath util.AbsolutePath) (bundles.PackageMap, error) {
+func (m *mockPackageMapper) GetManifestPackages(base util.AbsolutePath, lockfilePath util.AbsolutePath, log logging.Logger) (bundles.PackageMap, error) {
 	args := m.Called(base, lockfilePath)
 	pkgs := args.Get(0)
 	if pkgs == nil {
@@ -296,9 +296,9 @@ func (s *PublishSuite) publishWithClient(
 
 	rPackageMapper := &mockPackageMapper{}
 	if rPackageErr != nil {
-		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything).Return(nil, rPackageErr)
+		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything, mock.Anything).Return(nil, rPackageErr)
 	} else {
-		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything).Return(bundles.PackageMap{}, nil)
+		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything, mock.Anything).Return(bundles.PackageMap{}, nil)
 	}
 	publisher.rPackageMapper = rPackageMapper
 

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -1,0 +1,33 @@
+package publish
+
+import (
+	"github.com/posit-dev/publisher/internal/bundles"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/inspect"
+	"github.com/posit-dev/publisher/internal/logging"
+)
+
+type getRPackageDescriptionsStartData struct{}
+type getRPackageDescriptionsSuccessData struct{}
+
+func (p *defaultPublisher) getRPackages(log logging.Logger) (bundles.PackageMap, error) {
+	op := events.PublishGetRPackageDescriptionsOp
+	log = log.WithArgs(logging.LogKeyOp, op)
+
+	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, getRPackageDescriptionsStartData{}))
+	log.Info("Collecting R package descriptions")
+
+	lockfileString := p.Config.R.PackageFile
+	if lockfileString == "" {
+		lockfileString = inspect.DefaultRenvLockfile
+	}
+	lockfilePath := p.Dir.Join(lockfileString)
+
+	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
+	if err != nil {
+		return nil, err
+	}
+	log.Info("Done collecting R package descriptions")
+	p.emitter.Emit(events.New(op, events.SuccessPhase, events.NoError, getRPackageDescriptionsSuccessData{}))
+	return rPackages, nil
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR puts the events from `getRPackages` into their own log phase. Currently, they appear as `agent/log` events. This adds a new phase to the logs view.


Fixes #1593 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Create a new log/event operation. Inject a logger into the code that gets the R package descriptions so that all log messages will have the correct operation.

## Automated Tests

Existing tests have been updated.

## Directions for Reviewers

Deploy R content. See the new phase in the Posit Publisher Logs view.
