### PR TITLE
Select entrypoint first in new deployment input

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -60,134 +60,6 @@ type possibleSteps = {
 };
 
 const steps: Record<string, possibleSteps | undefined> = {
-  pickCredentials: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 0,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        step: 0,
-        totalSteps: 5,
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 1,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        step: 1,
-        totalSteps: 6,
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 1,
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        step: 1,
-        totalSteps: 3,
-      },
-    },
-  },
-  inputServerUrl: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 1,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        step: 1,
-        totalSteps: 5,
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 2,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        step: 2,
-        totalSteps: 6,
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 0,
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        step: 0,
-        totalSteps: 3,
-      },
-    },
-  },
-  inputAPIKey: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 2,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        step: 2,
-        totalSteps: 5,
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 3,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        step: 3,
-        totalSteps: 6,
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 0,
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        step: 0,
-        totalSteps: 3,
-      },
-    },
-  },
-  inputCredentialName: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 3,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        step: 3,
-        totalSteps: 5,
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 4,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        step: 4,
-        totalSteps: 6,
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 0,
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        step: 0,
-        totalSteps: 3,
-      },
-    },
-  },
   inputEntryPointSelection: {
     noCredentials: {
       singleEntryPoint: {
@@ -195,13 +67,141 @@ const steps: Record<string, possibleSteps | undefined> = {
         totalSteps: 4,
       },
       multipleEntryPoints: {
-        step: 4,
+        step: 1,
         totalSteps: 5,
       },
     },
     newCredentials: {
       singleEntryPoint: {
         step: 0,
+        totalSteps: 5,
+      },
+      multipleEntryPoints: {
+        step: 1,
+        totalSteps: 6,
+      },
+    },
+    existingCredentials: {
+      singleEntryPoint: {
+        step: 0,
+        totalSteps: 2,
+      },
+      multipleEntryPoints: {
+        step: 1,
+        totalSteps: 3,
+      },
+    },
+  },
+  inputTitle: {
+    noCredentials: {
+      singleEntryPoint: {
+        step: 1,
+        totalSteps: 4,
+      },
+      multipleEntryPoints: {
+        step: 2,
+        totalSteps: 5,
+      },
+    },
+    newCredentials: {
+      singleEntryPoint: {
+        step: 1,
+        totalSteps: 5,
+      },
+      multipleEntryPoints: {
+        step: 2,
+        totalSteps: 6,
+      },
+    },
+    existingCredentials: {
+      singleEntryPoint: {
+        step: 1,
+        totalSteps: 2,
+      },
+      multipleEntryPoints: {
+        step: 2,
+        totalSteps: 3,
+      },
+    },
+  },
+  pickCredentials: {
+    noCredentials: {
+      singleEntryPoint: {
+        step: 0, // still 1
+        totalSteps: 4,
+      },
+      multipleEntryPoints: {
+        step: 0, // still 2
+        totalSteps: 5,
+      },
+    },
+    newCredentials: {
+      singleEntryPoint: {
+        step: 2,
+        totalSteps: 5,
+      },
+      multipleEntryPoints: {
+        step: 3,
+        totalSteps: 6,
+      },
+    },
+    existingCredentials: {
+      singleEntryPoint: {
+        step: 2,
+        totalSteps: 2,
+      },
+      multipleEntryPoints: {
+        step: 3,
+        totalSteps: 3,
+      },
+    },
+  },
+  inputServerUrl: {
+    noCredentials: {
+      singleEntryPoint: {
+        step: 2,
+        totalSteps: 4,
+      },
+      multipleEntryPoints: {
+        step: 3,
+        totalSteps: 5,
+      },
+    },
+    newCredentials: {
+      singleEntryPoint: {
+        step: 3,
+        totalSteps: 5,
+      },
+      multipleEntryPoints: {
+        step: 4,
+        totalSteps: 6,
+      },
+    },
+    existingCredentials: {
+      singleEntryPoint: {
+        step: 0, // still 2
+        totalSteps: 2,
+      },
+      multipleEntryPoints: {
+        step: 0, // still 3
+        totalSteps: 3,
+      },
+    },
+  },
+  inputAPIKey: {
+    noCredentials: {
+      singleEntryPoint: {
+        step: 3,
+        totalSteps: 4,
+      },
+      multipleEntryPoints: {
+        step: 4,
+        totalSteps: 5,
+      },
+    },
+    newCredentials: {
+      singleEntryPoint: {
+        step: 4,
         totalSteps: 5,
       },
       multipleEntryPoints: {
@@ -211,16 +211,16 @@ const steps: Record<string, possibleSteps | undefined> = {
     },
     existingCredentials: {
       singleEntryPoint: {
-        step: 0,
+        step: 0, // still 2
         totalSteps: 2,
       },
       multipleEntryPoints: {
-        step: 2,
+        step: 0, // still 3
         totalSteps: 3,
       },
     },
   },
-  inputTitle: {
+  inputCredentialName: {
     noCredentials: {
       singleEntryPoint: {
         step: 4,
@@ -243,11 +243,11 @@ const steps: Record<string, possibleSteps | undefined> = {
     },
     existingCredentials: {
       singleEntryPoint: {
-        step: 2,
+        step: 0, // still 2
         totalSteps: 2,
       },
       multipleEntryPoints: {
-        step: 3,
+        step: 0, // still 3
         totalSteps: 3,
       },
     },
@@ -432,14 +432,14 @@ export async function newDeployment(
   // NOTE: This multi-stepper is used for multiple commands
   // ***************************************************************
 
+  // Select the entrypoint, if there is more than one
+  // Prompt for Title
   // If no credentials, then skip to create new credential
   // If some credentials, select either use of existing or creation of a new one
   // If creating credential:
   // - Get the server url
   // - Get the credential nickname
   // - Get the API key
-  // Select the entrypoint, if there is more than one
-  // Prompt for Title
   // Auto-name the config file to use
   // Auto-name the contentRecord
   // Call APIs and hopefully succeed at everything
@@ -461,23 +461,105 @@ export async function newDeployment(
       data: {
         // each attribute is initialized to undefined
         // to be returned when it has not been cancelled to assist type guards
+        entryPoint: undefined, // eventual type is QuickPickItem
+        title: undefined, // eventual type is string
         credentialName: undefined, // eventual type is either a string or QuickPickItem
         url: undefined, // eventual type is string
         name: undefined, // eventual type is string
         apiKey: undefined, // eventual type is string
-        entryPoint: undefined, // eventual type is QuickPickItem
-        title: undefined, // eventual type is string
       },
       promptStepNumbers: {},
     };
 
     // start the progression through the steps
-    await MultiStepInput.run((input) => pickCredentials(input, state));
+    await MultiStepInput.run((input) => inputEntryPointSelection(input, state));
     return state as MultiStepState;
   }
 
   // ***************************************************************
-  // Step #2:
+  // Step #1 - maybe?:
+  // Select the entrypoint to be used w/ the contentRecord
+  // ***************************************************************
+  async function inputEntryPointSelection(
+    input: MultiStepInput,
+    state: MultiStepState,
+  ) {
+    // skip if we only have one choice.
+    if (entryPointListItems.length > 1) {
+      const step = getStepInfo("inputEntryPointSelection", state);
+      if (!step) {
+        throw new Error(
+          "newDeployment::inputEntryPointSelection step info not found.",
+        );
+      }
+
+      const pick = await input.showQuickPick({
+        title: state.title,
+        step: step.step,
+        totalSteps: step.totalSteps,
+        placeholder:
+          "Select main file and content type below. (Use this field to filter selections.)",
+        items: entryPointListItems,
+        buttons: [],
+        shouldResume: () => Promise.resolve(false),
+        ignoreFocusOut: true,
+      });
+
+      state.data.entryPoint = pick;
+      return (input: MultiStepInput) => inputTitle(input, state);
+    } else {
+      state.data.entryPoint = entryPointListItems[0];
+      // We're skipping this step, so we must silently just jump to the next step
+      return inputTitle(input, state);
+    }
+  }
+
+  // ***************************************************************
+  // Step #2 - maybe
+  // Input the Title
+  // ***************************************************************
+  async function inputTitle(input: MultiStepInput, state: MultiStepState) {
+    const step = getStepInfo("inputTitle", state);
+    if (!step) {
+      throw new Error("newDeployment::inputTitle step info not found.");
+    }
+    let initialValue = "";
+    if (
+      state.data.entryPoint &&
+      isQuickPickItemWithIndex(state.data.entryPoint)
+    ) {
+      const detail = configDetails[state.data.entryPoint.index].title;
+      if (detail) {
+        initialValue = detail;
+      }
+    }
+
+    const title = await input.showInputBox({
+      title: state.title,
+      step: step.step,
+      totalSteps: step.totalSteps,
+      value:
+        typeof state.data.title === "string" ? state.data.title : initialValue,
+      prompt: "Enter a title for your content or application.",
+      validate: (value) => {
+        if (value.length < 3) {
+          return Promise.resolve({
+            message: `Error: Invalid Title (value must be longer than 3 characters)`,
+            severity: InputBoxValidationSeverity.Error,
+          });
+        }
+        return Promise.resolve(undefined);
+      },
+      shouldResume: () => Promise.resolve(false),
+      ignoreFocusOut: true,
+    });
+
+    state.data.title = title;
+    return (input: MultiStepInput) => pickCredentials(input, state);
+  }
+
+  // ***************************************************************
+  // Step #3 - maybe
   // Select the credentials to be used
   // ***************************************************************
   async function pickCredentials(input: MultiStepInput, state: MultiStepState) {
@@ -509,7 +591,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #3 - maybe?:
+  // Step #4 - maybe?:
   // Get the server url
   // ***************************************************************
   async function inputServerUrl(input: MultiStepInput, state: MultiStepState) {
@@ -598,7 +680,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #4 - maybe?:
+  // Step #5 - maybe?:
   // Enter the API Key
   // ***************************************************************
   async function inputAPIKey(input: MultiStepInput, state: MultiStepState) {
@@ -677,7 +759,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #5 - maybe?:
+  // Step #6 - maybe?:
   // Name the credential
   // ***************************************************************
   async function inputCredentialName(
@@ -733,91 +815,8 @@ export async function newDeployment(
       });
 
       state.data.name = name.trim();
-      return (input: MultiStepInput) => inputEntryPointSelection(input, state);
     }
-    return inputEntryPointSelection(input, state);
-  }
-
-  // ***************************************************************
-  // Step #6 - maybe?:
-  // Select the config to be used w/ the contentRecord
-  // ***************************************************************
-  async function inputEntryPointSelection(
-    input: MultiStepInput,
-    state: MultiStepState,
-  ) {
-    // skip if we only have one choice.
-    if (entryPointListItems.length > 1) {
-      const step = getStepInfo("inputEntryPointSelection", state);
-      if (!step) {
-        throw new Error(
-          "newDeployment::inputEntryPointSelection step info not found.",
-        );
-      }
-
-      const pick = await input.showQuickPick({
-        title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
-        placeholder:
-          "Select main file and content type below. (Use this field to filter selections.)",
-        items: entryPointListItems,
-        buttons: [],
-        shouldResume: () => Promise.resolve(false),
-        ignoreFocusOut: true,
-      });
-
-      state.data.entryPoint = pick;
-      return (input: MultiStepInput) => inputTitle(input, state);
-    } else {
-      state.data.entryPoint = entryPointListItems[0];
-      // We're skipping this step, so we must silently just jump to the next step
-      return inputTitle(input, state);
-    }
-  }
-
-  // ***************************************************************
-  // Step #7
-  // Input the Title
-  // ***************************************************************
-  async function inputTitle(input: MultiStepInput, state: MultiStepState) {
-    const step = getStepInfo("inputTitle", state);
-    if (!step) {
-      throw new Error("newDeployment::inputTitle step info not found.");
-    }
-    let initialValue = "";
-    if (
-      state.data.entryPoint &&
-      isQuickPickItemWithIndex(state.data.entryPoint)
-    ) {
-      const detail = configDetails[state.data.entryPoint.index].title;
-      if (detail) {
-        initialValue = detail;
-      }
-    }
-
-    const title = await input.showInputBox({
-      title: state.title,
-      step: step.step,
-      totalSteps: step.totalSteps,
-      value:
-        typeof state.data.title === "string" ? state.data.title : initialValue,
-      prompt: "Enter a title for your content or application.",
-      validate: (value) => {
-        if (value.length < 3) {
-          return Promise.resolve({
-            message: `Error: Invalid Title (value must be longer than 3 characters)`,
-            severity: InputBoxValidationSeverity.Error,
-          });
-        }
-        return Promise.resolve(undefined);
-      },
-      shouldResume: () => Promise.resolve(false),
-      ignoreFocusOut: true,
-    });
-
-    state.data.title = title;
-    // last step, nothing gets returned.
+    // last step
   }
 
   // ***************************************************************


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This moves the entry point selection and the title entry up to the beginning of the New Deployment `multiStepInput`.

Resolves #1784 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The diff is strange because of the similar code blocks. I updated the `steps` object to have the new step number calculations and then moved the `inputEntryPointSelection` and the `inputTitle` entry methods to occur ahead of the credential collection.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

To validate, you should create deployments on the following, making sure a deployment can be created and that the step numbers update appropriately to your selections:
[ ] a project with a single entry point, using an existing credential 
[ ] a project with a single entry point, creating a new credential
[ ] a project with multiple entry points, using an existing credential
[ ] a project with multiple entry points, using a new credential
