### PR TITLE
Add entrypoint filtering to the inspect API

### DIFF
--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -28,7 +28,7 @@ func inspectProject(base util.AbsolutePath, python util.Path, rExecutable util.P
 	log.Info("Detecting deployment type and entrypoint...")
 	typeDetector := ContentDetectorFactory(log)
 
-	configs, err := typeDetector.InferType(base)
+	configs, err := typeDetector.InferType(base, util.RelativePath{})
 	if err != nil {
 		return nil, fmt.Errorf("error detecting content type: %w", err)
 	}
@@ -117,10 +117,16 @@ func requiresR(cfg *config.Config, base util.AbsolutePath, rExecutable util.Path
 	return false, nil
 }
 
-func GetPossibleConfigs(base util.AbsolutePath, python util.Path, rExecutable util.Path, log logging.Logger) ([]*config.Config, error) {
+func GetPossibleConfigs(
+	base util.AbsolutePath,
+	python util.Path,
+	rExecutable util.Path,
+	entrypoint util.RelativePath,
+	log logging.Logger) ([]*config.Config, error) {
+
 	log.Info("Detecting deployment type and entrypoint...")
 	typeDetector := ContentDetectorFactory(log)
-	configs, err := typeDetector.InferType(base)
+	configs, err := typeDetector.InferType(base, entrypoint)
 	if err != nil {
 		return nil, fmt.Errorf("error detecting content type: %w", err)
 	}
@@ -159,6 +165,17 @@ func GetPossibleConfigs(base util.AbsolutePath, python util.Path, rExecutable ut
 			cfg.R = rConfig
 		}
 		cfg.Comments = strings.Split(initialComment, "\n")
+
+		// Usually an entrypoint will be inferred.
+		// If not, use the specified entrypoint, or
+		// fall back to unknown.
+		if cfg.Entrypoint == "" {
+			cfg.Entrypoint = entrypoint.String()
+
+			if cfg.Entrypoint == "" {
+				cfg.Entrypoint = "unknown"
+			}
+		}
 	}
 	return configs, nil
 }

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -164,7 +164,7 @@ func (s *InitializeSuite) TestGetPossibleConfigs() {
 	s.NoError(err)
 
 	PythonInspectorFactory = makeMockPythonInspector
-	configs, err := GetPossibleConfigs(s.cwd, util.Path{}, util.Path{}, log)
+	configs, err := GetPossibleConfigs(s.cwd, util.Path{}, util.Path{}, util.RelativePath{}, log)
 	s.NoError(err)
 
 	s.Len(configs, 2)
@@ -175,4 +175,30 @@ func (s *InitializeSuite) TestGetPossibleConfigs() {
 	s.Equal(config.ContentTypeHTML, configs[1].Type)
 	s.Equal("index.html", configs[1].Entrypoint)
 	s.Nil(configs[1].Python)
+}
+
+func (s *InitializeSuite) TestGetPossibleConfigsEmpty() {
+	log := logging.New()
+
+	configs, err := GetPossibleConfigs(s.cwd, util.Path{}, util.Path{}, util.RelativePath{}, log)
+	s.NoError(err)
+
+	s.Len(configs, 1)
+	s.Equal(config.ContentTypeUnknown, configs[0].Type)
+	s.Equal("unknown", configs[0].Entrypoint)
+	s.Nil(configs[0].Python)
+}
+
+func (s *InitializeSuite) TestGetPossibleConfigsWithMissingEntrypoint() {
+	log := logging.New()
+	s.createAppPy()
+
+	entrypoint := util.NewRelativePath("nonexistent.py", s.cwd.Fs())
+	configs, err := GetPossibleConfigs(s.cwd, util.Path{}, util.Path{}, entrypoint, log)
+	s.NoError(err)
+
+	s.Len(configs, 1)
+	s.Equal(config.ContentTypeUnknown, configs[0].Type)
+	s.Equal("nonexistent.py", configs[0].Entrypoint)
+	s.Nil(configs[0].Python)
 }

--- a/internal/inspect/detectors/all.go
+++ b/internal/inspect/detectors/all.go
@@ -58,7 +58,7 @@ func filenameStem(filename string) string {
 	return strings.TrimSuffix(filename, ext)
 }
 
-func (t *ContentTypeDetector) InferType(base util.AbsolutePath) ([]*config.Config, error) {
+func (t *ContentTypeDetector) InferType(base util.AbsolutePath, entrypoint util.RelativePath) ([]*config.Config, error) {
 	var allConfigs []*config.Config
 
 	_, err := base.Stat()
@@ -67,7 +67,7 @@ func (t *ContentTypeDetector) InferType(base util.AbsolutePath) ([]*config.Confi
 	}
 
 	for _, detector := range t.detectors {
-		configs, err := detector.InferType(base)
+		configs, err := detector.InferType(base, entrypoint)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/inspect/detectors/all_test.go
+++ b/internal/inspect/detectors/all_test.go
@@ -37,7 +37,7 @@ func (s *AllSuite) TestInferTypeDirectory() {
 	s.NoError(err)
 
 	detector := NewContentTypeDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.NoError(err)
 	s.Len(configs, 2)
 
@@ -67,7 +67,7 @@ func (s *AllSuite) TestInferTypeDirectoryIndeterminate() {
 	s.NoError(err)
 
 	detector := NewContentTypeDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.NoError(err)
 	s.Len(configs, 1)
 	s.Equal(config.ContentTypeUnknown, configs[0].Type)
@@ -77,7 +77,7 @@ func (s *AllSuite) TestInferTypeErr() {
 	fs := afero.NewMemMapFs()
 	detector := NewContentTypeDetector(logging.New())
 	base := util.NewAbsolutePath("/foo", fs)
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.NotNil(err)
 	s.ErrorIs(err, os.ErrNotExist)
 	s.Nil(configs)
@@ -97,7 +97,7 @@ func (s *AllSuite) TestInferAll() {
 	s.NoError(err)
 
 	detector := NewContentTypeDetector(logging.New())
-	t, err := detector.InferType(base)
+	t, err := detector.InferType(base, util.RelativePath{})
 	s.NoError(err)
 	s.Equal([]*config.Config{
 		{
@@ -128,7 +128,7 @@ func (s *AllSuite) TestInferAllIndeterminate() {
 	s.NoError(err)
 
 	detector := NewContentTypeDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.NoError(err)
 
 	s.Len(configs, 1)

--- a/internal/inspect/detectors/infer.go
+++ b/internal/inspect/detectors/infer.go
@@ -15,7 +15,7 @@ import (
 // (nil, nil), i.e. failing inference is not an error.
 // If there's an error during inferences, it returns (nil, err).
 type ContentTypeInferer interface {
-	InferType(path util.AbsolutePath) ([]*config.Config, error)
+	InferType(path util.AbsolutePath, entrypoint util.RelativePath) ([]*config.Config, error)
 }
 
 type inferenceHelper interface {

--- a/internal/inspect/detectors/plumber_test.go
+++ b/internal/inspect/detectors/plumber_test.go
@@ -32,7 +32,7 @@ func (s *PlumberSuite) TestInferTypePlumberR() {
 	s.Nil(err)
 
 	detector := NewPlumberDetector()
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -58,7 +58,7 @@ func (s *PlumberSuite) TestInferTypeEntrypointR() {
 	s.Nil(err)
 
 	detector := NewPlumberDetector()
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -79,7 +79,37 @@ func (s *PlumberSuite) TestInferTypeNone() {
 	s.NoError(err)
 
 	detector := NewPlumberDetector()
-	t, err := detector.InferType(base)
+	t, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Nil(t)
+}
+
+func (s *PlumberSuite) TestInferTypeWithEntrypoint() {
+	base := util.NewAbsolutePath("/project", afero.NewMemMapFs())
+	err := base.MkdirAll(0777)
+	s.NoError(err)
+
+	filename := "entrypoint.R"
+	err = base.Join(filename).WriteFile(nil, 0600)
+	s.Nil(err)
+
+	otherFilename := "plumber.R"
+	err = base.Join(otherFilename).WriteFile(nil, 0600)
+	s.Nil(err)
+
+	detector := NewPlumberDetector()
+	entrypoint := util.NewRelativePath(filename, base.Fs())
+	configs, err := detector.InferType(base, entrypoint)
+	s.Nil(err)
+	s.Len(configs, 1)
+
+	s.Equal(&config.Config{
+		Schema:     schema.ConfigSchemaURL,
+		Type:       config.ContentTypeRPlumber,
+		Title:      "",
+		Entrypoint: filename,
+		Validate:   true,
+		Files:      []string{"*"},
+		R:          &config.R{},
+	}, configs[0])
 }

--- a/internal/inspect/detectors/quarto_test.go
+++ b/internal/inspect/detectors/quarto_test.go
@@ -57,7 +57,7 @@ func (s *QuartoDetectorSuite) runInferType(testName string) []*config.Config {
 		executor.On("RunCommand", "quarto", []string{"inspect", filename.String()}, mock.Anything, mock.Anything).Return(fileOutput, nil, nil)
 	}
 
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	return configs
 }

--- a/internal/inspect/detectors/rmarkdown_test.go
+++ b/internal/inspect/detectors/rmarkdown_test.go
@@ -47,7 +47,7 @@ func (s *RMarkdownSuite) TestInferType() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -84,7 +84,7 @@ func (s *RMarkdownSuite) TestInferTypeWithPython() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 	s.Equal(&config.Config{
@@ -131,7 +131,7 @@ func (s *RMarkdownSuite) TestInferTypeParameterized() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -170,7 +170,7 @@ func (s *RMarkdownSuite) TestInferTypeShinyRmdRuntime() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -208,7 +208,7 @@ func (s *RMarkdownSuite) TestInferTypeShinyRmdServer() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -247,7 +247,7 @@ func (s *RMarkdownSuite) TestInferTypeShinyRmdServerType() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -281,7 +281,7 @@ func (s *RMarkdownSuite) TestInferTypeNoMetadata() {
 	s.Nil(err)
 
 	detector := NewRMarkdownDetector(logging.New())
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -289,6 +289,36 @@ func (s *RMarkdownSuite) TestInferTypeNoMetadata() {
 		Schema:     schema.ConfigSchemaURL,
 		Type:       config.ContentTypeRMarkdown,
 		Title:      "",
+		Entrypoint: filename,
+		Validate:   true,
+		Files:      []string{"*"},
+		R:          &config.R{},
+	}, configs[0])
+}
+
+func (s *RMarkdownSuite) TestInferTypeWithEntrypoint() {
+	base := util.NewAbsolutePath("/project", afero.NewMemMapFs())
+	err := base.MkdirAll(0777)
+	s.NoError(err)
+
+	filename := "report.Rmd"
+	err = base.Join(filename).WriteFile([]byte(basicRmdContent), 0600)
+	s.Nil(err)
+
+	otherFilename := "something_else.Rmd"
+	err = base.Join(otherFilename).WriteFile([]byte(basicRmdContent), 0600)
+	s.Nil(err)
+
+	detector := NewRMarkdownDetector(logging.New())
+	entrypoint := util.NewRelativePath(filename, base.Fs())
+	configs, err := detector.InferType(base, entrypoint)
+	s.Nil(err)
+	s.Len(configs, 1)
+
+	s.Equal(&config.Config{
+		Schema:     schema.ConfigSchemaURL,
+		Type:       config.ContentTypeRMarkdown,
+		Title:      "Special Report",
 		Entrypoint: filename,
 		Validate:   true,
 		Files:      []string{"*"},

--- a/internal/inspect/detectors/rshiny_test.go
+++ b/internal/inspect/detectors/rshiny_test.go
@@ -32,7 +32,7 @@ func (s *ShinySuite) TestInferTypeAppR() {
 	s.Nil(err)
 
 	detector := NewRShinyDetector()
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -58,7 +58,7 @@ func (s *ShinySuite) TestInferTypeServerR() {
 	s.Nil(err)
 
 	detector := NewRShinyDetector()
-	configs, err := detector.InferType(base)
+	configs, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Len(configs, 1)
 
@@ -79,7 +79,37 @@ func (s *ShinySuite) TestInferTypeNone() {
 	s.NoError(err)
 
 	detector := NewRShinyDetector()
-	t, err := detector.InferType(base)
+	t, err := detector.InferType(base, util.RelativePath{})
 	s.Nil(err)
 	s.Nil(t)
+}
+
+func (s *ShinySuite) TestInferTypeWithEntrypoint() {
+	base := util.NewAbsolutePath("/project", afero.NewMemMapFs())
+	err := base.MkdirAll(0777)
+	s.NoError(err)
+
+	filename := "server.R"
+	err = base.Join(filename).WriteFile(nil, 0600)
+	s.Nil(err)
+
+	otherFilename := "app.R"
+	err = base.Join(otherFilename).WriteFile(nil, 0600)
+	s.Nil(err)
+
+	detector := NewRShinyDetector()
+	entrypoint := util.NewRelativePath(filename, base.Fs())
+	configs, err := detector.InferType(base, entrypoint)
+	s.Nil(err)
+	s.Len(configs, 1)
+
+	s.Equal(&config.Config{
+		Schema:     schema.ConfigSchemaURL,
+		Type:       config.ContentTypeRShiny,
+		Title:      "",
+		Entrypoint: filename,
+		Validate:   true,
+		Files:      []string{"*"},
+		R:          &config.R{},
+	}, configs[0])
 }

--- a/internal/services/api/post_inspect.go
+++ b/internal/services/api/post_inspect.go
@@ -28,6 +28,9 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 			// Response already returned by ProjectDirFromRequest
 			return
 		}
+		entrypoint := req.URL.Query().Get("entrypoint")
+		entrypointPath := util.NewRelativePath(entrypoint, base.Fs())
+
 		dec := json.NewDecoder(req.Body)
 		dec.DisallowUnknownFields()
 		var b postInspectRequestBody
@@ -37,7 +40,8 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 			return
 		}
 
-		configs, err := initialize.GetPossibleConfigs(projectDir, util.NewPath(b.Python, nil), util.Path{}, log)
+		pythonPath := util.NewPath(b.Python, nil)
+		configs, err := initialize.GetPossibleConfigs(projectDir, pythonPath, util.Path{}, entrypointPath, log)
 		if err != nil {
 			InternalError(w, req, log, err)
 			return

--- a/internal/services/api/post_inspect.go
+++ b/internal/services/api/post_inspect.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/posit-dev/publisher/internal/config"
@@ -30,7 +31,17 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 		}
 		entrypoint := req.URL.Query().Get("entrypoint")
 		entrypointPath := util.NewRelativePath(entrypoint, base.Fs())
-
+		entrypointAbsPath := projectDir.Join(entrypoint)
+		exists, err := entrypointAbsPath.Exists()
+		if err != nil {
+			InternalError(w, req, log, err)
+			return
+		}
+		if !exists {
+			err = fmt.Errorf("entrypoint %s does not exist", entrypoint)
+			NotFound(w, log, err)
+			return
+		}
 		dec := json.NewDecoder(req.Body)
 		dec.DisallowUnknownFields()
 		var b postInspectRequestBody

--- a/internal/services/api/post_inspect.go
+++ b/internal/services/api/post_inspect.go
@@ -4,7 +4,7 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 
 	"github.com/posit-dev/publisher/internal/config"
@@ -22,6 +22,37 @@ type postInspectResponseBody struct {
 	ProjectDir    string         `json:"projectDir"`
 }
 
+var errEntrypointNotFound = errors.New("entrypoint not found")
+
+func getEntrypointPath(projectDir util.AbsolutePath, w http.ResponseWriter, req *http.Request, log logging.Logger) (util.RelativePath, error) {
+	entrypoint := req.URL.Query().Get("entrypoint")
+	if entrypoint == "" {
+		return util.RelativePath{}, nil
+	}
+	entrypointPath, err := projectDir.SafeJoin(entrypoint)
+	if err != nil {
+		BadRequest(w, req, log, err)
+		return util.RelativePath{}, err
+	}
+	exists, err := entrypointPath.Exists()
+	if err != nil {
+		InternalError(w, req, log, err)
+		return util.RelativePath{}, err
+	}
+	if !exists {
+		err = errEntrypointNotFound
+		NotFound(w, log, err)
+		return util.RelativePath{}, err
+	}
+	// Return a relative path version of the entrypoint
+	relEntrypoint, err := entrypointPath.Rel(projectDir)
+	if err != nil {
+		InternalError(w, req, log, err)
+		return util.RelativePath{}, err
+	}
+	return relEntrypoint, nil
+}
+
 func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		projectDir, relProjectDir, err := ProjectDirFromRequest(base, w, req, log)
@@ -29,17 +60,9 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 			// Response already returned by ProjectDirFromRequest
 			return
 		}
-		entrypoint := req.URL.Query().Get("entrypoint")
-		entrypointPath := util.NewRelativePath(entrypoint, base.Fs())
-		entrypointAbsPath := projectDir.Join(entrypoint)
-		exists, err := entrypointAbsPath.Exists()
+		entrypointPath, err := getEntrypointPath(projectDir, w, req, log)
 		if err != nil {
-			InternalError(w, req, log, err)
-			return
-		}
-		if !exists {
-			err = fmt.Errorf("entrypoint %s does not exist", entrypoint)
-			NotFound(w, log, err)
+			// Response already returned by getEntrypointPath
 			return
 		}
 		dec := json.NewDecoder(req.Body)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds the `entrypoint` parameter to the POST /api/inspect endpoint.

Part of #1847

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Rather than inspecting as usual and then filtering, the entrypoint is passed down to `InferType` so the inspectors can avoid a lot of I/O when an entrypoint is specified.

## Automated Tests

Added tests for when an entrypoint is specified.

## Directions for Reviewers

```
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s -XPOST -d '{}' 'localhost:9001/api/inspect?dir=test/sample-content/rmd-static-1&entrypoint=index.htm' | jq
curl -s -XPOST -d '{}' 'localhost:9001/api/inspect?dir=test/sample-content/rmd-static-1&entrypoint=static.Rmd' | jq
curl -s -XPOST -d '{}' 'localhost:9001/api/inspect?dir=test/sample-content/rmd-static-1&entrypoint=meta.yaml' | jq
```
