### PR TITLE
Publishing Log: expand section on error and add bullets to log message lines

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -17,7 +17,11 @@ import {
 
 import { EventStream, displayEventStreamMessage } from "src/events";
 
-import { EventStreamMessage } from "src/api";
+import {
+  EventStreamMessage,
+  isPublishFailure,
+  isPublishSuccess,
+} from "src/api";
 import { Commands, Views } from "src/constants";
 
 enum LogStageStatus {
@@ -368,7 +372,9 @@ export class LogsTreeLogItem extends TreeItem {
     }
     super(displayEventStreamMessage(msg), state);
     this.tooltip = JSON.stringify(msg);
-    this.iconPath = new ThemeIcon("debug-stackframe-dot");
+    if (!isPublishSuccess(msg) && !isPublishFailure(msg)) {
+      this.iconPath = new ThemeIcon("debug-stackframe-dot");
+    }
 
     if (msg.data.dashboardUrl !== undefined) {
       this.command = {

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -349,6 +349,7 @@ export class LogsTreeStageItem extends TreeItem {
       case LogStageStatus.failed:
         this.label = this.stage.inactiveLabel;
         this.iconPath = new ThemeIcon("error");
+        this.collapsibleState = TreeItemCollapsibleState.Expanded;
         break;
     }
   }
@@ -362,8 +363,12 @@ export class LogsTreeLogItem extends TreeItem {
     msg: EventStreamMessage,
     state: TreeItemCollapsibleState = TreeItemCollapsibleState.None,
   ) {
+    if (msg.data.message) {
+      msg.data.message = msg.data.message.replaceAll("\n", " ");
+    }
     super(displayEventStreamMessage(msg), state);
     this.tooltip = JSON.stringify(msg);
+    this.iconPath = new ThemeIcon("debug-stackframe-dot");
 
     if (msg.data.dashboardUrl !== undefined) {
       this.command = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1790 

This PR will cause Publishing Log sections to automatically expand themselves upon receiving a failure message.

I've also taken the opportunity to add a small bullet to the beginning of each log message, as well as suppressing newline characters received in the log messages, since we can't display those correctly.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Simple set of changes. When encounter failure and viewing publisher log, you'll now see something like this:

![2024-06-28 at 3 01 PM](https://github.com/posit-dev/publisher/assets/17675905/84855ae5-52a3-4325-921e-92811a8b2e90)

Final success or failure messages do not have icons as a prefix, as shown in the following screenshot.

![2024-06-28 at 3 10 PM](https://github.com/posit-dev/publisher/assets/17675905/fa69ee32-9a28-4ba5-a8ef-3b7ebb7206c1)

NOTE: This behavior only occurs when the log is actively being updated. If you open the log after the publishing has occurred, the node will be closed by default.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Easiest way to force failure that I've found is to either specify the wrong python version (which will fail fast), or add a bogus package requirement to your requirements.txt file.

Please verify:
[ ] a successful deployment - only impact should be seeing bullets in the log messages except for the final success message.
[ ] a failed deployment - which should result in the publishing log section which encountered the error to be automatically expanded (with then the log messages having bullets visible). In this case, the final failure message should not have a bullet.
