### PR TITLE
Split publishing workflow into two separate jobs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,42 @@ jobs:
     needs:
       - build
     uses: ./.github/workflows/package.yaml
-  publish-vscode-extension:
+  publish-vscode-marketplace:
+    needs:
+      - package
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - darwin-amd64
+          - darwin-arm64
+          - linux-amd64
+          - linux-arm64
+          - windows-amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - id: get-extension-path
+        run: echo "extension_path=dist/$(just name)-$(just version)-${{ matrix.target }}.vsix" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          registryUrl: https://marketplace.visualstudio.com
+          pat: ${{ secrets.VSCE_PAT }}
+          extensionFile: ${{ steps.get-extension-path.outputs.extension_path }}
+          skipDuplicate: true
+
+  publish-open-vsx:
     needs:
       - package
     runs-on: ubuntu-latest
@@ -42,13 +77,5 @@ jobs:
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ${{ steps.get-extension-path.outputs.extension_path }}
-          skipDuplicate: true
-
-      - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          registryUrl: https://marketplace.visualstudio.com
-          pat: ${{ secrets.VSCE_PAT }}
           extensionFile: ${{ steps.get-extension-path.outputs.extension_path }}
           skipDuplicate: true


### PR DESCRIPTION
Splits the publishing workflow into two separate jobs so it is easier to re-run them.

## Intent

Resolves #1897

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->