### PR TITLE
Only request renv::paths() if no renv.lock present

### DIFF
--- a/internal/inspect/r.go
+++ b/internal/inspect/r.go
@@ -176,6 +176,15 @@ func (i *defaultRInspector) getRVersion(rExecutable string) (string, error) {
 var renvLockRE = regexp.MustCompile(`^\[1\] "(.*)"`)
 
 func (i *defaultRInspector) getRenvLockfile(rExecutable string) (util.AbsolutePath, error) {
+	defaultLockfilePath := i.base.Join(DefaultRenvLockfile)
+	exists, err := defaultLockfilePath.Exists()
+	if err != nil {
+		return util.AbsolutePath{}, err
+	}
+	if exists {
+		i.log.Info("Found default renv lockfile", "path", defaultLockfilePath.String())
+		return defaultLockfilePath, nil
+	}
 	i.log.Info("Getting renv lockfile path", "r", rExecutable)
 	args := []string{"-s", "-e", "renv::paths$lockfile()"}
 	output, _, err := i.executor.RunCommand(rExecutable, args, i.base, i.log)

--- a/internal/inspect/r.go
+++ b/internal/inspect/r.go
@@ -212,7 +212,7 @@ func (i *defaultRInspector) getRenvLockfile(rExecutable string) (util.AbsolutePa
 		}
 		// paths$lockfile returns an absolute path
 		path := m[1]
-		i.log.Info("Detected renv lockfile path", "path", path)
+		i.log.Info("renv::paths$lockfile returned lockfile path", "path", path)
 		return util.NewAbsolutePath(path, nil), nil
 	}
 	return util.AbsolutePath{}, fmt.Errorf("couldn't parse renv lockfile path from output: %s", output)

--- a/internal/inspect/r_test.go
+++ b/internal/inspect/r_test.go
@@ -119,7 +119,25 @@ func (s *RSuite) TestGetRVersionFromRealDefaultR() {
 	s.NoError(err)
 }
 
-func (s *RSuite) TestGetRenvLockfile() {
+func (s *RSuite) TestGetRenvLockfileFromDir() {
+	log := logging.New()
+	i := NewRInspector(s.cwd, util.Path{}, log)
+	inspector := i.(*defaultRInspector)
+
+	expectedPath := s.cwd.Join(DefaultRenvLockfile)
+	err := expectedPath.WriteFile(nil, 0666)
+	s.NoError(err)
+
+	// Executor should not be called
+	executor := executortest.NewMockExecutor()
+	inspector.executor = executor
+
+	lockfilePath, err := inspector.getRenvLockfile("")
+	s.NoError(err)
+	s.Equal(expectedPath, lockfilePath)
+}
+
+func (s *RSuite) TestGetRenvLockfileFromR() {
 	log := logging.New()
 	rPath := s.cwd.Join("bin", "R")
 	rPath.Dir().MkdirAll(0777)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR avoids invoking R to request `renv::paths$lockfile()` if there's an `renv.lock` in the project directory.

Follow-on to #1929 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [x] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added a test for this behavior.

## Directions for Reviewers
Inspect an R project that contains renv.lock, and one that doesn't.

If there's an renv.lock file, you shouldn't see a log line like:
```
level=DEBUG msg="Running command" cmd=/usr/local/bin/R args="-s -e renv::paths$lockfile()"
```
