### PR TITLE
Avoid opening new tabs with anchors in workbench

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -59,14 +59,14 @@
       <p v-if="isConfigEntryMissing">
         No Config Entry in Deployment record -
         {{ home.selectedContentRecord?.saveName }}.
-        <a href="" role="button" @click="selectConfiguration">{{
+        <a class="webview-link" role="button" @click="selectConfiguration">{{
           promptForConfigSelection
         }}</a
         >.
       </p>
       <p v-if="isConfigMissing">
         The last Configuration used for this Deployment was not found.
-        <a href="" role="button" @click="selectConfiguration">{{
+        <a class="webview-link" role="button" @click="selectConfiguration">{{
           promptForConfigSelection
         }}</a
         >.
@@ -74,7 +74,7 @@
       <p v-if="isConfigInError">
         The selected Configuration has an error.
         <a
-          href=""
+          class="webview-link"
           role="button"
           @click="
             onEditConfiguration(home.selectedConfiguration!.configurationPath)
@@ -85,7 +85,7 @@
 
       <p v-if="isCredentialMissing">
         A Credential for the Deployment's server URL was not found.
-        <a href="" role="button" @click="newCredential"
+        <a class="webview-link" role="button" @click="newCredential"
           >Create a new Credential</a
         >.
       </p>
@@ -113,7 +113,10 @@
             <div class="progress-desc">
               <div>Deployment in Progress...</div>
               <p class="progress-log-anchor">
-                <a href="" role="button" @click="onViewPublishingLog"
+                <a
+                  class="webview-link"
+                  role="button"
+                  @click="onViewPublishingLog"
                   >View Log</a
                 >
               </p>

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -8,6 +8,12 @@ body {
   padding: 0;
 }
 
+.webview-link {
+  pointer-events: auto;
+  opacity: 1;
+  cursor: pointer;
+}
+
 .w-full {
   width: 100%;
 }


### PR DESCRIPTION
This PR removes anchors with empty `href` attributes from the webview to avoid opening new tabs in Workbench.

The removal of `href` changed the default styling so a new class was introduced to avoid any changes.

## Intent

Resolves #2034

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->