### PR TITLE
Sort configurations of the same entrypoint by type

### DIFF
--- a/internal/inspect/detectors/all.go
+++ b/internal/inspect/detectors/all.go
@@ -93,7 +93,11 @@ func (t *ContentTypeDetector) InferType(base util.AbsolutePath, entrypoint util.
 		} else if !aIsPreferred && bIsPreferred {
 			return 1
 		} else {
-			return strings.Compare(entrypointA, entrypointB)
+			if entrypointA == entrypointB {
+				return strings.Compare(string(a.Type), string(b.Type))
+			} else {
+				return strings.Compare(entrypointA, entrypointB)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR sorts returned configurations by entrypoint and then by type; currently they are only sorted by entrypoint.

* For an Rmd, it will sort the `quarto` configuration before the `rmd` one (or `quarto-shiny` before `rmd-shiny`).
* For a notebook, it will sort the `notebook` configuration before the `quarto` one.

Fixes #2050

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

The sort order isn't tested; this PR doesn't add a test for it.

## Directions for Reviewers

Inspect files the can have multiple deployment types, and see that the sort order of the offered configurations is correct.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
