### PR TITLE
Add inspect recursive param support to API module

### DIFF
--- a/extensions/vscode/src/api/resources/Configurations.ts
+++ b/extensions/vscode/src/api/resources/Configurations.ts
@@ -69,7 +69,10 @@ export class Configurations {
   // 200 - success
   // 400 - bad request
   // 500 - internal server error
-  inspect(python?: string, params?: { dir?: string; entrypoint?: string }) {
+  inspect(
+    python?: string,
+    params?: { dir?: string; entrypoint?: string; recursive?: boolean },
+  ) {
     return this.client.post<ConfigurationInspectionResult[]>(
       "/inspect",
       {


### PR DESCRIPTION
Follow up to #1929 that adds support for the param to the API module.