### PR TITLE
Add recursive param support to config getAll

### DIFF
--- a/extensions/vscode/src/api/resources/Configurations.ts
+++ b/extensions/vscode/src/api/resources/Configurations.ts
@@ -31,7 +31,7 @@ export class Configurations {
   // Returns:
   // 200 - success
   // 500 - internal server error
-  getAll(params?: { dir?: string; entrypoint?: string }) {
+  getAll(params?: { dir?: string; entrypoint?: string; recursive?: boolean }) {
     return this.client.get<Array<Configuration | ConfigurationError>>(
       "/configurations",
       { params },


### PR DESCRIPTION
Follow up to #1925 which adds `recursive` param support to the `api.configurations.getAll()` method.