### PR TITLE
UX: Add debounce and throttling to main query methods

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hypersphere/omnibus": "0.1.6",
         "@vscode/codicons": "^0.0.36",
+        "async-mutex": "^0.5.0",
         "axios": "^1.6.0",
         "debounce": "^2.1.0",
         "eventsource": "^2.0.2",
@@ -1123,6 +1124,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -4655,6 +4665,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
     },
     "node_modules/ttf2eot": {
       "version": "3.1.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -538,6 +538,7 @@
   "dependencies": {
     "@hypersphere/omnibus": "0.1.6",
     "@vscode/codicons": "^0.0.36",
+    "async-mutex": "^0.5.0",
     "axios": "^1.6.0",
     "debounce": "^2.1.0",
     "eventsource": "^2.0.2",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -116,3 +116,9 @@ export const enum Views {
   HelpAndFeedback = "posit.publisher.helpAndFeedback",
   Logs = "posit.publisher.logs",
 }
+
+export const DebounceDelaysMS = {
+  file: 1000,
+  refreshRPackages: 1000,
+  refreshPythonPackages: 1000,
+};

--- a/extensions/vscode/src/utils/throttle.ts
+++ b/extensions/vscode/src/utils/throttle.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import { Mutex, MutexInterface } from "async-mutex";
+
+export const throttleWithLastPending = async (
+  mutex: Mutex,
+  fn: () => Promise<void>,
+) => {
+  if (mutex.isLocked()) {
+    // we have calls waiting, so cancel them, since we're here now and taking their place
+    mutex.cancel();
+  }
+  let release: MutexInterface.Releaser | undefined;
+  try {
+    release = await mutex.acquire();
+    return await fn();
+  } finally {
+    if (release) {
+      release();
+    }
+  }
+};

--- a/extensions/vscode/src/utils/throttle.ts
+++ b/extensions/vscode/src/utils/throttle.ts
@@ -2,6 +2,23 @@
 
 import { Mutex, MutexInterface } from "async-mutex";
 
+// This method allows throttling of a method (typically an api call), where only
+// one call is active, and the last one which is requested while an existing call
+// is still active, is then executed after the current call completes.
+//
+// We do not need any intermediate calls to be executed, because we're using this functionality
+// with pure functions, which we simply need to execute the latest request.
+//
+// For example if all of these come in sequence very quickly, and the API call is long:
+// call() // A
+// call() // B
+// call() // C
+// call() // D
+// Call A will be executed and if it takes a long time, only Call D will be executed. Under the
+// coves, When Call B comes in, it is queued up using the mutex, but then Call C cancels Call B
+// (using mutex.cancel()), and Call C waits on the mutex, then Call D cancels Call C and waits on
+// the mutex, which is then executed when Call A releases the mutex.
+//
 export const throttleWithLastPending = async (
   mutex: Mutex,
   fn: () => Promise<void>,

--- a/extensions/vscode/src/utils/throttle.ts
+++ b/extensions/vscode/src/utils/throttle.ts
@@ -2,23 +2,26 @@
 
 import { Mutex, MutexInterface } from "async-mutex";
 
-// This method allows throttling of a method (typically an api call), where only
-// one call is active, and the last one which is requested while an existing call
-// is still active, is then executed after the current call completes.
-//
-// We do not need any intermediate calls to be executed, because we're using this functionality
-// with pure functions, which we simply need to execute the latest request.
-//
-// For example if all of these come in sequence very quickly, and the API call is long:
-// call() // A
-// call() // B
-// call() // C
-// call() // D
-// Call A will be executed and if it takes a long time, only Call D will be executed. Under the
-// coves, When Call B comes in, it is queued up using the mutex, but then Call C cancels Call B
-// (using mutex.cancel()), and Call C waits on the mutex, then Call D cancels Call C and waits on
-// the mutex, which is then executed when Call A releases the mutex.
-//
+/**
+ * This method allows throttling of a method (typically an API call), where only
+ * one call is active, and the last one which is requested while an existing call
+ * is still active, is then executed after the current call completes.
+ *
+ * We do not need any intermediate calls to be executed, because we're using this functionality
+ * with pure functions, which we simply need to execute the latest request.
+ *
+ * For example, if all of these come in sequence very quickly, and the API call is long:
+ *
+ * call() // A
+ * call() // B
+ * call() // C
+ * call() // D
+ *
+ * Call A will be executed and if it takes a long time, only Call D will be executed. Under the
+ * covers, when Call B comes in, it is queued up using the mutex, but then Call C cancels Call B
+ * (using mutex.cancel()), and Call C waits on the mutex, then Call D cancels Call C and waits on
+ * the mutex, which is then executed when Call A releases the mutex.
+ */
 export const throttleWithLastPending = async (
   mutex: Mutex,
   fn: () => Promise<void>,

--- a/extensions/vscode/src/utils/webviewConduit.ts
+++ b/extensions/vscode/src/utils/webviewConduit.ts
@@ -63,14 +63,11 @@ export class WebviewConduit {
   };
 
   public sendMsg = (msg: HostToWebviewMessage) => {
-    const e = JSON.stringify(msg);
+    // don't send messages if the Webview hasn't initialized yet
     if (!this.target) {
-      console.warn(
-        `Warning: WebviewConduit::sendMsg queueing up msg called before webview reference established with init(): ${e}`,
-      );
-      this.pendingMsgs.push(msg);
       return;
     }
+    const e = JSON.stringify(msg);
     this.target.postMessage(e);
   };
 }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1262,7 +1262,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   };
 
   private refreshContentRecordsMutex = new Mutex();
-  public refreshContentRecords = async () => {
+  public refreshContentRecords = () => {
     return throttleWithLastPending(
       this.refreshContentRecordsMutex,
       async () => {
@@ -1277,7 +1277,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   };
 
   private refreshConfigurationsMutex = new Mutex();
-  public refreshConfigurations = async () => {
+  public refreshConfigurations = () => {
     return throttleWithLastPending(
       this.refreshConfigurationsMutex,
       async () => {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -20,6 +20,7 @@ import {
   workspace,
 } from "vscode";
 import { isAxiosError } from "axios";
+import { Mutex } from "async-mutex";
 
 import {
   Configuration,
@@ -72,17 +73,16 @@ import { selectNewOrExistingConfig } from "src/multiStepInputs/selectNewOrExisti
 import { RPackage, RVersionConfig } from "src/api/types/packages";
 import { calculateTitle } from "src/utils/titles";
 import { ConfigWatcherManager, WatcherManager } from "src/watchers";
-import { Commands, Contexts, Views } from "src/constants";
+import { Commands, Contexts, DebounceDelaysMS, Views } from "src/constants";
 import { showProgress } from "src/utils/progress";
 import { newCredential } from "src/multiStepInputs/newCredential";
 import { PublisherState } from "src/state";
+import { throttleWithLastPending } from "src/utils/throttle";
 
 enum HomeViewInitialized {
   initialized = "initialized",
   uninitialized = "uninitialized",
 }
-
-const fileEventDebounce = 200;
 
 export class HomeViewProvider implements WebviewViewProvider, Disposable {
   private disposables: Disposable[] = [];
@@ -141,8 +141,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       "activeConfigChanged",
       (cfg: Configuration | ConfigurationError | undefined) => {
         this.sendRefreshedFilesLists();
-        this.onRefreshPythonPackages();
-        this.onRefreshRPackages();
+        this.refreshPythonPackages();
+        this.refreshRPackages();
 
         this.configWatchers?.dispose();
         if (cfg && isConfigurationError(cfg)) {
@@ -151,33 +151,33 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         this.configWatchers = new ConfigWatcherManager(cfg);
 
         this.configWatchers.configFile?.onDidChange(
-          this.sendRefreshedFilesLists,
+          this.debounceSendRefreshedFilesLists,
           this,
         );
 
         this.configWatchers.pythonPackageFile?.onDidCreate(
-          this.onRefreshPythonPackages,
+          this.debounceRefreshPythonPackages,
           this,
         );
         this.configWatchers.pythonPackageFile?.onDidChange(
-          this.onRefreshPythonPackages,
+          this.debounceRefreshPythonPackages,
           this,
         );
         this.configWatchers.pythonPackageFile?.onDidDelete(
-          this.onRefreshPythonPackages,
+          this.debounceRefreshPythonPackages,
           this,
         );
 
         this.configWatchers.rPackageFile?.onDidCreate(
-          this.onRefreshRPackages,
+          this.debounceRefreshRPackages,
           this,
         );
         this.configWatchers.rPackageFile?.onDidChange(
-          this.onRefreshRPackages,
+          this.debounceRefreshRPackages,
           this,
         );
         this.configWatchers.rPackageFile?.onDidDelete(
-          this.onRefreshRPackages,
+          this.debounceRefreshRPackages,
           this,
         );
       },
@@ -201,9 +201,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       case WebviewToHostMessageType.SAVE_SELECTION_STATE:
         return await this.onSaveSelectionState(msg);
       case WebviewToHostMessageType.REFRESH_PYTHON_PACKAGES:
-        return await this.onRefreshPythonPackages();
+        return await this.debounceRefreshPythonPackages();
       case WebviewToHostMessageType.REFRESH_R_PACKAGES:
-        return await this.onRefreshRPackages();
+        return await this.debounceRefreshRPackages();
       case WebviewToHostMessageType.VSCODE_OPEN_RELATIVE:
         return await this.onRelativeOpenVSCode(msg);
       case WebviewToHostMessageType.SCAN_PYTHON_PACKAGE_REQUIREMENTS:
@@ -213,7 +213,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       case WebviewToHostMessageType.VSCODE_OPEN:
         return await this.onVSCodeOpen(msg);
       case WebviewToHostMessageType.REQUEST_FILES_LISTS:
-        return this.sendRefreshedFilesLists();
+        return this.debounceSendRefreshedFilesLists();
       case WebviewToHostMessageType.INCLUDE_FILE:
         return this.updateFileList(msg.content.path, FileAction.INCLUDE);
       case WebviewToHostMessageType.EXCLUDE_FILE:
@@ -474,7 +474,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     );
   }
 
-  private async onRefreshPythonPackages() {
+  public debounceRefreshPythonPackages = debounce(
+    this.refreshPythonPackages,
+    DebounceDelaysMS.refreshPythonPackages,
+  );
+
+  private async refreshPythonPackages() {
     const activeConfiguration = await this.state.getSelectedConfiguration();
     let pythonProject = true;
     let packages: string[] = [];
@@ -516,7 +521,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
             pythonProject = false;
           } else {
             const summary = getSummaryStringFromError(
-              "homeView::onRefreshPythonPackages",
+              "homeView::refreshPythonPackages",
               error,
             );
             window.showInformationMessage(summary);
@@ -536,7 +541,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     });
   }
 
-  private async onRefreshRPackages() {
+  public debounceRefreshRPackages = debounce(
+    this.refreshRPackages,
+    DebounceDelaysMS.refreshRPackages,
+  );
+
+  private async refreshRPackages() {
     const activeConfiguration = await this.state.getSelectedConfiguration();
     let rProject = true;
     let packages: RPackage[] = [];
@@ -579,7 +589,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
             rProject = false;
           } else {
             const summary = getSummaryStringFromError(
-              "homeView::onRefreshRPackages",
+              "homeView::refreshRPackages",
               error,
             );
             window.showInformationMessage(summary);
@@ -1249,21 +1259,33 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
   };
 
+  private refreshContentRecordsMutex = new Mutex();
   public refreshContentRecords = async () => {
-    await this.refreshContentRecordData();
-    this.updateWebViewViewContentRecords();
-    useBus().trigger(
-      "activeContentRecordChanged",
-      await this.state.getSelectedContentRecord(),
+    return throttleWithLastPending(
+      this.refreshContentRecordsMutex,
+      async () => {
+        await this.refreshContentRecordData();
+        this.updateWebViewViewContentRecords();
+        useBus().trigger(
+          "activeContentRecordChanged",
+          await this.state.getSelectedContentRecord(),
+        );
+      },
     );
   };
 
+  private refreshConfigurationsMutex = new Mutex();
   public refreshConfigurations = async () => {
-    await this.refreshConfigurationData();
-    this.updateWebViewViewConfigurations();
-    useBus().trigger(
-      "activeConfigChanged",
-      await this.state.getSelectedConfiguration(),
+    return throttleWithLastPending(
+      this.refreshConfigurationsMutex,
+      async () => {
+        await this.refreshConfigurationData();
+        this.updateWebViewViewConfigurations();
+        useBus().trigger(
+          "activeConfigChanged",
+          await this.state.getSelectedConfiguration(),
+        );
+      },
     );
   };
 
@@ -1296,6 +1318,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       }
     }
   };
+
+  public debounceSendRefreshedFilesLists = debounce(async () => {
+    return await this.sendRefreshedFilesLists();
+  }, DebounceDelaysMS.file);
 
   public initiatePublish(target: PublishProcessParams) {
     this.initiateDeployment(
@@ -1608,7 +1634,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       ),
       commands.registerCommand(
         Commands.PythonPackages.Refresh,
-        this.onRefreshPythonPackages,
+        this.refreshPythonPackages,
         this,
       ),
       commands.registerCommand(
@@ -1637,7 +1663,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       ),
       commands.registerCommand(
         Commands.RPackages.Refresh,
-        this.onRefreshRPackages,
+        this.refreshRPackages,
         this,
       ),
       commands.registerCommand(
@@ -1647,6 +1673,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       ),
     );
 
+    // directories
     watchers.positDir?.onDidDelete(() => {
       this.refreshContentRecords();
       this.refreshConfigurations();
@@ -1657,19 +1684,18 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }, this);
     watchers.contentRecordsDir?.onDidDelete(this.refreshContentRecords, this);
 
+    // configurations
     watchers.configurations?.onDidCreate(this.refreshConfigurations, this);
-    watchers.configurations?.onDidDelete(this.refreshConfigurations, this);
     watchers.configurations?.onDidChange(this.refreshConfigurations, this);
+    watchers.configurations?.onDidDelete(this.refreshConfigurations, this);
 
+    // content records
     watchers.contentRecords?.onDidCreate(this.refreshContentRecords, this);
-    watchers.contentRecords?.onDidDelete(this.refreshContentRecords, this);
     watchers.contentRecords?.onDidChange(this.refreshContentRecords, this);
+    watchers.contentRecords?.onDidDelete(this.refreshContentRecords, this);
 
-    const fileEventCallback = debounce(
-      this.sendRefreshedFilesLists,
-      fileEventDebounce,
-    );
-    watchers.allFiles?.onDidCreate(fileEventCallback, this);
-    watchers.allFiles?.onDidDelete(fileEventCallback, this);
+    // all files
+    watchers.allFiles?.onDidCreate(this.debounceSendRefreshedFilesLists, this);
+    watchers.allFiles?.onDidDelete(this.debounceSendRefreshedFilesLists, this);
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #1970 
Resolves #2107 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The existing codebase had a basic throttling implementation for a few API calls. This PR built upon that as well as adding a throttling capability for our recursive calls in which we only wanted one outstanding call at a time, but we also didn't want to lose the latest initiated call.

For the most part, the APIs being initiated in the background by the file watchers were debounced, while the APIs being initiated off of user action were not.

Different debounce intervals were evaluated, with an eye for minimizing user visual impact while making a significant reduction in calls. I evaluated in the range of 100ms - 1 second and ended up settling on the 1 second as being optimal.

Care was also focused on making sure configuration changes would be shown as quickly as possible in the UX. We have some room for future improvement in this area, as we probably want to update the UX ahead of the response coming back from the agent, so that the interface will be as responsive as possible.

API call volume was collected from the agent logs and I used a consistent testing environment with the same operations which simulated independent operations on active project directories. Specifically, within a python project, I created and populated a virtual environment as well as removed it. 

**volume of API calls being made to the agent when `pip install` was being executed:**
**Prior to my change**
```
time=2024-08-14T17:23:48.804-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55335
time=2024-08-14T17:23:48.913-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55337
time=2024-08-14T17:23:48.914-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55336
time=2024-08-14T17:23:49.007-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55338
time=2024-08-14T17:23:49.007-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55339
time=2024-08-14T17:23:49.161-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55340
time=2024-08-14T17:23:49.161-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55341
time=2024-08-14T17:23:49.274-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55343
time=2024-08-14T17:23:49.275-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=9 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55342
time=2024-08-14T17:23:49.426-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55344
time=2024-08-14T17:23:49.426-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55345
time=2024-08-14T17:23:49.549-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55346
time=2024-08-14T17:23:49.549-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55347
time=2024-08-14T17:23:51.115-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55348
time=2024-08-14T17:23:51.724-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55349
time=2024-08-14T17:23:51.869-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55350
time=2024-08-14T17:23:52.268-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=9 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55352
time=2024-08-14T17:23:52.268-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=9 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55351
time=2024-08-14T17:23:52.412-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55353
time=2024-08-14T17:23:52.759-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=9 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55355
time=2024-08-14T17:23:52.759-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=9 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55354
time=2024-08-14T17:23:52.904-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55356
time=2024-08-14T17:23:53.248-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=10 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55358
time=2024-08-14T17:23:53.248-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=10 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55357
time=2024-08-14T17:23:53.387-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55359
time=2024-08-14T17:23:56.557-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55361
time=2024-08-14T17:23:57.165-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55362
time=2024-08-14T17:23:57.336-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=7 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55363
time=2024-08-14T17:23:57.657-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55364
time=2024-08-14T17:23:57.831-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55365
time=2024-08-14T17:23:58.153-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55366
time=2024-08-14T17:23:58.324-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55367
time=2024-08-14T17:23:58.680-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=10 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55369
time=2024-08-14T17:23:58.681-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=10 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55368
time=2024-08-14T17:23:58.820-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55370
time=2024-08-14T17:23:58.946-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=8 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55371
time=2024-08-14T17:23:58.947-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=9 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55372
```
**After my changes***
```
time=2024-08-15T16:40:51.752-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=25 status=200 req_size=0 resp_size=137960 client_addr=127.0.0.1:58771
time=2024-08-15T16:40:55.746-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=29 status=200 req_size=0 resp_size=137960 client_addr=127.0.0.1:58772
time=2024-08-15T16:41:02.907-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=39 status=200 req_size=0 resp_size=137960 client_addr=127.0.0.1:58774
```

**The API calls when I removed the `.venv` directory:**
**Before**
```
time=2024-08-14T17:26:11.212-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=546 status=200 req_size=0 resp_size=4578785 client_addr=127.0.0.1:55480
time=2024-08-14T17:26:11.640-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=404 status=200 req_size=0 resp_size=3372273 client_addr=127.0.0.1:55481
time=2024-08-14T17:26:11.984-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=300 status=200 req_size=0 resp_size=2475574 client_addr=127.0.0.1:55482
time=2024-08-14T17:26:12.362-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=164 status=200 req_size=0 resp_size=1407252 client_addr=127.0.0.1:55485
time=2024-08-14T17:26:12.790-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=74 status=200 req_size=0 resp_size=392530 client_addr=127.0.0.1:55486
time=2024-08-14T17:26:13.116-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=5 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55487
```
**and after:**
```
time=2024-08-14T17:31:19.774-07:00 level=INFO msg="Access Log" method=GET url="/api/configurations/configuration-1/files?dir=stock-api-fastapi" elapsed_ms=6 status=200 req_size=0 resp_size=8161 client_addr=127.0.0.1:55679
```

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

Regress functionality for large and small project directories and confirm functionality still works.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
