### PR TITLE
Support link underlines accessibility setting

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -108,11 +108,11 @@
             <vscode-progress-ring class="progress-ring" />
             <div class="progress-desc">
               <div>Deployment in Progress...</div>
-              <div class="progress-log-anchor">
+              <p class="progress-log-anchor">
                 <a href="" role="button" @click="onViewPublishingLog"
                   >View Log</a
                 >
-              </div>
+              </p>
             </div>
           </div>
           <ActionToolbar
@@ -471,6 +471,7 @@ const newCredential = () => {
 
 .progress-log-anchor {
   margin-top: 5px;
+  margin-bottom: 0px;
 }
 
 .deployment-details-container {


### PR DESCRIPTION
VSCode `1.91.0` added a new setting `accessibility.underlineLinks` which does what it says on the tin

> To make links easier to distinguish from regular text in the workbench, you can enable the setting accessibility.underlineLinks to underline links.

https://code.visualstudio.com/updates/v1_91#_link-underlines

This PR ensures all of our text links (`<a>`) support the feature and toggle appropriately.

<details>
  <summary>Preview</summary>

https://github.com/posit-dev/publisher/assets/19917631/eb4d859f-7771-4c7f-a4ff-1cd501048800

</details> 

## Intent

Resolves #1934 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The injected CSS does the below

```
.monaco-workbench p>a {
    text-decoration: var(--text-link-decoration);
}
```

The `--text-link-decoration` variable changes based on the setting.

To support this, anywhere do an text anchor link we could use that CSS variable, or if it is text we can wrap the anchor in a `p` element. I did the latter here.