### PR TITLE
Relative file IDs

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1195,17 +1195,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
         const response = await apiRequest;
 
-        // Need to remove the projectDir from the id, since the files id
-        // which will be used to include or exclude is relative to the
-        // projectDir. We really should have the backend agent do this
-        // for us, but for now, it works.
-        response.data.files.forEach((contentRecordFile) => {
-          contentRecordFile.id = contentRecordFile.id.replace(
-            activeDeployment.projectDir + "/",
-            "",
-          );
-        });
-
         this.webviewConduit.sendMsg({
           kind: HostToWebviewMessageType.REFRESH_FILES_LISTS,
           content: {

--- a/internal/services/api/files/services.go
+++ b/internal/services/api/files/services.go
@@ -17,14 +17,12 @@ type FilesService interface {
 
 func CreateFilesService(base util.AbsolutePath, log logging.Logger) FilesService {
 	return filesService{
-		root: base,
-		log:  log,
+		log: log,
 	}
 }
 
 type filesService struct {
-	root util.AbsolutePath
-	log  logging.Logger
+	log logging.Logger
 }
 
 func (s filesService) GetFile(p util.AbsolutePath, matchList matcher.MatchList) (*File, error) {
@@ -37,7 +35,7 @@ func (s filesService) GetFile(p util.AbsolutePath, matchList matcher.MatchList) 
 	p = p.Clean()
 	m := matchList.Match(p)
 
-	file, err := CreateFile(s.root, p, m)
+	file, err := CreateFile(p, p, m)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +52,7 @@ func (s filesService) GetFile(p util.AbsolutePath, matchList matcher.MatchList) 
 		if err != nil {
 			return err
 		}
-		_, err = file.insert(s.root, path, matchList)
+		_, err = file.insert(p, path, matchList)
 		return err
 	})
 

--- a/internal/services/api/files/services_test.go
+++ b/internal/services/api/files/services_test.go
@@ -70,6 +70,16 @@ func (s *ServicesSuite) TestGetFileUsingSampleContent() {
 	file, err := service.GetFile(base, matchList)
 	s.NoError(err)
 	s.NotNil(file)
+
+	s.Equal(".", file.Id)
+	s.Equal(".", file.Rel)
+	s.Equal(".", file.RelDir)
+	s.Equal("fastapi-simple", file.Base)
+	s.Equal(Directory, file.FileType)
+	s.True(file.IsDir)
+	s.False(file.IsRegular)
+	s.False(file.IsEntrypoint)
+	s.NotNil(file.Files)
 }
 
 func (s *ServicesSuite) TestGetFileUsingSampleContentWithTrailingSlash() {
@@ -84,4 +94,29 @@ func (s *ServicesSuite) TestGetFileUsingSampleContentWithTrailingSlash() {
 	file, err := service.GetFile(base, matchList)
 	s.NoError(err)
 	s.NotNil(file)
+}
+
+func (s *ServicesSuite) TestGetFileUsingSampleContentFromParentDir() {
+	afs := afero.NewOsFs()
+	base := s.cwd.Join("..", "..", "..", "..").WithFs(afs)
+	toList := base.Join("test", "sample-content", "fastapi-simple")
+
+	service := CreateFilesService(base, s.log)
+	s.NotNil(service)
+	matchList, err := matcher.NewMatchList(toList, nil)
+	s.NoError(err)
+
+	file, err := service.GetFile(toList, matchList)
+	s.NoError(err)
+	s.NotNil(file)
+
+	s.Equal(".", file.Id)
+	s.Equal(".", file.Rel)
+	s.Equal(".", file.RelDir)
+	s.Equal("fastapi-simple", file.Base)
+	s.Equal(Directory, file.FileType)
+	s.True(file.IsDir)
+	s.False(file.IsRegular)
+	s.False(file.IsEntrypoint)
+	s.NotNil(file.Files)
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR changes the Files API's `id` field to be a path relative to the requested directory instead of the workspace root. It also removes the workaround introduced in #1954.

Fixes #1950 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [x] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added a test for the case where the requested directory is a subdirectory of the root.

## Directions for Reviewers

Run the VSCode extension, with a project and configuration file in a subdirectory of the root. Use the UI to exclude and include files; it should still work and the configuration file should show the paths correctly (relative to the project dir, not the workspace root).
