### PR TITLE
handle whitespace-only lines in requirements.txt

### DIFF
--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -181,9 +181,9 @@ func (i *defaultPythonInspector) ReadRequirementsFile(path util.AbsolutePath) ([
 		return nil, err
 	}
 	lines := strings.Split(string(content), "\n")
-	commentRE := regexp.MustCompile(`^\s*#`)
+	commentRE := regexp.MustCompile(`^\s*(#.*)?$`)
 	lines = slices.DeleteFunc(lines, func(line string) bool {
-		return line == "" || commentRE.MatchString(line)
+		return commentRE.MatchString(line)
 	})
 	return lines, nil
 }

--- a/internal/inspect/python_test.go
+++ b/internal/inspect/python_test.go
@@ -178,7 +178,7 @@ func (s *PythonSuite) TestReadRequirementsFile() {
 	i := NewPythonInspector(s.cwd, util.Path{}, log)
 
 	filePath := s.cwd.Join("requirements.txt")
-	filePath.WriteFile([]byte("# leading comment\nnumpy==1.26.1\npandas\n    # indented comment\n"), 0777)
+	filePath.WriteFile([]byte("# leading comment\nnumpy==1.26.1\n  \npandas\n    # indented comment\n"), 0777)
 
 	reqs, err := i.ReadRequirementsFile(filePath)
 	s.NoError(err)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Fixes #2033

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Update the comment-ignoring regexp to handle lines that are all whitespace.

## Automated Tests

Updated existing unit test to catch this.

## Directions for Reviewers

Have a whitespace-only line in requirements.txt. It shouldn't show up in the Python Packages view.
