### PR TITLE
Split out state logic to `PublisherState` class

### DIFF
--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
 import { Disposable, ExtensionContext } from "vscode";
 
 import {

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -1,0 +1,80 @@
+import { Disposable } from "vscode";
+
+import {
+  Configuration,
+  ConfigurationError,
+  ContentRecord,
+  Credential,
+  isConfigurationError,
+  PreContentRecord,
+  PreContentRecordWithConfig,
+  useApi,
+} from "src/api";
+
+// function findContentRecord<
+//   T extends ContentRecord | PreContentRecord | PreContentRecordWithConfig,
+// >(name: string, projectDir: string, records: T[]): T | undefined {
+//   return records.find(
+//     (r) => r.saveName === name && r.projectDir === projectDir,
+//   );
+// }
+
+function findConfiguration<T extends Configuration | ConfigurationError>(
+  name: string,
+  projectDir: string,
+  configs: Array<T>,
+): T | undefined {
+  return configs.find(
+    (c) => c.configurationName === name && c.projectDir === projectDir,
+  );
+}
+
+// function findCredential(
+//   name: string,
+//   creds: Credential[],
+// ): Credential | undefined {
+//   return creds.find((c) => c.name === name);
+// }
+
+export class PublisherState implements Disposable {
+  contentRecords: Array<
+    ContentRecord | PreContentRecord | PreContentRecordWithConfig
+  > = [];
+  credentials: Credential[] = [];
+  configurations: Array<Configuration | ConfigurationError> = [];
+
+  dispose() {
+    this.contentRecords.splice(0, this.contentRecords.length);
+    this.credentials.splice(0, this.contentRecords.length);
+    this.configurations.splice(0, this.contentRecords.length);
+  }
+
+  async refreshConfigurations() {
+    const api = await useApi();
+    const response = await api.configurations.getAll(".", { recursive: true });
+
+    this.configurations = response.data;
+  }
+
+  get validConfigs(): Configuration[] {
+    return this.configurations.filter(
+      (c): c is Configuration => !isConfigurationError(c),
+    );
+  }
+
+  get configsInError(): ConfigurationError[] {
+    return this.configurations.filter(isConfigurationError);
+  }
+
+  findConfig(name: string, projectDir: string) {
+    return findConfiguration(name, projectDir, this.configurations);
+  }
+
+  findValidConfig(name: string, projectDir: string) {
+    return findConfiguration(name, projectDir, this.validConfigs);
+  }
+
+  findConfigInError(name: string, projectDir: string) {
+    return findConfiguration(name, projectDir, this.configsInError);
+  }
+}

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -98,6 +98,17 @@ export class PublisherState implements Disposable {
     return this.findContentRecordByPath(selection.deploymentPath);
   }
 
+  getSelectedConfiguration() {
+    const contentRecord = this.getSelectedContentRecord();
+    if (!contentRecord) {
+      return undefined;
+    }
+    return this.findValidConfig(
+      contentRecord.configurationName,
+      contentRecord.projectDir,
+    );
+  }
+
   async refreshContentRecords() {
     const api = await useApi();
     const response = await api.contentRecords.getAll(".", { recursive: true });

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -90,6 +90,14 @@ export class PublisherState implements Disposable {
     );
   }
 
+  getSelectedContentRecord() {
+    const selection = this.getSelection();
+    if (!selection) {
+      return undefined;
+    }
+    return this.findContentRecordByPath(selection.deploymentPath);
+  }
+
   async refreshContentRecords() {
     const api = await useApi();
     const response = await api.contentRecords.getAll(".", { recursive: true });

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { HomeViewState } from "../shared";
+import { SelectionState } from "../shared";
 
 export enum WebviewToHostMessageType {
   // Sent from webviewView to host
@@ -113,7 +113,7 @@ export type NavigateMsg = AnyWebviewToHostMessage<
 export type SaveSelectionStatedMsg = AnyWebviewToHostMessage<
   WebviewToHostMessageType.SAVE_SELECTION_STATE,
   {
-    state: HomeViewState;
+    state: SelectionState;
   }
 >;
 

--- a/extensions/vscode/src/types/shared.ts
+++ b/extensions/vscode/src/types/shared.ts
@@ -23,7 +23,7 @@ export type DeploymentSelectionResult = {
   publishParams: PublishProcessParams;
 };
 
-export type HomeViewState = DeploymentSelector | null;
+export type SelectionState = DeploymentSelector | null;
 
 export type DeploymentObjects = {
   contentRecord: ContentRecord | PreContentRecord;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -121,7 +121,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       this.updateWebViewViewCredentials();
     });
     useBus().on("requestActiveConfig", () => {
-      useBus().trigger("activeConfigChanged", this.getActiveConfig());
+      useBus().trigger(
+        "activeConfigChanged",
+        this.state.getSelectedConfiguration(),
+      );
     });
     useBus().on("requestActiveContentRecord", () => {
       useBus().trigger(
@@ -302,7 +305,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async updateFileList(uri: string, action: FileAction) {
-    const activeConfig = this.getActiveConfig();
+    const activeConfig = this.state.getSelectedConfiguration();
     if (activeConfig === undefined) {
       console.error("homeView::updateFileList: No active configuration.");
       return;
@@ -433,27 +436,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     });
   }
 
-  private getActiveConfig(): Configuration | undefined {
-    const savedState = this.state.getSelection();
-    if (!savedState) {
-      return undefined;
-    }
-    return this.getConfigBySelector(savedState);
-  }
-
-  private getConfigBySelector(selector: DeploymentSelector) {
-    const deployment = this.state.findContentRecordByPath(
-      selector.deploymentPath,
-    );
-    if (deployment) {
-      return this.state.findValidConfig(
-        deployment.configurationName,
-        deployment.projectDir,
-      );
-    }
-    return undefined;
-  }
-
   private async saveSelectionState(state: SelectionState): Promise<void> {
     await this.state.updateSelection(state);
 
@@ -461,11 +443,14 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       "activeContentRecordChanged",
       this.state.getSelectedContentRecord(),
     );
-    useBus().trigger("activeConfigChanged", this.getActiveConfig());
+    useBus().trigger(
+      "activeConfigChanged",
+      this.state.getSelectedConfiguration(),
+    );
   }
 
   private async onRefreshPythonPackages() {
-    const activeConfiguration = this.getActiveConfig();
+    const activeConfiguration = this.state.getSelectedConfiguration();
     let pythonProject = true;
     let packages: string[] = [];
     let packageFile: string | undefined;
@@ -527,7 +512,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async onRefreshRPackages() {
-    const activeConfiguration = this.getActiveConfig();
+    const activeConfiguration = this.state.getSelectedConfiguration();
     let rProject = true;
     let packages: RPackage[] = [];
     let packageFile: string | undefined;
@@ -612,7 +597,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       // We shouldn't get here if there's no workspace folder open.
       return;
     }
-    const activeConfiguration = this.getActiveConfig();
+    const activeConfiguration = this.state.getSelectedConfiguration();
     if (activeConfiguration === undefined) {
       // Cannot scan if there is no active configuration.
       return;
@@ -669,7 +654,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       // We shouldn't get here if there's no workspace folder open.
       return;
     }
-    const activeConfiguration = this.getActiveConfig();
+    const activeConfiguration = this.state.getSelectedConfiguration();
     if (activeConfiguration === undefined) {
       // Cannot scan if there is no active configuration.
       return;
@@ -748,7 +733,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const config = await selectNewOrExistingConfig(
         targetContentRecord,
         Views.HomeView,
-        this.getActiveConfig(),
+        this.state.getSelectedConfiguration(),
       );
       if (config) {
         const api = await useApi();
@@ -908,7 +893,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const lastContentRecordProjectDir = projectDir
         ? projectDir
         : this.state.getSelectedContentRecord()?.projectDir;
-      const lastConfigName = this.getActiveConfig()?.configurationName;
+      const lastConfigName =
+        this.state.getSelectedConfiguration()?.configurationName;
 
       const includedContentRecords = contentRecordsSubset
         ? contentRecordsSubset
@@ -1185,7 +1171,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         "activeContentRecordChanged",
         this.state.getSelectedContentRecord(),
       );
-      useBus().trigger("activeConfigChanged", this.getActiveConfig());
+      useBus().trigger(
+        "activeConfigChanged",
+        this.state.getSelectedConfiguration(),
+      );
     }
   };
 
@@ -1201,12 +1190,15 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   public refreshConfigurations = async () => {
     await this.refreshConfigurationData();
     this.updateWebViewViewConfigurations();
-    useBus().trigger("activeConfigChanged", this.getActiveConfig());
+    useBus().trigger(
+      "activeConfigChanged",
+      this.state.getSelectedConfiguration(),
+    );
   };
 
   public sendRefreshedFilesLists = async () => {
     const api = await useApi();
-    const activeConfig = this.getActiveConfig();
+    const activeConfig = this.state.getSelectedConfiguration();
     if (activeConfig) {
       try {
         const apiRequest = api.files.getByConfiguration(
@@ -1529,7 +1521,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           if (this.root === undefined) {
             return;
           }
-          const cfg = this.getActiveConfig();
+          const cfg = this.state.getSelectedConfiguration();
           const packageFile = cfg?.configuration.python?.packageFile;
           if (packageFile === undefined) {
             return;
@@ -1555,7 +1547,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           if (this.root === undefined) {
             return;
           }
-          const cfg = this.getActiveConfig();
+          const cfg = this.state.getSelectedConfiguration();
           const packageFile = cfg?.configuration.r?.packageFile;
           if (packageFile === undefined) {
             return;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1514,6 +1514,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   public dispose() {
     Disposable.from(...this.disposables).dispose();
 
+    this.state.dispose();
     this.configWatchers?.dispose();
   }
 


### PR DESCRIPTION
This PR moves out some of the state logic in `homeView.ts` to a new `PublisherState` class to make it a bit easier to reason about our lists of resources (Content Records, Configurations, and Credentials) and the current selections.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

I kept the logic exactly the same, just moved the location of the code. I did it one resource at a time so the commits may be helpful to review this in segments.
