### PR TITLE
Make vscode context in ActionToolbar more readable

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/ActionToolbar.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ActionToolbar.vue
@@ -25,7 +25,7 @@
       <li
         v-if="contextMenu"
         ref="contextMenuButton"
-        :data-vscode-context="`{&quot;webviewSection&quot;: &quot;${contextMenu}&quot;, &quot;preventDefaultContextMenuItems&quot;: true}`"
+        :data-vscode-context="vscodeContext"
         class="action-item menu-entry"
         role="presentation"
       >
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 export type ActionButton = {
   label: string;
@@ -53,7 +53,7 @@ export type ActionButton = {
   fn: () => void;
 };
 
-defineProps<{
+const props = defineProps<{
   title: string;
   actions?: ActionButton[];
   contextMenu?: string;
@@ -80,6 +80,17 @@ const openContextMenu = (e: Event) => {
     );
   }
 };
+
+const vscodeContext = computed(() => {
+  if (!props.contextMenu) {
+    return undefined;
+  }
+
+  return JSON.stringify({
+    webviewSection: props.contextMenu,
+    preventDefaultContextMenuItems: true,
+  });
+});
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
A small refactor to make the `ActionToolbar` `data-vscode-context` more readable. 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

Test out the `EvenEasierDeploy` more menu (`...`) - this is the only spot that `ActionToolbar` receives a Context Menu.