### PR TITLE
Default to only including specific files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ func New() *Config {
 		Schema:   schema.ConfigSchemaURL,
 		Type:     ContentTypeUnknown,
 		Validate: true,
-		Files:    []string{"*"},
+		Files:    []string{},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,7 +50,7 @@ func (s *ConfigSuite) TestNew() {
 	s.NotNil(cfg)
 	s.Equal(schema.ConfigSchemaURL, cfg.Schema)
 	s.Equal(true, cfg.Validate)
-	s.Equal([]string{"*"}, cfg.Files)
+	s.Equal([]string{}, cfg.Files)
 }
 
 func (s *ConfigSuite) TestGetConfigPath() {

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -137,6 +137,11 @@ func GetPossibleConfigs(
 			// Default title is the name of the project directory.
 			cfg.Title = base.Base()
 		}
+		// The inspector may populate the file list.
+		// If it doesn't, default to just the entrypoint file.
+		if len(cfg.Files) == 0 {
+			cfg.Files = []string{cfg.Entrypoint}
+		}
 		needPython, err := requiresPython(cfg, base)
 		if err != nil {
 			return nil, err
@@ -174,11 +179,6 @@ func GetPossibleConfigs(
 			if cfg.Entrypoint == "" {
 				cfg.Entrypoint = "unknown"
 			}
-		}
-		// The inspector may populate the file list.
-		// If it doesn't, default to just the entrypoint file.
-		if len(cfg.Files) == 0 {
-			cfg.Files = []string{cfg.Entrypoint}
 		}
 	}
 	return configs, nil

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -130,7 +130,6 @@ func GetPossibleConfigs(
 	if err != nil {
 		return nil, fmt.Errorf("error detecting content type: %w", err)
 	}
-	var pyConfig *config.Python
 
 	for _, cfg := range configs {
 		log.Info("Possible deployment type", "Entrypoint", cfg.Entrypoint, "Type", cfg.Type)
@@ -143,14 +142,13 @@ func GetPossibleConfigs(
 			return nil, err
 		}
 		if needPython {
-			if pyConfig == nil {
-				inspector := PythonInspectorFactory(base, python, log)
-				pyConfig, err = inspector.InspectPython()
-				if err != nil {
-					return nil, err
-				}
+			inspector := PythonInspectorFactory(base, python, log)
+			pyConfig, err := inspector.InspectPython()
+			if err != nil {
+				return nil, err
 			}
 			cfg.Python = pyConfig
+			cfg.Files = append(cfg.Files, cfg.Python.PackageFile)
 		}
 		needR, err := requiresR(cfg, base, rExecutable)
 		if err != nil {
@@ -163,6 +161,7 @@ func GetPossibleConfigs(
 				return nil, err
 			}
 			cfg.R = rConfig
+			cfg.Files = append(cfg.Files, cfg.R.PackageFile)
 		}
 		cfg.Comments = strings.Split(initialComment, "\n")
 

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -176,6 +176,11 @@ func GetPossibleConfigs(
 				cfg.Entrypoint = "unknown"
 			}
 		}
+		// The inspector may populate the file list.
+		// If it doesn't, default to just the entrypoint file.
+		if len(cfg.Files) == 0 {
+			cfg.Files = []string{cfg.Entrypoint}
+		}
 	}
 	return configs, nil
 }

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -117,6 +117,65 @@ func requiresR(cfg *config.Config, base util.AbsolutePath, rExecutable util.Path
 	return false, nil
 }
 
+func normalizeConfig(
+	cfg *config.Config,
+	base util.AbsolutePath,
+	python util.Path,
+	rExecutable util.Path,
+	entrypoint util.RelativePath,
+	log logging.Logger,
+) error {
+	log.Info("Possible deployment type", "Entrypoint", cfg.Entrypoint, "Type", cfg.Type)
+	if cfg.Title == "" {
+		// Default title is the name of the project directory.
+		cfg.Title = base.Base()
+	}
+	// The inspector may populate the file list.
+	// If it doesn't, default to just the entrypoint file.
+	if len(cfg.Files) == 0 {
+		cfg.Files = []string{cfg.Entrypoint}
+	}
+	needPython, err := requiresPython(cfg, base)
+	if err != nil {
+		return err
+	}
+	if needPython {
+		inspector := PythonInspectorFactory(base, python, log)
+		pyConfig, err := inspector.InspectPython()
+		if err != nil {
+			return err
+		}
+		cfg.Python = pyConfig
+		cfg.Files = append(cfg.Files, cfg.Python.PackageFile)
+	}
+	needR, err := requiresR(cfg, base, rExecutable)
+	if err != nil {
+		return err
+	}
+	if needR {
+		inspector := RInspectorFactory(base, rExecutable, log)
+		rConfig, err := inspector.InspectR()
+		if err != nil {
+			return err
+		}
+		cfg.R = rConfig
+		cfg.Files = append(cfg.Files, cfg.R.PackageFile)
+	}
+	cfg.Comments = strings.Split(initialComment, "\n")
+
+	// Usually an entrypoint will be inferred.
+	// If not, use the specified entrypoint, or
+	// fall back to unknown.
+	if cfg.Entrypoint == "" {
+		cfg.Entrypoint = entrypoint.String()
+
+		if cfg.Entrypoint == "" {
+			cfg.Entrypoint = "unknown"
+		}
+	}
+	return nil
+}
+
 func GetPossibleConfigs(
 	base util.AbsolutePath,
 	python util.Path,
@@ -132,53 +191,9 @@ func GetPossibleConfigs(
 	}
 
 	for _, cfg := range configs {
-		log.Info("Possible deployment type", "Entrypoint", cfg.Entrypoint, "Type", cfg.Type)
-		if cfg.Title == "" {
-			// Default title is the name of the project directory.
-			cfg.Title = base.Base()
-		}
-		// The inspector may populate the file list.
-		// If it doesn't, default to just the entrypoint file.
-		if len(cfg.Files) == 0 {
-			cfg.Files = []string{cfg.Entrypoint}
-		}
-		needPython, err := requiresPython(cfg, base)
+		err = normalizeConfig(cfg, base, python, rExecutable, entrypoint, log)
 		if err != nil {
 			return nil, err
-		}
-		if needPython {
-			inspector := PythonInspectorFactory(base, python, log)
-			pyConfig, err := inspector.InspectPython()
-			if err != nil {
-				return nil, err
-			}
-			cfg.Python = pyConfig
-			cfg.Files = append(cfg.Files, cfg.Python.PackageFile)
-		}
-		needR, err := requiresR(cfg, base, rExecutable)
-		if err != nil {
-			return nil, err
-		}
-		if needR {
-			inspector := RInspectorFactory(base, rExecutable, log)
-			rConfig, err := inspector.InspectR()
-			if err != nil {
-				return nil, err
-			}
-			cfg.R = rConfig
-			cfg.Files = append(cfg.Files, cfg.R.PackageFile)
-		}
-		cfg.Comments = strings.Split(initialComment, "\n")
-
-		// Usually an entrypoint will be inferred.
-		// If not, use the specified entrypoint, or
-		// fall back to unknown.
-		if cfg.Entrypoint == "" {
-			cfg.Entrypoint = entrypoint.String()
-
-			if cfg.Entrypoint == "" {
-				cfg.Entrypoint = "unknown"
-			}
 		}
 	}
 	return configs, nil
@@ -189,6 +204,10 @@ func Init(base util.AbsolutePath, configName string, python util.Path, rExecutab
 		configName = config.DefaultConfigName
 	}
 	cfg, err := inspectProject(base, python, rExecutable, log)
+	if err != nil {
+		return nil, err
+	}
+	err = normalizeConfig(cfg, base, python, rExecutable, util.RelativePath{}, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -170,10 +170,12 @@ func (s *InitializeSuite) TestGetPossibleConfigs() {
 	s.Len(configs, 2)
 	s.Equal(config.ContentTypePythonFlask, configs[0].Type)
 	s.Equal("app.py", configs[0].Entrypoint)
+	s.Equal([]string{"app.py"}, configs[0].Files)
 	s.Equal(expectedPyConfig, configs[0].Python)
 
 	s.Equal(config.ContentTypeHTML, configs[1].Type)
 	s.Equal("index.html", configs[1].Entrypoint)
+	s.Equal([]string{"index.html"}, configs[1].Files)
 	s.Nil(configs[1].Python)
 }
 

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -170,7 +170,7 @@ func (s *InitializeSuite) TestGetPossibleConfigs() {
 	s.Len(configs, 2)
 	s.Equal(config.ContentTypePythonFlask, configs[0].Type)
 	s.Equal("app.py", configs[0].Entrypoint)
-	s.Equal([]string{"app.py"}, configs[0].Files)
+	s.Equal([]string{"app.py", "requirements.txt"}, configs[0].Files)
 	s.Equal(expectedPyConfig, configs[0].Python)
 
 	s.Equal(config.ContentTypeHTML, configs[1].Type)

--- a/internal/inspect/detectors/all_test.go
+++ b/internal/inspect/detectors/all_test.go
@@ -46,14 +46,14 @@ func (s *AllSuite) TestInferTypeDirectory() {
 		Type:       config.ContentTypeHTML,
 		Entrypoint: "index.html",
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{"index.html"},
 	}, configs[0])
 	s.Equal(&config.Config{
 		Schema:     schema.ConfigSchemaURL,
 		Type:       config.ContentTypePythonDash,
 		Entrypoint: appFilename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[1])
 }
@@ -105,7 +105,7 @@ func (s *AllSuite) TestInferAll() {
 			Type:       config.ContentTypePythonDash,
 			Entrypoint: appFilename,
 			Validate:   true,
-			Files:      []string{"*"},
+			Files:      []string{},
 			Python:     &config.Python{},
 		},
 		{
@@ -113,7 +113,7 @@ func (s *AllSuite) TestInferAll() {
 			Type:       config.ContentTypeHTML,
 			Entrypoint: "myfile.html",
 			Validate:   true,
-			Files:      []string{"*"},
+			Files:      []string{"myfile.html"},
 			Python:     nil,
 		},
 	}, t)

--- a/internal/inspect/detectors/html.go
+++ b/internal/inspect/detectors/html.go
@@ -48,6 +48,20 @@ func (d *StaticHTMLDetector) InferType(base util.AbsolutePath, entrypoint util.R
 		cfg := config.New()
 		cfg.Type = config.ContentTypeHTML
 		cfg.Entrypoint = relEntrypoint.String()
+		cfg.Files = []string{
+			relEntrypoint.String(),
+		}
+		extraDirs := []string{"_site", relEntrypoint.WithoutExt().String() + "_files"}
+		for _, filename := range extraDirs {
+			path := base.Join(filename)
+			exists, err := path.Exists()
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				cfg.Files = append(cfg.Files, filename)
+			}
+		}
 		configs = append(configs, cfg)
 	}
 	return configs, nil

--- a/internal/inspect/detectors/html_test.go
+++ b/internal/inspect/detectors/html_test.go
@@ -46,14 +46,14 @@ func (s *StaticHTMLDetectorSuite) TestInferType() {
 		Type:       config.ContentTypeHTML,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{filename},
 	}, configs[0])
 	s.Equal(&config.Config{
 		Schema:     schema.ConfigSchemaURL,
 		Type:       config.ContentTypeHTML,
 		Entrypoint: otherFilename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{otherFilename},
 	}, configs[1])
 }
 
