### PR TITLE
Add document tracker to set `activeFileEntrypoint` context

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -16,7 +16,8 @@
         "eventsource": "^2.0.2",
         "get-port": "5.1.1",
         "mutexify": "^1.4.0",
-        "retry": "^0.13.1"
+        "retry": "^0.13.1",
+        "vscode-uri": "^3.0.8"
       },
       "devDependencies": {
         "@types/eventsource": "^1.1.15",
@@ -3344,6 +3345,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -251,9 +251,22 @@
         "title": "View Content Log on Connect",
         "icon": "$(output)",
         "category": "Posit Publisher"
+      },
+      {
+        "command": "posit.publisher.deployWithEntrypoint",
+        "title": "Deploy with this Entrypoint",
+        "icon": "$(cloud-upload)",
+        "category": "Posit Publisher"
       }
     ],
     "menus": {
+      "editor/title": [
+        {
+          "command": "posit.publisher.deployWithEntrypoint",
+          "group": "navigation",
+          "when": "posit.publish.activeFileEntrypoint == true"
+        }
+      ],
       "view/title": [
         {
           "command": "posit.publisher.configurations.add",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -698,6 +698,7 @@
     "eventsource": "^2.0.2",
     "get-port": "5.1.1",
     "mutexify": "^1.4.0",
-    "retry": "^0.13.1"
+    "retry": "^0.13.1",
+    "vscode-uri": "^3.0.8"
   }
 }

--- a/extensions/vscode/src/api/resources/Configurations.ts
+++ b/extensions/vscode/src/api/resources/Configurations.ts
@@ -69,7 +69,7 @@ export class Configurations {
   // 200 - success
   // 400 - bad request
   // 500 - internal server error
-  inspect(python?: string, params?: { dir?: string }) {
+  inspect(python?: string, params?: { dir?: string; entrypoint?: string }) {
     return this.client.post<ConfigurationInspectionResult[]>(
       "/inspect",
       {

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -14,6 +14,7 @@ const baseCommands = {
   InitProject: "posit.publisher.init-project",
   ShowOutputChannel: "posit.publisher.showOutputChannel",
   ShowPublishingLog: "posit.publisher.showPublishingLog",
+  DeployWithEntrypoint: "posit.publisher.deployWithEntrypoint",
 } as const;
 
 const logsCommands = {

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -17,6 +17,10 @@ const baseCommands = {
   DeployWithEntrypoint: "posit.publisher.deployWithEntrypoint",
 } as const;
 
+const baseContexts = {
+  ActiveFileEntrypoint: "posit.publish.activeFileEntrypoint",
+} as const;
+
 const logsCommands = {
   Visit: "posit.publisher.logs.visit",
   // Added automatically by VSCode with view registration
@@ -123,6 +127,7 @@ export const Commands = {
 };
 
 export const Contexts = {
+  ...baseContexts,
   Configurations: configurationsContexts,
   ContentRecords: contentRecordsContexts,
   Credentials: credentialsContexts,

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -92,6 +92,8 @@ const homeViewCommands = {
   NavigateToDeploymentContent:
     "posit.publisher.homeView.navigateToDeployment.Content",
   ShowContentLogs: "posit.publisher.homeView.navigateToDeployment.ContentLog",
+  // Added automatically by VSCode with view registration
+  Focus: "posit.publisher.homeView.focus",
 } as const;
 
 const homeViewContexts = {

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -1,18 +1,11 @@
-import {
-  Disposable,
-  TextDocument,
-  TextEditor,
-  commands,
-  window,
-  workspace,
-} from "vscode";
+import { Disposable, TextDocument, TextEditor, commands, window } from "vscode";
 
 const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
 
 /**
  * Tracks whether a document is an entrypoint file and sets extension context.
  */
-export class TrackedEntrypointDocument implements Disposable {
+export class TrackedEntrypointDocument {
   readonly document: TextDocument;
   private isEntrypoint: boolean;
 
@@ -23,6 +16,7 @@ export class TrackedEntrypointDocument implements Disposable {
 
   static async create(document: TextDocument) {
     // set entrypoint with API call
+    // workspace.asRelativePath(editor.document.uri),
     return new TrackedEntrypointDocument(document, false);
   }
 
@@ -36,10 +30,6 @@ export class TrackedEntrypointDocument implements Disposable {
       ACTIVE_FILE_ENTRYPOINT_CONTEXT,
       this.isEntrypoint,
     );
-  }
-
-  dispose() {
-    return;
   }
 }
 
@@ -58,12 +48,13 @@ export class DocumentTracker implements Disposable {
     this.disposable = Disposable.from(
       window.onDidChangeActiveTextEditor(this.onActiveTextEditorChanged, this),
     );
+
+    // activate the initial active file
+    this.onActiveTextEditorChanged(window.activeTextEditor);
   }
 
   dispose() {
     this.disposable.dispose();
-
-    this.documents.forEach((doc) => doc.dispose());
     this.documents.clear();
   }
 
@@ -87,7 +78,6 @@ export class DocumentTracker implements Disposable {
    */
   async onActiveTextEditorChanged(editor: TextEditor | undefined) {
     if (editor === undefined) {
-      console.log("ACTIVE FILE undefined");
       commands.executeCommand(
         "setContext",
         ACTIVE_FILE_ENTRYPOINT_CONTEXT,
@@ -104,10 +94,5 @@ export class DocumentTracker implements Disposable {
     }
 
     tracked?.activate();
-
-    console.log(
-      "ACTIVE FILE EDITOR CHANGED",
-      workspace.asRelativePath(editor.document.uri),
-    );
   }
 }

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -1,4 +1,11 @@
-import { Disposable, TextDocument, TextEditor, commands, window } from "vscode";
+import {
+  Disposable,
+  TextDocument,
+  TextEditor,
+  commands,
+  window,
+  workspace,
+} from "vscode";
 
 const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
 
@@ -47,6 +54,7 @@ export class DocumentTracker implements Disposable {
   constructor() {
     this.disposable = Disposable.from(
       window.onDidChangeActiveTextEditor(this.onActiveTextEditorChanged, this),
+      workspace.onDidCloseTextDocument(this.onTextDocumentClosed, this),
     );
 
     // activate the initial active file
@@ -59,7 +67,7 @@ export class DocumentTracker implements Disposable {
   }
 
   /**
-   * Adds a document to be tracked
+   * Starts tracking a document
    * @param document The document to track
    * @returns The document passed
    */
@@ -67,6 +75,14 @@ export class DocumentTracker implements Disposable {
     const entrypoint = await TrackedEntrypointDocument.create(document);
     this.documents.set(document, entrypoint);
     return document;
+  }
+
+  /**
+   * Stops tracking a document
+   * @param document The document to stop tracking
+   */
+  removeDocument(document: TextDocument) {
+    this.documents.delete(document);
   }
 
   /**
@@ -94,5 +110,13 @@ export class DocumentTracker implements Disposable {
     }
 
     tracked?.activate();
+  }
+
+  /**
+   * Listener function for the closing of a text document.
+   * @param document The closed document
+   */
+  onTextDocumentClosed(document: TextDocument) {
+    this.removeDocument(document);
   }
 }

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -8,11 +8,12 @@ import {
   window,
   workspace,
 } from "vscode";
+import { Utils as uriUtils } from "vscode-uri";
 
 import { useApi } from "src/api";
 import { getPythonInterpreterPath } from "src/utils/config";
 import { isActiveDocument } from "src/utils/files";
-import { hasKnownContentType } from "./utils/inspect";
+import { hasKnownContentType } from "src/utils/inspect";
 
 const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
 
@@ -27,14 +28,14 @@ async function isDocumentEntrypoint(document: TextDocument): Promise<boolean> {
   const python = await getPythonInterpreterPath();
 
   // If the file is outside the workspace, it cannot be an entrypoint
-  const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
-  if (workspaceFolder === undefined) {
+  const dirname = uriUtils.dirname(document.uri);
+  if (dirname === undefined) {
     return false;
   }
 
   const response = await api.configurations.inspect(python, {
-    dir: workspace.asRelativePath(workspaceFolder.uri),
-    entrypoint: workspace.asRelativePath(document.fileName),
+    dir: workspace.asRelativePath(dirname),
+    entrypoint: uriUtils.basename(document.uri),
   });
   return hasKnownContentType(response.data);
 }

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -1,0 +1,113 @@
+import {
+  Disposable,
+  TextDocument,
+  TextEditor,
+  commands,
+  window,
+  workspace,
+} from "vscode";
+
+const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
+
+/**
+ * Tracks whether a document is an entrypoint file and sets extension context.
+ */
+export class TrackedEntrypointDocument implements Disposable {
+  readonly document: TextDocument;
+  private isEntrypoint: boolean;
+
+  private constructor(document: TextDocument, isEntrypoint: boolean) {
+    this.document = document;
+    this.isEntrypoint = isEntrypoint;
+  }
+
+  static async create(document: TextDocument) {
+    // set entrypoint with API call
+    return new TrackedEntrypointDocument(document, false);
+  }
+
+  /**
+   * Sets the file entrypoint context with this as the active file
+   */
+  activate() {
+    // change based on if entrypoint
+    commands.executeCommand(
+      "setContext",
+      ACTIVE_FILE_ENTRYPOINT_CONTEXT,
+      this.isEntrypoint,
+    );
+  }
+
+  dispose() {
+    return;
+  }
+}
+
+/**
+ * Tracks active documents and assists in determining extension context.
+ */
+export class DocumentTracker implements Disposable {
+  private disposable: Disposable;
+
+  private readonly documents = new Map<
+    TextDocument,
+    TrackedEntrypointDocument
+  >();
+
+  constructor() {
+    this.disposable = Disposable.from(
+      window.onDidChangeActiveTextEditor(this.onActiveTextEditorChanged, this),
+    );
+  }
+
+  dispose() {
+    this.disposable.dispose();
+
+    this.documents.forEach((doc) => doc.dispose());
+    this.documents.clear();
+  }
+
+  /**
+   * Adds a document to be tracked
+   * @param document The document to track
+   * @returns The document passed
+   */
+  async addDocument(document: TextDocument) {
+    const entrypoint = await TrackedEntrypointDocument.create(document);
+    this.documents.set(document, entrypoint);
+    return document;
+  }
+
+  /**
+   * Listener function for changes to the active text editor.
+   *
+   * Adds new documents to the tracker, and activates the associated
+   * TrackedEntrypointDocument
+   * @param editor The active text editor
+   */
+  async onActiveTextEditorChanged(editor: TextEditor | undefined) {
+    if (editor === undefined) {
+      console.log("ACTIVE FILE undefined");
+      commands.executeCommand(
+        "setContext",
+        ACTIVE_FILE_ENTRYPOINT_CONTEXT,
+        undefined,
+      );
+      return;
+    }
+
+    let tracked = this.documents.get(editor.document);
+
+    if (tracked === undefined) {
+      await this.addDocument(editor.document);
+      tracked = this.documents.get(editor.document);
+    }
+
+    tracked?.activate();
+
+    console.log(
+      "ACTIVE FILE EDITOR CHANGED",
+      workspace.asRelativePath(editor.document.uri),
+    );
+  }
+}

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 by Posit Software, PBC.
+
 import {
   Disposable,
   TextDocument,

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -24,20 +24,21 @@ import { getSummaryStringFromError } from "src/utils/errors";
  * @returns If the text document is an entrypoint
  */
 async function isDocumentEntrypoint(document: TextDocument): Promise<boolean> {
+  const dir = relativeDir(document.uri);
+  // If the file is outside the workspace, it cannot be an entrypoint
+  if (dir === undefined) {
+    return false;
+  }
+
   try {
     const api = await useApi();
     const python = await getPythonInterpreterPath();
-
-    const dir = relativeDir(document.uri);
-    // If the file is outside the workspace, it cannot be an entrypoint
-    if (dir === undefined) {
-      return false;
-    }
 
     const response = await api.configurations.inspect(python, {
       dir: dir,
       entrypoint: uriUtils.basename(document.uri),
     });
+
     return hasKnownContentType(response.data);
   } catch (error: unknown) {
     const summary = getSummaryStringFromError(

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -6,6 +6,7 @@ import {
   window,
   workspace,
 } from "vscode";
+import { isActiveDocument } from "src/utils/files";
 
 const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
 
@@ -15,6 +16,8 @@ const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
 export class TrackedEntrypointDocument {
   readonly document: TextDocument;
   private isEntrypoint: boolean;
+
+  private requiresUpdate: boolean = false;
 
   private constructor(document: TextDocument, isEntrypoint: boolean) {
     this.document = document;
@@ -28,15 +31,39 @@ export class TrackedEntrypointDocument {
   }
 
   /**
-   * Sets the file entrypoint context with this as the active file
+   * Sets the file entrypoint context with this as the active file.
+   * @param options Options for the activation
+   * @param options.forceUpdate Whether to force the entrypoint to update
    */
-  activate() {
+  async activate(options?: { forceUpdate?: boolean }) {
     // change based on if entrypoint
+    if (options?.forceUpdate) {
+      await this.update();
+    } else if (this.requiresUpdate) {
+      await this.update();
+    }
+
     commands.executeCommand(
       "setContext",
       ACTIVE_FILE_ENTRYPOINT_CONTEXT,
       this.isEntrypoint,
     );
+  }
+
+  /**
+   * Updates the entrypoint next time the document is activated.
+   */
+  updateNextActivate() {
+    this.requiresUpdate = true;
+  }
+
+  /**
+   * Updates whether or not the document is an entrypoint file.
+   */
+  private async update() {
+    // set entrypoint with API call
+    // workspace.asRelativePath(editor.document.uri),
+    this.isEntrypoint = !this.isEntrypoint;
   }
 }
 
@@ -55,6 +82,7 @@ export class DocumentTracker implements Disposable {
     this.disposable = Disposable.from(
       window.onDidChangeActiveTextEditor(this.onActiveTextEditorChanged, this),
       workspace.onDidCloseTextDocument(this.onTextDocumentClosed, this),
+      workspace.onDidSaveTextDocument(this.onTextDocumentSaved, this),
     );
 
     // activate the initial active file
@@ -69,12 +97,12 @@ export class DocumentTracker implements Disposable {
   /**
    * Starts tracking a document
    * @param document The document to track
-   * @returns The document passed
+   * @returns The TrackedEntrypointDocument created
    */
   async addDocument(document: TextDocument) {
     const entrypoint = await TrackedEntrypointDocument.create(document);
     this.documents.set(document, entrypoint);
-    return document;
+    return entrypoint;
   }
 
   /**
@@ -105,18 +133,44 @@ export class DocumentTracker implements Disposable {
     let tracked = this.documents.get(editor.document);
 
     if (tracked === undefined) {
-      await this.addDocument(editor.document);
-      tracked = this.documents.get(editor.document);
+      tracked = await this.addDocument(editor.document);
     }
 
-    tracked?.activate();
+    tracked.activate();
   }
 
   /**
    * Listener function for the closing of a text document.
+   * Stops the document from being tracked.
+   *
    * @param document The closed document
    */
   onTextDocumentClosed(document: TextDocument) {
     this.removeDocument(document);
+  }
+
+  /**
+   * Listener function for the saving of a text document.
+   * Triggers the document to update next time it is activated.
+   *
+   * @param document The saved document
+   */
+  async onTextDocumentSaved(document: TextDocument) {
+    const tracked = this.documents.get(document);
+
+    if (tracked) {
+      if (isActiveDocument(document)) {
+        tracked.activate({ forceUpdate: true });
+      } else {
+        tracked.updateNextActivate();
+      }
+      return;
+    }
+
+    // Track the untracked document
+    const newTracked = await this.addDocument(document);
+    if (isActiveDocument(document)) {
+      newTracked.activate();
+    }
   }
 }

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -11,12 +11,11 @@ import {
 import { Utils as uriUtils } from "vscode-uri";
 
 import { useApi } from "src/api";
+import { Contexts } from "src/constants";
 import { getPythonInterpreterPath } from "src/utils/config";
 import { isActiveDocument } from "src/utils/files";
 import { hasKnownContentType } from "src/utils/inspect";
 import { getSummaryStringFromError } from "src/utils/errors";
-
-const ACTIVE_FILE_ENTRYPOINT_CONTEXT = "posit.publish.activeFileEntrypoint";
 
 /**
  * Determines if a text document is an entrypoint file.
@@ -84,7 +83,7 @@ export class TrackedEntrypointDocument {
 
     commands.executeCommand(
       "setContext",
-      ACTIVE_FILE_ENTRYPOINT_CONTEXT,
+      Contexts.ActiveFileEntrypoint,
       this.isEntrypoint,
     );
   }
@@ -162,7 +161,7 @@ export class DocumentTracker implements Disposable {
     if (editor === undefined) {
       commands.executeCommand(
         "setContext",
-        ACTIVE_FILE_ENTRYPOINT_CONTEXT,
+        Contexts.ActiveFileEntrypoint,
         undefined,
       );
       return;

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -13,7 +13,7 @@ import { Utils as uriUtils } from "vscode-uri";
 import { useApi } from "src/api";
 import { Contexts } from "src/constants";
 import { getPythonInterpreterPath } from "src/utils/config";
-import { isActiveDocument } from "src/utils/files";
+import { isActiveDocument, relativeDir } from "src/utils/files";
 import { hasKnownContentType } from "src/utils/inspect";
 import { getSummaryStringFromError } from "src/utils/errors";
 
@@ -28,14 +28,14 @@ async function isDocumentEntrypoint(document: TextDocument): Promise<boolean> {
     const api = await useApi();
     const python = await getPythonInterpreterPath();
 
+    const dir = relativeDir(document.uri);
     // If the file is outside the workspace, it cannot be an entrypoint
-    const dirname = uriUtils.dirname(document.uri);
-    if (dirname === undefined) {
+    if (dir === undefined) {
       return false;
     }
 
     const response = await api.configurations.inspect(python, {
-      dir: workspace.asRelativePath(dirname),
+      dir: dir,
       entrypoint: uriUtils.basename(document.uri),
     });
     return hasKnownContentType(response.data);

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { ExtensionContext, commands } from "vscode";
+import { ExtensionContext, Uri, commands } from "vscode";
 
 import * as ports from "src/ports";
 import { Service } from "src/services";
@@ -104,9 +104,9 @@ export async function activate(context: ExtensionContext) {
 
   context.subscriptions.push(
     new DocumentTracker(),
-    commands.registerCommand(Commands.DeployWithEntrypoint, () => {
+    commands.registerCommand(Commands.DeployWithEntrypoint, (uri: Uri) => {
       commands.executeCommand(Commands.HomeView.Focus);
-      console.log("'Deploy with this Entrypoint' button hit!");
+      console.log("'Deploy with this Entrypoint' button hit!", uri);
     }),
   );
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -14,6 +14,7 @@ import { EventStream } from "src/events";
 import { HomeViewProvider } from "src/views/homeView";
 import { WatcherManager } from "src/watchers";
 import { Commands } from "src/constants";
+import { DocumentTracker } from "./entrypointTracker";
 
 const STATE_CONTEXT = "posit.publish.state";
 
@@ -100,6 +101,8 @@ export async function activate(context: ExtensionContext) {
     ),
   );
   setStateContext(PositPublishState.initialized);
+
+  context.subscriptions.push(new DocumentTracker());
 }
 
 // This method is called when your extension is deactivated

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -102,7 +102,13 @@ export async function activate(context: ExtensionContext) {
   );
   setStateContext(PositPublishState.initialized);
 
-  context.subscriptions.push(new DocumentTracker());
+  context.subscriptions.push(
+    new DocumentTracker(),
+    commands.registerCommand(Commands.DeployWithEntrypoint, () => {
+      commands.executeCommand(Commands.HomeView.Focus);
+      console.log("'Deploy with this Entrypoint' button hit!");
+    }),
+  );
 }
 
 // This method is called when your extension is deactivated

--- a/extensions/vscode/src/utils/files.ts
+++ b/extensions/vscode/src/utils/files.ts
@@ -11,7 +11,7 @@ import {
   TextDocument,
 } from "vscode";
 
-import { ContentRecordFile } from "../api";
+import { ContentRecordFile } from "src/api";
 
 export async function fileExists(fileUri: Uri): Promise<boolean> {
   try {

--- a/extensions/vscode/src/utils/files.ts
+++ b/extensions/vscode/src/utils/files.ts
@@ -8,6 +8,7 @@ import {
   workspace,
   window,
   commands,
+  TextDocument,
 } from "vscode";
 
 import { ContentRecordFile } from "../api";
@@ -230,4 +231,9 @@ export function splitFilesOnInclusion(
 
 export function isRelativePathRoot(path: string): boolean {
   return path === ".";
+}
+
+export function isActiveDocument(document: TextDocument): boolean {
+  const editor = window.activeTextEditor;
+  return editor?.document === document;
 }

--- a/extensions/vscode/src/utils/files.ts
+++ b/extensions/vscode/src/utils/files.ts
@@ -10,6 +10,7 @@ import {
   commands,
   TextDocument,
 } from "vscode";
+import { Utils as uriUtils } from "vscode-uri";
 
 import { ContentRecordFile } from "src/api";
 
@@ -236,4 +237,30 @@ export function isRelativePathRoot(path: string): boolean {
 export function isActiveDocument(document: TextDocument): boolean {
   const editor = window.activeTextEditor;
   return editor?.document === document;
+}
+
+/**
+ * Returns a VSCode workspace relative directory path for a given URI.
+ *
+ * @param uri The URI to get the relative dirname of
+ * @returns A relative path `string` if the URI is in the workspace
+ * @returns `undefined` if the URI is not in the workspace
+ */
+export function relativeDir(uri: Uri): string | undefined {
+  const workspaceFolder = workspace.getWorkspaceFolder(uri);
+
+  if (!workspaceFolder) {
+    // File is outside of the workspace
+    return undefined;
+  }
+
+  const dirname = uriUtils.dirname(uri);
+
+  // If the file is in the workspace root, return "."
+  if (dirname.fsPath === workspaceFolder.uri.fsPath) {
+    return ".";
+  }
+
+  // Otherwise, return the relative path VSCode expects
+  return workspace.asRelativePath(dirname);
 }

--- a/extensions/vscode/src/utils/inspect.ts
+++ b/extensions/vscode/src/utils/inspect.ts
@@ -1,0 +1,15 @@
+import { ConfigurationInspectionResult, ContentType } from "src/api";
+
+/**
+ * Determines if some of the inspections have a known content type.
+ *
+ * @param inspections The results of an /api/inspect request
+ * @returns boolean - if any of the inspections have a known content type
+ */
+export function hasKnownContentType(
+  inspections: ConfigurationInspectionResult[],
+) {
+  return inspections.some(
+    (inspection) => inspection.configuration.type !== ContentType.UNKNOWN,
+  );
+}

--- a/extensions/vscode/src/utils/inspect.ts
+++ b/extensions/vscode/src/utils/inspect.ts
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 by Posit Software, PBC.
+
 import { ConfigurationInspectionResult, ContentType } from "src/api";
 
 /**


### PR DESCRIPTION
This PR adds a new context to the extension that tracks if the active document is an entrypoint with a `ContentType` that is known (aka not `Unknown`)

If the active document is an entrypoint - found via `/api/inspect` - we show a button which currently is non-functional, but will lead a user through deploying.

Note that `licenses.md` didn't need to change since `vscode-uri` is already included from dependencies.

## Intent

Start of #1848

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to create a tracker that created all of the listeners needed itself, tracked the documents it needed to, and updated the context.

This way the extension could create a `DocumentTracker` and add it to its `diposables` with no other interaction between the two.

The `DocumentTracker` handles which documents need to be tracked via VSCode listeners, and `TrackedEntrypointDocument`s handle updating themselves if they are or are becoming the active document.

Everything else was broken off as a utility function.

## Directions for Reviewers

Test the entrypoint context in a few cases:
- open a non-entrypoint file
- open an entrypoint file
- open a file outside of the workspace entirely (I do this by running `code some-file.txt` from the Desktop for example)

Then do the same from a folder at a higher level. The `dir` and `entrypoint` query params should take care of the nested folder part for us.
