### PR TITLE
Remove need for recursive deployment query from initial evenEasierDeploy

### DIFF
--- a/extensions/vscode/src/types/quickPicks.ts
+++ b/extensions/vscode/src/types/quickPicks.ts
@@ -9,7 +9,7 @@ import {
 import { QuickPickItem } from "vscode";
 
 export interface DeploymentQuickPick extends QuickPickItem {
-  contentRecord: ContentRecord | PreContentRecordWithConfig;
+  contentRecord?: ContentRecord | PreContentRecordWithConfig;
   config?: Configuration | ConfigurationError;
   credentialName?: string;
   lastMatch: boolean;

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -14,26 +14,13 @@
       />
     </div>
 
-    <template v-if="home.contentRecords.length > 0">
-      <div
-        class="deployment-control"
-        :disabled="home.contentRecords.length === 0 ? true : undefined"
-        v-on="home.contentRecords.length ? { click: onSelectDeployment } : {}"
-      >
+    <template v-if="home.selectedContentRecord">
+      <div class="deployment-control" v-on="{ click: onSelectDeployment }">
         <QuickPickItem
-          v-if="home.selectedContentRecord"
           :label="deploymentTitle"
           :detail="deploymentSubTitle"
           :title="toolTipText"
         />
-
-        <QuickPickItem
-          v-else
-          class="text-placeholder"
-          label="Select a Deployment"
-          detail="Get deploying"
-        />
-
         <div
           class="select-indicator codicon codicon-chevron-down"
           aria-hidden="true"
@@ -95,10 +82,10 @@
     <vscode-button
       v-else
       class="w-full add-deployment-btn"
-      @click="onAddDeployment"
+      @click="onSelectDeployment"
       data-automation="add-deployment-button"
     >
-      Add Deployment
+      Select Deployment...
     </vscode-button>
 
     <template

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -79,15 +79,17 @@
 
       <DeployButton class="w-full" />
     </template>
-    <vscode-button
-      v-else
-      class="w-full add-deployment-btn"
-      @click="onSelectDeployment"
-      data-automation="add-deployment-button"
-    >
-      Select Deployment...
-    </vscode-button>
-
+    <div v-else class="deployment-control" v-on="{ click: onSelectDeployment }">
+      <QuickPickItem
+        label="Select..."
+        detail="(new or existing)"
+        data-automation="add-deployment-button"
+      />
+      <div
+        class="select-indicator codicon codicon-chevron-down"
+        aria-hidden="true"
+      />
+    </div>
     <template
       v-if="home.selectedContentRecord && home.selectedContentRecord.serverType"
     >


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2102 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Updated EvenEasierDeploy UX so as to not require a full recursive query for deployments and configurations before showing the UX, when the workspace opened within VSCode does not have a previous selection recorded.

To do this, I've renamed the button to a more generic `Select Deployment...` and then updated the Select Deployment code to also include a list entry which allows creating a new deployment. I've also added two separators within the list, one for existing deployments and a second for new.

The following videos were recorded with an abnormally large project dir (my entire dev directory), but it nicely shows one of the worse cases we might see.

Before: Note the initial delay when we display "Scanning directories..." before the UX is enabled. (Roughly 20 seconds)
https://github.com/user-attachments/assets/c2e4dc89-b97c-4143-b815-785569e12b5f

After: Delay goes away! (Do not be confused with untouched delay in recursive queries when click on select deployment. This is same as before, but with this change, we've cut time for user to interact with Publisher down 50%.
https://github.com/user-attachments/assets/e7db3511-1445-4542-9655-75be74abe1a0

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Validate functionality when opening project folders which you've previously deployed (and VSCode has kept track of your past selection) and new ones. 
Validate deployment selection and new deployment creation, using very large project directories.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
