### PR TITLE
Provide ability to dismiss deployment in progress

### DIFF
--- a/extensions/vscode/src/api/types/events.ts
+++ b/extensions/vscode/src/api/types/events.ts
@@ -1261,6 +1261,7 @@ export interface PublishFailure extends EventStreamMessage {
   data: {
     dashboardUrl: string;
     url: string;
+    canceled?: string; // not defined if not user cancelled. Value of "true" if true.
     // and other non-defined attributes
   };
   error: string; // translated internally

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -180,12 +180,16 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       this.stages.forEach((stage) => {
         if (stage.status === LogStageStatus.notStarted) {
           stage.status = LogStageStatus.neverStarted;
+        } else if (stage.status === LogStageStatus.inProgress) {
+          stage.status = LogStageStatus.failed;
         }
       });
 
       let showLogsOption = "View Log";
       const selection = await window.showErrorMessage(
-        `Deployment failed: ${msg.data.message}`,
+        msg.data.cancelled === "true"
+          ? `Deployment cancelled: ${msg.data.message}`
+          : `Deployment failed: ${msg.data.message}`,
         showLogsOption,
       );
       if (selection === showLogsOption) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2057 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

As discussed with the team, we'll be implementing this within the UX only, while the agent continues to process the deployment in the background.

A new cancel button is available on the deployment in progress message. Clicking this causes a mock `publish/failure` message to be sent out and then causes all newer messages received within the same localId, to be discarded.

Components will continue to provide status per the file watchers, so a special canceled notification provides some direction as to what to expect.

![2024-08-05 at 4 29 PM](https://github.com/user-attachments/assets/657c9201-7d99-47a3-99d9-d03cf17e3f40)

![2024-08-05 at 4 30 PM](https://github.com/user-attachments/assets/925d88d9-5894-4759-a46a-3908f0e394d3)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Validate full deployments complete.

Validate you can cancel one, seeing the error notification message as indicated above. Open the log and confirm none of the phases are still spinning.

Validate you can start another deployment after cancelling the last one and that all behavior is as expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
