### PR TITLE
Fail CI if ccheck fails

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,3 +16,5 @@ jobs:
 
       - run: just vscode deps
       - run: just vscode lint
+
+      - run: just lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -17,4 +20,5 @@ jobs:
       - run: just vscode deps
       - run: just vscode lint
 
+      - run: just install
       - run: just lint

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
 package credentials
 
 import (

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
 package publish
 
 import (


### PR DESCRIPTION
This adds our `just lint` command to the lint workflow which runs `ccheck`.

This ensures that our code has the license header as a part of CI.

## Intent

Resolves #1906 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->