### PR TITLE
Add jupyter notebook as valid type for quarto

### DIFF
--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -180,8 +180,7 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath, entrypoint util.Relat
 	if entrypoint.String() != "" {
 		// Optimization: skip inspection if there's a specified entrypoint
 		// and it's not one of ours.
-		suffix := entrypoint.Ext()
-		if suffix != ".qmd" && suffix != ".Rmd" && suffix != ".ipynb" {
+		if !slices.Contains(quartoSuffixes, entrypoint.Ext()) {
 			return nil, nil
 		}
 	}

--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -181,7 +181,7 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath, entrypoint util.Relat
 		// Optimization: skip inspection if there's a specified entrypoint
 		// and it's not one of ours.
 		suffix := entrypoint.Ext()
-		if suffix != ".qmd" && suffix != ".Rmd" {
+		if suffix != ".qmd" && suffix != ".Rmd" && suffix != ".ipynb" {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #2059 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Quarto inspection needs to proceed for jupyter notebook when an entrypoint file is specified.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
```
$(just executable-path) ui -vv --listen=localhost:9001
curl -s -XPOST -d '{}' 'localhost:9001/api/inspect?dir=internal/inspect/detectors/testdata/stock-report-jupyter' | jq
curl -s -XPOST -d '{}' 'localhost:9001/api/inspect?dir=internal/inspect/detectors/testdata/stock-report-jupyter&entrypoint=stock-report-jupyter.ipynb' | jq
```
Both should return two configurations:
```
[
  {
    "configuration": {
      "comments": [
        " Configuration file generated by Posit Publisher.",
        " Please review and modify as needed. See the documentation for more options:",
        " https://github.com/posit-dev/publisher/blob/main/docs/configuration.md"
      ],
      "$schema": "https://cdn.posit.co/publisher/schemas/posit-publishing-schema-v3.json",
      "type": "jupyter-notebook",
      "entrypoint": "stock-report-jupyter.ipynb",
      "validate": true,
      "hasParameters": false,
      "files": [
        "*"
      ],
      "title": "stock-report-jupyter",
      "python": {
        "version": "3.11.3",
        "packageFile": "requirements.txt",
        "packageManager": "pip"
      }
    },
    "projectDir": "internal/inspect/detectors/testdata/stock-report-jupyter"
  },
  {
    "configuration": {
      "comments": [
        " Configuration file generated by Posit Publisher.",
        " Please review and modify as needed. See the documentation for more options:",
        " https://github.com/posit-dev/publisher/blob/main/docs/configuration.md"
      ],
      "$schema": "https://cdn.posit.co/publisher/schemas/posit-publishing-schema-v3.json",
      "type": "quarto",
      "entrypoint": "stock-report-jupyter.ipynb",
      "validate": true,
      "hasParameters": false,
      "files": [
        "*",
        "!stock-report-jupyter.html",
        "!stock-report-jupyter_files"
      ],
      "title": "Stock Report: TSLA",
      "python": {
        "version": "3.11.3",
        "packageFile": "requirements.txt",
        "packageManager": "pip"
      },
      "quarto": {
        "version": "1.4.551",
        "engines": [
          "jupyter"
        ]
      }
    },
    "projectDir": "internal/inspect/detectors/testdata/stock-report-jupyter"
  }
]
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
