### PR TITLE
Show the entrypoint button in valid notebooks

### DIFF
--- a/extensions/vscode/src/utils/files.ts
+++ b/extensions/vscode/src/utils/files.ts
@@ -11,6 +11,7 @@ import {
   commands,
   TextDocument,
   TabInputText,
+  NotebookDocument,
 } from "vscode";
 import { Utils as uriUtils } from "vscode-uri";
 
@@ -239,9 +240,14 @@ export function isRelativePathRoot(path: string): boolean {
   return path === ".";
 }
 
-export function isActiveDocument(document: TextDocument): boolean {
-  const editor = window.activeTextEditor;
-  return editor?.document === document;
+export function isActiveDocument(
+  document: TextDocument | NotebookDocument,
+): boolean {
+  const textEditor = window.activeTextEditor;
+  const notebookEditor = window.activeNotebookEditor;
+  return (
+    textEditor?.document === document || notebookEditor?.notebook === document
+  );
 }
 
 /**

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -3,9 +3,9 @@
     "baseUrl": ".",
     "esModuleInterop": true,
     "module": "commonjs",
-    "target": "ES2021",
+    "target": "ES2022",
     "outDir": "out",
-    "lib": ["ES2021", "DOM"],
+    "lib": ["ES2022", "DOM"],
     "sourceMap": true,
     "rootDir": "src",
     /* Linting */


### PR DESCRIPTION
VSCode treats editors and notebooks a bit differently and the `entrypointTracker` only tracked editors. With this PR it now tracks notebooks as well which adds the entrypoint button when an opened notebook is an entrypoint.

## Intent

Resolves #2090

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

I upgraded our TypeScript configuration to target and use `ES2022` to support [`Object.hasOwn()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)

The rest of the approach was to:
- Add listeners for notebooks mirroring the text editor listening
- Refactor functions to accept either a text document/editor or notebook document/editor since the behavior was essentially the same

## Directions for Reviewers

Test the `sample-content/stock-report-jupyter/stock-report-jupyter.ipynb` file. The entrypoint button should appear.

The notebook can be opened in a Text Editor or Notebook Editor and it should appear. If the opened notebook file is empty the entrypoint button should not appear.