### PR TITLE
Invoke creation of credentials rather than immediate failure, plus followup items for pr2005

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -839,21 +839,42 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
       const credential =
         this.getCredentialForContentRecord(targetContentRecord);
+      let credentialName = credential?.name;
+      if (!credentialName) {
+        // prompt for creation
+        credentialName = await newCredential(
+          Views.HomeView,
+          targetContentRecord.serverUrl,
+        );
+        if (!credentialName) {
+          // user has hit ESC on credential creation
+          return;
+        }
+        useBus().trigger("refreshCredentials", undefined);
+      }
 
       if (
         !targetContentRecord.deploymentName ||
-        !credential ||
         !config.configurationName ||
         !targetContentRecord.projectDir
       ) {
+        let summary = "Selection has failed.";
+        if (!targetContentRecord.deploymentName) {
+          summary += ` ContentRecord: ${targetContentRecord.deploymentPath} has no name value.`;
+        } else if (!config.configurationName) {
+          summary += ` Configuration: ${config.configurationPath} has no name value.`;
+        } else {
+          summary += ` ContentRecord: ${targetContentRecord.deploymentPath} has no projectDir value.`;
+        }
         // display an error.
+        window.showErrorMessage(`Selection has failed. ${summary}`);
         return undefined;
       }
       return {
         selector: deploymentSelector,
         publishParams: {
           deploymentName: targetContentRecord.deploymentName,
-          credentialName: credential.name,
+          credentialName,
           configurationName: config.configurationName,
           projectDir: targetContentRecord.projectDir,
         },
@@ -1421,6 +1442,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         if (!credentialName) {
           return;
         }
+        useBus().trigger("refreshCredentials", undefined);
       }
       const target: PublishProcessParams = {
         deploymentName: contentRecord.saveName,
@@ -1462,6 +1484,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       if (!credentialName) {
         return;
       }
+      useBus().trigger("refreshCredentials", undefined);
     }
     const target: PublishProcessParams = {
       deploymentName: currentContentRecord.saveName,

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -778,15 +778,15 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     this.requestWebviewSaveSelection();
   }
 
-  private getCredentialNameForContentRecord(
+  private getCredentialForContentRecord(
     contentRecord: ContentRecord | PreContentRecord,
-  ): string | undefined {
+  ): Credential | undefined {
     const credential = this.credentials.find(
       (credential) =>
         normalizeURL(credential.url).toLowerCase() ===
         normalizeURL(contentRecord.serverUrl).toLowerCase(),
     );
-    return credential?.name;
+    return credential;
   }
 
   private async showSelectOrCreateConfigForDeployment(): Promise<
@@ -822,12 +822,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       };
       this.propagateDeploymentSelection(deploymentSelector);
 
-      const credentialName =
-        this.getCredentialNameForContentRecord(targetContentRecord);
+      const credential =
+        this.getCredentialForContentRecord(targetContentRecord);
 
       if (
         !targetContentRecord.deploymentName ||
-        !credentialName ||
+        !credential ||
         !config.configurationName ||
         !targetContentRecord.projectDir
       ) {
@@ -838,7 +838,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         selector: deploymentSelector,
         publishParams: {
           deploymentName: targetContentRecord.deploymentName,
-          credentialName: credentialName,
+          credentialName: credential.name,
           configurationName: config.configurationName,
           projectDir: targetContentRecord.projectDir,
         },
@@ -1394,9 +1394,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         deploymentPath: contentRecord.deploymentPath,
       };
       await this.propagateDeploymentSelection(deploymentSelector);
