### PR TITLE
Move VSCode context strings into constants file.

### DIFF
--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -32,11 +32,19 @@ const configurationsCommands = {
   Delete: "posit.publisher.configurations.delete",
 } as const;
 
+const configurationsContexts = {
+  TreeItem: "posit.publisher.configurations.tree.item",
+} as const;
+
 const credentialsCommands = {
   Add: "posit.publisher.credentials.add",
   Delete: "posit.publisher.credentials.delete",
   Refresh: "posit.publisher.credentials.refresh",
 } as const;
+
+const credentialsContexts = {
+  Keychain: "posit.publisher.credentials.tree.item.keychain",
+};
 
 const contentRecordsCommands = {
   Edit: "posit.publisher.contentRecords.edit",
@@ -44,6 +52,12 @@ const contentRecordsCommands = {
   Forget: "posit.publisher.contentRecords.forget",
   Visit: "posit.publisher.contentRecords.visit",
   Refresh: "posit.publisher.contentRecords.refresh",
+} as const;
+
+const contentRecordsContexts = {
+  ContentRecord: "posit.publisher.contentRecords.tree.item.contentRecord",
+  PreContentRecord: "posit.publisher.contentRecords.tree.item.precontentRecord",
+  DeploymentError: "posit.publisher.contentRecords.tree.item.deploymentError",
 } as const;
 
 const filesCommands = {
@@ -79,10 +93,18 @@ const homeViewCommands = {
   ShowContentLogs: "posit.publisher.homeView.navigateToDeployment.ContentLog",
 } as const;
 
+const homeViewContexts = {
+  Initialized: "posit.publisher.homeView.initialized",
+};
+
 const helpAndFeedbackCommands = {
   OpenFeedback: "posit.publisher.helpAndFeedback.openFeedback",
   OpenGettingStarted: "posit.publisher.helpAndFeedback.gettingStarted",
 } as const;
+
+export const LocalState = {
+  LastSelectionState: "posit.publisher.homeView.lastSelectionState.v2",
+};
 
 export const Commands = {
   ...baseCommands,
@@ -95,7 +117,14 @@ export const Commands = {
   RPackages: rPackagesCommands,
   HomeView: homeViewCommands,
   HelpAndFeedback: helpAndFeedbackCommands,
-} as const;
+};
+
+export const Contexts = {
+  Configurations: configurationsContexts,
+  ContentRecords: contentRecordsContexts,
+  Credentials: credentialsContexts,
+  HomeView: homeViewContexts,
+};
 
 export const enum Views {
   Project = "posit.publisher.project",

--- a/extensions/vscode/src/views/configurations.ts
+++ b/extensions/vscode/src/views/configurations.ts
@@ -28,7 +28,7 @@ import { ensureSuffix, fileExists, isValidFilename } from "src/utils/files";
 import { untitledConfigurationName } from "src/utils/names";
 import { newConfig } from "src/multiStepInputs/newConfig";
 import { WatcherManager } from "src/watchers";
-import { Commands, Views } from "src/constants";
+import { Commands, Contexts, Views } from "src/constants";
 
 type ConfigurationEventEmitter = EventEmitter<
   ConfigurationTreeItem | undefined | void
@@ -200,7 +200,7 @@ export class ConfigurationsTreeDataProvider
 }
 
 export class ConfigurationTreeItem extends TreeItem {
-  contextValue = "posit.publisher.configurations.tree.item";
+  contextValue = Contexts.Configurations.TreeItem;
 
   constructor(
     public readonly config: Configuration | ConfigurationError,

--- a/extensions/vscode/src/views/contentRecords.ts
+++ b/extensions/vscode/src/views/contentRecords.ts
@@ -32,7 +32,7 @@ import { getSummaryStringFromError } from "src/utils/errors";
 import { ensureSuffix } from "src/utils/files";
 import { contentRecordNameValidator } from "src/utils/names";
 import { WatcherManager } from "src/watchers";
-import { Commands, Views } from "src/constants";
+import { Commands, Contexts, Views } from "src/constants";
 
 type ContentRecordsEventEmitter = EventEmitter<
   ContentRecordsTreeItem | undefined | void
@@ -226,8 +226,7 @@ export class ContentRecordsTreeItem extends TreeItem {
   }
 
   private initializeContentRecord(contentRecord: ContentRecord) {
-    this.contextValue =
-      "posit.publisher.contentRecords.tree.item.contentRecord";
+    this.contextValue = Contexts.ContentRecords.ContentRecord;
     if (!contentRecord.deploymentError) {
       this.tooltip =
         `ContentRecord file: ${contentRecord.deploymentPath}\n` +
@@ -253,8 +252,7 @@ export class ContentRecordsTreeItem extends TreeItem {
   }
 
   private initializePreContentRecord(precontentRecord: PreContentRecord) {
-    this.contextValue =
-      "posit.publisher.contentRecords.tree.item.precontentRecord";
+    this.contextValue = Contexts.ContentRecords.PreContentRecord;
     this.tooltip =
       `Deployment Record file: ${precontentRecord.deploymentPath}\n` +
       `\n` +
@@ -266,8 +264,7 @@ export class ContentRecordsTreeItem extends TreeItem {
   }
 
   private initializeContentRecordError(deploymentError: ContentRecordError) {
-    this.contextValue =
-      "posit.publisher.contentRecords.tree.item.deploymentError";
+    this.contextValue = Contexts.ContentRecords.DeploymentError;
     this.tooltip =
       `Deployment Record file: ${deploymentError.deploymentPath}\n` +
       `\n` +

--- a/extensions/vscode/src/views/credentials.ts
+++ b/extensions/vscode/src/views/credentials.ts
@@ -16,7 +16,7 @@ import { useBus } from "src/bus";
 import { confirmDelete } from "src/dialogs";
 import { getSummaryStringFromError } from "src/utils/errors";
 import { newCredential } from "src/multiStepInputs/newCredential";
-import { Commands, Views } from "src/constants";
+import { Commands, Contexts, Views } from "src/constants";
 
 type CredentialEventEmitter = EventEmitter<
   CredentialsTreeItem | undefined | void
@@ -129,6 +129,6 @@ export class CredentialsTreeItem extends TreeItem {
     super(cred.name);
     this.iconPath = new ThemeIcon("key");
     this.description = `${cred.url}`;
-    this.contextValue = `posit.publisher.credentials.tree.item.keychain`;
+    this.contextValue = Contexts.Credentials.Keychain;
   }
 }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -65,16 +65,12 @@ import { selectConfig } from "src/multiStepInputs/selectConfig";
 import { RPackage, RVersionConfig } from "src/api/types/packages";
 import { calculateTitle } from "src/utils/titles";
 import { ConfigWatcherManager, WatcherManager } from "src/watchers";
-import { Commands, Views } from "src/constants";
-
-const contextIsHomeViewInitialized = "posit.publisher.homeView.initialized";
+import { Commands, Contexts, LocalState, Views } from "src/constants";
 
 enum HomeViewInitialized {
   initialized = "initialized",
   uninitialized = "uninitialized",
 }
-
-const lastSelectionState = "posit.publisher.homeView.lastSelectionState.v2";
 
 const fileEventDebounce = 200;
 
@@ -244,7 +240,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   private setInitializationContext(context: HomeViewInitialized) {
     commands.executeCommand(
       "setContext",
-      contextIsHomeViewInitialized,
+      Contexts.HomeView.Initialized,
       context,
     );
   }
@@ -431,7 +427,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   private _getSelectionState(): HomeViewState {
     const state = this._context.workspaceState.get<HomeViewState>(
-      lastSelectionState,
+      LocalState.LastSelectionState,
       {
         deploymentName: undefined,
         configurationName: undefined,
@@ -462,7 +458,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async _saveSelectionState(state: HomeViewState): Promise<void> {
-    await this._context.workspaceState.update(lastSelectionState, state);
+    await this._context.workspaceState.update(
+      LocalState.LastSelectionState,
+      state,
+    );
 
     useBus().trigger(
       "activeContentRecordChanged",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1864 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

I searched for any string occurrence of "posit.publisher." and moved context related definitions into constants file.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Verify functionality impacted:

[ ] Storage location for last selected deployment and configuration file
[ ] Availability of these command pallette commands once the Home View has initialized:
  - Select Deployment
  - New Deployment
  - Go to Debug Log
  - Go to Publishing Log
  - Browse Deployment Server
  - Show Content Logs
[ ] Context menu items or right-clicks
  - View Deployment in Connect for successful deployments (content records), but not for pre-deployment or deployment errors
  - Delete option (right-click menu) for credentials
