### PR TITLE
Recursive configuration API

### DIFF
--- a/internal/bundles/matcher/walker.go
+++ b/internal/bundles/matcher/walker.go
@@ -72,7 +72,6 @@ func (i *matchingWalker) Walk(base util.AbsolutePath, fn util.AbsoluteWalkFunc) 
 				return filepath.SkipDir
 			}
 		}
-		i.log.Debug("including", "path", path)
 		return fn(path, info, err)
 	})
 }

--- a/internal/services/api/get_configurations_test.go
+++ b/internal/services/api/get_configurations_test.go
@@ -196,3 +196,121 @@ func (s *GetConfigurationsSuite) TestGetConfigurationsByEntrypoint() {
 	s.Nil(res[0].Error)
 	s.Equal(matchingConfig, res[0].Configuration)
 }
+
+func (s *GetConfigurationsSuite) makeSubdirConfiguration(name string, subdir string) *config.Config {
+	subdirPath := s.cwd.Join(subdir)
+	err := subdirPath.MkdirAll(0777)
+	s.NoError(err)
+
+	path := config.GetConfigPath(subdirPath, name)
+	cfg := config.New()
+	cfg.Type = config.ContentTypePythonDash
+
+	// make entrypoints unique by subdirectory for filtering
+	cfg.Entrypoint = subdir + ".py"
+	cfg.Python = &config.Python{
+		Version:        "3.4.5",
+		PackageManager: "pip",
+	}
+	err = cfg.WriteFile(path)
+	s.NoError(err)
+	return cfg
+}
+
+func (s *GetConfigurationsSuite) TestGetConfigurationsRecursive() {
+	cfg0 := s.makeSubdirConfiguration("config0", ".")
+	cfg1 := s.makeSubdirConfiguration("config1", "subdir")
+	cfg2 := s.makeSubdirConfiguration("config2", "subdir")
+	subsubdir := filepath.Join("theAlphabeticvallyLastSubdir", "nested")
+	cfg3 := s.makeSubdirConfiguration("config3", subsubdir)
+
+	h := GetConfigurationsHandlerFunc(s.cwd, s.log)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/configurations?recursive=true", nil)
+	s.NoError(err)
+
+	h(rec, req)
+
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	res := []configDTO{}
+	dec := json.NewDecoder(rec.Body)
+	dec.DisallowUnknownFields()
+	s.NoError(dec.Decode(&res))
+	s.Len(res, 4)
+
+	relPath := filepath.Join(".posit", "publish", "config0.toml")
+	s.Equal(s.cwd.Join(relPath).String(), res[0].Path)
+	s.Equal(relPath, res[0].RelPath)
+	s.Equal("config0", res[0].Name)
+	s.Equal(".", res[0].ProjectDir)
+	s.Nil(res[0].Error)
+	s.Equal(cfg0, res[0].Configuration)
+
+	relPath = filepath.Join(".posit", "publish", "config1.toml")
+	s.Equal(s.cwd.Join("subdir", relPath).String(), res[1].Path)
+	s.Equal(relPath, res[1].RelPath)
+	s.Equal("config1", res[1].Name)
+	s.Equal("subdir", res[1].ProjectDir)
+	s.Nil(res[1].Error)
+	s.Equal(cfg1, res[1].Configuration)
+
+	relPath = filepath.Join(".posit", "publish", "config2.toml")
+	s.Equal(s.cwd.Join("subdir", relPath).String(), res[2].Path)
+	s.Equal(relPath, res[2].RelPath)
+	s.Equal("config2", res[2].Name)
+	s.Equal("subdir", res[2].ProjectDir)
+	s.Nil(res[2].Error)
+	s.Equal(cfg2, res[2].Configuration)
+
+	relPath = filepath.Join(".posit", "publish", "config3.toml")
+	s.Equal(s.cwd.Join(subsubdir, relPath).String(), res[3].Path)
+	s.Equal(relPath, res[3].RelPath)
+	s.Equal("config3", res[3].Name)
+	s.Equal(subsubdir, res[3].ProjectDir)
+	s.Nil(res[3].Error)
+	s.Equal(cfg3, res[3].Configuration)
+}
+
+func (s *GetConfigurationsSuite) TestGetConfigurationsRecursiveWithEntrypoint() {
+	_ = s.makeSubdirConfiguration("config0", ".")
+	cfg1 := s.makeSubdirConfiguration("config1", "subdir")
+	cfg2 := s.makeSubdirConfiguration("config2", "subdir")
+	subsubdir := filepath.Join("theAlphabeticvallyLastSubdir", "nested")
+	_ = s.makeSubdirConfiguration("config3", subsubdir)
+
+	h := GetConfigurationsHandlerFunc(s.cwd, s.log)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/configurations?recursive=true&dir=subdir&entrypoint=subdir.py", nil)
+	s.NoError(err)
+
+	h(rec, req)
+
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	res := []configDTO{}
+	dec := json.NewDecoder(rec.Body)
+	dec.DisallowUnknownFields()
+	s.NoError(dec.Decode(&res))
+	s.Len(res, 2)
+
+	relPath := filepath.Join(".posit", "publish", "config1.toml")
+	s.Equal(s.cwd.Join("subdir", relPath).String(), res[0].Path)
+	s.Equal(relPath, res[0].RelPath)
+	s.Equal("config1", res[0].Name)
+	s.Equal("subdir", res[0].ProjectDir)
+	s.Nil(res[0].Error)
+	s.Equal(cfg1, res[0].Configuration)
+
+	relPath = filepath.Join(".posit", "publish", "config2.toml")
+	s.Equal(s.cwd.Join("subdir", relPath).String(), res[1].Path)
+	s.Equal(relPath, res[1].RelPath)
+	s.Equal("config2", res[1].Name)
+	s.Equal("subdir", res[1].ProjectDir)
+	s.Nil(res[1].Error)
+	s.Equal(cfg2, res[1].Configuration)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR implements a recursive option to the GET /api/configurations endpoint.

Part of #1850 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Walk the tree looking for .posit directories; when one is found, list configurations from the parent directory. The built-in exclusions are applied to avoid excess directory traversals.

## Automated Tests

Added tests for the recursive flag.

## Directions for Reviewers

```
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s localhost:9001/api/configurations?recursive=true | jq
$ curl -s 'localhost:9001/api/configurations?recursive=true&dir=test' | jq
$ curl -s 'localhost:9001/api/configurations?recursive=true&dir=test&entrypoint=simple.py' | jq
```
