### PR TITLE
Add file size and count for directories

### DIFF
--- a/extensions/vscode/src/api/types/files.ts
+++ b/extensions/vscode/src/api/types/files.ts
@@ -18,6 +18,7 @@ export type ContentRecordFile = {
   rel: string;
   relDir: string;
   size: number;
+  fileCount: number;
   abs: string;
 };
 

--- a/internal/services/api/files/files.go
+++ b/internal/services/api/files/files.go
@@ -23,6 +23,7 @@ type File struct {
 	Rel              string           `json:"rel"`              // the relative path to the project root, which is used as the identifier
 	RelDir           string           `json:"relDir"`           // the relative path of the directory containing the file
 	Size             int64            `json:"size"`             // nullable; length in bytes for regular files; system-dependent
+	FileCount        int64            `json:"fileCount"`        // total number of files in the subtree rooted at this node
 	Abs              string           `json:"abs"`              // the absolute path
 }
 
@@ -56,6 +57,23 @@ func CreateFile(root util.AbsolutePath, path util.AbsolutePath, match *matcher.P
 		Files:            make([]*File, 0),
 		Abs:              path.String(),
 	}, nil
+}
+
+func (f *File) CalculateDirectorySizes() {
+	var fileCount int64
+	var size int64
+
+	for _, child := range f.Files {
+		if child.IsDir {
+			child.CalculateDirectorySizes()
+		} else {
+			child.FileCount = 1
+		}
+		size += child.Size
+		fileCount += child.FileCount
+	}
+	f.FileCount = fileCount
+	f.Size = size
 }
 
 func (f *File) insert(root util.AbsolutePath, path util.AbsolutePath, matchList matcher.MatchList) (*File, error) {

--- a/internal/services/api/files/services.go
+++ b/internal/services/api/files/services.go
@@ -56,5 +56,6 @@ func (s filesService) GetFile(p util.AbsolutePath, matchList matcher.MatchList) 
 		return err
 	})
 
+	file.CalculateDirectorySizes()
 	return file, err
 }

--- a/internal/services/api/files/services_test.go
+++ b/internal/services/api/files/services_test.go
@@ -120,3 +120,31 @@ func (s *ServicesSuite) TestGetFileUsingSampleContentFromParentDir() {
 	s.False(file.IsEntrypoint)
 	s.NotNil(file.Files)
 }
+
+func (s *ServicesSuite) TestGetFileSizeAndCount() {
+	base := s.cwd
+	service := CreateFilesService(base, s.log)
+	s.NotNil(service)
+	matchList, err := matcher.NewMatchList(base, nil)
+	s.NoError(err)
+
+	cwdFile := s.cwd.Join("cwdFile")
+	err = cwdFile.WriteFile([]byte("abcd"), 0666)
+	s.NoError(err)
+
+	subdir := s.cwd.Join("subdir")
+	err = subdir.MkdirAll(0777)
+	s.NoError(err)
+
+	subdirFile := subdir.Join("subdirFile")
+	err = subdirFile.WriteFile([]byte("abc"), 0666)
+	s.NoError(err)
+
+	file, err := service.GetFile(base, matchList)
+	s.NoError(err)
+	s.NotNil(file)
+
+	// There are two files (not directories) totaling 7 bytes
+	s.Equal(int64(2), file.FileCount)
+	s.Equal(int64(7), file.Size)
+}

--- a/internal/services/api/get_config_files.go
+++ b/internal/services/api/get_config_files.go
@@ -26,8 +26,12 @@ func GetConfigFilesHandlerFunc(base util.AbsolutePath, filesService files.FilesS
 		}
 		configPath := config.GetConfigPath(projectDir, name)
 		cfg, err := config.FromFile(configPath)
-		if err != nil && errors.Is(err, fs.ErrNotExist) {
-			http.NotFound(w, req)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				http.NotFound(w, req)
+			} else {
+				InternalError(w, req, log, err)
+			}
 			return
 		}
 		matchList, err := matcher.NewMatchList(projectDir, matcher.StandardExclusions)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

The Files API populates the `size` field for directories with a total size of all contained files. There is a new `fileCount` field containing the count of files (not directories).

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->


## Automated Tests

Added a test for this.

## Directions for Reviewers

Run the agent, and access `/api/configurations/$NAME/files`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
