### PR TITLE
Return empty array instead of nil

### DIFF
--- a/internal/clients/connect/client_connect_test.go
+++ b/internal/clients/connect/client_connect_test.go
@@ -60,7 +60,7 @@ type taskTest struct {
 }
 
 func (s *ConnectClientSuite) TestWaitForTask() {
-	var actualPackages []packageStatusEvent
+	actualPackages := []packageStatusEvent{}
 	emitter := events.NewMockEmitter()
 	emitter.On("Emit", mock.Anything).Run(func(args mock.Arguments) {
 		event := args.Get(0).(*events.Event)

--- a/internal/inspect/dependencies/pydeps/project_dependencies.go
+++ b/internal/inspect/dependencies/pydeps/project_dependencies.go
@@ -34,7 +34,7 @@ func (s *defaultDependencyScanner) ScanDependencies(base util.AbsolutePath, pyth
 	if err != nil {
 		return nil, err
 	}
-	var specs []*PackageSpec
+	specs := []*PackageSpec{}
 	for _, importName := range importNames {
 		spec, ok := mapping[importName]
 		if ok {

--- a/internal/inspect/dependencies/pydeps/project_imports.go
+++ b/internal/inspect/dependencies/pydeps/project_imports.go
@@ -36,7 +36,7 @@ func (s *defaultProjectImportScanner) ScanProjectImports(base util.AbsolutePath)
 		return nil, err
 	}
 
-	var projectImports []ImportName
+	projectImports := []ImportName{}
 
 	err = matchList.Walk(base, func(path util.AbsolutePath, info fs.FileInfo, err error) error {
 		if err != nil {

--- a/internal/inspect/dependencies/pydeps/qmd_contents.go
+++ b/internal/inspect/dependencies/pydeps/qmd_contents.go
@@ -20,7 +20,7 @@ func GetQuartoFilePythonCode(path util.AbsolutePath) (string, error) {
 func GetQuartoPythonCode(content string) string {
 	lines := strings.Split(content, "\n")
 	inCodeBlock := false
-	var codeLines []string
+	codeLines := []string{}
 
 	for _, line := range lines {
 		if inCodeBlock {

--- a/internal/inspect/detectors/all.go
+++ b/internal/inspect/detectors/all.go
@@ -59,7 +59,7 @@ func filenameStem(filename string) string {
 }
 
 func (t *ContentTypeDetector) InferType(base util.AbsolutePath, entrypoint util.RelativePath) ([]*config.Config, error) {
-	var allConfigs []*config.Config
+	allConfigs := []*config.Config{}
 
 	_, err := base.Stat()
 	if err != nil {
@@ -75,7 +75,7 @@ func (t *ContentTypeDetector) InferType(base util.AbsolutePath, entrypoint util.
 			allConfigs = append(allConfigs, configs...)
 		}
 	}
-	if allConfigs == nil {
+	if len(allConfigs) == 0 {
 		allConfigs = append(allConfigs, newUnknownConfig())
 	}
 

--- a/internal/services/api/post_inspect.go
+++ b/internal/services/api/post_inspect.go
@@ -72,7 +72,7 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 			return
 		}
 		pythonPath := util.NewPath(b.Python, nil)
-		var response []postInspectResponseBody
+		response := []postInspectResponseBody{}
 
 		if req.URL.Query().Get("recursive") == "true" {
 			walker, err := matcher.NewMatchingWalker([]string{"*"}, projectDir, log)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Fixes #2032

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

There are a number of places in the Go code where we return nil when a result set would be empty. This PR changes those to return an empty slice. We only return nil on error returns, where the slice value won't be used by the caller.

## Automated Tests

Existing tests should pass.

## Directions for Reviewers

Open an empty folder, and try to add a deployment.
