### PR TITLE
Use `activeConfiguration.projectDir` where appropriate

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -120,49 +120,43 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     });
 
     useBus().on("activeConfigChanged", (cfg: Configuration | undefined) => {
-      const activeContentRecord = this.getActiveContentRecord();
-      if (!activeContentRecord) {
-        return;
-      }
-
       this.sendRefreshedFilesLists();
       this.onRefreshPythonPackages();
       this.onRefreshRPackages();
 
       this.configWatchers?.dispose();
-      if (cfg) {
-        this.configWatchers = new ConfigWatcherManager(cfg);
-        this.configWatchers.configFile?.onDidChange(
-          this.sendRefreshedFilesLists,
-          this,
-        );
+      this.configWatchers = new ConfigWatcherManager(cfg);
 
-        this.configWatchers.pythonPackageFile?.onDidCreate(
-          this.onRefreshPythonPackages,
-          this,
-        );
-        this.configWatchers.pythonPackageFile?.onDidChange(
-          this.onRefreshPythonPackages,
-          this,
-        );
-        this.configWatchers.pythonPackageFile?.onDidDelete(
-          this.onRefreshPythonPackages,
-          this,
-        );
+      this.configWatchers.configFile?.onDidChange(
+        this.sendRefreshedFilesLists,
+        this,
+      );
 
-        this.configWatchers.rPackageFile?.onDidCreate(
-          this.onRefreshRPackages,
-          this,
-        );
-        this.configWatchers.rPackageFile?.onDidChange(
-          this.onRefreshRPackages,
-          this,
-        );
-        this.configWatchers.rPackageFile?.onDidDelete(
-          this.onRefreshRPackages,
-          this,
-        );
-      }
+      this.configWatchers.pythonPackageFile?.onDidCreate(
+        this.onRefreshPythonPackages,
+        this,
+      );
+      this.configWatchers.pythonPackageFile?.onDidChange(
+        this.onRefreshPythonPackages,
+        this,
+      );
+      this.configWatchers.pythonPackageFile?.onDidDelete(
+        this.onRefreshPythonPackages,
+        this,
+      );
+
+      this.configWatchers.rPackageFile?.onDidCreate(
+        this.onRefreshRPackages,
+        this,
+      );
+      this.configWatchers.rPackageFile?.onDidChange(
+        this.onRefreshRPackages,
+        this,
+      );
+      this.configWatchers.rPackageFile?.onDidDelete(
+        this.onRefreshRPackages,
+        this,
+      );
     });
   }
   /**
@@ -517,7 +511,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async onRefreshPythonPackages() {
-    const activeContentRecord = this.getActiveContentRecord();
     const activeConfiguration = this.getActiveConfig();
     let pythonProject = true;
     let packages: string[] = [];
@@ -526,7 +519,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
     const api = await useApi();
 
-    if (activeConfiguration && activeContentRecord?.projectDir) {
+    if (activeConfiguration) {
       const pythonSection = activeConfiguration?.configuration.python;
       if (!pythonSection) {
         pythonProject = false;
@@ -537,7 +530,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
           const apiRequest = api.packages.getPythonPackages(
             activeConfiguration.configurationName,
-            { dir: activeContentRecord.projectDir },
+            { dir: activeConfiguration.projectDir },
           );
           showProgress(
             "Refreshing Python Packages",
@@ -580,7 +573,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async onRefreshRPackages() {
-    const activeContentRecord = this.getActiveContentRecord();
     const activeConfiguration = this.getActiveConfig();
     let rProject = true;
     let packages: RPackage[] = [];
@@ -590,7 +582,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
     const api = await useApi();
 
-    if (activeConfiguration && activeContentRecord?.projectDir) {
+    if (activeConfiguration) {
       const rSection = activeConfiguration?.configuration.r;
       if (!rSection) {
         rProject = false;
@@ -601,7 +593,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
           const apiRequest = api.packages.getRPackages(
             activeConfiguration.configurationName,
-            { dir: activeContentRecord.projectDir },
+            { dir: activeConfiguration.projectDir },
           );
           showProgress("Refreshing R Packages", Views.HomeView, apiRequest);
 
@@ -1168,16 +1160,16 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   public sendRefreshedFilesLists = async () => {
     const api = await useApi();
-    const activeDeployment = this.getActiveContentRecord();
-    if (activeDeployment) {
+    const activeConfig = this.getActiveConfig();
+    if (activeConfig) {
       try {
         const apiRequest = api.files.getByConfiguration(
-          activeDeployment.configurationName,
+          activeConfig.configurationName,
           {
-            dir: activeDeployment.projectDir,
+            dir: activeConfig.projectDir,
           },
         );
-        showProgress("ReFreshing Files", Views.HomeView, apiRequest);
+        showProgress("Refreshing Files", Views.HomeView, apiRequest);
 
         const response = await apiRequest;
 

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -709,11 +709,11 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       // We shouldn't get here if there's no workspace folder open.
       return;
     }
-    const activeContentRecord = this.getActiveContentRecord();
-    if (activeContentRecord === undefined) {
+    const activeConfiguration = this.getActiveConfig();
+    if (activeConfiguration === undefined) {
+      // Cannot scan if there is no active configuration.
       return;
     }
-    const activeConfiguration = this.getActiveConfig();
 
     const relPathPackageFile =
       activeConfiguration?.configuration.r?.packageFile;
@@ -723,7 +723,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
     const fileUri = Uri.joinPath(
       this.root.uri,
-      activeContentRecord.projectDir,
+      activeConfiguration.projectDir,
       relPathPackageFile,
     );
 
@@ -739,7 +739,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     try {
       const api = await useApi();
       const apiRequest = api.packages.createRRequirementsFile(
-        { dir: activeContentRecord.projectDir },
+        { dir: activeConfiguration.projectDir },
         relPathPackageFile,
       );
       showProgress("Creating R Requirements File", Views.HomeView, apiRequest);

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -280,12 +280,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async updateFileList(uri: string, action: FileAction) {
-    const activeDeployment = this.getActiveContentRecord();
-    if (!activeDeployment) {
-      console.error("homeView::updateFileList: No active deployment.");
-      return;
-    }
-    // this will only be true if the config really exists
     const activeConfig = this.getActiveConfig();
     if (activeConfig === undefined) {
       console.error("homeView::updateFileList: No active configuration.");
@@ -298,7 +292,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         uri,
         action,
         {
-          dir: activeDeployment.projectDir,
+          dir: activeConfig.projectDir,
         },
       );
       showProgress("Updating File List", Views.HomeView, apiRequest);

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -652,12 +652,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       // We shouldn't get here if there's no workspace folder open.
       return;
     }
-    const activeContentRecord = this.getActiveContentRecord();
-    if (activeContentRecord === undefined) {
+    const activeConfiguration = this.getActiveConfig();
+    if (activeConfiguration === undefined) {
+      // Cannot scan if there is no active configuration.
       return;
     }
 
-    const activeConfiguration = this.getActiveConfig();
     const relPathPackageFile =
       activeConfiguration?.configuration.python?.packageFile;
     if (relPathPackageFile === undefined) {
@@ -666,7 +666,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
     const fileUri = Uri.joinPath(
       this.root.uri,
-      activeContentRecord.projectDir,
+      activeConfiguration.projectDir,
       relPathPackageFile,
     );
 
@@ -683,7 +683,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const api = await useApi();
       const python = await getPythonInterpreterPath();
       const apiRequest = api.packages.createPythonRequirementsFile(
-        { dir: activeContentRecord?.projectDir },
+        { dir: activeConfiguration.projectDir },
         python,
         relPathPackageFile,
       );

--- a/extensions/vscode/src/watchers.ts
+++ b/extensions/vscode/src/watchers.ts
@@ -89,9 +89,9 @@ export class ConfigWatcherManager implements Disposable {
   pythonPackageFile: FileSystemWatcher | undefined;
   rPackageFile: FileSystemWatcher | undefined;
 
-  constructor(cfg: Configuration) {
+  constructor(cfg?: Configuration) {
     const root = workspace.workspaceFolders?.[0];
-    if (root === undefined) {
+    if (root === undefined || cfg === undefined) {
       return;
     }
 


### PR DESCRIPTION
This PR reverts some of the refactoring done in the nested project work and utilizes `activeConfiguration.projectDir` directly rather than using only `activeContentRecord.projectDir` since all of these operations rely on the configuration. This makes it a bit easier to understand what some of those functions are relying on, and a bit simpler.

This also makes the `activeConfigChanged` listener function use optionality again rather than terminating early to avoid errors caused by the active content record becoming `undefined` but the file watchers were still firing.

## Intent

Part of [#1984](https://github.com/posit-dev/publisher/issues/1984)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->