-      const credentialName =
-        this.getCredentialNameForContentRecord(contentRecord);
-      if (!credentialName) {
+      const credential = this.getCredentialForContentRecord(contentRecord);
+      if (!credential) {
         window.showErrorMessage(
           `Error: Unable to Deploy. No credential found for server at ${contentRecord.serverUrl}`,
         );
@@ -1405,7 +1404,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
       const target: PublishProcessParams = {
         deploymentName: contentRecord.saveName,
-        credentialName,
+        credentialName: credential.name,
         configurationName: contentRecord.configurationName,
         projectDir: contentRecord.projectDir,
       };
@@ -1433,9 +1432,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return false;
     }
     // compatible content record already active. Publish
-    const credentialName =
-      this.getCredentialNameForContentRecord(currentContentRecord);
-    if (!credentialName) {
+    const credential = this.getCredentialForContentRecord(currentContentRecord);
+    if (!credential) {
       window.showErrorMessage(
         `Error: Unable to Deploy. No credential found for server at ${currentContentRecord.serverUrl}`,
       );
@@ -1443,7 +1441,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
     const target: PublishProcessParams = {
       deploymentName: currentContentRecord.saveName,
-      credentialName,
+      credentialName: credential.name,
       configurationName: currentContentRecord.configurationName,
       projectDir: currentContentRecord.projectDir,
     };

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -231,20 +231,34 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     );
   }
 
-  private async onDeployMsg(msg: DeployMsg) {
+  private async initiateDeployment(
+    deploymentName: string,
+    credentialName: string,
+    configurationName: string,
+    projectDir: string,
+  ) {
     try {
       const api = await useApi();
       const response = await api.contentRecords.publish(
-        msg.content.deploymentName,
-        msg.content.credentialName,
-        msg.content.configurationName,
-        msg.content.projectDir,
+        deploymentName,
+        credentialName,
+        configurationName,
+        projectDir,
       );
       deployProject(response.data.localId, this.stream);
     } catch (error: unknown) {
       const summary = getSummaryStringFromError("homeView, deploy", error);
       window.showInformationMessage(`Failed to deploy . ${summary}`);
     }
+  }
+
+  private async onDeployMsg(msg: DeployMsg) {
+    this.initiateDeployment(
+      msg.content.deploymentName,
+      msg.content.credentialName,
+      msg.content.configurationName,
+      msg.content.projectDir,
+    );
   }
 
   private async onInitializingMsg() {
@@ -1267,10 +1281,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   };
 
   public initiatePublish(target: PublishProcessParams) {
-    this.onDeployMsg({
-      kind: WebviewToHostMessageType.DEPLOY,
-      content: target,
-    });
+    this.initiateDeployment(
+      target.deploymentName,
+      target.credentialName,
+      target.configurationName,
+      target.projectDir,
+    );
   }
 
   public async handleFileInitiatedDeployment(uri: Uri) {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -839,42 +839,21 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
       const credential =
         this.getCredentialForContentRecord(targetContentRecord);
-      let credentialName = credential?.name;
-      if (!credentialName) {
-        // prompt for creation
-        credentialName = await newCredential(
-          Views.HomeView,
-          targetContentRecord.serverUrl,
-        );
-        if (!credentialName) {
-          // user has hit ESC on credential creation
-          return;
-        }
-        useBus().trigger("refreshCredentials", undefined);
-      }
 
       if (
         !targetContentRecord.deploymentName ||
+        !credential ||
         !config.configurationName ||
         !targetContentRecord.projectDir
       ) {
-        let summary = "Selection has failed.";
-        if (!targetContentRecord.deploymentName) {
-          summary += ` ContentRecord: ${targetContentRecord.deploymentPath} has no name value.`;
-        } else if (!config.configurationName) {
-          summary += ` Configuration: ${config.configurationPath} has no name value.`;
-        } else {
-          summary += ` ContentRecord: ${targetContentRecord.deploymentPath} has no projectDir value.`;
-        }
         // display an error.
-        window.showErrorMessage(`Selection has failed. ${summary}`);
         return undefined;
       }
       return {
         selector: deploymentSelector,
         publishParams: {
           deploymentName: targetContentRecord.deploymentName,
-          credentialName,
+          credentialName: credential.name,
           configurationName: config.configurationName,
           projectDir: targetContentRecord.projectDir,
         },
@@ -1442,7 +1421,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         if (!credentialName) {
           return;
         }
-        useBus().trigger("refreshCredentials", undefined);
       }
       const target: PublishProcessParams = {
         deploymentName: contentRecord.saveName,
@@ -1484,7 +1462,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       if (!credentialName) {
         return;
       }
-      useBus().trigger("refreshCredentials", undefined);
     }
     const target: PublishProcessParams = {
       deploymentName: currentContentRecord.saveName,

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -73,6 +73,7 @@ import { calculateTitle } from "src/utils/titles";
 import { ConfigWatcherManager, WatcherManager } from "src/watchers";
 import { Commands, Contexts, LocalState, Views } from "src/constants";
 import { showProgress } from "src/utils/progress";
+import { newCredential } from "src/multiStepInputs/newCredential";
 
 enum HomeViewInitialized {
   initialized = "initialized",
@@ -1411,16 +1412,19 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       };
       await this.propagateDeploymentSelection(deploymentSelector);
       const credential = this.getCredentialForContentRecord(contentRecord);
-      if (!credential) {
-        window.showErrorMessage(
-          `Error: Unable to Deploy. No credential found for server at ${contentRecord.serverUrl}`,
+      let credentialName = credential?.name;
+      if (!credentialName) {
+        credentialName = await newCredential(
+          Views.HomeView,
+          contentRecord.serverUrl,
         );
-        return;
+        if (!credentialName) {
+          return;
+        }
       }
-
       const target: PublishProcessParams = {
         deploymentName: contentRecord.saveName,
-        credentialName: credential.name,
+        credentialName,
         configurationName: contentRecord.configurationName,
         projectDir: contentRecord.projectDir,
       };
@@ -1449,15 +1453,19 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
     // compatible content record already active. Publish
     const credential = this.getCredentialForContentRecord(currentContentRecord);
-    if (!credential) {
-      window.showErrorMessage(
-        `Error: Unable to Deploy. No credential found for server at ${currentContentRecord.serverUrl}`,
+    let credentialName = credential?.name;
+    if (!credentialName) {
+      credentialName = await newCredential(
+        Views.HomeView,
+        currentContentRecord.serverUrl,
       );
-      return;
+      if (!credentialName) {
+        return;
+      }
     }
     const target: PublishProcessParams = {
       deploymentName: currentContentRecord.saveName,
-      credentialName: credential.name,
+      credentialName,
       configurationName: currentContentRecord.configurationName,
       projectDir: currentContentRecord.projectDir,
     };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

resolves #2022 

This PR started out with implementing some simple updates requested within PR #2005. However, one of the comments questioned the failures during a few of the flows when there were no credentials available to the deployment record. A solution is provided for that problem as well, which makes a change to the workflows.

Those impacted scenarios are:
- Prompt for credentials when publishing entrypoint - when single deployment or compatible selected deployment has no credential.
- ~~Prompt for credentials during selectNewOrExistingConfig, when missing.~~

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Each of the changes has been committed separately. This should help facilitate the easiest review. There is not much overlap, if at all.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Exercise the scenarios with and without credentials available to the selected deployments, to confirm the behavior. There should not be a scenario in which they are performing the operations indicated where they receive the old error message that there are no credentials for this server. (Although that can be displayed within the HomeView.)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
