### PR TITLE
Fix empty array response for recursive resources

### DIFF
--- a/internal/services/api/get_configurations.go
+++ b/internal/services/api/get_configurations.go
@@ -86,7 +86,7 @@ func GetConfigurationsHandlerFunc(base util.AbsolutePath, log logging.Logger) ht
 		}
 		entrypoint := req.URL.Query().Get("entrypoint")
 
-		var response []configDTO
+		response := make([]configDTO, 0)
 		if req.URL.Query().Get("recursive") == "true" {
 			// Recursively search for .posit directories
 			walker, err := matcher.NewMatchingWalker([]string{"*"}, projectDir, log)

--- a/internal/services/api/get_deployments.go
+++ b/internal/services/api/get_deployments.go
@@ -40,7 +40,7 @@ func GetDeploymentsHandlerFunc(base util.AbsolutePath, log logging.Logger) http.
 			// Response already returned by ProjectDirFromRequest
 			return
 		}
-		var response []any
+		response := make([]any, 0)
 		entrypoint := req.URL.Query().Get("entrypoint")
 
 		if req.URL.Query().Get("recursive") == "true" {


### PR DESCRIPTION
This fixes the case where there are no Deployments or Configurations and the `recursive` param was passed. In that case the `response` array was never created and was being encoded to `null`.

This fixes that by instantiating the `response` immediately as a variable length slice.

If `recursive` isn't passed it will be overwritten by `readLatestDeploymentFiles`

If `recursive` is passed and nothing is found it will still be an empty `[]`

## Intent

Fixes #1937 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

Test with deployments/configs, without, and recursively
