### PR TITLE
Add dir parameter to config packages api

### DIFF
--- a/internal/services/api/get_config_python_packages.go
+++ b/internal/services/api/get_config_python_packages.go
@@ -35,7 +35,12 @@ func NewGetConfigPythonPackagesHandler(base util.AbsolutePath, log logging.Logge
 
 func (h *getConfigPythonPackagesHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	name := mux.Vars(req)["name"]
-	configPath := config.GetConfigPath(h.base, name)
+	projectDir, _, err := ProjectDirFromRequest(h.base, w, req, h.log)
+	if err != nil {
+		// Response already returned by ProjectDirFromRequest
+		return
+	}
+	configPath := config.GetConfigPath(projectDir, name)
 	cfg, err := config.FromFile(configPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -59,7 +64,7 @@ func (h *getConfigPythonPackagesHandler) ServeHTTP(w http.ResponseWriter, req *h
 		requirementsFilename = inspect.PythonRequirementsFilename
 	}
 
-	path := h.base.Join(requirementsFilename)
+	path := projectDir.Join(requirementsFilename)
 	reqs, err := h.inspector.ReadRequirementsFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds the `dir` parameter to the configuration-specific Packages APIs.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Same as the other APIs (#1860, #1873).

## Automated Tests

Added unit tests to the Python packages suite. There isn't a suite for the R packages API yet.

## Directions for Reviewers

Run the agent in a parent directory (one or more levels up from your deployable projects). Access the Pacakges API from subdirectories:

```
$publisher ui -vv --listen=localhost:9001 &
curl localhost:9001/api/configuration/$NAME/packages/python?dir=test/sample-content/quarto-proj-py | jq
curl localhost:9001/api/configuration/$NAME/packages/r?dir=test/sample-content/quarto-proj-py | jq
curl localhost:9001/api/configuration/$NAME/packages/python?dir=test/sample-content/rmd-static-1 | jq
curl localhost:9001/api/configuration/$NAME/packages/r?dir=test/sample-content/rmd-static-1 | jq
```
