### PR TITLE
Add dir parameter to files API

### DIFF
--- a/internal/services/api/get_config_files.go
+++ b/internal/services/api/get_config_files.go
@@ -19,25 +19,30 @@ import (
 func GetConfigFilesHandlerFunc(base util.AbsolutePath, filesService files.FilesService, log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		name := mux.Vars(req)["name"]
-		configPath := config.GetConfigPath(base, name)
+		projectDir, _, err := ProjectDirFromRequest(base, w, req, log)
+		if err != nil {
+			// Response already returned by ProjectDirFromRequest
+			return
+		}
+		configPath := config.GetConfigPath(projectDir, name)
 		cfg, err := config.FromFile(configPath)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {
 			http.NotFound(w, req)
 			return
 		}
-		matchList, err := matcher.NewMatchList(base, matcher.StandardExclusions)
+		matchList, err := matcher.NewMatchList(projectDir, matcher.StandardExclusions)
 		if err != nil {
 			InternalError(w, req, log, err)
 			return
 		}
-		err = matchList.AddFromFile(base, configPath, cfg.Files)
+		err = matchList.AddFromFile(projectDir, configPath, cfg.Files)
 		if err != nil {
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			w.Write([]byte("invalid pattern in configuration 'files'"))
 			return
 		}
 
-		file, err := filesService.GetFile(base, matchList)
+		file, err := filesService.GetFile(projectDir, matchList)
 		if err != nil {
 			InternalError(w, req, log, err)
 			return


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds the `dir` parameter to the configuration-specific Files API.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Same as the other APIs (#1860, #1873).

## Automated Tests

Added unit tests.

## Directions for Reviewers

Run the agent in a parent directory (one or more levels up from your deployable projects). Access the Files API from subdirectories:

```
$publisher ui -vv --listen=localhost:9001 &
curl localhost:9001/api/configuration/$NAME/files?dir=test/sample-content/quarto-proj-py | jq
curl localhost:9001/api/configuration/$NAME/files?dir=test/sample-content/quarto-proj-none | jq
```
