### PR TITLE
Make webview home store `selectedConfiguration` computed

### DIFF
--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -100,11 +100,6 @@ const onRefreshContentRecordDataMsg = (msg: RefreshContentRecordDataMsg) => {
   } else {
     home.selectedContentRecord = undefined;
   }
-
-  // If no contentRecord is selected, unset the selected configuration
-  if (home.selectedContentRecord === undefined) {
-    home.selectedConfiguration = undefined;
-  }
 };
 
 /**


### PR DESCRIPTION
To fix the regression where we lost updates to the selected configuration when configuration(s) data updated without undoing the refactoring work we can make `selectedConfiguration` entirely `computed` similar to `serverCredential`.

This PR removes any specification of `selectedConfiguration.value` and makes it computed using the `configurations` in the store and `selectedContentRecord.configurationName`. It falls back to `undefined` just like `selectedConfiguration` did.

This keeps `selectedConfiguration` updated without the need to ever set it.

The name `selectedConfiguration` stayed to make this PR a bit quicker and easier to review.

## Intent

Resolves #1984

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

Try:
- updating the `title` inside of a Configuration and see the Deployment title change as it did before
- delete the configuration and see the configuration error appear as it did before without 404ing files API requests