### PR TITLE
Add subdirectory support to package scanning APIs

### DIFF
--- a/internal/services/api/post_packages_python_scan.go
+++ b/internal/services/api/post_packages_python_scan.go
@@ -42,10 +42,15 @@ func (h *PostPackagesPythonScanHandler) scan(inspector inspect.PythonInspector, 
 }
 
 func (h *PostPackagesPythonScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	projectDir, _, err := ProjectDirFromRequest(h.base, w, req, h.log)
+	if err != nil {
+		// Response already returned by ProjectDirFromRequest
+		return
+	}
 	dec := json.NewDecoder(req.Body)
 	dec.DisallowUnknownFields()
 	var b PostPackagesPythonScanRequest
-	err := dec.Decode(&b)
+	err = dec.Decode(&b)
 	if err != nil && !errors.Is(err, io.EOF) {
 		BadRequest(w, req, h.log, err)
 		return
@@ -54,13 +59,19 @@ func (h *PostPackagesPythonScanHandler) ServeHTTP(w http.ResponseWriter, req *ht
 		b.SaveName = inspect.PythonRequirementsFilename
 	}
 	python := util.NewPath(b.Python, nil)
-	inspector := inspectorFactory(h.base, python, h.log)
+	inspector := inspectorFactory(projectDir, python, h.log)
 	err = util.ValidateFilename(b.SaveName)
 	if err != nil {
 		BadRequest(w, req, h.log, err)
 		return
 	}
-	err = h.scan(inspector, b.SaveName)
+	reqs, _, err := inspector.ScanRequirements(projectDir)
+	if err != nil {
+		InternalError(w, req, h.log, err)
+		return
+	}
+	dest := projectDir.Join(b.SaveName)
+	err = inspector.WriteRequirementsFile(dest, reqs)
 	if err != nil {
 		InternalError(w, req, h.log, err)
 		return

--- a/internal/services/api/post_packages_python_scan.go
+++ b/internal/services/api/post_packages_python_scan.go
@@ -32,15 +32,6 @@ func NewPostPackagesPythonScanHandler(base util.AbsolutePath, log logging.Logger
 	}
 }
 
-func (h *PostPackagesPythonScanHandler) scan(inspector inspect.PythonInspector, saveName string) error {
-	reqs, _, err := inspector.ScanRequirements(h.base)
-	if err != nil {
-		return err
-	}
-	dest := h.base.Join(saveName)
-	return inspector.WriteRequirementsFile(dest, reqs)
-}
-
 func (h *PostPackagesPythonScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	projectDir, _, err := ProjectDirFromRequest(h.base, w, req, h.log)
 	if err != nil {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds the `dir` parameter to the package scanning APIs: POST /api/packages/r/scan and POST /api/packages/python/scan.

Part of #1851

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added unit tests for the new parameter.

## Directions for Reviewers

```
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s localhost:9001/api/packages/python/scan?dir=test/sample-content/rmd-static-1 -XPOST
curl -s localhost:9001/api/packages/r/scan?dir=test/sample-content/rmd-static-1 -XPOST
```
etc.

requirements.txt/renv.lock should be created in the specified subdirectory, and only contain package dependencies discoverable from the code in that subdirectory.
