### PR TITLE
Use path.sep for path strings

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/newConfig.ts
@@ -1,5 +1,7 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
+import path from "path";
+
 import {
   MultiStepInput,
   MultiStepState,
@@ -51,7 +53,7 @@ export async function newConfig(title: string, viewId?: string) {
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: `${result.projectDir}/`,
+              detail: `${result.projectDir}${path.sep}`,
               index: i,
             });
           }

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -1,5 +1,7 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
+import path from "path";
+
 import {
   MultiStepInput,
   MultiStepState,
@@ -373,7 +375,7 @@ export async function newDeployment(
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: `${result.projectDir}/`,
+              detail: `${result.projectDir}${path.sep}`,
               index: i,
             });
           }

--- a/extensions/vscode/src/multiStepInputs/selectConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectConfig.ts
@@ -1,5 +1,7 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
+import path from "path";
+
 import {
   InputBoxValidationSeverity,
   QuickPickItem,
@@ -154,7 +156,7 @@ export async function selectConfig(
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: `${result.projectDir}/`,
+              detail: `${result.projectDir}${path.sep}`,
               index: i,
             });
           }


### PR DESCRIPTION
Uses [`path.sep`](https://nodejs.org/api/path.html#pathsep) to display separation characters (`\` or `/`) based on the  platform.

## Intent

Resolves #1980

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->