### PR TITLE
Logs url from backend

### DIFF
--- a/extensions/vscode/src/api/types/contentRecords.ts
+++ b/extensions/vscode/src/api/types/contentRecords.ts
@@ -55,6 +55,7 @@ export type ContentRecord = {
   bundleUrl: string;
   dashboardUrl: string;
   directUrl: string;
+  logsUrl: string;
   files: string[];
   deployedAt: string;
   state: ContentRecordState.DEPLOYED;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1508,8 +1508,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       commands.registerCommand(Commands.HomeView.ShowContentLogs, async () => {
         const contentRecord = this.state.getSelectedContentRecord();
         if (contentRecord && !isPreContentRecord(contentRecord)) {
-          const logUrl = `${contentRecord.dashboardUrl}/logs`;
-          await env.openExternal(Uri.parse(logUrl));
+          await env.openExternal(Uri.parse(contentRecord.logsUrl));
         }
       }),
       commands.registerCommand(

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -35,6 +35,7 @@ type Deployment struct {
 	BundleURL     string            `toml:"bundle_url,omitempty" json:"bundleUrl"`
 	DashboardURL  string            `toml:"dashboard_url,omitempty" json:"dashboardUrl"`
 	DirectURL     string            `toml:"direct_url,omitempty" json:"directUrl"`
+	LogsURL       string            `toml:"logs_url,omitempty" json:"logsUrl"`
 	Error         *types.AgentError `toml:"deployment_error,omitempty" json:"deploymentError"`
 	Files         []string          `toml:"files,multiline,omitempty" json:"files"`
 	Requirements  []string          `toml:"requirements,multiline,omitempty" json:"requirements"`
@@ -102,6 +103,10 @@ func FromFile(path util.AbsolutePath) (*Deployment, error) {
 	err = util.ReadTOMLFile(path, d)
 	if err != nil {
 		return nil, err
+	}
+	if d.LogsURL == "" && d.DashboardURL != "" {
+		// Migration
+		d.LogsURL = d.DashboardURL + "/logs"
 	}
 	return d, nil
 }

--- a/internal/deployment/deployment_test.go
+++ b/internal/deployment/deployment_test.go
@@ -96,6 +96,8 @@ func (s *DeploymentSuite) TestFromExampleFile() {
 	s.Equal(types.ContentID("de2e7bdb-b085-401e-a65c-443e40009749"), d.ID)
 	s.Equal(types.BundleID("123"), d.BundleID)
 	s.Equal("https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download", d.BundleURL)
+	s.Equal("https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749", d.DashboardURL)
+	s.Equal("https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs", d.LogsURL)
 }
 
 func (s *DeploymentSuite) TestFromFileErr() {

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -47,6 +47,7 @@ type publishStartData struct {
 type publishSuccessData struct {
 	ContentID    types.ContentID `mapstructure:"contentId"`
 	DashboardURL string          `mapstructure:"dashboardUrl"`
+	LogsURL      string          `mapstructure:"logsUrl"`
 	DirectURL    string          `mapstructure:"directUrl"`
 	ServerURL    string          `mapstructure:"serverUrl"`
 }
@@ -57,6 +58,7 @@ type publishFailureData struct {
 
 type publishDeployedFailureData struct {
 	DashboardURL string `mapstructure:"dashboardUrl"`
+	LogsURL      string `mapstructure:"logsUrl"`
 	DirectURL    string `mapstructure:"url"`
 }
 
@@ -79,16 +81,16 @@ func NewFromState(s *state.State, emitter events.Emitter, log logging.Logger) (P
 	}, nil
 }
 
-func getDashboardURL(accountURL string, contentID types.ContentID, failed bool) string {
-	url := fmt.Sprintf("%s/connect/#/apps/%s", accountURL, contentID)
-	if failed {
-		url += "/logs"
-	}
-	return url
+func getDashboardURL(accountURL string, contentID types.ContentID) string {
+	return fmt.Sprintf("%s/connect/#/apps/%s", accountURL, contentID)
+}
+
+func getLogsURL(accountURL string, contentID types.ContentID) string {
+	return getDashboardURL(accountURL, contentID) + "/logs"
 }
 
 func getDirectURL(accountURL string, contentID types.ContentID) string {
-	return fmt.Sprintf("%s/content/%s", accountURL, contentID)
+	return fmt.Sprintf("%s/content/%s/", accountURL, contentID)
 }
 
 func getBundleURL(accountURL string, contentID types.ContentID, bundleID types.BundleID) string {
@@ -96,7 +98,8 @@ func getBundleURL(accountURL string, contentID types.ContentID, bundleID types.B
 }
 
 func logAppInfo(w io.Writer, accountURL string, contentID types.ContentID, log logging.Logger, publishingErr error) {
-	dashboardURL := getDashboardURL(accountURL, contentID, publishingErr != nil)
+	dashboardURL := getDashboardURL(accountURL, contentID)
+	logsURL := getLogsURL(accountURL, contentID)
 	directURL := getDirectURL(accountURL, contentID)
 	if publishingErr != nil {
 		if contentID == "" {
@@ -104,12 +107,13 @@ func logAppInfo(w io.Writer, accountURL string, contentID types.ContentID, log l
 			return
 		}
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Dashboard URL: ", dashboardURL)
+		fmt.Fprintln(w, "Logs URL: ", logsURL)
 	} else {
 		log.Info("Deployment information",
 			logging.LogKeyOp, events.AgentOp,
 			"dashboardURL", dashboardURL,
 			"directURL", directURL,
+			"logsURL", logsURL,
 			"serverURL", accountURL,
 			"contentID", contentID,
 		)
@@ -130,6 +134,7 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 	}
 	dashboardURL := ""
 	directURL := ""
+	logsURL := ""
 
 	var data events.EventData
 
@@ -146,11 +151,13 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 		}
 		if p.isDeployed() {
 			// Provide URL in the event, if we got far enough in the deployment.
-			dashboardURL = getDashboardURL(p.Account.URL, p.Target.ID, err != nil)
+			dashboardURL = getDashboardURL(p.Account.URL, p.Target.ID)
+			logsURL = getLogsURL(p.Account.URL, p.Target.ID)
 			directURL = getDirectURL(p.Account.URL, p.Target.ID)
 
 			mapstructure.Decode(publishDeployedFailureData{
 				DashboardURL: dashboardURL,
+				LogsURL:      logsURL,
 				DirectURL:    directURL,
 			}, &data)
 		}
@@ -195,7 +202,8 @@ func (p *defaultPublisher) PublishDirectory(log logging.Logger) error {
 		p.emitErrorEvents(err, log)
 	} else {
 		p.emitter.Emit(events.New(events.PublishOp, events.SuccessPhase, events.NoError, publishSuccessData{
-			DashboardURL: getDashboardURL(p.Account.URL, p.Target.ID, false),
+			DashboardURL: getDashboardURL(p.Account.URL, p.Target.ID),
+			LogsURL:      getLogsURL(p.Account.URL, p.Target.ID),
 			DirectURL:    getDirectURL(p.Account.URL, p.Target.ID),
 			ServerURL:    p.Account.URL,
 			ContentID:    p.Target.ID,
@@ -258,7 +266,7 @@ func (p *defaultPublisher) createDeploymentRecord(
 		Requirements:  nil,
 		Configuration: &cfg,
 		BundleID:      "",
-		DashboardURL:  getDashboardURL(p.Account.URL, contentID, false),
+		DashboardURL:  getDashboardURL(p.Account.URL, contentID),
 		DirectURL:     getDirectURL(p.Account.URL, contentID),
 		Error:         nil,
 	}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -403,7 +403,7 @@ func (s *PublishSuite) TestEmitErrorEventsWithTarget() {
 	for _, event := range emitter.Events {
 		s.True(strings.HasSuffix(event.Type, "/failure"))
 		s.Equal(expectedErr.Error(), event.Data["message"])
-		s.Equal(getDashboardURL("connect.example.com", targetID, true), event.Data["dashboardUrl"])
+		s.Equal(getDashboardURL("connect.example.com", targetID), event.Data["dashboardUrl"])
 		s.Equal(getDirectURL("connect.example.com", targetID), event.Data["url"])
 	}
 	s.Equal("publish/failure", emitter.Events[1].Type)
@@ -411,16 +411,11 @@ func (s *PublishSuite) TestEmitErrorEventsWithTarget() {
 
 func (s *PublishSuite) TestGetDashboardURL() {
 	expected := "https://connect.example.com:1234/connect/#/apps/d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f"
-	s.Equal(expected, getDashboardURL("https://connect.example.com:1234", "d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f", false))
-}
-
-func (s *PublishSuite) TestGetDashboardURLFailed() {
-	expected := "https://connect.example.com:1234/connect/#/apps/d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f/logs"
-	s.Equal(expected, getDashboardURL("https://connect.example.com:1234", "d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f", true))
+	s.Equal(expected, getDashboardURL("https://connect.example.com:1234", "d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f"))
 }
 
 func (s *PublishSuite) TestGetDirectURL() {
-	expected := "https://connect.example.com:1234/content/d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f"
+	expected := "https://connect.example.com:1234/content/d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f/"
 	s.Equal(expected, getDirectURL("https://connect.example.com:1234", "d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f"))
 }
 
@@ -428,12 +423,12 @@ func (s *PublishSuite) TestLogAppInfo() {
 	accountURL := "https://connect.example.com:1234"
 	contentID := types.ContentID("myContentID")
 	directURL := getDirectURL(accountURL, contentID)
-	dashboardURL := getDashboardURL(accountURL, contentID, false)
+	dashboardURL := getDashboardURL(accountURL, contentID)
 
 	buf := new(bytes.Buffer)
 	a := mock.Anything
 	log := loggingtest.NewMockLogger()
-	log.On("Info", "Deployment information", a, a, a, a, a, a, a, a, a, a).Return()
+	log.On("Info", "Deployment information", a, a, a, a, a, a, a, a, a, a, a, a).Return()
 
 	logAppInfo(buf, accountURL, contentID, log, nil)
 	str := buf.String()
@@ -445,7 +440,8 @@ func (s *PublishSuite) TestLogAppInfoErr() {
 	accountURL := "https://connect.example.com:1234"
 	contentID := types.ContentID("myContentID")
 	directURL := getDirectURL(accountURL, contentID)
-	dashboardURL := getDashboardURL(accountURL, contentID, true)
+	dashboardURL := getDashboardURL(accountURL, contentID)
+	logsURL := getLogsURL(accountURL, contentID)
 
 	buf := new(bytes.Buffer)
 
@@ -454,6 +450,7 @@ func (s *PublishSuite) TestLogAppInfoErr() {
 	str := buf.String()
 	s.NotContains(str, directURL)
 	s.Contains(str, dashboardURL)
+	s.Contains(str, logsURL)
 }
 
 func (s *PublishSuite) TestLogAppInfoErrNoContentID() {

--- a/internal/schema/schemas/record.toml
+++ b/internal/schema/schemas/record.toml
@@ -8,7 +8,7 @@ configuration_name = "production"
 deployed_at = '2024-01-19T09:33:33.131481-05:00'
 bundle_id = '123'
 bundle_url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
-dashboard_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/'
+dashboard_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749'
 direct_url = 'https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/'
 
 [configuration]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Small cleanup that moves computation of the logs URL for a piece of content to the backend and stores it in the deployment record, rather than computing it in the front end. This also ensures that trailing slashes are correct for the dashboard and direct URLs (matching how they are returned from Connect).

Fixes #1750

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Updated existing tests.

## Directions for Reviewers

"View Content Log on Connect" from the ellipsis menu in the home view should still work.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
