### PR TITLE
Set logs URL immediately upon deployment

### DIFF
--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -106,7 +106,7 @@ func FromFile(path util.AbsolutePath) (*Deployment, error) {
 	}
 	if d.LogsURL == "" && d.DashboardURL != "" {
 		// Migration
-		d.LogsURL = d.DashboardURL + "/logs"
+		d.LogsURL = util.URLJoin(d.DashboardURL, "logs")
 	}
 	return d, nil
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -268,6 +268,7 @@ func (p *defaultPublisher) createDeploymentRecord(
 		BundleID:      "",
 		DashboardURL:  getDashboardURL(p.Account.URL, contentID),
 		DirectURL:     getDirectURL(p.Account.URL, contentID),
+		LogsURL:       getLogsURL(p.Account.URL, contentID),
 		Error:         nil,
 	}
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -335,6 +335,10 @@ func (s *PublishSuite) publishWithClient(
 		if couldCreateDeployment {
 			logs := s.logBuffer.String()
 			s.Contains(logs, "content_id="+myContentID)
+			s.Equal("https://connect.example.com/connect/#/apps/myContentID", record.DashboardURL)
+			s.Equal("https://connect.example.com/content/myContentID/", record.DirectURL)
+			s.Equal("https://connect.example.com/connect/#/apps/myContentID/logs", record.LogsURL)
+
 			// Files are written after upload.
 			if uploadErr == nil {
 				s.Contains(record.Files, "app.py")
@@ -405,6 +409,7 @@ func (s *PublishSuite) TestEmitErrorEventsWithTarget() {
 		s.Equal(expectedErr.Error(), event.Data["message"])
 		s.Equal(getDashboardURL("connect.example.com", targetID), event.Data["dashboardUrl"])
 		s.Equal(getDirectURL("connect.example.com", targetID), event.Data["url"])
+		s.Equal(getLogsURL("connect.example.com", targetID), event.Data["logsUrl"])
 	}
 	s.Equal("publish/failure", emitter.Events[1].Type)
 }
@@ -417,6 +422,11 @@ func (s *PublishSuite) TestGetDashboardURL() {
 func (s *PublishSuite) TestGetDirectURL() {
 	expected := "https://connect.example.com:1234/content/d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f/"
 	s.Equal(expected, getDirectURL("https://connect.example.com:1234", "d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f"))
+}
+
+func (s *PublishSuite) TestGetLogsURL() {
+	expected := "https://connect.example.com:1234/connect/#/apps/d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f/logs"
+	s.Equal(expected, getLogsURL("https://connect.example.com:1234", "d0e5c94a-d37f-4f26-bfc5-515c4c5ea50f"))
 }
 
 func (s *PublishSuite) TestLogAppInfo() {

--- a/internal/schema/schemas/draft/posit-publishing-record-schema-v3.json
+++ b/internal/schema/schemas/draft/posit-publishing-record-schema-v3.json
@@ -108,6 +108,14 @@
         "https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/"
       ]
     },
+    "logs_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to the logs for this deployment in the Connect dashboard.",
+      "examples": [
+        "https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs"
+      ]
+    },
     "deployment_error": {
       "type": "object",
       "description": "Error from the deployment operation. Will be omitted if no error occurred.",

--- a/internal/schema/schemas/draft/record.toml
+++ b/internal/schema/schemas/draft/record.toml
@@ -10,6 +10,7 @@ bundle_id = '123'
 bundle_url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
 dashboard_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/'
 direct_url = 'https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/'
+logs_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs'
 
 [configuration]
 "$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"

--- a/internal/schema/schemas/posit-publishing-record-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-record-schema-v3.json
@@ -108,6 +108,14 @@
         "https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/"
       ]
     },
+    "logs_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to the logs for this deployment in the Connect dashboard.",
+      "examples": [
+        "https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs"
+      ]
+    },
     "deployment_error": {
       "type": "object",
       "description": "Error from the deployment operation. Will be omitted if no error occurred.",

--- a/internal/schema/schemas/record.toml
+++ b/internal/schema/schemas/record.toml
@@ -10,6 +10,7 @@ bundle_id = '123'
 bundle_url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
 dashboard_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749'
 direct_url = 'https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/'
+logs_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs'
 
 [configuration]
 "$schema" = "https://cdn.posit.co/publisher/schemas/posit-publishing-schema-v3.json"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

#2099 added a new `logs_url` field to the content record TOML. This PR ensures that it is set on deployment (a case missed in the original PR), and updates the jsonschema for the content records so the new deployment records can be validated.

A schema update on the CDN will be needed when this PR merges.

Fixes #2133

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added test assertions for the new field.

## Directions for Reviewers

Create a deployment, open the deployment file, and then click Deploy. You should see the `logs_url` populated as soon as the Connect content item is created.

The TOML extension will continue to show that as an undefined field until the new schema is pushed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
