### PR TITLE
Ignore local imports during dependency scanning

### DIFF
--- a/internal/inspect/dependencies/pydeps/project_imports_test.go
+++ b/internal/inspect/dependencies/pydeps/project_imports_test.go
@@ -36,9 +36,13 @@ func (s *ProjectDepsSuite) TestScanProjectImports() {
 
 	importNames, err := scanner.ScanProjectImports(path)
 	s.NoError(err)
+
+	// "lib" and "example" are not included because they are
+	// local imports, not dependencies.
 	s.Equal([]ImportName{
 		"numpy",
 		"scipy",
+		"somelib",
 		"that",
 	}, importNames)
 }

--- a/internal/inspect/dependencies/pydeps/qmd_contents_test.go
+++ b/internal/inspect/dependencies/pydeps/qmd_contents_test.go
@@ -25,7 +25,7 @@ func (s *QMDContentsSuite) TestGetQuartoFilePythonCode() {
 
 	inputs, err := GetQuartoFilePythonCode(path)
 	s.Nil(err)
-	s.Equal("import that\n\nthat.do_something()\n", inputs)
+	s.Equal("import that\nfrom example import *\n\nthat.do_something()\n", inputs)
 }
 
 func (s *QMDContentsSuite) TestDetectMarkdownLanguagesInContentEmpty() {

--- a/internal/inspect/dependencies/pydeps/testdata/example.py
+++ b/internal/inspect/dependencies/pydeps/testdata/example.py
@@ -1,2 +1,4 @@
 import numpy as np
 import scipy
+
+from lib.utils import foo

--- a/internal/inspect/dependencies/pydeps/testdata/lib/utils.py
+++ b/internal/inspect/dependencies/pydeps/testdata/lib/utils.py
@@ -1,0 +1,4 @@
+from somelib import somefunc
+
+def foo():
+    somefunc()

--- a/internal/inspect/dependencies/pydeps/testdata/test.qmd
+++ b/internal/inspect/dependencies/pydeps/testdata/test.qmd
@@ -11,6 +11,7 @@ Not actually an import! That's not in a code block.
 
 ```{python}
 import that
+from example import *
 
 that.do_something()
 ```

--- a/internal/util/fspath.go
+++ b/internal/util/fspath.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -162,6 +163,21 @@ func (p RelativePath) Dir() RelativePath {
 
 func (p Path) Ext() string {
 	return filepath.Ext(p.path)
+}
+
+func (p Path) WithoutExt() Path {
+	withoutExt := strings.TrimSuffix(p.path, p.Ext())
+	return NewPath(withoutExt, p.fs)
+}
+
+func (p AbsolutePath) WithoutExt() AbsolutePath {
+	withoutExt := strings.TrimSuffix(p.path, p.Ext())
+	return NewAbsolutePath(withoutExt, p.fs)
+}
+
+func (p RelativePath) WithoutExt() RelativePath {
+	withoutExt := strings.TrimSuffix(p.path, p.Ext())
+	return NewRelativePath(withoutExt, p.fs)
 }
 
 func PathFromSlash(fs afero.Fs, path string) Path {
@@ -382,6 +398,20 @@ func (p Path) ReadFile() ([]byte, error) {
 
 func (p Path) ReadDir() ([]os.FileInfo, error) {
 	return afero.ReadDir(p.fs, p.path)
+}
+
+func (p Path) ReadDirNames() ([]string, error) {
+	f, err := p.Open()
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func (p Path) WriteFile(data []byte, perm os.FileMode) error {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR omits local module/package import from being listed as package dependencies from the scanning process.

Fixes #2096

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Check for the existence of a module or local directory matching the top-level import name.

## Automated Tests

Updated an existing test to check for these cases.

## Directions for Reviewers

Scan for Python dependencies in the `posit-conf-survey` project. The local imports (`data`, `location`, etc) should be excluded from the generated `requirements.txt` file.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
