### PR TITLE
Allow credentials to be specified via environment variables

### DIFF
--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -36,6 +36,11 @@ const credentialsCommands = {
 
 const credentialsContexts = {
   Keychain: "posit.publisher.credentials.tree.item.keychain",
+  EnvironmentVars: "posit.publisher.credentials.tree.item.environmentVars",
+};
+
+export const CredentialGUIs = {
+  EnvironmentGUID: "00000000-0000-0000-0000-000000000000",
 };
 
 const filesCommands = {

--- a/extensions/vscode/src/views/credentials.ts
+++ b/extensions/vscode/src/views/credentials.ts
@@ -16,7 +16,7 @@ import { useBus } from "src/bus";
 import { confirmDelete } from "src/dialogs";
 import { getSummaryStringFromError } from "src/utils/errors";
 import { newCredential } from "src/multiStepInputs/newCredential";
-import { Commands, Contexts, Views } from "src/constants";
+import { Commands, Contexts, CredentialGUIs, Views } from "src/constants";
 
 type CredentialEventEmitter = EventEmitter<
   CredentialsTreeItem | undefined | void
@@ -116,6 +116,7 @@ export class CredentialsTreeDataProvider
     }
     try {
       const api = await useApi();
+      item.cred.guid;
       await api.credentials.delete(item.cred.guid);
       window.setStatusBarMessage(
         `Credential for ${item.cred.name} has been erased from our memory!`,
@@ -131,8 +132,14 @@ export class CredentialsTreeDataProvider
 export class CredentialsTreeItem extends TreeItem {
   constructor(public readonly cred: Credential) {
     super(cred.name);
-    this.iconPath = new ThemeIcon("key");
+    this.iconPath =
+      cred.guid === CredentialGUIs.EnvironmentGUID
+        ? new ThemeIcon("bracket")
+        : new ThemeIcon("key");
     this.description = `${cred.url}`;
-    this.contextValue = Contexts.Credentials.Keychain;
+    this.contextValue =
+      cred.guid === CredentialGUIs.EnvironmentGUID
+        ? Contexts.Credentials.EnvironmentVars
+        : Contexts.Credentials.Keychain;
   }
 }

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -9,9 +9,47 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+type Cred struct {
+	GUID   string
+	Server string
+	ApiKey string
+	Name   string
+}
+
+var environmentCred = Credential{
+	GUID:   "00000000-0000-0000-0000-000000000000",
+	URL:    "https://connect.localtest.me/rsc/dev-password-copy",
+	ApiKey: "3456789",
+	Name:   "dev-password-copy",
+}
+
+func initializeEnv(t *testing.T, cs *CredentialsService) {
+	t.Setenv("CONNECT_SERVER", environmentCred.URL)
+	t.Setenv("CONNECT_API_KEY", environmentCred.ApiKey)
+	t.Setenv("CONNECT_SERVER_NAME", environmentCred.Name)
+
+	res, err := cs.Get(environmentCred.GUID)
+	assert.NoError(t, err)
+	expected := Credential{
+		GUID:   environmentCred.GUID,
+		Name:   environmentCred.Name,
+		URL:    environmentCred.URL,
+		ApiKey: environmentCred.ApiKey,
+	}
+	assert.Equal(t, res, &expected)
+}
+
+func clearEnv(t *testing.T) {
+	t.Setenv("CONNECT_SERVER", "")
+	t.Setenv("CONNECT_API_KEY", "")
+	t.Setenv("CONNECT_SERVER_NAME", "")
+}
+
 func TestSet(t *testing.T) {
 	keyring.MockInit()
 	cs := CredentialsService{}
+	clearEnv(t)
+
 	cred, err := cs.Set("example", "https://example.com", "12345")
 	assert.NoError(t, err)
 	assert.NotNil(t, cred.GUID)
@@ -23,16 +61,28 @@ func TestSet(t *testing.T) {
 func TestSetURLCollisionError(t *testing.T) {
 	keyring.MockInit()
 	cs := CredentialsService{}
+	clearEnv(t)
+
 	_, err := cs.Set("example", "https://example.com", "12345")
 	assert.NoError(t, err)
 	_, err = cs.Set("example", "https://example.com", "12345")
 	assert.Error(t, err)
 	assert.IsType(t, &URLCollisionError{}, err)
+
+	// validate collision with env var credentials
+	initializeEnv(t, &cs)
+
+	_, err = cs.Set("unique", environmentCred.URL, "12345")
+	assert.Error(t, err)
+	assert.IsType(t, &EnvURLCollisionError{}, err)
 }
 
 func TestGet(t *testing.T) {
 	keyring.MockInit()
 	cs := CredentialsService{}
+	clearEnv(t)
+
+	// First test without any credentials in environment
 
 	// error if missing
 	_, err := cs.Get("example")
@@ -45,11 +95,24 @@ func TestGet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, res, cred)
 
+	// Test with credentials in environment
+	initializeEnv(t, &cs)
+
+	// retest prior test
+	res, err = cs.Get(cred.GUID)
+	assert.NoError(t, err)
+	assert.Equal(t, res, cred)
+
+	// request environment credentials
+	res, err = cs.Get(environmentCred.GUID)
+	assert.NoError(t, err)
+	assert.Equal(t, res, &environmentCred)
 }
 
 func TestNormalizedSet(t *testing.T) {
 	keyring.MockInit()
 	cs := CredentialsService{}
+	clearEnv(t)
 
 	// pass if no change (already normalized)
 	cred, err := cs.Set("example", "https://example.com", "12345")
@@ -59,7 +122,7 @@ func TestNormalizedSet(t *testing.T) {
 	assert.Equal(t, res.URL, cred.URL)
 
 	// pass if URL ends up normalized
-	cred, err = cs.Set("example", "https://example.com///another/seg/", "12345")
+	cred, err = cs.Set("example2", "https://example.com///another/seg/", "12345")
 	assert.NoError(t, err)
 	assert.NotEqual(t, cred.URL, "https://example.com///another/seg/")
 
@@ -69,9 +132,43 @@ func TestNormalizedSet(t *testing.T) {
 	assert.Equal(t, cred.URL, res.URL)
 }
 
+func TestSetCollisions(t *testing.T) {
+	keyring.MockInit()
+	cs := CredentialsService{}
+
+	// Add credentials into environment
+	initializeEnv(t, &cs)
+
+	// add a non-environment credential
+	_, err := cs.Set("example", "https://example.com", "12345")
+	assert.NoError(t, err)
+
+	// non-environment name collision
+	_, err = cs.Set("example", "https://more_examples.com", "12345")
+	assert.Error(t, err)
+	assert.IsType(t, &NameCollisionError{}, err)
+
+	// environment name collision
+	_, err = cs.Set(environmentCred.Name, "https://more_examples2.com", "12345")
+	assert.Error(t, err)
+	assert.IsType(t, &EnvNameCollisionError{}, err)
+
+	// non-environment URL collision
+	_, err = cs.Set("another_example", "https://example.com", "12345")
+	assert.Error(t, err)
+	assert.IsType(t, &URLCollisionError{}, err)
+
+	// environment URL collision
+	_, err = cs.Set("one_more", environmentCred.URL, "12345")
+	assert.Error(t, err)
+	assert.IsType(t, &EnvURLCollisionError{}, err)
+}
+
 func TestDelete(t *testing.T) {
 	keyring.MockInit()
 	cs := CredentialsService{}
+	clearEnv(t)
+
 	cred, err := cs.Set("example", "https://example.com", "12345")
 	assert.NoError(t, err)
 
@@ -82,4 +179,12 @@ func TestDelete(t *testing.T) {
 	// err if missing
 	err = cs.Delete(cred.GUID)
 	assert.Error(t, err)
+
+	// Add credentials into environment
+	initializeEnv(t, &cs)
+
+	// err for our special GUID
+	err = cs.Delete(environmentCred.GUID)
+	assert.Error(t, err)
+	assert.IsType(t, &EnvURLDeleteError{}, err)
 }

--- a/internal/credentials/errors.go
+++ b/internal/credentials/errors.go
@@ -30,11 +30,51 @@ func (e *NotFoundError) Error() string {
 
 // URL is used by another credential
 type URLCollisionError struct {
-	URL string
+	Name string
+	URL  string
 }
 
 func (e *URLCollisionError) Error() string {
-	return fmt.Sprintf("URL already in use: %s", e.URL)
+	return fmt.Sprintf("URL value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
+}
+
+// Environment URL overlaps with Credential URL
+type EnvURLCollisionError struct {
+	Name string
+	URL  string
+}
+
+func (e *EnvURLCollisionError) Error() string {
+	return fmt.Sprintf("CONNECT_SERVER URL value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
+}
+
+// Name is used by another credential
+type NameCollisionError struct {
+	Name string
+	URL  string
+}
+
+func (e *NameCollisionError) Error() string {
+	return fmt.Sprintf("Name value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
+}
+
+// Environment URL overlaps with Credential URL
+type EnvNameCollisionError struct {
+	Name string
+	URL  string
+}
+
+func (e *EnvNameCollisionError) Error() string {
+	return fmt.Sprintf("CONNECT_SERVER Name value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
+}
+
+// Deleting Environment Credentials Not allowed
+type EnvURLDeleteError struct {
+	GUID string
+}
+
+func (e *EnvURLDeleteError) Error() string {
+	return fmt.Sprintf("DELETING an environment credential is not allowed. (GUID=%s)", e.GUID)
 }
 
 type VersionError struct {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2062 
Partially addresses #1831 

This PR introduces automatic credentials, which are imported from environment variables.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Since we do not want environment variables to persist, the actual keychain storage does not include these new types of credentials. Instead, they are inserted into the memory copy of the store and are removed before that store is persisted.

The environment credential has a fixed GUID of "00000000-0000-0000-0000-000000000000". This allows us to identify it, provide more contextual error messages, and restrict operations (deletes are not allowed).

Validation of the URL is not done at creation time. This will show up as a normal connectivity error within the pre-checks.

Conflict checks occur when credentials are created. They do not occur once credentials are in the store or environment.

I have selected different icons for the different types of credentials.

With the following entries within my environment (present before VSCode is launched - `~.zshenv`):

![2024-08-01 at 1 25 PM](https://github.com/user-attachments/assets/e1ca3154-a9c7-46bb-babe-e6f7b12d1ee4)

I now can see:

![2024-08-01 at 1 23 PM](https://github.com/user-attachments/assets/6096dc64-5610-4ff6-b4fe-7b421ecd1ec3)


## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Go unit tests have been updated to cover new functionality.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

To validate this, you must set environment variables ahead of launching the first instance of VSCode. What this involved for me was to insert them into my `~.zshenv` file, close all instances of VSCode, and then restart VSCode, launching the extension directly or via debug.

Confirm that if no environment variables are set, then you do not see any extra credentials. 
- Validate that you can still add a new credential after this fix.
- Validate that credential creation will not allow overlap of the name or the URL.

Set the environment variables appropriately, and then relaunch VSCode. Validate that:
- you see the new credential
- you can use it to publish. 
- right-click does not show the delete option for the environment credential
- Validate that credential creation will not allow overlap of the Environment variable name or its URL.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
