### PR TITLE
Remove some throws which were left in the web view

### DIFF
--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -38,9 +38,10 @@ export function useHostConduitService() {
 
   const sendMsg = (msg: WebviewToHostMessage) => {
     if (!hostConduit) {
-      throw new Error(
-        "HostCondiutService::sendMsg attemped ahead of call to useHostConduitService",
+      console.error(
+        `HostCondiutService::sendMsg attempted ahead of call to useHostConduitService. Message Dropped: ${JSON.stringify(msg)}`,
       );
+      return;
     }
     console.debug(`HostConduitService - Sending Msg: ${JSON.stringify(msg)}`);
     return hostConduit.sendMsg(msg);

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -39,9 +39,10 @@ const deploy = () => {
     !home.selectedConfiguration ||
     !home.serverCredential
   ) {
-    throw new Error(
-      "DeployButton::deploy trying to send message with undefined values",
+    console.error(
+      "DeployButton::deploy trying to send message with undefined values. Action ignored.",
     );
+    return;
   }
 
   hostConduit.sendMsg({

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -141,7 +141,24 @@
         >
           <span class="codicon codicon-error error-icon"></span>
           <span class="error-message">
-            Error: {{ home.selectedContentRecord.deploymentError.msg }}
+            <span v-if="showEditLink" class="error-message">
+              Error: {{ errorMessageSplit[0] }}
+              <a
+                class="webview-link"
+                role="button"
+                @click="
+                  onEditConfiguration(
+                    home.selectedConfiguration!.configurationPath,
+                  )
+                "
+              >
+                {{ editingSplitStr }}
+              </a>
+              {{ errorMessageSplit[1] }}
+            </span>
+            <span v-else class="error-message">
+              Error: {{ home.selectedContentRecord.deploymentError.msg }}
+            </span>
           </span>
         </div>
         <div
@@ -189,6 +206,9 @@ import { filterConfigurationsToValidAndType } from "../../../../src/utils/filter
 
 const home = useHomeStore();
 const hostConduit = useHostConduitService();
+
+const editingSplitStr = "editing";
+const editConfigFileDetectionStr = "editing your configuration file";
 
 const toolbarActions = computed(() => {
   const result = [];
@@ -347,6 +367,20 @@ const toolTipText = computed(() => {
 - Credential In Use: ${home.serverCredential?.name || "<undefined>"}
 - Project Dir: ${home.selectedContentRecord?.projectDir || "<undefined>"}
 - Server URL: ${home.serverCredential?.url || "<undefined>"}`;
+});
+
+const showEditLink = computed(() => {
+  return home.selectedContentRecord?.deploymentError?.msg.includes(
+    editConfigFileDetectionStr,
+  );
+});
+const errorMessageSplit = computed(() => {
+  const errorSplitResult =
+    home.selectedContentRecord?.deploymentError?.msg.split(editingSplitStr);
+  if (errorSplitResult?.length === 2) {
+    return errorSplitResult;
+  }
+  return ["", ""];
 });
 
 const navigateToUrl = (url: string) => {

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -141,24 +141,7 @@
         >
           <span class="codicon codicon-error error-icon"></span>
           <span class="error-message">
-            <span v-if="showEditLink" class="error-message">
-              Error: {{ errorMessageSplit[0] }}
-              <a
-                class="webview-link"
-                role="button"
-                @click="
-                  onEditConfiguration(
-                    home.selectedConfiguration!.configurationPath,
-                  )
-                "
-              >
-                {{ editingSplitStr }}
-              </a>
-              {{ errorMessageSplit[1] }}
-            </span>
-            <span v-else class="error-message">
-              Error: {{ home.selectedContentRecord.deploymentError.msg }}
-            </span>
+            Error: {{ home.selectedContentRecord.deploymentError.msg }}
           </span>
         </div>
         <div
@@ -206,9 +189,6 @@ import { filterConfigurationsToValidAndType } from "../../../../src/utils/filter
 
 const home = useHomeStore();
 const hostConduit = useHostConduitService();
-
-const editingSplitStr = "editing";
-const editConfigFileDetectionStr = "editing your configuration file";
 
 const toolbarActions = computed(() => {
   const result = [];
@@ -367,20 +347,6 @@ const toolTipText = computed(() => {
 - Credential In Use: ${home.serverCredential?.name || "<undefined>"}
 - Project Dir: ${home.selectedContentRecord?.projectDir || "<undefined>"}
 - Server URL: ${home.serverCredential?.url || "<undefined>"}`;
-});
-
-const showEditLink = computed(() => {
-  return home.selectedContentRecord?.deploymentError?.msg.includes(
-    editConfigFileDetectionStr,
-  );
-});
-const errorMessageSplit = computed(() => {
-  const errorSplitResult =
-    home.selectedContentRecord?.deploymentError?.msg.split(editingSplitStr);
-  if (errorSplitResult?.length === 2) {
-    return errorSplitResult;
-  }
-  return ["", ""];
 });
 
 const navigateToUrl = (url: string) => {

--- a/extensions/vscode/webviews/homeView/src/utils/hostConduit.ts
+++ b/extensions/vscode/webviews/homeView/src/utils/hostConduit.ts
@@ -23,7 +23,10 @@ export class HostConduit {
       if (isHostToWebviewMessage(obj)) {
         this.externalMsgCB(obj);
       } else {
-        throw new Error(`NonConduitMessage Received: ${JSON.stringify(e)}`);
+        console.error(
+          `HostConduit::rawMsgCB, NonConduitMessage Received: ${JSON.stringify(e)}`,
+        );
+        return;
       }
     }
   };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

@dotNomad is looking into why we aren't applying the linting rules to the webview, but these came up because VSCode does (and we want it to).

This PR contains quick fixes to remove those throws.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

In these cases, I simply output a console error and abort processing the function call. These conditions are all "assert-like" catches for us, so this approach should work fine.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Just a quick regression should be fine.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
