### PR TITLE
Handle indented comments in requirements.txt

### DIFF
--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -180,8 +181,9 @@ func (i *defaultPythonInspector) ReadRequirementsFile(path util.AbsolutePath) ([
 		return nil, err
 	}
 	lines := strings.Split(string(content), "\n")
+	commentRE := regexp.MustCompile(`^\s*#`)
 	lines = slices.DeleteFunc(lines, func(line string) bool {
-		return line == "" || strings.HasPrefix(line, "#")
+		return line == "" || commentRE.MatchString(line)
 	})
 	return lines, nil
 }

--- a/internal/inspect/python_test.go
+++ b/internal/inspect/python_test.go
@@ -172,3 +172,18 @@ func (s *PythonSuite) TestScanRequirements() {
 	s.Equal(pythonPath.String(), python)
 	scanner.AssertExpectations(s.T())
 }
+
+func (s *PythonSuite) TestReadRequirementsFile() {
+	log := logging.New()
+	i := NewPythonInspector(s.cwd, util.Path{}, log)
+
+	filePath := s.cwd.Join("requirements.txt")
+	filePath.WriteFile([]byte("# leading comment\nnumpy==1.26.1\npandas\n    # indented comment\n"), 0777)
+
+	reqs, err := i.ReadRequirementsFile(filePath)
+	s.NoError(err)
+	s.Equal([]string{
+		"numpy==1.26.1",
+		"pandas",
+	}, reqs)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR makes the requirements.txt reader properly ignore indented comments, such as those produced by `uv`.

Fixes #2010

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

Added a test for `ReadRequirementsFile`.

## Directions for Reviewers

Add comments to your requirements.txt file that begin with a space:
```
# this is a comment
numpy
pandas
   # this comment is indented
statsmodels
```

The comments should not show up in the Python Packages view.
