### PR TITLE
Update release docs for VSCode extension versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,19 @@ See [the Contribution Guide for the VSCode Extension](./extensions/vscode/CONTRI
 
 ## Release
 
+The Posit Publisher VSCode extension releases follow guidelines from the
+[VSCode Publishing Extensions docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions).
+
+[SemVer versioning](https://semver.org/spec/v2.0.0.html) is used , but the
+VSCode Marketplace will only support `major.minor.patch` for extension versions,
+semver pre-release tags are not supported.
+
+The recommendation is releases use `major.EVEN_NUMBER.patch` for release
+versions and `major.ODD_NUMBER.patch` for pre-release versions.
+
+CI facilitates this and will automatically publish as a pre-release if the
+minor version number is odd.
+
 ### Before Releasing
 
 - Ensure that all relevant changes are documented in:
@@ -133,27 +146,33 @@ and committing any changes.
 
 ### Instructions
 
-To start a release create a semver compatible tag.
-
-_For this example, we will use the tag `v0.0.dev0`. This tag already exists, so you will not be able run the following commands verbatim._
-
 **Step 1**
 
-Create a proper SemVer compatible tag. Consult the [SemVer specification](https://semver.org/spec/v2.0.0.html) if you are unsure what this means.
+Create a proper SemVer and extension version compatible tag using the guidelines
+above.
 
-`git tag v0.0.dev0`
+Use an even minor version for releases, or an odd minor version for
+pre-releases.
+
+_For this example, we will use the tag `v1.1.0` to create a pre-release. This
+tag already exists, so you will not be able run the following commands
+verbatim._
+
+`git tag v1.1.0`
 
 **Step 2**
 
 Push the tag GitHub.
 
-`git push origin v0.0.dev0`
+`git push origin v1.1.0`
 
 This command will trigger the [Release GitHub Action](https://github.com/rstudio/publishing-client/actions/workflows/release.yaml).
 
 **Step 3**
 
-Once complete the action has completed, the release will be available on the [Releases page](https://github.com/rstudio/publishing-client/releases).
+Once complete the action has completed, the release will be available on the
+[Releases page](https://github.com/rstudio/publishing-client/releases), and
+published to the VSCode Marketplace.
 
 **Step 4**
 
@@ -163,62 +182,3 @@ for the new release, using the links to the `.vsix` files uploaded to the CDN.
 **Step 5**
 
 Update the release / latest version string in the `install-publisher.bash` script.
-
-### Pre-Releases
-
-Any tags denoted as a pre-release as defined by the [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) specification will be marked as such in GitHub. For example, the `v0.0.dev0` is a pre-release. Tag `v0.0.0` is a standard-release. Please consult the specification for additional information.
-
-[PEP-440](https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering) provides a good example of common pre-release tag combinations.
-
-For additional definitions see https://en.wikipedia.org/wiki/Software_release_life_cycle.
-
-Currently, the following suffix lineage is in use:
-
-### Release Lifecycle
-
-- `X`: The major version.
-- `Y`: The minor version.
-- `Z`: The patch version.
-- `N`: A variable representing the incremental version value.
-
-**`X.Y.devN`**
-
-A development pre-release. Created to test changes to the release procces. `N` starts at **0** and increments by 1 (`X.Y.dev0`, `X.Y.dev1`, ..., `X.Y.devN`).
-
-*https://peps.python.org/pep-0440/#implicit-development-release-number*
-
-**`X.Y.alphaN`**
-
-An alpha pre-release. Created to support internal user testing. `N` starts at **1** and increments by 1 (`X.Y.alpha1`, `X.Y.alpha2`, ..., `X.Y.alphaN`).
-
-*https://peps.python.org/pep-0440/#pre-releases*
-
-**`X.Y.betaN`**
-
-An beta pre-release. Created to support closed external user testing. `N` starts at **1** and increments by 1 (`X.Y.beta1`, `X.Y.beta2`, ..., `X.Y.betaN`).
-
-*https://peps.python.org/pep-0440/#pre-releases*
-
-**`X.Y.rcN`**
-
-An release-candidate pre-release. Created to support open external user testing. `N` starts at **1** and increments by 1 (`X.Y.rc1`, `X.Y.rc2`, ..., `X.Y.rcN`).
-
-*https://peps.python.org/pep-0440/#pre-releases*
-
-**`X.Y.N`**
-
-A stable patch release. Created for backward compatible bug fixes. `N` starts at **0** and increments by 1 (`X.Y.0`, `X.Y.1`, ..., `X.Y.N`).
-
-*https://semver.org*
-
-**`X.N.Z`**
-
-A stable minor release. Created for added functionality in a backward compatible manner. `N` starts at **0** and increments by 1 (`X.0.Z`, `X.1.Z`, ..., `X.N.Z`).
-
-*https://semver.org*
-
-**`N.Y.Z`**
-
-A stable major release. Created for incompatbile API changes. `N` starts at **0** and increments by 1 (`0.Y.Z`, `1.Y.Z`, ..., `N.Y.Z`).
-
-*https://semver.org*


### PR DESCRIPTION
This PR updates the release instructions in our `CONTRIBUTING.md` guide to reflect our version number for the VSCode extension.

It is based on the VSCode recommendations found here: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions

## Intent

Resolves #1868

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->