### PR TITLE
Use projectDir for package file watchers

### DIFF
--- a/extensions/vscode/src/watchers.ts
+++ b/extensions/vscode/src/watchers.ts
@@ -5,6 +5,7 @@ import {
   RelativePattern,
   FileSystemWatcher,
   workspace,
+  Uri,
 } from "vscode";
 
 import { Configuration } from "src/api";
@@ -101,14 +102,14 @@ export class ConfigWatcherManager implements Disposable {
 
     this.pythonPackageFile = workspace.createFileSystemWatcher(
       new RelativePattern(
-        root,
+        Uri.joinPath(root.uri, cfg.projectDir),
         cfg.configuration.python?.packageFile || DEFAULT_PYTHON_PACKAGE_FILE,
       ),
     );
 
     this.rPackageFile = workspace.createFileSystemWatcher(
       new RelativePattern(
-        root,
+        Uri.joinPath(root.uri, cfg.projectDir),
         cfg.configuration.r?.packageFile || DEFAULT_R_PACKAGE_FILE,
       ),
     );


### PR DESCRIPTION
This PR uses Configuration's `projectDir` to setup the two package file system watchers for the Python package file, and the R package file.

With the simplification of the `ConfigWatcherManager` in #1977 I removed the need for `contentRecord`, but didn't replace the `projectDir` used to reference the Configuration. This fixes that.

## Directions for Reviewers

Test that the Python and R Packages views are reactive in a nested and non-nested project.
