### PR TITLE
Avoid showing relative root dir in inputs

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/newConfig.ts
@@ -28,6 +28,7 @@ import { getPythonInterpreterPath } from "../utils/config";
 import { getSummaryStringFromError } from "../utils/errors";
 import { untitledConfigurationName } from "../utils/names";
 import { showProgress } from "src/utils/progress";
+import { isRelativePathRoot } from "src/utils/files";
 
 export async function newConfig(title: string, viewId?: string) {
   // ***************************************************************
@@ -53,7 +54,9 @@ export async function newConfig(title: string, viewId?: string) {
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: `${result.projectDir}${path.sep}`,
+              detail: isRelativePathRoot(result.projectDir)
+                ? undefined
+                : `${result.projectDir}${path.sep}`,
               index: i,
             });
           }

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -40,6 +40,7 @@ import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
 import { DeploymentObjects } from "src/types/shared";
 import { showProgress } from "src/utils/progress";
+import { isRelativePathRoot } from "src/utils/files";
 
 type stepInfo = {
   step: number;
@@ -375,7 +376,9 @@ export async function newDeployment(
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: `${result.projectDir}${path.sep}`,
+              detail: isRelativePathRoot(result.projectDir)
+                ? undefined
+                : `${result.projectDir}${path.sep}`,
               index: i,
             });
           }

--- a/extensions/vscode/src/multiStepInputs/selectConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectConfig.ts
@@ -37,6 +37,7 @@ import {
   filterConfigurationsToValidAndType,
 } from "src/utils/filters";
 import { showProgress } from "src/utils/progress";
+import { isRelativePathRoot } from "src/utils/files";
 
 export async function selectConfig(
   activeDeployment: ContentRecord | PreContentRecord,
@@ -156,7 +157,9 @@ export async function selectConfig(
               iconPath: new ThemeIcon("file"),
               label: config.entrypoint,
               description: `(${contentTypeStrings[config.type]})`,
-              detail: `${result.projectDir}${path.sep}`,
+              detail: isRelativePathRoot(result.projectDir)
+                ? undefined
+                : `${result.projectDir}${path.sep}`,
               index: i,
             });
           }


### PR DESCRIPTION
This PR refines the `multiInputs` a bit to avoid showing `./` as the path if the `projectDir` `isRelativePathRoot`.

The path will continue to show if the `projectDir !== '.'`