### PR TITLE
Don't detect notebooks as quarto docs

### DIFF
--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -139,7 +139,7 @@ func (d *QuartoDetector) getTitle(inspectOutput *quartoInspectOutput, entrypoint
 	return ""
 }
 
-var quartoSuffixes = []string{".qmd", ".Rmd", ".ipynb"}
+var quartoSuffixes = []string{".qmd", ".Rmd"}
 
 func (d *QuartoDetector) findEntrypoints(base util.AbsolutePath) ([]util.AbsolutePath, error) {
 	allPaths := []util.AbsolutePath{}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR removes .ipynb files from the list of documents that will be detected as Quarto documents. 

Fixes #1863 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Directions for Reviewers

Inspect a project (create a new deployment) that contains a .ipynb file. Verify that the only configuration choice presented for that entrypoint is to render it with Jupyter.
