### PR TITLE
Find matches in subdirectories

### DIFF
--- a/internal/bundles/matcher/walker.go
+++ b/internal/bundles/matcher/walker.go
@@ -59,20 +59,25 @@ func (i *matchingWalker) Walk(base util.AbsolutePath, fn util.AbsoluteWalkFunc) 
 	return base.Walk(func(path util.AbsolutePath, info fs.FileInfo, err error) error {
 		if path != base {
 			m := i.matchList.Match(path)
-			if m == nil || m.Exclude {
-				i.log.Debug("excluding", "path", path)
-				if info.IsDir() {
+			if info.IsDir() {
+				// If there was not an explicit exclusion, we need to
+				// traverse the directory to see if any patterns match
+				// within it.
+				if m != nil && m.Exclude {
+					i.log.Debug("excluding directory", "path", path)
 					return filepath.SkipDir
-				} else {
+				}
+				// Ignore Python environment directories. We check for these
+				// separately because they aren't expressible as gitignore patterns.
+				if util.IsPythonEnvironmentDir(path) || util.IsRenvLibraryDir(path) {
+					i.log.Debug("excluding library dir", "path", path)
+					return filepath.SkipDir
+				}
+			} else {
+				if m == nil || m.Exclude {
+					i.log.Debug("excluding file", "path", path)
 					return nil
 				}
-			}
-
-			// Ignore Python environment directories. We check for these
-			// separately because they aren't expressible as gitignore patterns.
-			if info.IsDir() && (util.IsPythonEnvironmentDir(path) || util.IsRenvLibraryDir(path)) {
-				i.log.Debug("excluding library dir", "path", path)
-				return filepath.SkipDir
 			}
 		}
 		return fn(path, info, err)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

When walking the file tree using an inclusion/exclusion list, we need to visit subdirectories unless they are excluded. Even if there's not an explicit inclusion, a file pattern might match within the subdirectory.

Fixes #2075

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [x] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Don't prune the search of the filesystem on a directory node when there's no match; only prune it if there's an explicit exclusion.

## Automated Tests

Added a test for this case.

## Directions for Reviewers

Configure your project to include specific files (no `*` pattern), including some files in a subdirectory. When you deploy, those files should be included even though you didn't add a pattern for their parent directory.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
