### PR TITLE
Handle configuration errors in selected configuration

### DIFF
--- a/extensions/vscode/src/types/quickPicks.ts
+++ b/extensions/vscode/src/types/quickPicks.ts
@@ -2,6 +2,7 @@
 
 import {
   Configuration,
+  ConfigurationError,
   ContentRecord,
   PreContentRecordWithConfig,
 } from "src/api";
@@ -9,6 +10,6 @@ import { QuickPickItem } from "vscode";
 
 export interface DeploymentQuickPick extends QuickPickItem {
   contentRecord: ContentRecord | PreContentRecordWithConfig;
-  config?: Configuration;
+  config?: Configuration | ConfigurationError;
   lastMatch: boolean;
 }

--- a/extensions/vscode/src/utils/titles.ts
+++ b/extensions/vscode/src/utils/titles.ts
@@ -1,15 +1,24 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { Configuration, ContentRecord, PreContentRecord } from "../api";
+import {
+  Configuration,
+  ConfigurationError,
+  ContentRecord,
+  isConfigurationError,
+  PreContentRecord,
+} from "../api";
 
 export const calculateTitle = (
   contentRecord: ContentRecord | PreContentRecord,
-  config?: Configuration,
+  config?: Configuration | ConfigurationError,
 ): {
   title: string;
   problem: boolean;
 } => {
-  let title = config?.configuration.title;
+  let title =
+    config && isConfigurationError(config)
+      ? undefined
+      : config?.configuration.title;
   if (title) {
     return {
       title,
@@ -31,6 +40,14 @@ export const calculateTitle = (
       problem: true,
     };
   }
+
+  if (isConfigurationError(config)) {
+    return {
+      title: `Unknown Title • Error in ${config.configurationName}`,
+      problem: true,
+    };
+  }
+
   let configName = config.configurationName;
   if (!configName) {
     // we're guaranteed to have a value because of the check above

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -907,13 +907,20 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         return;
       }
 
-      let config: Configuration | undefined;
+      let config: Configuration | ConfigurationError | undefined;
       if (contentRecord.configurationName) {
         config = this.configs.find(
           (config) =>
             config.configurationName === contentRecord.configurationName &&
             config.projectDir === contentRecord.projectDir,
         );
+        if (!config) {
+          config = this.configsInError.find(
+            (config) =>
+              config.configurationName === contentRecord.configurationName &&
+              config.projectDir === contentRecord.projectDir,
+          );
+        }
       }
 
       let credential = this.credentials.find(

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -1,6 +1,6 @@
 <template>
   <vscode-button
-    :disabled="!haveResources || home.publishInProgress"
+    :disabled="!haveResources || isConfigInError || home.publishInProgress"
     @click="deploy"
   >
     Deploy Your Project
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { isConfigurationError } from "../../../../src/api";
 import { useHomeStore } from "src/stores/home";
 import { useHostConduitService } from "src/HostConduitService";
 
@@ -24,6 +25,13 @@ const haveResources = computed(
     Boolean(home.selectedConfiguration) &&
     Boolean(home.serverCredential),
 );
+
+const isConfigInError = computed(() => {
+  return Boolean(
+    home.selectedConfiguration &&
+      isConfigurationError(home.selectedConfiguration),
+  );
+});
 
 const deploy = () => {
   if (

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -41,7 +41,11 @@
       </div>
 
       <div
-        v-if="home.selectedConfiguration?.configuration?.entrypoint"
+        v-if="
+          home.selectedConfiguration &&
+          !isConfigurationError(home.selectedConfiguration) &&
+          home.selectedConfiguration?.configuration?.entrypoint
+        "
         class="deployment-details-container"
       >
         <div class="deployment-details-row">
@@ -175,7 +179,11 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
-import { Configuration, isPreContentRecord } from "../../../../src/api";
+import {
+  Configuration,
+  isPreContentRecord,
+  isConfigurationError,
+} from "../../../../src/api";
 import { WebviewToHostMessageType } from "../../../../src/types/messages/webviewToHostMessages";
 import { calculateTitle } from "../../../../src/utils/titles";
 
@@ -292,9 +300,8 @@ const isConfigMissing = computed((): boolean => {
 
 const isConfigInError = computed((): boolean => {
   return Boolean(
-    home.selectedContentRecord &&
-      !home.selectedConfiguration &&
-      isConfigInErrorList(home.selectedContentRecord?.configurationName),
+    home.selectedConfiguration &&
+      isConfigurationError(home.selectedConfiguration),
   );
 });
 

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -28,17 +28,28 @@ export const useHomeStore = defineStore("home", () => {
   // Always use the content record as the source of truth for the
   // configuration. Can be undefined if a Configuration is not specified or
   // found.
-  const selectedConfiguration = computed((): Configuration | undefined => {
-    if (!selectedContentRecord.value) {
-      return undefined;
-    }
-    const { configurationName, projectDir } = selectedContentRecord.value;
-    return configurations.value.find(
-      (c) =>
-        c.configurationName === configurationName &&
-        c.projectDir === projectDir,
-    );
-  });
+  const selectedConfiguration = computed(
+    (): Configuration | ConfigurationError | undefined => {
+      if (!selectedContentRecord.value) {
+        return undefined;
+      }
+      const { configurationName, projectDir } = selectedContentRecord.value;
+      let result;
+      result = configurations.value.find(
+        (c) =>
+          c.configurationName === configurationName &&
+          c.projectDir === projectDir,
+      );
+      if (!result) {
+        result = configurationsInError.value.find(
+          (c) =>
+            c.configurationName === configurationName &&
+            c.projectDir === projectDir,
+        );
+      }
+      return result;
+    },
+  );
 
   // Always use the content record as the source of truth for the
   // credential. Can be undefined if a Credential is not specified or found.


### PR DESCRIPTION
This PR addresses an issue where `ConfigurationError` selected configurations were not handled well:
- the edit button to edit the configuration would not appear
- the selection would not propagate to the webview
- the "Edit the Configuration" error link would not open the configuration for editting

This bug came from a combination of the refactor in #1961 removing updates to the selected configuration when configurations were sent to the frontend, and from the move to make selected configurations computed in the webview.

## Approach

The approach here was to always grab the selected Configuration even if it was in error and handle the typing in the areas that did not support `ConfigurationError` yet.

## Directions for Reviewers

- Test Configuration Errors (invalid schema) in a nested and non-nested workspace root
- Ensure the error and edit button both link to the correct erroring config
- Ensure the multi-selectors are correctly showing the erroring title
- Ensure that normal Configuration workflows function (selecting a new one, adding a new one, etc)
