### PR TITLE
Fast entrypoint scanning

### DIFF
--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -74,6 +74,10 @@ func RouterHandlerFunc(base util.AbsolutePath, lister accounts.AccountList, log 
 	r.Handle(ToPath("files"), GetFileHandlerFunc(base, filesService, pathsService, log)).
 		Methods(http.MethodGet)
 
+	// POST /api/entrypoints
+	r.Handle(ToPath("entrypoints"), GetEntrypointsHandlerFunc(base, log)).
+		Methods(http.MethodPost)
+
 	// POST /api/inspect
 	r.Handle(ToPath("inspect"), PostInspectHandlerFunc(base, log)).
 		Methods(http.MethodPost)

--- a/internal/services/api/get_entrypoints.go
+++ b/internal/services/api/get_entrypoints.go
@@ -26,8 +26,8 @@ func GetEntrypointsHandlerFunc(base util.AbsolutePath, log logging.Logger) http.
 		files := []string{
 			"*",
 			"!**/renv/activate.R",
-			"!_site",
-			"_site/index.html",
+			"!**/_site/*.html",
+			"**/_site/index.html",
 			"!*_files",
 		}
 

--- a/internal/services/api/get_entrypoints.go
+++ b/internal/services/api/get_entrypoints.go
@@ -1,0 +1,59 @@
+package api
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"slices"
+
+	"github.com/posit-dev/publisher/internal/bundles/matcher"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util"
+)
+
+func GetEntrypointsHandlerFunc(base util.AbsolutePath, log logging.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		projectDir, _, err := ProjectDirFromRequest(base, w, req, log)
+		if err != nil {
+			// Response already returned by ProjectDirFromRequest
+			return
+		}
+
+		response := []string{}
+		suffixes := []string{".htm", ".html", ".ipynb", ".py", ".qmd", ".R", ".Rmd"}
+		files := []string{
+			"*",
+			"!**/renv/activate.R",
+		}
+
+		walker, err := matcher.NewMatchingWalker(files, projectDir, log)
+		if err != nil {
+			InternalError(w, req, log, err)
+			return
+		}
+		err = walker.Walk(projectDir, func(path util.AbsolutePath, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if slices.Contains(suffixes, path.Ext()) {
+				relPath, err := path.Rel(projectDir)
+				if err != nil {
+					return err
+				}
+				response = append(response, relPath.String())
+			}
+			return nil
+		})
+		if err != nil {
+			InternalError(w, req, log, err)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}
+}

--- a/internal/services/api/get_entrypoints.go
+++ b/internal/services/api/get_entrypoints.go
@@ -26,6 +26,9 @@ func GetEntrypointsHandlerFunc(base util.AbsolutePath, log logging.Logger) http.
 		files := []string{
 			"*",
 			"!**/renv/activate.R",
+			"!_site",
+			"_site/index.html",
+			"!*_files",
 		}
 
 		walker, err := matcher.NewMatchingWalker(files, projectDir, log)

--- a/internal/services/api/get_entrypoints_test.go
+++ b/internal/services/api/get_entrypoints_test.go
@@ -1,0 +1,97 @@
+package api
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+)
+
+type GetEntrypointsSuite struct {
+	utiltest.Suite
+	log logging.Logger
+	cwd util.AbsolutePath
+}
+
+func TestGetEntrypointsSuite(t *testing.T) {
+	suite.Run(t, new(GetEntrypointsSuite))
+}
+
+func (s *GetEntrypointsSuite) SetupSuite() {
+	s.log = logging.New()
+}
+
+func (s *GetEntrypointsSuite) SetupTest() {
+	fs := afero.NewMemMapFs()
+	cwd, err := util.Getwd(fs)
+	s.Nil(err)
+	s.cwd = cwd
+	s.cwd.MkdirAll(0700)
+}
+
+func (s *GetEntrypointsSuite) makeFile(path util.AbsolutePath) {
+	err := path.Dir().MkdirAll(0700)
+	s.NoError(err)
+	err = path.WriteFile(nil, 0600)
+	s.NoError(err)
+}
+
+func (s *GetEntrypointsSuite) TestGetEntrypoints() {
+	base := s.cwd.Join("subdir", "subsubdir")
+	err := base.MkdirAll(0700)
+	s.NoError(err)
+
+	goodFiles := []string{
+		filepath.Join("_site", "index.html"),
+		"app.R",
+		"app.py",
+		"index.htm",
+		"index.html",
+		"index.qmd",
+		"notebook.ipynb",
+		"plumber.R",
+		"report.Rmd",
+		"streamlit_app.py",
+	}
+	badFiles := []string{
+		"something.txt",
+		"whatever",
+		filepath.Join("renv", "activate.R"),
+		filepath.Join("_site", "somepage.html"),
+		filepath.Join("report_files", "index.html"),
+	}
+	for _, f := range goodFiles {
+		s.makeFile(base.Join(f))
+	}
+	for _, f := range badFiles {
+		s.makeFile(base.Join(f))
+	}
+
+	h := GetEntrypointsHandlerFunc(s.cwd, s.log)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/entrypoints", nil)
+	s.NoError(err)
+	h(rec, req)
+
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	res := []string{}
+	dec := json.NewDecoder(rec.Body)
+	s.NoError(dec.Decode(&res))
+
+	expected := util.Map(func(f string) string {
+		return filepath.Join("subdir", "subsubdir", f)
+	}, goodFiles)
+	s.Equal(expected, res)
+}

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -14,3 +14,11 @@ func RemoveDuplicates[T comparable](list []T) []T {
 	}
 	return out
 }
+
+func Map[T any](fn func(T) T, list []T) []T {
+	out := make([]T, len(list))
+	for i, item := range list {
+		out[i] = fn(item)
+	}
+	return out
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds the GET /api/entrypoints endpoint, which scans the project directory for potential entrypoints by file suffix. It excludes the standard exclusions, as well as some files with the right suffix that aren't good entrypoints. The returned files might be entrypoints; they need to be inspected with /api/inspect to be sure.

Fixes #2029

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added a basic unit test for the new endpoint.

## Directions for Reviewers

```
just build
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s localhost:9001/api/entrypoints -XPOST |jq
```
