### PR TITLE
Remove dryRun from extension publishing CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,7 +46,6 @@ jobs:
           target: ${{ matrix.target }}
           preRelease: ${{ steps.get-prerelease.outputs.prerelease == 'true' }}
           skipDuplicate: true
-          dryRun: true # TODO: testing
 
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
@@ -57,4 +56,3 @@ jobs:
           target: ${{ matrix.target }}
           preRelease: ${{ steps.get-prerelease.outputs.prerelease == 'true' }}
           skipDuplicate: true
-          dryRun: true # TODO: testing


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR switches extension release publishing on in CI.

Fixes #1688

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Remove the `dryRun` flag.

## Directions for Reviewers

This will be run when we push a release tag (`v*.*.*`). Credentials are live so this will publish the extension to both marketplaces. If troubleshooting is needed, we may burn some pre-release version numbers.
