### PR TITLE
Add subdirectory support to deployments API

### DIFF
--- a/internal/services/api/delete_deployment.go
+++ b/internal/services/api/delete_deployment.go
@@ -16,8 +16,13 @@ import (
 func DeleteDeploymentHandlerFunc(base util.AbsolutePath, log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		name := mux.Vars(req)["name"]
-		path := deployment.GetDeploymentPath(base, name)
-		err := path.Remove()
+		projectDir, _, err := ProjectDirFromRequest(base, w, req, log)
+		if err != nil {
+			// Response already returned by ProjectDirFromRequest
+			return
+		}
+		path := deployment.GetDeploymentPath(projectDir, name)
+		err = path.Remove()
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				http.NotFound(w, req)

--- a/internal/services/api/get_configuration_test.go
+++ b/internal/services/api/get_configuration_test.go
@@ -168,3 +168,18 @@ func (s *GetConfigurationuite) TestGetConfigurationFromSubdir() {
 	s.Nil(res.Error)
 	s.Equal(cfg, res.Configuration)
 }
+
+func (s *GetConfigurationuite) TestGetConfigurationBadDir() {
+	// It's a Bad Request to try to get a config from a directory outside the project
+	_ = s.makeConfiguration("myConfig")
+
+	h := GetConfigurationHandlerFunc(s.cwd, s.log)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/configurations/myConfig?dir=../middleware", nil)
+	s.NoError(err)
+	req = mux.SetURLVars(req, map[string]string{"id": "myConfig"})
+	h(rec, req)
+
+	s.Equal(http.StatusBadRequest, rec.Result().StatusCode)
+}

--- a/internal/services/api/get_deployments.go
+++ b/internal/services/api/get_deployments.go
@@ -11,22 +11,27 @@ import (
 	"github.com/posit-dev/publisher/internal/util"
 )
 
-func readLatestDeploymentFiles(base util.AbsolutePath) ([]any, error) {
-	paths, err := deployment.ListDeploymentFiles(base)
+func readLatestDeploymentFiles(projectDir util.AbsolutePath, relProjectDir util.RelativePath) ([]any, error) {
+	paths, err := deployment.ListDeploymentFiles(projectDir)
 	if err != nil {
 		return nil, err
 	}
 	response := make([]any, 0, len(paths))
 	for _, path := range paths {
 		d, err := deployment.FromFile(path)
-		response = append(response, deploymentAsDTO(d, err, base, path))
+		response = append(response, deploymentAsDTO(d, err, projectDir, relProjectDir, path))
 	}
 	return response, nil
 }
 
 func GetDeploymentsHandlerFunc(base util.AbsolutePath, log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		response, err := readLatestDeploymentFiles(base)
+		projectDir, relProjectDir, err := ProjectDirFromRequest(base, w, req, log)
+		if err != nil {
+			// Response already returned by ProjectDirFromRequest
+			return
+		}
+		response, err := readLatestDeploymentFiles(projectDir, relProjectDir)
 		if err != nil {
 			InternalError(w, req, log, err)
 			return

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -36,10 +36,15 @@ func PostDeploymentHandlerFunc(
 
 	return func(w http.ResponseWriter, req *http.Request) {
 		name := mux.Vars(req)["name"]
+		projectDir, _, err := ProjectDirFromRequest(base, w, req, log)
+		if err != nil {
+			// Response already returned by ProjectDirFromRequest
+			return
+		}
 		dec := json.NewDecoder(req.Body)
 		dec.DisallowUnknownFields()
 		var b PostDeploymentRequestBody
-		err := dec.Decode(&b)
+		err = dec.Decode(&b)
 		if err != nil {
 			BadRequest(w, req, log, err)
 			return
@@ -49,7 +54,7 @@ func PostDeploymentHandlerFunc(
 			InternalError(w, req, log, err)
 			return
 		}
-		newState, err := stateFactory(base, b.AccountName, b.ConfigName, name, "", accountList)
+		newState, err := stateFactory(projectDir, b.AccountName, b.ConfigName, name, "", accountList)
 		if err != nil {
 			if errors.Is(err, accounts.ErrAccountNotFound) {
 				NotFound(w, log, err)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds support for an optional `dir` query parameter to the deployment API endpoints:

* GET /api/deployments
* GET /api/deployments/$NAME
* POST /api/deployments
* POST /api/deployments/$NAME
* PATCH /api/deployments/$NAME
* DELETE /api/deployments/$NAME

The directory is relative to the workspace root directory, and cannot escape it (the API should return a 400 if you provide a path that would be outside of the workspace root).

It also populates the returned configuration DTO with a new `projectDir` field that contains the subdirectory (again, relative to the workspace root).

This is part of https://github.com/posit-dev/publisher/issues/1844 and part of https://github.com/posit-dev/publisher/issues/1851.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

Existing tests have been updated to assert that the projectDir is correct when no dir is specified. New tests have been added specifically to test the subdirectory case for each API.

## Directions for Reviewers

Run the agent in a parent directory (one or more levels up from your deployable projects). Access deployment info from subdirectories using the various APIs:

```
$publisher ui -vv --listen=localhost:9001 &
curl localhost:9001/api/deployments?dir=test/sample-content/quarto-proj-py | jq
curl localhost:9001/api/deployments?dir=test/sample-content/quarto-proj-none | jq
```

The `POST /api/deployments/$NAME` endpoint should load the configuration named in the deployment from the same directory path; verify that.

Also run the extension and regression test basic publishing (you can't use subdirectories in the extension yet, but everything should default to the current behavior).

