### PR TITLE
Deactivate Easy Deploy View when selections in progress

### DIFF
--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -25,6 +25,8 @@ export enum HostToWebviewMessageType {
   REFRESH_FILES_LISTS = "refreshFilesLists",
   UPDATE_PYTHON_PACKAGES = "updatePythonPackages",
   UPDATE_R_PACKAGES = "updateRPackages",
+  SHOW_DISABLE_OVERLAY = "showDisableOverlay",
+  HIDE_DISABLE_OVERLAY = "hideDisableOverlay",
 }
 
 export type AnyHostToWebviewMessage<
@@ -49,7 +51,9 @@ export type HostToWebviewMessage =
   | SaveSelectionMsg
   | RefreshFilesListsMsg
   | UpdatePythonPackages
-  | UpdateRPackages;
+  | UpdateRPackages
+  | ShowDisableOverlayMsg
+  | HideDisableOverlayMsg;
 
 export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
   return (
@@ -64,7 +68,9 @@ export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
     msg.kind === HostToWebviewMessageType.SAVE_SELECTION ||
     msg.kind === HostToWebviewMessageType.REFRESH_FILES_LISTS ||
     msg.kind === HostToWebviewMessageType.UPDATE_PYTHON_PACKAGES ||
-    msg.kind === HostToWebviewMessageType.UPDATE_R_PACKAGES
+    msg.kind === HostToWebviewMessageType.UPDATE_R_PACKAGES ||
+    msg.kind === HostToWebviewMessageType.SHOW_DISABLE_OVERLAY ||
+    msg.kind === HostToWebviewMessageType.HIDE_DISABLE_OVERLAY
   );
 }
 
@@ -141,3 +147,9 @@ export type UpdateRPackages = AnyHostToWebviewMessage<
     packages?: RPackage[];
   }
 >;
+
+export type ShowDisableOverlayMsg =
+  AnyHostToWebviewMessage<HostToWebviewMessageType.SHOW_DISABLE_OVERLAY>;
+
+export type HideDisableOverlayMsg =
+  AnyHostToWebviewMessage<HostToWebviewMessageType.HIDE_DISABLE_OVERLAY>;

--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -3,14 +3,12 @@
 <template>
   <main>
     <OverlayableView :activateOverlay="home.showDisabledOverlay">
-      <div>
-        <EvenEasierDeploy class="easy-deploy-container" />
-        <template v-if="home.selectedConfiguration">
-          <ProjectFiles v-model:expanded="projectFilesExpanded" />
-          <PythonPackages />
-          <RPackages />
-        </template>
-      </div>
+      <EvenEasierDeploy class="easy-deploy-container" />
+      <template v-if="home.selectedConfiguration">
+        <ProjectFiles v-model:expanded="projectFilesExpanded" />
+        <PythonPackages />
+        <RPackages />
+      </template>
     </OverlayableView>
   </main>
 </template>

--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -2,18 +2,23 @@
 
 <template>
   <main>
-    <EvenEasierDeploy class="easy-deploy-container" />
-    <template v-if="home.selectedConfiguration">
-      <ProjectFiles v-model:expanded="projectFilesExpanded" />
-      <PythonPackages />
-      <RPackages />
-    </template>
+    <OverlayableView :activateOverlay="home.showDisabledOverlay">
+      <div>
+        <EvenEasierDeploy class="easy-deploy-container" />
+        <template v-if="home.selectedConfiguration">
+          <ProjectFiles v-model:expanded="projectFilesExpanded" />
+          <PythonPackages />
+          <RPackages />
+        </template>
+      </div>
+    </OverlayableView>
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 
+import OverlayableView from "src/components/OverlayableView.vue";
 import EvenEasierDeploy from "src/components/EvenEasierDeploy.vue";
 import ProjectFiles from "src/components/views/ProjectFiles.vue";
 import PythonPackages from "src/components/views/PythonPackages.vue";

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -77,6 +77,10 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
       return onUpdatePythonPackages(msg);
     case HostToWebviewMessageType.UPDATE_R_PACKAGES:
       return onUpdateRPackages(msg);
