### PR TITLE
Skip recursive query of deployments and configurations if selection was saved and is present

### DIFF
--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -25,9 +25,9 @@ export type ConfigurationInspectionResult = {
 };
 
 export function isConfigurationError(
-  c: Configuration | ConfigurationError,
-): c is ConfigurationError {
-  return (c as ConfigurationError).error !== undefined;
+  cfg: Configuration | ConfigurationError,
+): cfg is ConfigurationError {
+  return (cfg as ConfigurationError).error !== undefined;
 }
 
 export enum ContentType {

--- a/extensions/vscode/src/bus.ts
+++ b/extensions/vscode/src/bus.ts
@@ -1,7 +1,12 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import { Omnibus, args } from "@hypersphere/omnibus";
-import { Configuration, ContentRecord, PreContentRecord } from "src/api";
+import {
+  Configuration,
+  ConfigurationError,
+  ContentRecord,
+  PreContentRecord,
+} from "src/api";
 
 export const bus = Omnibus.builder()
   // activeContentRecordChanged: triggered if contentRecord name or value has changed
@@ -10,7 +15,10 @@ export const bus = Omnibus.builder()
     args<ContentRecord | PreContentRecord | undefined>(),
   )
   // activeConfigurationChanged: triggered if configuration name or value has changed
-  .register("activeConfigChanged", args<Configuration | undefined>())
+  .register(
+    "activeConfigChanged",
+    args<Configuration | ConfigurationError | undefined>(),
+  )
   // requestActive*: simple events which will cause an Active*Change event to be sent back out.
   .register("requestActiveConfig", args<undefined>())
   .register("requestActiveContentRecord", args<undefined>())

