### PR TITLE
Improve deployment quick pick detail string

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1,5 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
+import path from "path";
 import debounce from "debounce";
 
 import {
@@ -41,7 +42,7 @@ import { getNonce } from "src/utils/getNonce";
 import { getUri } from "src/utils/getUri";
 import { deployProject } from "src/views/deployProgress";
 import { WebviewConduit } from "src/utils/webviewConduit";
-import { fileExists } from "src/utils/files";
+import { fileExists, isRelativePathRoot } from "src/utils/files";
 import { newDeployment } from "src/multiStepInputs/newDeployment";
 
 import type { DeploymentSelector, HomeViewState } from "src/types/shared";
@@ -954,13 +955,17 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         problem = true;
       }
 
-      let detail = credential?.name;
-      if (!credential?.name) {
-        detail = `Missing Credential for ${contentRecord.serverUrl}`;
-        problem = true;
-      } else {
-        detail = `${contentRecord.projectDir} (${detail})`;
+      let details = [];
+      if (!isRelativePathRoot(contentRecord.projectDir)) {
+        details.push(`${contentRecord.projectDir}${path.sep}`);
       }
+      if (credential?.name) {
+        details.push(credential.name);
+      } else {
+        details.push(`Missing Credential for ${contentRecord.serverUrl}`);
+        problem = true;
+      }
+      const detail = details.join(" • ");
 
       let lastMatch =
         lastContentRecordName === contentRecord.saveName &&


### PR DESCRIPTION
This PR improves the strings for the Deployment quick picker by:
- Only showing the path if it isn't `.`
- Always showing the path even if there is a credential error
- Using the `•` separator so it is a bit easier to read

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-07-17 at 13 51 44@2x](https://github.com/user-attachments/assets/29ddded2-da4c-44c1-b455-92557e492178)
![CleanShot 2024-07-17 at 13 52 47@2x](https://github.com/user-attachments/assets/6219db2b-ab18-434e-bc69-a377e1bed07c)


</details> 

## Intent

Part of #1854