### PR TITLE
Use python3 to run licenses script

### DIFF
--- a/docs/justfile
+++ b/docs/justfile
@@ -1,3 +1,3 @@
 
 licenses:
-    ../scripts/licenses.py > licenses.md
+    python3 ../scripts/licenses.py > licenses.md

--- a/scripts/licenses.py
+++ b/scripts/licenses.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import fnmatch
 


### PR DESCRIPTION
This PR changes the `just docs/licenses` target to run `python3` rather than relying on `/usr/bin/env python`

## Intent

Resolves #1913

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->