@@ -83,6 +83,6 @@ func (s *StaticHTMLDetectorSuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypeHTML,
 		Entrypoint: otherFilename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{otherFilename},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/notebook_test.go
+++ b/internal/inspect/detectors/notebook_test.go
@@ -82,7 +82,7 @@ func (s *NotebookDetectorSuite) TestInferTypePlainNotebook() {
 		Type:       config.ContentTypeJupyterNotebook,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -107,7 +107,7 @@ func (s *NotebookDetectorSuite) TestInferTypeVoilaNotebook() {
 		Type:       config.ContentTypeJupyterVoila,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -186,7 +186,7 @@ func (s *NotebookDetectorSuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypeJupyterNotebook,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/plumber_test.go
+++ b/internal/inspect/detectors/plumber_test.go
@@ -42,7 +42,7 @@ func (s *PlumberSuite) TestInferTypePlumberR() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -68,7 +68,7 @@ func (s *PlumberSuite) TestInferTypeEntrypointR() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -109,7 +109,7 @@ func (s *PlumberSuite) TestInferTypeWithEntrypoint() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/pyshiny_test.go
+++ b/internal/inspect/detectors/pyshiny_test.go
@@ -41,7 +41,7 @@ func (s *PyShinySuite) TestInferType() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -66,7 +66,7 @@ func (s *PyShinySuite) TestInferTypeShinyExpress() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: "shiny.express.app:app_2e_py",
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -95,7 +95,7 @@ func (s *PyShinySuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -123,7 +123,7 @@ func (s *PyShinySuite) TestInferTypeWithExtraFile() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/python_test.go
+++ b/internal/inspect/detectors/python_test.go
@@ -43,7 +43,7 @@ func (s *PythonSuite) TestInferTypePreferredFilename() {
 		Type:       config.ContentTypePythonFlask,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -71,7 +71,7 @@ func (s *PythonSuite) TestInferTypeAlternatePreferredFilename() {
 		Type:       config.ContentTypePythonFlask,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -96,7 +96,7 @@ func (s *PythonSuite) TestInferTypeOnlyPythonFile() {
 		Type:       config.ContentTypePythonFlask,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -164,7 +164,7 @@ func (s *PythonSuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypePythonFlask,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -106,7 +106,7 @@ func getInputFiles(inspectOutput *quartoInspectOutput) []string {
 	}
 	if inspectOutput.FileInformation != nil {
 		filenames := []string{}
-		for name, _ := range inspectOutput.FileInformation {
+		for name := range inspectOutput.FileInformation {
 			filenames = append(filenames, name)
 		}
 		return filenames

--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -230,10 +230,7 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath, entrypoint util.Relat
 			d.log.Warn("quarto inspect failed", "file", entrypointPath.String(), "error", err)
 			continue
 		}
-		inputFiles := getInputFiles(inspectOutput)
-		if len(inputFiles) == 0 {
-			continue
-		}
+
 		cfg := config.New()
 		cfg.Entrypoint = relEntrypoint.String()
 		cfg.Title = d.getTitle(inspectOutput, relEntrypoint.String())
@@ -280,10 +277,16 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath, entrypoint util.Relat
 		}
 
 		// Only include the entrypoint and its associated files.
+		inputFiles := getInputFiles(inspectOutput)
 		for _, inputFile := range inputFiles {
-			relPath, err := filepath.Rel(base.String(), inputFile)
-			if err != nil {
-				return nil, err
+			var relPath string
+			if filepath.IsAbs(inputFile) {
+				relPath, err = filepath.Rel(base.String(), inputFile)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				relPath = inputFile
 			}
 			cfg.Files = append(cfg.Files, relPath)
 		}

--- a/internal/inspect/detectors/quarto_test.go
+++ b/internal/inspect/detectors/quarto_test.go
@@ -3,6 +3,7 @@ package detectors
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"bytes"
 	"fmt"
 	"runtime"
 	"strings"
@@ -42,6 +43,7 @@ func (s *QuartoDetectorSuite) runInferType(testName string) []*config.Config {
 	if exists {
 		dirOutput, err := dirOutputPath.ReadFile()
 		s.NoError(err)
+		dirOutput = bytes.ReplaceAll(dirOutput, []byte("$DIR"), []byte(base.Dir().String()))
 		executor.On("RunCommand", "quarto", []string{"inspect", base.String()}, mock.Anything, mock.Anything).Return(dirOutput, nil, nil)
 	}
 
@@ -53,7 +55,7 @@ func (s *QuartoDetectorSuite) runInferType(testName string) []*config.Config {
 		outputPath := base.Join(fmt.Sprintf("inspect_%s.json", fileBase))
 		fileOutput, err := outputPath.ReadFile()
 		s.NoError(err)
-
+		fileOutput = bytes.ReplaceAll(fileOutput, []byte("$DIR"), []byte(base.Dir().String()))
 		executor.On("RunCommand", "quarto", []string{"inspect", filename.String()}, mock.Anything, mock.Anything).Return(fileOutput, nil, nil)
 	}
 
@@ -74,7 +76,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownDoc() {
 		Entrypoint: "quarto-doc-none.qmd",
 		Title:      "quarto-doc-none",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-doc-none.html", "!quarto-doc-none_files"},
+		Files:      []string{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -94,7 +96,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownProject() {
 		Entrypoint: "quarto-proj-none.qmd",
 		Title:      "quarto-proj-none",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-proj-none.html", "!quarto-proj-none_files"},
+		Files:      []string{"quarto-proj-none.qmd", "_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -114,7 +116,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownProjectWindows() {
 		Entrypoint: "quarto-proj-none.qmd",
 		Title:      "quarto-proj-none",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-proj-none.html", "!quarto-proj-none_files"},
+		Files:      []string{"quarto-proj-none.qmd", "_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -134,7 +136,7 @@ func (s *QuartoDetectorSuite) TestInferTypePythonProject() {
 		Entrypoint: "quarto-proj-py.qmd",
 		Title:      "quarto-proj-py",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-proj-py.html", "!quarto-proj-py_files"},
+		Files:      []string{"quarto-proj-py.qmd", "_quarto.yml"},
 		Python:     &config.Python{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -155,7 +157,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRProject() {
 		Entrypoint: "quarto-proj-r.qmd",
 		Title:      "quarto-proj-r",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-proj-r.html", "!quarto-proj-r_files"},
+		Files:      []string{"quarto-proj-r.qmd", "_quarto.yml"},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -176,7 +178,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRAndPythonProject() {
 		Entrypoint: "quarto-proj-r-py.qmd",
 		Title:      "quarto-proj-r-py",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-proj-r-py.html", "!quarto-proj-r-py_files"},
+		Files:      []string{"quarto-proj-r-py.qmd", "_quarto.yml"},
 		Python:     &config.Python{},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
@@ -198,7 +200,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRShinyProject() {
 		Entrypoint: "quarto-proj-r-shiny.qmd",
 		Title:      "quarto-proj-r-shiny",
 		Validate:   true,
-		Files:      []string{"*", "!quarto-proj-r-shiny.html", "!quarto-proj-r-shiny_files"},
+		Files:      []string{"quarto-proj-r-shiny.qmd", "_quarto.yml"},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -219,7 +221,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 		Entrypoint: "about.qmd",
 		Title:      "About",
 		Validate:   true,
-		Files:      []string{"*", "!about.html", "!about_files", "!_site"},
+		Files:      []string{"index.qmd", "about.qmd", "_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -231,7 +233,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 		Entrypoint: "index.qmd",
 		Title:      "quarto-website-none",
 		Validate:   true,
-		Files:      []string{"*", "!index.html", "!index_files", "!_site"},
+		Files:      []string{"index.qmd", "about.qmd", "_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -251,7 +253,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRMarkdownDoc() {
 		Entrypoint: "static.Rmd",
 		Title:      "static",
 		Validate:   true,
-		Files:      []string{"*", "!static.html", "!static_files"},
+		Files:      []string{},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -272,7 +274,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMultidocProject() {
 		Entrypoint: "document1.qmd",
 		Title:      "quarto-proj-none-multidocument",
 		Validate:   true,
-		Files:      []string{"*", "!document1.html", "!document1_files"},
+		Files:      []string{"document1.qmd", "document2.qmd", "_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -284,7 +286,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMultidocProject() {
 		Entrypoint: "document2.qmd",
 		Title:      "quarto-proj-none-multidocument",
 		Validate:   true,
-		Files:      []string{"*", "!document2.html", "!document2_files"},
+		Files:      []string{"document1.qmd", "document2.qmd", "_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -304,7 +306,7 @@ func (s *QuartoDetectorSuite) TestInferTypeNotebook() {
 		Entrypoint: "stock-report-jupyter.ipynb",
 		Title:      "Stock Report: TSLA",
 		Validate:   true,
-		Files:      []string{"*", "!stock-report-jupyter.html", "!stock-report-jupyter_files"},
+		Files:      []string{"stock-report-jupyter.ipynb"},
 		Python:     &config.Python{},
 		Quarto: &config.Quarto{
 			Version: "1.5.54",
@@ -325,7 +327,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRevalJSQuartoShiny() {
 		Entrypoint: "dashboard.qmd",
 		Title:      "posit::conf(2024)",
 		Validate:   true,
-		Files:      []string{"*", "!dashboard.html", "!dashboard_files"},
+		Files:      []string{"dashboard.qmd"},
 		Quarto: &config.Quarto{
 			Version: "1.5.54",
 			Engines: []string{"knitr"},

--- a/internal/inspect/detectors/rmarkdown_test.go
+++ b/internal/inspect/detectors/rmarkdown_test.go
@@ -57,7 +57,7 @@ func (s *RMarkdownSuite) TestInferType() {
 		Title:      "Special Report",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -93,7 +93,7 @@ func (s *RMarkdownSuite) TestInferTypeWithPython() {
 		Title:      "Special Report",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -142,7 +142,7 @@ func (s *RMarkdownSuite) TestInferTypeParameterized() {
 		Entrypoint:    filename,
 		Validate:      true,
 		HasParameters: true,
-		Files:         []string{"*"},
+		Files:         []string{},
 		R:             &config.R{},
 	}, configs[0])
 }
@@ -180,7 +180,7 @@ func (s *RMarkdownSuite) TestInferTypeShinyRmdRuntime() {
 		Title:      "Interactive Report",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -218,7 +218,7 @@ func (s *RMarkdownSuite) TestInferTypeShinyRmdServer() {
 		Title:      "Interactive Report",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -257,7 +257,7 @@ func (s *RMarkdownSuite) TestInferTypeShinyRmdServerType() {
 		Title:      "Interactive Report",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -291,7 +291,7 @@ func (s *RMarkdownSuite) TestInferTypeNoMetadata() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -321,7 +321,7 @@ func (s *RMarkdownSuite) TestInferTypeWithEntrypoint() {
 		Title:      "Special Report",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/rshiny_test.go
+++ b/internal/inspect/detectors/rshiny_test.go
@@ -42,7 +42,7 @@ func (s *ShinySuite) TestInferTypeAppR() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -68,7 +68,7 @@ func (s *ShinySuite) TestInferTypeServerR() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }
@@ -109,7 +109,7 @@ func (s *ShinySuite) TestInferTypeWithEntrypoint() {
 		Title:      "",
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{"*"},
+		Files:      []string{},
 		R:          &config.R{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/testdata/quarto-multidoc-proj-none/inspect_document1.json
+++ b/internal/inspect/detectors/testdata/quarto-multidoc-proj-none/inspect_document1.json
@@ -209,7 +209,7 @@
     "quarto": {
       "version": "1.4.554"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none",
+    "dir": "$DIR/quarto-multidoc-proj-none",
     "engines": ["markdown"],
     "config": {
       "project": {
@@ -221,13 +221,11 @@
     },
     "files": {
       "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none/document1.qmd",
-        "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none/document2.qmd"
+        "$DIR/quarto-multidoc-proj-none/document1.qmd",
+        "$DIR/quarto-multidoc-proj-none/document2.qmd"
       ],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-multidoc-proj-none/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-multidoc-proj-none/inspect_document2.json
+++ b/internal/inspect/detectors/testdata/quarto-multidoc-proj-none/inspect_document2.json
@@ -209,7 +209,7 @@
     "quarto": {
       "version": "1.4.554"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none",
+    "dir": "$DIR/quarto-multidoc-proj-none",
     "engines": ["markdown"],
     "config": {
       "project": {
@@ -221,13 +221,11 @@
     },
     "files": {
       "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none/document1.qmd",
-        "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none/document2.qmd"
+        "$DIR/quarto-multidoc-proj-none/document1.qmd",
+        "$DIR/quarto-multidoc-proj-none/document2.qmd"
       ],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-multidoc-proj-none/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-multidoc-proj-none/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-proj-none-windows/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-none-windows/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "C:\\Users\\somebody\\quarto-proj-none",
+  "dir": "$DIR\\quarto-proj-none",
   "engines": ["markdown"],
   "config": {
     "project": {
@@ -12,9 +12,9 @@
     "language": {}
   },
   "files": {
-    "input": ["C:\\Users\\somebody\\quarto-proj-none\\quarto-proj-none.qmd"],
+    "input": ["$DIR\\quarto-proj-none\\quarto-proj-none.qmd"],
     "resources": [],
-    "config": ["C:\\Users\\somebody\\quarto-proj-none\\_quarto.yml"],
+    "config": ["$DIR\\quarto-proj-none\\_quarto.yml"],
     "configResources": []
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-proj-none-windows/inspect_quarto-proj-none.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-none-windows/inspect_quarto-proj-none.json
@@ -208,7 +208,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "C:\\Users\\somebody\\quarto-proj-none",
+    "dir": "$DIR\\quarto-proj-none-windows",
     "engines": ["markdown"],
     "config": {
       "project": {
@@ -218,9 +218,9 @@
       "language": {}
     },
     "files": {
-      "input": ["C:\\Users\\somebody\\quarto-proj-none\\quarto-proj-none.qmd"],
+      "input": ["$DIR\\quarto-proj-none-windows\\quarto-proj-none.qmd"],
       "resources": [],
-      "config": ["C:\\Users\\somebody\\quarto-proj-none\\_quarto.yml"],
+      "config": ["$DIR\\quarto-proj-none-windows\\_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-proj-none/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-none/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-none",
+  "dir": "$DIR/quarto-proj-none",
   "engines": ["markdown"],
   "config": {
     "project": {
@@ -12,13 +12,9 @@
     "language": {}
   },
   "files": {
-    "input": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-none/quarto-proj-none.qmd"
-    ],
+    "input": ["$DIR/quarto-proj-none/quarto-proj-none.qmd"],
     "resources": [],
-    "config": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-none/_quarto.yml"
-    ],
+    "config": ["$DIR/quarto-proj-none/_quarto.yml"],
     "configResources": []
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-proj-none/inspect_quarto-proj-none.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-none/inspect_quarto-proj-none.json
@@ -208,7 +208,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-none",
+    "dir": "$DIR/quarto-proj-none",
     "engines": ["markdown"],
     "config": {
       "project": {
@@ -218,13 +218,9 @@
       "language": {}
     },
     "files": {
-      "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-none/quarto-proj-none.qmd"
-      ],
+      "input": ["$DIR/quarto-proj-none/quarto-proj-none.qmd"],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-none/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-proj-none/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-proj-py/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-py/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-py",
+  "dir": "$DIR/quarto-proj-py",
   "engines": ["jupyter"],
   "config": {
     "project": {
@@ -12,13 +12,9 @@
     "language": {}
   },
   "files": {
-    "input": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-py/quarto-proj-py.qmd"
-    ],
+    "input": ["$DIR/quarto-proj-py/quarto-proj-py.qmd"],
     "resources": [],
-    "config": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-py/_quarto.yml"
-    ],
+    "config": ["$DIR/quarto-proj-py/_quarto.yml"],
     "configResources": []
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-proj-py/inspect_quarto-proj-py.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-py/inspect_quarto-proj-py.json
@@ -210,7 +210,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-py",
+    "dir": "$DIR/quarto-proj-py",
     "engines": ["jupyter"],
     "config": {
       "project": {
@@ -220,13 +220,9 @@
       "language": {}
     },
     "files": {
-      "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-py/quarto-proj-py.qmd"
-      ],
+      "input": ["$DIR/quarto-proj-py/quarto-proj-py.qmd"],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-py/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-proj-py/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-proj-r-py/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-r-py/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-py",
+  "dir": "$DIR/quarto-proj-r-py",
   "engines": ["knitr"],
   "config": {
     "project": {
@@ -12,13 +12,9 @@
     "language": {}
   },
   "files": {
-    "input": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-py/quarto-proj-r-py.qmd"
-    ],
+    "input": ["$DIR/quarto-proj-r-py/quarto-proj-r-py.qmd"],
     "resources": [],
-    "config": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-py/_quarto.yml"
-    ],
+    "config": ["$DIR/quarto-proj-r-py/_quarto.yml"],
     "configResources": []
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-proj-r-py/inspect_quarto-proj-r-py.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-r-py/inspect_quarto-proj-r-py.json
@@ -209,7 +209,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-py",
+    "dir": "$DIR/quarto-proj-r-py",
     "engines": ["knitr"],
     "config": {
       "project": {
@@ -219,13 +219,9 @@
       "language": {}
     },
     "files": {
-      "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-py/quarto-proj-r-py.qmd"
-      ],
+      "input": ["$DIR/quarto-proj-r-py/quarto-proj-r-py.qmd"],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-py/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-proj-r-py/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-proj-r-shiny/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-r-shiny/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-shiny",
+  "dir": "$DIR/quarto-proj-r-shiny",
   "engines": ["knitr"],
   "config": {
     "project": {
@@ -12,13 +12,9 @@
     "language": {}
   },
   "files": {
-    "input": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-shiny/quarto-proj-r-shiny.qmd"
-    ],
+    "input": ["$DIR/quarto-proj-r-shiny/quarto-proj-r-shiny.qmd"],
     "resources": [],
-    "config": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-shiny/_quarto.yml"
-    ],
+    "config": ["$DIR/quarto-proj-r-shiny/_quarto.yml"],
     "configResources": []
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-proj-r-shiny/inspect_quarto-proj-r-shiny.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-r-shiny/inspect_quarto-proj-r-shiny.json
@@ -213,7 +213,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-shiny",
+    "dir": "$DIR/quarto-proj-r-shiny",
     "engines": ["knitr"],
     "config": {
       "project": {
@@ -223,13 +223,9 @@
       "language": {}
     },
     "files": {
-      "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-shiny/quarto-proj-r-shiny.qmd"
-      ],
+      "input": ["$DIR/quarto-proj-r-shiny/quarto-proj-r-shiny.qmd"],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r-shiny/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-proj-r-shiny/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-proj-r/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-r/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r",
+  "dir": "$DIR/quarto-proj-r",
   "engines": ["knitr"],
   "config": {
     "project": {
@@ -12,13 +12,9 @@
     "language": {}
   },
   "files": {
-    "input": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r/quarto-proj-r.qmd"
-    ],
+    "input": ["$DIR/quarto-proj-r/quarto-proj-r.qmd"],
     "resources": [],
-    "config": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r/_quarto.yml"
-    ],
+    "config": ["$DIR/quarto-proj-r/_quarto.yml"],
     "configResources": []
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-proj-r/inspect_quarto-proj-r.json
+++ b/internal/inspect/detectors/testdata/quarto-proj-r/inspect_quarto-proj-r.json
@@ -209,7 +209,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r",
+    "dir": "$DIR/quarto-proj-r",
     "engines": ["knitr"],
     "config": {
       "project": {
@@ -219,13 +219,9 @@
       "language": {}
     },
     "files": {
-      "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r/quarto-proj-r.qmd"
-      ],
+      "input": ["$DIR/quarto-proj-r/quarto-proj-r.qmd"],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-proj-r/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-proj-r/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-website-none/inspect.json
+++ b/internal/inspect/detectors/testdata/quarto-website-none/inspect.json
@@ -2,7 +2,7 @@
   "quarto": {
     "version": "1.4.553"
   },
-  "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-website-none",
+  "dir": "$DIR/quarto-website-none",
   "engines": ["markdown"],
   "config": {
     "project": {
@@ -34,15 +34,11 @@
   },
   "files": {
     "input": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/index.qmd",
-      "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/about.qmd"
+      "$DIR/quarto-website-none/index.qmd",
+      "$DIR/quarto-website-none/about.qmd"
     ],
     "resources": [],
-    "config": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/_quarto.yml"
-    ],
-    "configResources": [
-      "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/styles.css"
-    ]
+    "config": ["$DIR/quarto-website-none/_quarto.yml"],
+    "configResources": ["$DIR/quarto-website-none/styles.css"]
   }
 }

--- a/internal/inspect/detectors/testdata/quarto-website-none/inspect_about.json
+++ b/internal/inspect/detectors/testdata/quarto-website-none/inspect_about.json
@@ -210,7 +210,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/posit-dev/publisher/internal/inspect/detectors/testdata/quarto-website-none",
+    "dir": "$DIR/quarto-website-none",
     "engines": ["markdown"],
     "config": {
       "project": {
@@ -242,13 +242,11 @@
     },
     "files": {
       "input": [
-        "/Users/mike/posit-dev/publisher/internal/inspect/detectors/testdata/quarto-website-none/index.qmd",
-        "/Users/mike/posit-dev/publisher/internal/inspect/detectors/testdata/quarto-website-none/about.qmd"
+        "$DIR/quarto-website-none/index.qmd",
+        "$DIR/quarto-website-none/about.qmd"
       ],
       "resources": [],
-      "config": [
-        "/Users/mike/posit-dev/publisher/internal/inspect/detectors/testdata/quarto-website-none/_quarto.yml"
-      ],
+      "config": ["$DIR/quarto-website-none/_quarto.yml"],
       "configResources": []
     }
   }

--- a/internal/inspect/detectors/testdata/quarto-website-none/inspect_index.json
+++ b/internal/inspect/detectors/testdata/quarto-website-none/inspect_index.json
@@ -210,7 +210,7 @@
     "quarto": {
       "version": "1.4.553"
     },
-    "dir": "/Users/mike/rstudio/connect-content/bundles/quarto-website-none",
+    "dir": "$DIR/quarto-website-none",
     "engines": ["markdown"],
     "config": {
       "project": {
@@ -242,16 +242,12 @@
     },
     "files": {
       "input": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/index.qmd",
-        "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/about.qmd"
+        "$DIR/quarto-website-none/index.qmd",
+        "$DIR/quarto-website-none/about.qmd"
       ],
       "resources": [],
-      "config": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/_quarto.yml"
-      ],
-      "configResources": [
-        "/Users/mike/rstudio/connect-content/bundles/quarto-website-none/styles.css"
-      ]
+      "config": ["$DIR/quarto-website-none/_quarto.yml"],
+      "configResources": ["$DIR/quarto-website-none/styles.css"]
     }
   }
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -273,11 +273,6 @@ func (p *defaultPublisher) publishWithClient(
 	log logging.Logger) error {
 
 	manifest := bundles.NewManifestFromConfig(p.Config)
-	filePatterns := p.Config.Files
-	if len(filePatterns) == 0 {
-		log.Info("No file patterns specified; using default pattern '*'")
-		filePatterns = []string{"*"}
-	}
 	if p.Config.R != nil {
 		rPackages, err := p.getRPackages(log)
 		if err != nil {
@@ -285,7 +280,7 @@ func (p *defaultPublisher) publishWithClient(
 		}
 		manifest.Packages = rPackages
 	}
-	bundler, err := bundles.NewBundler(p.Dir, manifest, filePatterns, log)
+	bundler, err := bundles.NewBundler(p.Dir, manifest, p.Config.Files, log)
 	if err != nil {
 		return err
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -82,7 +82,7 @@ func (s *StateSuite) TestLoadConfig() {
 		Type:        "python-dash",
 		Entrypoint:  "app:app",
 		Validate:    true,
-		Files:       []string{"*"},
+		Files:       []string{},
 		Title:       "Super Title",
 		Description: "minimal description",
 		Python: &config.Python{Version: "3.11.3",

--- a/internal/util/fspath.go
+++ b/internal/util/fspath.go
@@ -164,6 +164,21 @@ func (p Path) Ext() string {
 	return filepath.Ext(p.path)
 }
 
+func (p Path) WithoutExt() Path {
+	withoutExt := strings.TrimSuffix(p.path, p.Ext())
+	return NewPath(withoutExt, p.fs)
+}
+
+func (p AbsolutePath) WithoutExt() AbsolutePath {
+	withoutExt := strings.TrimSuffix(p.path, p.Ext())
+	return NewAbsolutePath(withoutExt, p.fs)
+}
+
+func (p RelativePath) WithoutExt() RelativePath {
+	withoutExt := strings.TrimSuffix(p.path, p.Ext())
+	return NewRelativePath(withoutExt, p.fs)
+}
+
 func PathFromSlash(fs afero.Fs, path string) Path {
 	return NewPath(filepath.FromSlash(path), fs)
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR eliminates the default `*` file pattern, in favor of only listing the entrypoint in most cases.

HTML and Quarto have some special handling to include other files.

Fixes #2068

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [x] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Remove the default `*` file pattern. Allow detectors to fill in the file list; if they don't, only include the entrypoint.

## Automated Tests

Some tests need added assertions to cover new functionality.

## Directions for Reviewers

Inspect projects of various types.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