+    case HostToWebviewMessageType.SHOW_DISABLE_OVERLAY:
+      return onShowDisableOverlayMsg();
+    case HostToWebviewMessageType.HIDE_DISABLE_OVERLAY:
+      return onHideDisableOverlayMsg();
     default:
       console.warn(`unexpected command: ${JSON.stringify(msg)}`);
   }
@@ -84,6 +88,14 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
 
 const onInitializingRequestCompleteMsg = () => {
   useHomeStore().initializingRequestComplete = true;
+};
+
+const onShowDisableOverlayMsg = () => {
+  useHomeStore().showDisabledOverlay = true;
+};
+
+const onHideDisableOverlayMsg = () => {
+  useHomeStore().showDisabledOverlay = false;
 };
 
 /**

--- a/extensions/vscode/webviews/homeView/src/components/OverlayableView.vue
+++ b/extensions/vscode/webviews/homeView/src/components/OverlayableView.vue
@@ -19,10 +19,8 @@ defineProps<{
 .overlay {
   background: var(--dropdown-background);
   position: absolute;
-  top: 0px;
+  inset: 0;
   z-index: 3;
   opacity: var(--disabled-opacity);
-  min-width: 100%;
-  min-height: 100%;
 }
 </style>

--- a/extensions/vscode/webviews/homeView/src/components/OverlayableView.vue
+++ b/extensions/vscode/webviews/homeView/src/components/OverlayableView.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="container">
+    <div v-if="activateOverlay" class="overlay"></div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  activateOverlay: boolean;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.container {
+  position: relative;
+  z-index: 1;
+}
+.overlay {
+  background: var(--dropdown-background);
+  position: absolute;
+  top: 0px;
+  z-index: 3;
+  opacity: var(--disabled-opacity);
+  min-width: 100%;
+  min-height: 100%;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -23,6 +23,8 @@ export const useHomeStore = defineStore("home", () => {
   const configurationsInError = ref<ConfigurationError[]>([]);
   const credentials = ref<Credential[]>([]);
 
+  const showDisabledOverlay = ref(false);
+
   const selectedContentRecord = ref<ContentRecord | PreContentRecord>();
 
   // Always use the content record as the source of truth for the
@@ -165,6 +167,7 @@ export const useHomeStore = defineStore("home", () => {
   };
 
   return {
+    showDisabledOverlay,
     publishInProgress,
     contentRecords,
     configurations,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1995 
Resolves #2016 

This PR addresses user feedback which indicated confusion within the UX when the multi-stepper inputs / selections were in progress.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

I've implemented a new component that can activate an overlay with an opacity set to indicate the WebView view is disabled. This is then invoked from within the extension's homeView when sequences are started which will possibly update the selection.  For example, this is what the view looks like when the user initiates creating a new deployment:

Dark mode:
Enabled without a multi-stepper invoked:
![2024-07-25 at 4 05 PM](https://github.com/user-attachments/assets/1b3573f8-da71-4b3b-9591-440b80acf26d)
with Overlay enabled and multi-stepper initiated:
![2024-07-25 at 4 02 PM](https://github.com/user-attachments/assets/0813e177-637f-4c02-af8c-949f1164e171)

Light mode:
Enabled without a multi-stepper invoked:
![2024-07-25 at 4 04 PM](https://github.com/user-attachments/assets/7b41d4bc-fd88-4c8d-98f8-1a5327388fd1)
with Overlay enabled and multi-stepper initiated:
![2024-07-25 at 4 05 PM](https://github.com/user-attachments/assets/dca3ec7a-27ab-4456-b911-f5ef4a1c80a4)

While the differences are minor, they are consistent with the styles for each theme, so they'll be familiar to the user.

Another create advantage of this approach is that everything is disabled below the overlay, since the overlay absorbs the clicks.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

The behavior is invoked for the following scenarios:

- Clicking new deployment button 
- Select or Create configuration for deployment 
- When clicking on the publish button (which appears for an entrypoint file):
    - When there are no existing deployments for the entrypoint (set within the active configuration file) found within the same directory as the entrypoint file, the new deployment multi-stepper is initiated.
    - When there are multiple compatible deployments found but a different or no deployment is actively selected, then we display a selection list of the compatible deployments.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
