### PR TITLE
Refactor DeploymentSelector and SelectionState

### DIFF
--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -14,7 +14,7 @@ import {
   useApi,
 } from "src/api";
 import { normalizeURL } from "src/utils/url";
-import { SelectionState } from "src/types/shared";
+import { DeploymentSelector, SelectionState } from "src/types/shared";
 import { LocalState } from "./constants";
 
 function findContentRecord<
@@ -78,11 +78,24 @@ export class PublisherState implements Disposable {
     this.configurations.splice(0, this.contentRecords.length);
   }
 
-  getSelection(): SelectionState {
-    return this.context.workspaceState.get<SelectionState>(
+  getSelection(): DeploymentSelector | undefined {
+    const savedState = this.context.workspaceState.get<SelectionState>(
       LocalState.LastSelectionState,
       null,
     );
+    if (!savedState) {
+      return undefined;
+    }
+    if (savedState.version === "v1") {
+      return {
+        deploymentName: savedState.deploymentName,
+        deploymentPath: savedState.deploymentPath,
+        projectDir: savedState.projectDir,
+      };
+    }
+    // We don't know about this one, including the last
+    // one which didn't have the version string in it.
+    return undefined;
   }
 
   async updateSelection(state: SelectionState) {

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { SelectionState } from "../shared";
+import { DeploymentSelector } from "../shared";
 
 export enum WebviewToHostMessageType {
   // Sent from webviewView to host
@@ -113,7 +113,7 @@ export type NavigateMsg = AnyWebviewToHostMessage<
 export type SaveSelectionStatedMsg = AnyWebviewToHostMessage<
   WebviewToHostMessageType.SAVE_SELECTION_STATE,
   {
-    state: SelectionState;
+    state: DeploymentSelector;
   }
 >;
 

--- a/extensions/vscode/src/types/shared.ts
+++ b/extensions/vscode/src/types/shared.ts
@@ -8,22 +8,21 @@ import {
 } from "../api";
 
 export type DeploymentSelector = {
-  deploymentPath: string;
-};
-
-export type PublishProcessParams = {
   deploymentName: string;
-  credentialName: string;
-  configurationName: string;
+  deploymentPath: string;
   projectDir: string;
 };
 
-export type DeploymentSelectionResult = {
-  selector: DeploymentSelector;
-  publishParams: PublishProcessParams;
+export type PublishProcessParams = DeploymentSelector & {
+  credentialName: string;
+  configurationName: string;
 };
 
-export type SelectionState = DeploymentSelector | null;
+export type SelectionState =
+  | (DeploymentSelector & {
+      version: "v1";
+    })
+  | null;
 
 export type DeploymentObjects = {
   contentRecord: ContentRecord | PreContentRecord;

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -120,6 +120,8 @@ const onRefreshContentRecordDataMsg = (msg: RefreshContentRecordDataMsg) => {
     if (home.selectedContentRecord) {
       home.updateSelectedContentRecordBySelector({
         deploymentPath: home.selectedContentRecord.deploymentPath,
+        deploymentName: home.selectedContentRecord.deploymentName,
+        projectDir: home.selectedContentRecord.projectDir,
       });
     }
     return;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

I've refactored the types of DocumentSelector and SelectionState, ahead of a separate PR for #2049.

This change allows us to version the selection state structure being saved into the VSCode workspace storage and have enough information to make an API call to retrieve the last deployment file used, simply off of the information persisted.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Because of the version check, the previous saved selection will be thrown away. Once you have selected a deployment, the new structure is saved and used. You can confirm this by using the command palette to reload the window and confirm that your last deployment selection is restored.
