### PR TITLE
Add timestamp to AxiosRequestConfig type

### DIFF
--- a/extensions/vscode/src/api/axios.d.ts
+++ b/extensions/vscode/src/api/axios.d.ts
@@ -6,5 +6,6 @@ import { AxiosRequestConfig } from "axios";
 declare module "axios" {
   interface AxiosRequestConfig {
     ignoreCamelCase?: string[];
+    ts?: DOMHighResTimeStamp;
   }
 }

--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -23,16 +23,17 @@ class PublishingClientApi {
       baseURL: apiBaseUrl,
     });
     this.client.interceptors.request.use((request) => {
-      (<any>request).ts = performance.now();
+      request.ts = performance.now();
       return request;
     });
 
     this.client.interceptors.response.use((response) => {
-      const request = response.request;
-      const duration = Math.round(
-        Number(performance.now() - (<any>response).config.ts),
-      );
-      console.log(`Request: ${request.path} took ${duration}ms`);
+      const timestamp = response.config.ts;
+      if (timestamp) {
+        const request = response.request;
+        const duration = Math.round(Number(performance.now() - timestamp));
+        console.log(`Request: ${request.path} took ${duration}ms`);
+      }
       return response;
     });
     this.apiServiceIsUp = apiServiceIsUp;

--- a/extensions/vscode/webviews/homeView/src/axios.d.ts
+++ b/extensions/vscode/webviews/homeView/src/axios.d.ts
@@ -1,0 +1,11 @@
+// Copyright (C) 2023 by Posit Software, PBC.
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { AxiosRequestConfig } from "axios";
+
+declare module "axios" {
+  interface AxiosRequestConfig {
+    ignoreCamelCase?: string[];
+    ts?: DOMHighResTimeStamp;
+  }
+}


### PR DESCRIPTION
PR feedback follow-up. Adds the `ts` attribute as an optional attribute for the `AxiosRequestConfig` so we get type safety.