### PR TITLE
Force directory param to be required on API calls and refactor config-based watchers to work in subdirectories

### DIFF
--- a/extensions/vscode/src/api/resources/Configurations.ts
+++ b/extensions/vscode/src/api/resources/Configurations.ts
@@ -20,7 +20,7 @@ export class Configurations {
   // 200 - success
   // 404 - not found
   // 500 - internal server error
-  get(configName: string, params?: { dir?: string }) {
+  get(configName: string, params: { dir: string }) {
     const encodedName = encodeURIComponent(configName);
     return this.client.get<Configuration | ConfigurationError>(
       `/configurations/${encodedName}`,
@@ -31,7 +31,7 @@ export class Configurations {
   // Returns:
   // 200 - success
   // 500 - internal server error
-  getAll(params?: { dir?: string; entrypoint?: string; recursive?: boolean }) {
+  getAll(params: { dir: string; entrypoint?: string; recursive?: boolean }) {
     return this.client.get<Array<Configuration | ConfigurationError>>(
       "/configurations",
       { params },
@@ -45,7 +45,7 @@ export class Configurations {
   createOrUpdate(
     configName: string,
     cfg: ConfigurationDetails,
-    params?: { dir?: string },
+    params: { dir: string },
   ) {
     const encodedName = encodeURIComponent(configName);
     return this.client.put<Configuration>(
@@ -59,7 +59,7 @@ export class Configurations {
   // 204 - success (no response)
   // 404 - not found
   // 500 - internal server error
-  delete(configName: string, params?: { dir?: string }) {
+  delete(configName: string, params: { dir: string }) {
     const encodedName = encodeURIComponent(configName);
     return this.client.delete(`configurations/${encodedName}`, { params });
   }
@@ -70,8 +70,8 @@ export class Configurations {
   // 400 - bad request
   // 500 - internal server error
   inspect(
+    params: { dir: string; entrypoint?: string; recursive?: boolean },
     python?: string,
-    params?: { dir?: string; entrypoint?: string; recursive?: boolean },
   ) {
     return this.client.post<ConfigurationInspectionResult[]>(
       "/inspect",

--- a/extensions/vscode/src/api/resources/ContentRecords.ts
+++ b/extensions/vscode/src/api/resources/ContentRecords.ts
@@ -18,7 +18,7 @@ export class ContentRecords {
   // Returns:
   // 200 - success
   // 500 - internal server error
-  getAll(params?: { dir?: string; entrypoints?: string; recursive?: boolean }) {
+  getAll(params: { dir: string; entrypoints?: string; recursive?: boolean }) {
     return this.client.get<Array<AllContentRecordTypes>>("/deployments", {
       params,
     });
@@ -28,7 +28,7 @@ export class ContentRecords {
   // 200 - success
   // 404 - not found
   // 500 - internal server error
-  get(id: string, params?: { dir?: string }) {
+  get(id: string, params: { dir: string }) {
     const encodedId = encodeURIComponent(id);
     return this.client.get<AllContentRecordTypes>(`deployments/${encodedId}`, {
       params,
@@ -42,10 +42,10 @@ export class ContentRecords {
   // 500 - internal server error
   // Errors returned through event stream
   createNew(
+    params: { dir: string },
     accountName?: string,
     configName?: string,
     saveName?: string,
-    params?: { dir?: string },
   ) {
     const data = {
       account: accountName,
@@ -61,10 +61,10 @@ export class ContentRecords {
   // 500 - internal server error
   // Errors returned through event stream
   publish(
+    params: { dir: string },
     targetName: string,
     accountName: string,
     configName: string = "default",
-    params?: { dir?: string },
   ) {
     const data = {
       account: accountName,
@@ -82,7 +82,7 @@ export class ContentRecords {
   // 204 - no content
   // 404 - not found
   // 500 - internal server error
-  delete(saveName: string, params?: { dir?: string }) {
+  delete(saveName: string, params: { dir: string }) {
     const encodedSaveName = encodeURIComponent(saveName);
     return this.client.delete(`deployments/${encodedSaveName}`, { params });
   }
@@ -91,7 +91,7 @@ export class ContentRecords {
   // 204 - no content
   // 404 - contentRecord or config file not found
   // 500 - internal server error
-  patch(deploymentName: string, configName: string, params?: { dir?: string }) {
+  patch(deploymentName: string, configName: string, params: { dir: string }) {
     const encodedName = encodeURIComponent(deploymentName);
     return this.client.patch<ContentRecord>(
       `deployments/${encodedName}`,

--- a/extensions/vscode/src/api/resources/Files.ts
+++ b/extensions/vscode/src/api/resources/Files.ts
@@ -25,7 +25,7 @@ export class Files {
   // 404 - configuration does not exist
   // 422 - configuration files list contains invalid patterns
   // 500 - internal server error
-  getByConfiguration(configName: string, params?: { dir?: string }) {
+  getByConfiguration(configName: string, params: { dir: string }) {
     const encodedName = encodeURIComponent(configName);
     return this.client.get<ContentRecordFile>(
       `/configurations/${encodedName}/files`,
@@ -37,7 +37,7 @@ export class Files {
     configName: string,
     path: string,
     action: FileAction,
-    params?: { dir?: string },
+    params: { dir: string },
   ) {
     const encodedName = encodeURIComponent(configName);
     const body = {

--- a/extensions/vscode/src/api/resources/Packages.ts
+++ b/extensions/vscode/src/api/resources/Packages.ts
@@ -19,7 +19,7 @@ export class Packages {
   // 409 - conflict (Python is not configured)
   // 422 - package file is invalid
   // 500 - internal server error
-  getPythonPackages(configName: string, params?: { dir?: string }) {
+  getPythonPackages(configName: string, params: { dir: string }) {
     const encodedName = encodeURIComponent(configName);
     return this.client.get<PythonPackagesResponse>(
       `/configurations/${encodedName}/packages/python`,
@@ -33,7 +33,7 @@ export class Packages {
   // 409 - conflict (R is not configured)
   // 422 - package file is invalid
   // 500 - internal server error
-  getRPackages(configName: string, params?: { dir?: string }) {
+  getRPackages(configName: string, params: { dir: string }) {
     const encodedName = encodeURIComponent(configName);
     return this.client.get<GetRPackagesResponse>(
       `/configurations/${encodedName}/packages/r`,
@@ -46,9 +46,9 @@ export class Packages {
   // 400 - bad request
   // 500 - internal server error
   createPythonRequirementsFile(
+    params: { dir: string },
     python?: string,
     saveName?: string,
-    params?: { dir?: string },
   ) {
     return this.client.post<void>(
       "packages/python/scan",
@@ -61,7 +61,7 @@ export class Packages {
   // 200 - success
   // 400 - bad request
   // 500 - internal server error
-  createRRequirementsFile(saveName?: string, params?: { dir?: string }) {
+  createRRequirementsFile(params: { dir: string }, saveName?: string) {
     return this.client.post<void>("packages/r/scan", { saveName }, { params });
   }
 }

--- a/extensions/vscode/src/bus.ts
+++ b/extensions/vscode/src/bus.ts
@@ -19,24 +19,25 @@ export const bus = Omnibus.builder()
   .build();
 
 // Setup message logging
-bus.on("activeContentRecordChanged", (msg) => {
-  console.debug(
-    `\nbus trace: activeContentRecordChanged: ${JSON.stringify(msg)}\n`,
-  );
-});
-bus.on("activeConfigChanged", (msg) => {
+bus.on(
+  "activeContentRecordChanged",
+  (msg: ContentRecord | PreContentRecord | undefined) => {
+    console.debug(
+      `\nbus trace: activeContentRecordChanged: ${JSON.stringify(msg)}\n`,
+    );
+  },
+);
+bus.on("activeConfigChanged", (msg: Configuration | undefined) => {
   console.debug(`\nbus trace: activeConfigChanged: ${JSON.stringify(msg)}\n`);
 });
-bus.on("requestActiveConfig", (msg) => {
-  console.debug(`\nbus trace: requestActiveConfig: ${JSON.stringify(msg)}`);
+bus.on("requestActiveConfig", () => {
+  console.debug(`\nbus trace: requestActiveConfig`);
 });
-bus.on("requestActiveContentRecord", (msg) => {
-  console.debug(
-    `\nbus trace: requestActiveContentRecord: ${JSON.stringify(msg)}`,
-  );
+bus.on("requestActiveContentRecord", () => {
+  console.debug(`\nbus trace: requestActiveContentRecord`);
 });
-bus.on("refreshCredentials", (msg) => {
-  console.debug(`\nbus trace: refreshCredentials: ${JSON.stringify(msg)}`);
+bus.on("refreshCredentials", () => {
+  console.debug(`\nbus trace: refreshCredentials`);
 });
 
 export const useBus = () => {

--- a/extensions/vscode/src/entrypointTracker.ts
+++ b/extensions/vscode/src/entrypointTracker.ts
@@ -34,10 +34,13 @@ async function isDocumentEntrypoint(document: TextDocument): Promise<boolean> {
     const api = await useApi();
     const python = await getPythonInterpreterPath();
 
-    const response = await api.configurations.inspect(python, {
-      dir: dir,
-      entrypoint: uriUtils.basename(document.uri),
-    });
+    const response = await api.configurations.inspect(
+      {
+        dir: dir,
+        entrypoint: uriUtils.basename(document.uri),
+      },
+      python,
+    );
 
     return hasKnownContentType(response.data);
   } catch (error: unknown) {

--- a/extensions/vscode/src/multiStepInputs/newConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/newConfig.ts
@@ -39,7 +39,10 @@ export async function newConfig(title: string, viewId?: string) {
     async (resolve, reject) => {
       try {
         const python = await getPythonInterpreterPath();
-        const inspectResponse = await api.configurations.inspect(python);
+        const inspectResponse = await api.configurations.inspect(
+          { dir: ".", recursive: true },
+          python,
+        );
         inspectionResults = inspectResponse.data;
         inspectionResults.forEach((result, i) => {
           const config = result.configuration;
@@ -239,10 +242,15 @@ export async function newConfig(title: string, viewId?: string) {
       return;
     }
     selectedInspectionResult.configuration.title = state.data.title;
-    const configName = await untitledConfigurationName();
+    const configName = await untitledConfigurationName(
+      selectedInspectionResult.projectDir,
+    );
     const createResponse = await api.configurations.createOrUpdate(
       configName,
       selectedInspectionResult.configuration,
+      {
+        dir: selectedInspectionResult.projectDir,
+      },
     );
     newConfig = createResponse.data;
     const fileUri = Uri.file(newConfig.configurationPath);

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -358,9 +358,13 @@ export async function newDeployment(
     async (resolve, reject) => {
       try {
         const python = await getPythonInterpreterPath();
-        const inspectResponse = await api.configurations.inspect(python, {
-          recursive: true,
-        });
+        const inspectResponse = await api.configurations.inspect(
+          {
+            dir: ".",
+            recursive: true,
+          },
+          python,
+        );
         inspectionResults = inspectResponse.data;
         inspectionResults.forEach((result, i) => {
           const config = result.configuration;
@@ -395,7 +399,10 @@ export async function newDeployment(
 
   const getContentRecords = new Promise<void>(async (resolve, reject) => {
     try {
-      const response = await api.contentRecords.getAll({ recursive: true });
+      const response = await api.contentRecords.getAll({
+        dir: ".",
+        recursive: true,
+      });
       const contentRecordList = response.data;
       // Note.. we want all of the contentRecord filenames regardless if they are valid or not.
       contentRecordList.forEach((contentRecord) => {
@@ -915,7 +922,9 @@ export async function newDeployment(
   selectedInspectionResult.configuration.title = state.data.title;
 
   try {
-    configName = await untitledConfigurationName();
+    configName = await untitledConfigurationName(
+      selectedInspectionResult.projectDir,
+    );
     const createResponse = await api.configurations.createOrUpdate(
       configName,
       selectedInspectionResult.configuration,
@@ -965,10 +974,10 @@ export async function newDeployment(
       existingNames = [];
     }
     const response = await api.contentRecords.createNew(
+      { dir: selectedInspectionResult.projectDir },
       finalCredentialName,
       configName,
       untitledContentRecordName(existingNames),
-      { dir: selectedInspectionResult.projectDir },
     );
     newContentRecord = response.data;
   } catch (error: unknown) {

--- a/extensions/vscode/src/multiStepInputs/selectConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectConfig.ts
@@ -137,9 +137,12 @@ export async function selectConfig(
     async (resolve, reject) => {
       try {
         const python = await getPythonInterpreterPath();
-        const inspectResponse = await api.configurations.inspect(python, {
-          dir: activeDeployment.projectDir,
-        });
+        const inspectResponse = await api.configurations.inspect(
+          {
+            dir: activeDeployment.projectDir,
+          },
+          python,
+        );
         inspectionResults = filterInspectionResultsToType(
           inspectResponse.data,
           activeDeployment.type,
@@ -394,7 +397,6 @@ export async function selectConfig(
 
     // Create the Config File
     try {
-      const configName = await untitledConfigurationName();
       const selectedInspectionResult =
         inspectionResults[state.data.entryPoint.index];
       if (!selectedInspectionResult) {
@@ -403,10 +405,16 @@ export async function selectConfig(
         );
         return;
       }
+      const configName = await untitledConfigurationName(
+        selectedInspectionResult.projectDir,
+      );
       selectedInspectionResult.configuration.title = state.data.title;
       const createResponse = await api.configurations.createOrUpdate(
         configName,
         selectedInspectionResult.configuration,
+        {
+          dir: selectedInspectionResult.projectDir,
+        },
       );
       const fileUri = Uri.file(createResponse.data.configurationPath);
       const newConfig = createResponse.data;

--- a/extensions/vscode/src/utils/names.ts
+++ b/extensions/vscode/src/utils/names.ts
@@ -5,9 +5,13 @@ import { InputBoxValidationSeverity } from "vscode";
 import { useApi } from "src/api";
 import { isValidFilename } from "src/utils/files";
 
-export async function untitledConfigurationName(): Promise<string> {
+export async function untitledConfigurationName(
+  projectDir: string,
+): Promise<string> {
   const api = await useApi();
-  const existingConfigurations = (await api.configurations.getAll()).data;
+  const existingConfigurations = (
+    await api.configurations.getAll({ dir: projectDir })
+  ).data;
 
   if (existingConfigurations.length === 0) {
     return "configuration-1";

--- a/extensions/vscode/src/views/configurations.ts
+++ b/extensions/vscode/src/views/configurations.ts
@@ -75,7 +75,10 @@ export class ConfigurationsTreeDataProvider
 
     try {
       const api = await useApi();
-      const response = await api.configurations.getAll({ recursive: true });
+      const response = await api.configurations.getAll({
+        dir: ".",
+        recursive: true,
+      });
       const configurations = response.data;
 
       return configurations.map((config) => {
@@ -140,7 +143,9 @@ export class ConfigurationsTreeDataProvider
   };
 
   private clone = async (item: ConfigurationTreeItem) => {
-    const defaultName = await untitledConfigurationName();
+    const defaultName = await untitledConfigurationName(
+      item.config.configurationRelPath,
+    );
     const newUri = await this.promptForNewName(item.fileUri, defaultName);
     if (newUri === undefined) {
       return;

--- a/extensions/vscode/src/views/contentRecords.ts
+++ b/extensions/vscode/src/views/contentRecords.ts
@@ -82,7 +82,10 @@ export class ContentRecordsTreeDataProvider
       // 200 - success
       // 500 - internal server error
       const api = await useApi();
-      const response = await api.contentRecords.getAll({ recursive: true });
+      const response = await api.contentRecords.getAll({
+        dir: ".",
+        recursive: true,
+      });
       const contentRecords = response.data;
 
       return contentRecords.map((contentRecord) => {
@@ -158,7 +161,9 @@ export class ContentRecordsTreeDataProvider
 
           try {
             const api = await useApi();
-            const response = await api.contentRecords.getAll();
+            const response = await api.contentRecords.getAll({
+              dir: item.contentRecord.projectDir,
+            });
             const contentRecordList = response.data;
             // Note.. we want all of the contentRecord filenames regardless if they are valid or not.
             contentRecordNames = contentRecordList.map(

--- a/extensions/vscode/src/watchers.ts
+++ b/extensions/vscode/src/watchers.ts
@@ -5,9 +5,10 @@ import {
   RelativePattern,
   FileSystemWatcher,
   workspace,
+  Uri,
 } from "vscode";
 
-import { Configuration } from "src/api";
+import { Configuration, ContentRecord, PreContentRecord } from "src/api";
 import {
   PUBLISH_DEPLOYMENTS_FOLDER,
   POSIT_FOLDER,
@@ -89,28 +90,41 @@ export class ConfigWatcherManager implements Disposable {
   pythonPackageFile: FileSystemWatcher | undefined;
   rPackageFile: FileSystemWatcher | undefined;
 
-  constructor(cfg?: Configuration) {
+  constructor(
+    contentRecord: ContentRecord | PreContentRecord,
+    cfg: Configuration,
+  ) {
     const root = workspace.workspaceFolders?.[0];
-    if (root === undefined || cfg === undefined) {
+    if (root === undefined) {
       return;
     }
-
+    const configurationFileUri = Uri.joinPath(
+      root.uri,
+      contentRecord.projectDir,
+      ".posit",
+      "publisher",
+      contentRecord.configurationName,
+    );
     this.configFile = workspace.createFileSystemWatcher(
-      new RelativePattern(root, cfg.configurationPath),
+      configurationFileUri.fsPath,
     );
 
+    const packageFileUri = Uri.joinPath(
+      root.uri,
+      contentRecord.projectDir,
+      cfg.configuration.python?.packageFile || DEFAULT_PYTHON_PACKAGE_FILE,
+    );
     this.pythonPackageFile = workspace.createFileSystemWatcher(
-      new RelativePattern(
-        root,
-        cfg.configuration.python?.packageFile || DEFAULT_PYTHON_PACKAGE_FILE,
-      ),
+      packageFileUri.fsPath,
     );
 
+    const rPackageFileUri = Uri.joinPath(
+      root.uri,
+      contentRecord.projectDir,
+      cfg.configuration.r?.packageFile || DEFAULT_R_PACKAGE_FILE,
+    );
     this.rPackageFile = workspace.createFileSystemWatcher(
-      new RelativePattern(
-        root,
-        cfg.configuration.r?.packageFile || DEFAULT_R_PACKAGE_FILE,
-      ),
+      rPackageFileUri.fsPath,
     );
   }
 


### PR DESCRIPTION
refactored changes to make dir mandatory for API calls. Updated watchers for package files to work with subdirectories, and updated package views to work in subdirectories. Updated Bus callbacks to be typesafe.

<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Refactored changes to make dir mandatory for API calls. 
Updated watchers for package files to work with subdirectories
Updated package views to work in subdirectories. 
Updated Bus callbacks to be typesafe.

Resolves #1855 
Reolves #1949 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Use VSCode to open project's subdirectory directly as well as from a few parent subdirectories up.
With these projects, verify the functionality related to packages for both R and Python projects.
Be sure to both manually and automatically update the package file, along with verifying that a non-default package file name within the active config file will be watched and update within the view.
