### PR TITLE
Cache interpreter versions

### DIFF
--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -151,7 +151,12 @@ func (i *defaultPythonInspector) getPythonVersion(pythonExecutable string) (stri
 	}
 	version := strings.TrimSpace(string(output))
 	i.log.Info("Detected Python", "version", version)
-	pythonVersionCache[pythonExecutable] = version
+
+	// Cache interpreter version result, unless it's a pyenv shim
+	// (where the real Python interpreter may vary from run to run)
+	if !strings.Contains(pythonExecutable, "shims") {
+		pythonVersionCache[pythonExecutable] = version
+	}
 	return version, nil
 }
 

--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -36,6 +36,8 @@ var _ PythonInspector = &defaultPythonInspector{}
 
 const PythonRequirementsFilename = "requirements.txt"
 
+var pythonVersionCache = make(map[string]string)
+
 func NewPythonInspector(base util.AbsolutePath, pythonPath util.Path, log logging.Logger) PythonInspector {
 	return &defaultPythonInspector{
 		executor:   executor.NewExecutor(),
@@ -63,7 +65,11 @@ func (i *defaultPythonInspector) InspectPython() (*config.Python, error) {
 	}
 	defer util.Chdir(oldWD)
 
-	pythonVersion, err := i.getPythonVersion()
+	pythonExecutable, err := i.getPythonExecutable()
+	if err != nil {
+		return nil, err
+	}
+	pythonVersion, err := i.getPythonVersion(pythonExecutable)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +85,7 @@ func (i *defaultPythonInspector) InspectPython() (*config.Python, error) {
 }
 
 func (i *defaultPythonInspector) validatePythonExecutable(pythonExecutable string) error {
-	args := []string{"--version"}
-	_, _, err := i.executor.RunCommand(pythonExecutable, args, i.base, i.log)
+	_, err := i.getPythonVersion(pythonExecutable)
 	if err != nil {
 		return fmt.Errorf("could not run python executable '%s': %w", pythonExecutable, err)
 	}
@@ -130,10 +135,9 @@ func (i *defaultPythonInspector) getPythonExecutable() (string, error) {
 	return "", err
 }
 
-func (i *defaultPythonInspector) getPythonVersion() (string, error) {
-	pythonExecutable, err := i.getPythonExecutable()
-	if err != nil {
-		return "", err
+func (i *defaultPythonInspector) getPythonVersion(pythonExecutable string) (string, error) {
+	if version, ok := pythonVersionCache[pythonExecutable]; ok {
+		return version, nil
 	}
 	i.log.Info("Getting Python version", "python", pythonExecutable)
 	args := []string{
@@ -147,6 +151,7 @@ func (i *defaultPythonInspector) getPythonVersion() (string, error) {
 	}
 	version := strings.TrimSpace(string(output))
 	i.log.Info("Detected Python", "version", version)
+	pythonVersionCache[pythonExecutable] = version
 	return version, nil
 }
 

--- a/internal/inspect/r.go
+++ b/internal/inspect/r.go
@@ -121,12 +121,7 @@ func (i *defaultRInspector) CreateLockfile(lockfilePath util.AbsolutePath) error
 }
 
 func (i *defaultRInspector) validateRExecutable(rExecutable string) error {
-	if _, ok := rVersionCache[rExecutable]; ok {
-		// We've successfully run this executable before.
-		return nil
-	}
-	args := []string{"--version"}
-	_, _, err := i.executor.RunCommand(rExecutable, args, util.AbsolutePath{}, i.log)
+	_, err := i.getRVersion(rExecutable)
 	if err != nil {
 		return fmt.Errorf("could not run R executable '%s': %w", rExecutable, err)
 	}

--- a/internal/inspect/r_test.go
+++ b/internal/inspect/r_test.go
@@ -33,6 +33,8 @@ func (s *RSuite) SetupTest() {
 	s.cwd = cwd
 	err = cwd.MkdirAll(0700)
 	s.NoError(err)
+
+	rVersionCache = make(map[string]string)
 }
 
 func (s *RSuite) TestNewRInspector() {
@@ -217,10 +219,10 @@ func (s *RSuite) TestGetRVersionFromLockFile() {
 	s.Equal("4.3.1", version)
 }
 
-func (s *PythonSuite) TestGetRExecutable() {
+func (s *RSuite) TestGetRExecutable() {
 	log := logging.New()
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", "/some/R", []string{"--version"}, mock.Anything, mock.Anything).Return(nil, nil, nil)
+	executor.On("RunCommand", "/some/R", []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(rOutput), nil, nil)
 	i := &defaultRInspector{
 		executor: executor,
 		log:      log,
@@ -234,7 +236,7 @@ func (s *PythonSuite) TestGetRExecutable() {
 	s.Equal("/some/R", executable)
 }
 
-func (s *PythonSuite) TestGetRExecutableSpecifiedR() {
+func (s *RSuite) TestGetRExecutableSpecifiedR() {
 	log := logging.New()
 	rPath := s.cwd.Join("bin", "R")
 	rPath.Dir().MkdirAll(0777)
@@ -253,7 +255,7 @@ func (s *PythonSuite) TestGetRExecutableSpecifiedR() {
 	s.Equal(rPath.String(), executable)
 }
 
-func (s *PythonSuite) TestGetRExecutableSpecifiedRNotFound() {
+func (s *RSuite) TestGetRExecutableSpecifiedRNotFound() {
 	log := logging.New()
 
 	i := NewRInspector(s.cwd, util.NewPath("/some/R", nil), log)
@@ -264,7 +266,7 @@ func (s *PythonSuite) TestGetRExecutableSpecifiedRNotFound() {
 	s.Equal("", executable)
 }
 
-func (s *PythonSuite) TestGetRExecutableNotRunnable() {
+func (s *RSuite) TestGetRExecutableNotRunnable() {
 	log := logging.New()
 
 	testError := errors.New("test error from RunCommand")
@@ -280,6 +282,7 @@ func (s *PythonSuite) TestGetRExecutableNotRunnable() {
 	i.pathLooker = pathLooker
 
 	executable, err := i.getRExecutable()
+	s.NotNil(err)
 	s.ErrorIs(err, testError)
 	s.Equal("", executable)
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR avoids repeatedly invoking R and Python interpreters to query their versions, by caching those versions.

Draft PR because I need to think about whether we need to not cache the `.pyenv/shims/python` interpreter, which runs different interpreters based on pyenv settings and potentially `.python-version` files. 

Follow-on to #1929 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
- - [x] Performance

## Approach

Cache interpreter versions in agent memory, using interpreter path as the key.

## Automated Tests

Existing tests have been updated.

## Directions for Reviewers

Inspect projects (especially recursively). We should only request each R or Python interpreter version once.
