### PR TITLE
Publish from entrypoint file click

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -410,7 +410,7 @@ export async function newDeployment(
       const response = await api.contentRecords.getAll(
         projectDir ? projectDir : ".",
         {
-          recursive: true,
+          recursive: projectDir ? false : true,
         },
       );
       const contentRecordList = response.data;

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -406,7 +406,7 @@ export async function newDeployment(
     try {
       const response = await api.contentRecords.getAll({
         dir: projectDir ? projectDir : ".",
-        recursive: false,
+        recursive: true,
       });
       const contentRecordList = response.data;
       // Note.. we want all of the contentRecord filenames regardless if they are valid or not.

--- a/extensions/vscode/src/types/quickPicks.ts
+++ b/extensions/vscode/src/types/quickPicks.ts
@@ -10,5 +10,6 @@ import { QuickPickItem } from "vscode";
 export interface DeploymentQuickPick extends QuickPickItem {
   contentRecord: ContentRecord | PreContentRecordWithConfig;
   config?: Configuration;
+  credentialName?: string;
   lastMatch: boolean;
 }

--- a/extensions/vscode/src/types/shared.ts
+++ b/extensions/vscode/src/types/shared.ts
@@ -11,6 +11,18 @@ export type DeploymentSelector = {
   deploymentPath: string;
 };
 
+export type PublishProcessParams = {
+  deploymentName: string;
+  credentialName: string;
+  configurationName: string;
+  projectDir: string;
+};
+
+export type DeploymentSelectionResult = {
+  selector: DeploymentSelector;
+  publishParams: PublishProcessParams;
+};
+
 export type HomeViewState = DeploymentSelector | null;
 
 export type DeploymentObjects = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolve #2003 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Initiating deployment after selection of existing or new deployment occurs.

I avoided race conditions with new deployments and configs by collecting the necessary API parameters for publishing directly from the multi-steppers that called the backend APIs after collecting the input from the user. Since they have confirmation from the APIs that the associated file updates were successful, then by using these same values, they are guaranteed to exist. This avoids trying to find the matching objects within the local caches, which are being asynchronously updated by the file watchers.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Verify functionality within both mutli-folders and single folder projects for:

1. Clear out any configurations or deployments for the project
2. Do not activate the publishing extension
3. open one of the entrypoint files from the file explorer and click the publishing icon
4. verify that the new deployment flow is initiated and that it attempts to publish that entrypoint project automatically. Also confirm that this deployment is now selected.
5. select another deployment from this one created within the webview, then click the entrypoint's publish button again. Confirm it publishes it again (while updating the current deployment back to it).
6. add another deployment for this entrypoint, which should automatically select the new deployment. Click the entrypoint's publish button and it should publish the current one.
7. Switch to another deployment for a different project, then click on the entrypoint publishing button. Confirm you are presented with the ability to select between the two deployments which you created. Pick one of them and confirm that it is pubished.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
