### PR TITLE
Handle JSON errors in server validation

### DIFF
--- a/extensions/vscode/src/utils/url.ts
+++ b/extensions/vscode/src/utils/url.ts
@@ -5,6 +5,10 @@ export const formatURL = (input: string): string => {
   if (/^[a-zA-Z]+:\/\//.test(input)) {
     return input;
   }
+  if (input.endsWith("/connect/")) {
+    // This is a dashboard URL; trim to get the server URL.
+    input = input.slice(0, -8);
+  }
   return `https://${input}`;
 };
 

--- a/extensions/vscode/src/utils/url.ts
+++ b/extensions/vscode/src/utils/url.ts
@@ -5,10 +5,6 @@ export const formatURL = (input: string): string => {
   if (/^[a-zA-Z]+:\/\//.test(input)) {
     return input;
   }
-  if (input.endsWith("/connect/")) {
-    // This is a dashboard URL; trim to get the server URL.
-    input = input.slice(0, -8);
-  }
   return `https://${input}`;
 };
 

--- a/internal/clients/connect/client_connect_test.go
+++ b/internal/clients/connect/client_connect_test.go
@@ -471,6 +471,29 @@ func (s *ConnectClientSuite) TestTestAuthentication404() {
 	s.ErrorIs(err, errInvalidServer)
 }
 
+func (s *ConnectClientSuite) TestTestAuthenticationAuthRedirect() {
+	// in this case, the end result of the request is a 200 with HTML payload.
+	httpClient := &http_client.MockHTTPClient{}
+	httpClient.On("Get", "/__api__/v1/user", mock.Anything, mock.Anything).Run(
+		func(args mock.Arguments) {
+			user := args.Get(1).(*UserDTO)
+			*user = UserDTO{
+				Confirmed: true,
+				UserRole:  "publisher",
+			}
+		}).Return(nil)
+
+	client := &ConnectClient{
+		client: httpClient,
+		account: &accounts.Account{
+			ApiKey: "my-api-key",
+		},
+	}
+	user, err := client.TestAuthentication(logging.New())
+	s.NotNil(user)
+	s.NoError(err)
+}
+
 func (s *ConnectClientSuite) TestTestAuthentication404WithKey() {
 	httpClient := &http_client.MockHTTPClient{}
 	httpErr := &http_client.HTTPError{

--- a/internal/clients/http_client/http_client.go
+++ b/internal/clients/http_client/http_client.go
@@ -137,7 +137,12 @@ func (c *defaultHTTPClient) doJSON(method string, path string, body any, into an
 	}
 	respBody, err := c.do(method, path, reqBody, "application/json", log)
 	if log.Enabled(context.Background(), slog.LevelDebug) {
-		log.Debug("API request", "method", method, "path", path, "body", string(bodyJSON), "response", string(respBody), "error", err)
+		const maxBody = 2000
+		trimmedRespBody := respBody
+		if len(trimmedRespBody) > maxBody {
+			trimmedRespBody = trimmedRespBody[:maxBody]
+		}
+		log.Debug("API request", "method", method, "path", path, "body", string(bodyJSON), "response", string(trimmedRespBody), "error", err)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

An authenticating proxy such as the one in front of [palm](https://pub.palm.ptd.posit.it/) may return a login page redirect for an unauthenticated API request. We make such a request when testing a server URL without an API key (during the Add Credential flow in the extension). This PR changes loosens the URL-only validation to consider HTML responses to be successful. The next validation step includes an API key, and remains strict.

Fixes #1974

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added a unit test for this case.

## Directions for Reviewers

Try various server URLs:
* https://rsc.radixu.com
* https://pub.palm.ptd.posit.it/
* ~https://pub.palm.ptd.posit.it/connect/~
* https://google.com
