### PR TITLE
Show project dir when selecting entrypoints

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/newConfig.ts
@@ -51,6 +51,7 @@ export async function newConfig(title: string, viewId?: string) {
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
+              detail: `${result.projectDir}/`,
               index: i,
             });
           }

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -373,7 +373,7 @@ export async function newDeployment(
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: result.projectDir,
+              detail: `${result.projectDir}/`,
               index: i,
             });
           }

--- a/extensions/vscode/src/multiStepInputs/selectConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectConfig.ts
@@ -154,6 +154,7 @@ export async function selectConfig(
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
+              detail: `${result.projectDir}/`,
               index: i,
             });
           }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Type of Change

Show the projectDirs in the multit-step selectors for entrypoints

Part of #1845 

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

![2024-07-12 at 10 18 AM](https://github.com/user-attachments/assets/7e6fb3fa-9eda-4c25-9278-bdcaa7d7b21d)


## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

The three multi-steppers were updated in the same way, adding the projectDir to their detail attribute.

You can invoke them by:
- New Config from config view
- New Deployment when there are multiple entrypoints
- Select Config, when there are multiple entrypoints with the same content type as the current deployment.

You should verify that the projectDir is shown in those multiSteps.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
