### PR TITLE
Updates to configurations view to work with subdirectories

### DIFF
--- a/extensions/vscode/src/views/configurations.ts
+++ b/extensions/vscode/src/views/configurations.ts
@@ -75,10 +75,22 @@ export class ConfigurationsTreeDataProvider
 
     try {
       const api = await useApi();
-      const response = await api.configurations.getAll({
+      const getAllPromise = api.configurations.getAll({
         dir: ".",
         recursive: true,
       });
+
+      window.withProgress(
+        {
+          title: "Initializing",
+          location: { viewId: Views.Configurations },
+        },
+        async () => {
+          return getAllPromise;
+        },
+      );
+
+      const response = await getAllPromise;
       const configurations = response.data;
 
       return configurations.map((config) => {

--- a/extensions/vscode/src/views/configurations.ts
+++ b/extensions/vscode/src/views/configurations.ts
@@ -126,7 +126,10 @@ export class ConfigurationsTreeDataProvider
     // We only create a new configuration through this
     // command. We do not associate it automatically with
     // the current deployment
-    await newConfig("Create a Configuration File for your Project", viewId);
+    await newConfig(
+      "Create a Configuration File for your Project",
+      viewId ? viewId : Views.Configurations,
+    );
   };
 
   private edit = async (config: ConfigurationTreeItem) => {
@@ -143,9 +146,7 @@ export class ConfigurationsTreeDataProvider
   };
 
   private clone = async (item: ConfigurationTreeItem) => {
-    const defaultName = await untitledConfigurationName(
-      item.config.configurationRelPath,
-    );
+    const defaultName = await untitledConfigurationName(item.config.projectDir);
     const newUri = await this.promptForNewName(item.fileUri, defaultName);
     if (newUri === undefined) {
       return;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1951 

- move progress indicator to configurations view
- update clone initial name for projectDir
- add progress indicator for children tree population (relies upon sometimes slow API)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

- Verify operations work for configurations view
- Verify that when creating a new configuration when VSCode has opened a folder containing a lot of entrypoints, that the progress indicator is shown within the Configurations view (vs. down below in the bottom status line).
- Verify that when opening very large directory tree and switching over to publisher, that configurations window when expanded shows progress indicator until it is able to load.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
