### PR TITLE
Update quick pick items to be displayed in consistent manner when we offer selection of "new"

### DIFF
--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -5,6 +5,7 @@ import path from "path";
 import {
   InputBoxValidationSeverity,
   QuickPickItem,
+  QuickPickItemKind,
   ThemeIcon,
   Uri,
   commands,
@@ -117,26 +118,46 @@ export async function selectNewOrExistingConfig(
 
       configFileListItems = [];
 
+      // Display New Deployment at beginning
+      configFileListItems.push({
+        label: "New",
+        kind: QuickPickItemKind.Separator,
+      });
+      configFileListItems.push({
+        iconPath: new ThemeIcon("plus"),
+        label: createNewConfigurationLabel,
+        detail: "(or pick one of the existing deployments below)",
+        picked: configurations.length ? false : true,
+      });
+
+      // Then we display the existing deployments
+      if (configurations.length) {
+        configFileListItems.push({
+          label: "Existing",
+          kind: QuickPickItemKind.Separator,
+        });
+      }
+      let existingConfigFileListItems: QuickPickItem[] = [];
       configurations.forEach((config) => {
         const { title, problem } = calculateTitle(activeDeployment, config);
         if (problem) {
           return;
         }
-        configFileListItems.push({
+        existingConfigFileListItems.push({
           iconPath: new ThemeIcon("gear"),
           label: title,
           detail: config.configurationName,
         });
       });
-      configFileListItems.sort((a: QuickPickItem, b: QuickPickItem) => {
+      existingConfigFileListItems.sort((a: QuickPickItem, b: QuickPickItem) => {
         var x = a.label.toLowerCase();
         var y = b.label.toLowerCase();
         return x < y ? -1 : x > y ? 1 : 0;
       });
-      configFileListItems.push({
-        iconPath: new ThemeIcon("plus"),
-        label: createNewConfigurationLabel,
-      });
+      // add to end of our list items
+      configFileListItems = configFileListItems.concat(
+        existingConfigFileListItems,
+      );
     } catch (error: unknown) {
       const summary = getSummaryStringFromError(
         "selectNewOrExistingConfig, configurations.getAll",

--- a/extensions/vscode/src/types/quickPicks.ts
+++ b/extensions/vscode/src/types/quickPicks.ts
@@ -12,5 +12,5 @@ export interface DeploymentQuickPick extends QuickPickItem {
   contentRecord?: ContentRecord | PreContentRecordWithConfig;
   config?: Configuration | ConfigurationError;
   credentialName?: string;
-  lastMatch: boolean;
+  lastMatch?: boolean;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Move items allowing "new" to top of list and make sure "existing" are sorted by title. Also making use of separators consistent.

Resolves #2110 

This PR updates the two quick input selectors that we use, which can allow a "new" operation rather than selecting an existing item, to have:
-  the "new" item is listed first and use two lines to match any existing entries.
- separators of "new" and "existing" added
- existing items sorted by the title

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

We have two operations which display the updated lists:
- The "select" deployment list:
![deployment picker with new item shown first](https://github.com/user-attachments/assets/54e02fa1-552d-436c-86b2-3b9e4d5e0f9f)
- The "select" configuration list:
![config picker with new item shown first](https://github.com/user-attachments/assets/fdf41c7f-171c-42bc-982f-d157fdcb1f01)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

Invoke operations for selecting a deployment and selecting a configuration for the deployment:
- making sure that "new" operation is spawned correctly when selected
- make sure that selection of an "existing" item selects the correct one and applies it.