--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -105,7 +105,7 @@ export async function selectNewOrExistingConfig(
       let rawConfigs = response.data;
       // remove the errors
       configurations = configurations.filter(
-        (c): c is Configuration => !isConfigurationError(c),
+        (cfg): cfg is Configuration => !isConfigurationError(cfg),
       );
       // Filter down configs to same content type as active deployment,
       // but also allowing configs if active Deployment is a preDeployment

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -176,7 +176,7 @@ export class PublisherState implements Disposable {
       return cfg;
     } catch (error: unknown) {
       const code = getStatusFromError(error);
-      if (code !== 400) {
+      if (code !== 404) {
         // 400 is expected when doesn't exist on disk
         const summary = getSummaryStringFromError(
           "getSelectedConfiguration, contentRecords.get",

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -38,7 +38,7 @@ function findConfiguration<T extends Configuration | ConfigurationError>(
   configs: Array<T>,
 ): T | undefined {
   return configs.find(
-    (c) => c.configurationName === name && c.projectDir === projectDir,
+    (cfg) => cfg.configurationName === name && cfg.projectDir === projectDir,
   );
 }
 
@@ -46,7 +46,7 @@ function findCredential(
   name: string,
   creds: Credential[],
 ): Credential | undefined {
-  return creds.find((c) => c.name === name);
+  return creds.find((cfg) => cfg.name === name);
 }
 
 function findCredentialForContentRecord(
@@ -54,8 +54,8 @@ function findCredentialForContentRecord(
   creds: Credential[],
 ): Credential | undefined {
   return creds.find(
-    (c) =>
-      normalizeURL(c.url).toLowerCase() ===
+    (cfg) =>
+      normalizeURL(cfg.url).toLowerCase() ===
       normalizeURL(contentRecord.serverUrl).toLowerCase(),
   );
 }
@@ -154,12 +154,12 @@ export class PublisherState implements Disposable {
     if (!contentRecord) {
       return undefined;
     }
-    const c = this.findValidConfig(
+    const cfg = this.findValidConfig(
       contentRecord.configurationName,
       contentRecord.projectDir,
     );
-    if (c) {
-      return c;
+    if (cfg) {
+      return cfg;
     }
     // if not found, then retrieve it and add it to our cache.
     try {
@@ -168,12 +168,12 @@ export class PublisherState implements Disposable {
         contentRecord.configurationName,
         contentRecord.projectDir,
       );
-      const c = response.data;
+      const cfg = response.data;
       // its not foolproof, but it may help
-      if (!this.findConfig(c.configurationName, c.projectDir)) {
-        this.configurations.push(c);
+      if (!this.findConfig(cfg.configurationName, cfg.projectDir)) {
+        this.configurations.push(cfg);
       }
-      return c;
+      return cfg;
     } catch (error: unknown) {
       const code = getStatusFromError(error);
       if (code !== 400) {
@@ -218,7 +218,7 @@ export class PublisherState implements Disposable {
 
   get validConfigs(): Configuration[] {
     return this.configurations.filter(
-      (c): c is Configuration => !isConfigurationError(c),
+      (cfg): cfg is Configuration => !isConfigurationError(cfg),
     );
   }
 

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -126,7 +126,10 @@ export class PublisherState implements Disposable {
       );
       const cr = response.data;
       if (!isContentRecordError(cr)) {
-        this.contentRecords.push(cr);
+        // its not foolproof, but it may help
+        if (!this.findContentRecord(cr.saveName, cr.projectDir)) {
+          this.contentRecords.push(cr);
+        }
         return cr;
       }
       return undefined;
@@ -166,7 +169,10 @@ export class PublisherState implements Disposable {
         contentRecord.projectDir,
       );
       const c = response.data;
-      this.configurations.push(c);
+      // its not foolproof, but it may help
+      if (!this.findConfig(c.configurationName, c.projectDir)) {
+        this.configurations.push(c);
+      }
       return c;
     } catch (error: unknown) {
       const code = getStatusFromError(error);

--- a/extensions/vscode/src/utils/filters.ts
+++ b/extensions/vscode/src/utils/filters.ts
@@ -15,7 +15,7 @@ export function filterInspectionResultsToType(
   if (!type || type === ContentType.UNKNOWN) {
     return inspectionResults;
   }
-  return inspectionResults.filter((c) => isInspectionResultOfType(c, type));
+  return inspectionResults.filter((cfg) => isInspectionResultOfType(cfg, type));
 }
 
 export function isInspectionResultOfType(
@@ -33,10 +33,10 @@ export function filterConfigurationsToValidAndType(
   type: ContentType | undefined,
 ): Configuration[] {
   let result = configs.filter(
-    (c): c is Configuration => !isConfigurationError(c),
+    (cfg): cfg is Configuration => !isConfigurationError(cfg),
   );
   if (type && type !== ContentType.UNKNOWN) {
-    result = result.filter((c) => isConfigurationOfType(c, type));
+    result = result.filter((cfg) => isConfigurationOfType(cfg, type));
   }
   return result;
 }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1299,9 +1299,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         const response = await api.contentRecords.getAll(dir, {
           recursive: false,
         });
-        response.data.forEach((c) => {
-          if (!isContentRecordError(c)) {
-            contentRecordList.push(c);
+        response.data.forEach((cfg) => {
+          if (!isContentRecordError(cfg)) {
+            contentRecordList.push(cfg);
           }
         });
       } catch (error: unknown) {
@@ -1325,9 +1325,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           recursive: false,
         });
         let rawConfigs = response.data;
-        rawConfigs.forEach((c) => {
-          if (!isConfigurationError(c)) {
-            configMap.set(c.configurationName, c);
+        rawConfigs.forEach((cfg) => {
+          if (!isConfigurationError(cfg)) {
+            configMap.set(cfg.configurationName, cfg);
           }
         });
       } catch (error: unknown) {
@@ -1362,9 +1362,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     // Unable to do this within the API because pre-deployments do not have
     // their entrypoint recorded.
     const compatibleContentRecords: (ContentRecord | PreContentRecord)[] = [];
-    contentRecordList.forEach((c) => {
-      if (configMap.get(c.configurationName)) {
-        compatibleContentRecords.push(c);
+    contentRecordList.forEach((cfg) => {
+      if (configMap.get(cfg.configurationName)) {
+        compatibleContentRecords.push(cfg);
       }
     });
 
@@ -1429,8 +1429,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     const currentContentRecord = await this.state.getSelectedContentRecord();
     if (
       !currentContentRecord ||
-      !compatibleContentRecords.find((c) => {
-        return c.deploymentPath === currentContentRecord.deploymentPath;
+      !compatibleContentRecords.find((cfg) => {
+        return cfg.deploymentPath === currentContentRecord.deploymentPath;
       })
     ) {
       // none of the compatible ones are selected

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -269,7 +269,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async onInitializingMsg() {
-    // send back the data needed.
+    // send back the data needed. Optimize request for initialization...
     await this.refreshAll(false, true);
     this.setInitializationContext(HomeViewInitialized.initialized);
 

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -38,15 +38,15 @@ export const useHomeStore = defineStore("home", () => {
       const { configurationName, projectDir } = selectedContentRecord.value;
       let result;
       result = configurations.value.find(
-        (c) =>
-          c.configurationName === configurationName &&
-          c.projectDir === projectDir,
+        (cfg) =>
+          cfg.configurationName === configurationName &&
+          cfg.projectDir === projectDir,
       );
       if (!result) {
         result = configurationsInError.value.find(
-          (c) =>
-            c.configurationName === configurationName &&
-            c.projectDir === projectDir,
+          (cfg) =>
+            cfg.configurationName === configurationName &&
+            cfg.projectDir === projectDir,
         );
       }
       return result;
@@ -56,8 +56,8 @@ export const useHomeStore = defineStore("home", () => {
   // Always use the content record as the source of truth for the
   // credential. Can be undefined if a Credential is not specified or found.
   const serverCredential = computed(() => {
-    return credentials.value.find((c) => {
-      const credentialUrl = c.url.toLowerCase();
+    return credentials.value.find((cfg) => {
+      const credentialUrl = cfg.url.toLowerCase();
       const recordUrl = selectedContentRecord.value?.serverUrl.toLowerCase();
       if (!recordUrl) {
         return false;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Part of addressing #1970 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

If the extension is able to retrieve the previous selection from VSCode workspace storage, and the content record is valid and configuration can be found (valid or not), then skip the recursive API query for all deployments and configurations as we don't need the list yet.

This PR does also change the select deployment list to perform a full query first, matching the behavior of the multi-step flows. I was finding circumstances where the population of the content records within the homeView was not correct, so this change, while it does slow down the selection, does allow it to be correct.

We are balancing on the edge of needing to implement the data state within the homeview, and keep it up-to-date and accurate via the file-watchers, so that all of our views can just worry about data.

The result of these changes can be seen in the difference of these two videos, before and after:

https://github.com/user-attachments/assets/e0cad970-4a3f-4633-8f77-da498c05d8a6

https://github.com/user-attachments/assets/2e789e3f-8fef-48f1-b510-d782e91d5fff

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
This PR depends upon another, which introduced versioning for the object we are storing within VSCode workspace storage for the user's last selection. If a valid selection is not found (as in the newest version), then you'll see the initial recursive retrieval, since we need to know if there are deployments or not.  

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
