### PR TITLE
Avoid race condition when creating new deployments

### DIFF
--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -75,7 +75,7 @@ export type RefreshContentRecordDataMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.REFRESH_CONTENTRECORD_DATA,
   {
     contentRecords: (ContentRecord | PreContentRecord)[];
-    deploymentSelected: DeploymentSelector | null;
+    deploymentSelected?: DeploymentSelector | null;
   }
 >;
 export type RefreshConfigDataMsg = AnyHostToWebviewMessage<

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1146,7 +1146,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   public refreshContentRecords = async () => {
     await this.refreshContentRecordData();
-    this.updateWebViewViewContentRecords(this.getSelectionState());
+    this.updateWebViewViewContentRecords();
     useBus().trigger(
       "activeContentRecordChanged",
       this.getActiveContentRecord(),

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -839,7 +839,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       if (
         !this.contentRecords.find(
           (contentRecord) =>
-            contentRecord.saveName === deploymentObjects.contentRecord.saveName,
+            contentRecord.saveName ===
+              deploymentObjects.contentRecord.saveName &&
+            contentRecord.projectDir ===
+              deploymentObjects.contentRecord.projectDir,
         )
       ) {
         this.contentRecords.push(deploymentObjects.contentRecord);
@@ -849,8 +852,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           (config) =>
             config.configurationName ===
               deploymentObjects.configuration.configurationName &&
-            config.configurationPath ===
-              deploymentObjects.contentRecord.projectDir,
+            config.projectDir === deploymentObjects.configuration.projectDir,
         )
       ) {
         this.configs.push(deploymentObjects.configuration);

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -411,7 +411,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private updateWebViewViewContentRecords(
-    deploymentSelector: DeploymentSelector | null,
+    deploymentSelector?: DeploymentSelector | null,
   ) {
     this.webviewConduit.sendMsg({
       kind: HostToWebviewMessageType.REFRESH_CONTENTRECORD_DATA,

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -95,11 +95,25 @@ const onRefreshContentRecordDataMsg = (msg: RefreshContentRecordDataMsg) => {
   const home = useHomeStore();
   home.contentRecords = msg.content.contentRecords;
 
-  if (msg.content.deploymentSelected) {
-    home.updateSelectedContentRecordBySelector(msg.content.deploymentSelected);
-  } else {
+  let selector = msg.content.deploymentSelected;
+  if (selector === null) {
     home.selectedContentRecord = undefined;
+    return;
   }
+
+  // If the selector is undefined don't change the selection, but update
+  // the data
+  if (selector === undefined) {
+    if (home.selectedContentRecord) {
+      home.updateSelectedContentRecordBySelector({
+        deploymentPath: home.selectedContentRecord.deploymentPath,
+      });
+    }
+    return;
+  }
+
+  // At this point we have a selector, so update the selection
+  home.updateSelectedContentRecordBySelector(selector);
 };
 
 /**

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -79,12 +79,14 @@ export const useHomeStore = defineStore("home", () => {
    * @param name the name of the new contentRecord to select
    * @returns true if the selected contentRecord was the same, false if not
    */
-  function updateSelectedContentRecordBySelector(selector: DeploymentSelector) {
+  function updateSelectedContentRecordBySelector(
+    selector?: DeploymentSelector,
+  ) {
     const previousSelectedContentRecord = selectedContentRecord.value;
     const previousSelectedConfig = selectedConfiguration.value;
 
     const contentRecord = contentRecords.value.find(
-      (d) => d.deploymentPath === selector.deploymentPath,
+      (d) => d.deploymentPath === selector?.deploymentPath,
     );
 
     selectedContentRecord.value = contentRecord;


### PR DESCRIPTION
This PR solves a race condition and other issues found around creating new deployments.

The previous edge-case capturing logic was re-introduced that handled optionally sending the selection to the webview. It needs to be optional to avoid this race condition where the new deployment async code fires before the file watcher listeners. It also now handles `undefined` and `null` again so we can specify if we want to force de-selection or just update data.

Some equality checking was also fixed which was causing some of the errors seen.

## Intent

Resolves #1989

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

- Ensure last selection loads correctly on Extension init
- Ensure that a deleted deployment causes the selection to be unselected if the selection was deleted
- Ensure that when a selected deployment changes that it is updated in the sidebar
- Ensure that when a deployment is created it is selected (regardless of what the previous selection was)