### PR TITLE
Remove (and enforce) use of await expression when not needed

### DIFF
--- a/extensions/vscode/.eslintrc.json
+++ b/extensions/vscode/.eslintrc.json
@@ -26,7 +26,8 @@
     "curly": "warn",
     "eqeqeq": "warn",
     "no-throw-literal": "warn",
-    "semi": "off"
+    "semi": "off",
+    "require-await": "error"
   },
   "ignorePatterns": ["out", "dist", "**/*.d.ts", "api"]
 }

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -16,8 +16,6 @@ export const create = async (
   return [executable, [subcommand, "-vv", `--listen=${HOST}:${port}`, path]];
 };
 
-const getExecutableBinary = async (
-  context: ExtensionContext,
-): Promise<string> => {
+const getExecutableBinary = (context: ExtensionContext): string => {
   return path.join(context.extensionPath, "bin", "publisher");
 };

--- a/extensions/vscode/src/dialogs.ts
+++ b/extensions/vscode/src/dialogs.ts
@@ -40,27 +40,27 @@ async function confirm(
   return choice === affirmativeItem;
 }
 
-export async function confirmOK(message: string): Promise<boolean> {
+export function confirmOK(message: string): Promise<boolean> {
   return confirm(message, okItem);
 }
 
-export async function confirmYes(message: string): Promise<boolean> {
+export function confirmYes(message: string): Promise<boolean> {
   return confirm(message, yesItem);
 }
 
-export async function confirmDelete(message: string): Promise<boolean> {
+export function confirmDelete(message: string): Promise<boolean> {
   return confirm(message, deleteItem);
 }
 
-export async function confirmForget(message: string): Promise<boolean> {
+export function confirmForget(message: string): Promise<boolean> {
   return confirm(message, forgetItem);
 }
 
-export async function confirmReplace(message: string): Promise<boolean> {
+export function confirmReplace(message: string): Promise<boolean> {
   return confirm(message, replaceItem);
 }
 
-export async function confirmOverwrite(message: string): Promise<boolean> {
+export function confirmOverwrite(message: string): Promise<boolean> {
   return confirm(message, overwriteItem);
 }
 

--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -82,7 +82,7 @@ interface InputBoxParameters {
 
 export class MultiStepInput {
   // These were templatized: static async run<T>(start: InputStep) {
-  static async run(start: InputStep) {
+  static run(start: InputStep) {
     const input = new MultiStepInput();
     return input.stepThrough(start);
   }

--- a/extensions/vscode/src/ports.ts
+++ b/extensions/vscode/src/ports.ts
@@ -2,6 +2,6 @@
 
 import getPort = require("get-port");
 
-export const acquire = async (): Promise<number> => {
+export const acquire = (): Promise<number> => {
   return getPort();
 };

--- a/extensions/vscode/src/servers.ts
+++ b/extensions/vscode/src/servers.ts
@@ -92,9 +92,9 @@ export class Server implements Disposable {
    * @returns {Promise<boolean>} A Promise that resolves to `true` if the server is up, and rejects if all attempts fail.
    * @throws {Error} Will throw an error if the connection check encounters an error or reaches the maximum number of retries.
    */
-  async isUp(): Promise<boolean> {
+  isUp(): Promise<boolean> {
     const operation = retry.operation();
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // Attempt the operation with exponential backoff
       operation.attempt(async (attempt) => {
         try {
@@ -122,9 +122,9 @@ export class Server implements Disposable {
    * @returns {Promise<boolean>} A Promise that resolves to `true` if the server is down, and rejects if all attempts fail.
    * @throws {Error} Will throw an error if the connection check encounters an error (excluding ECONNREFUSED) or reaches the maximum number of retries.
    */
-  async isDown(): Promise<boolean> {
+  isDown(): Promise<boolean> {
     const operation = retry.operation();
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // Attempt the operation with exponential backoff
       operation.attempt(async (attempt) => {
         try {
@@ -172,7 +172,7 @@ export class Server implements Disposable {
    * @returns {Promise<boolean>} A Promise that resolves to `true` if the server is reachable within the timeout, resolves to `false` if the connection times out, and rejects if an error occurs.
    * @throws {Error} Will throw an error if the connection encounters an error or is closed with an error.
    */
-  private async check(timeout: number = 1000): Promise<boolean> {
+  private check(timeout: number = 1000): Promise<boolean> {
     return new Promise((resolve, reject) => {
       // Create a new socket
       const socket = new net.Socket();

--- a/extensions/vscode/src/test/suite/extension.test.ts
+++ b/extensions/vscode/src/test/suite/extension.test.ts
@@ -5,8 +5,8 @@ import { Extension, extensions } from "vscode";
 
 // import * as myExtension from '../../extension';
 
-suite("Extension Test Suite", async () => {
-  test("extension is registered", async () => {
+suite("Extension Test Suite", () => {
+  test("extension is registered", () => {
     const extension: Extension<any> =
       extensions.getExtension("posit.publisher")!;
     assert.ok(extension !== undefined);

--- a/extensions/vscode/src/utils/names.ts
+++ b/extensions/vscode/src/utils/names.ts
@@ -68,7 +68,7 @@ export function contentRecordNameValidator(
   contentRecordNames: string[],
   currentName: string,
 ) {
-  return async (value: string) => {
+  return (value: string) => {
     const isUnique =
       value === currentName ||
       uniqueContentRecordName(value, contentRecordNames);

--- a/extensions/vscode/src/utils/progress.ts
+++ b/extensions/vscode/src/utils/progress.ts
@@ -14,7 +14,7 @@ export async function showProgress(
       title,
       location: viewId ? { viewId } : ProgressLocation.Window,
     },
-    async () => {
+    () => {
       return until;
     },
   );

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -257,8 +257,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
   }
 
-  private async onDeployMsg(msg: DeployMsg) {
-    this.initiateDeployment(
+  private onDeployMsg(msg: DeployMsg) {
+    return this.initiateDeployment(
       msg.content.deploymentName,
       msg.content.credentialName,
       msg.content.configurationName,
@@ -727,7 +727,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
   }
 
-  private async propagateDeploymentSelection(
+  private propagateDeploymentSelection(
     deploymentSelector: DeploymentSelector | null,
   ) {
     // We have to break our protocol and go ahead and write this into storage,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves: #2124 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

ESLint rule was added and code was cleaned up. In each case where the await was removed, I looked at all existing callers and made sure they were using `await` or not, properly.

The errors reported by ESLint, once I added the rule and ran `npm run lint` were:
```
~/dev/publishing-client/extensions/vscode main > npm run lint

> publisher@99.0.0 lint
> eslint src --ext ts --max-warnings 0


/Users/billsager/dev/publishing-client/extensions/vscode/src/commands.ts
  21:20  error  Async arrow function has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/dialogs.ts
  43:8  error  Async function 'confirmOK' has no 'await' expression         require-await
  47:8  error  Async function 'confirmYes' has no 'await' expression        require-await
  51:8  error  Async function 'confirmDelete' has no 'await' expression     require-await
  55:8  error  Async function 'confirmForget' has no 'await' expression     require-await
  59:8  error  Async function 'confirmReplace' has no 'await' expression    require-await
  63:8  error  Async function 'confirmOverwrite' has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
  85:3  error  Static async method 'run' has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/ports.ts
  5:50  error  Async arrow function has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/servers.ts
   95:3   error  Async method 'isUp' has no 'await' expression    require-await
   97:48  error  Async arrow function has no 'await' expression   require-await
  125:3   error  Async method 'isDown' has no 'await' expression  require-await
  127:48  error  Async arrow function has no 'await' expression   require-await
  175:3   error  Async method 'check' has no 'await' expression   require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/test/suite/extension.test.ts
  8:40  error  Async arrow function has no 'await' expression  require-await
  9:44  error  Async arrow function has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/utils/names.ts
  71:32  error  Async arrow function has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/utils/progress.ts
  17:14  error  Async arrow function has no 'await' expression  require-await

/Users/billsager/dev/publishing-client/extensions/vscode/src/views/homeView.ts
  260:3  error  Async method 'onDeployMsg' has no 'await' expression                   require-await
  730:3  error  Async method 'propagateDeploymentSelection' has no 'await' expression  require-await

✖ 20 problems (20 errors, 0 warnings)
```

ESBuild reported this failure for the webview, which was cleaned up:
```
debug: > project-selector-web-view-view@0.0.1 build
debug: > vue-tsc --noEmit && vite build
debug: 
debug: src/components/views/ProjectFiles.vue(31,11): error TS2322: Type 'Promise<string>' is not assignable to type 'string'.
 ERROR  npm failed with exit code 2
```

Simple regression plus CI tests should be enough to verify.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
