### PR TITLE
Enable command URIs and remove view log message

### DIFF
--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -24,7 +24,6 @@ export enum WebviewToHostMessageType {
   NEW_DEPLOYMENT = "newDeployment",
   NEW_CREDENTIAL_FOR_DEPLOYMENT = "newCredentialForDeployment",
   NEW_CREDENTIAL = "newCredential",
-  VIEW_PUBLISHING_LOG = "viewPublishingLog",
 }
 
 export type AnyWebviewToHostMessage<
@@ -57,8 +56,7 @@ export type WebviewToHostMessage =
   | SelectDeploymentMsg
   | NewDeploymentMsg
   | NewCredentialForDeploymentMsg
-  | NewCredentialMsg
-  | ViewPublishingLog;
+  | NewCredentialMsg;
 
 export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
   return (
@@ -81,8 +79,7 @@ export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
     msg.kind === WebviewToHostMessageType.SELECT_DEPLOYMENT ||
     msg.kind === WebviewToHostMessageType.NEW_DEPLOYMENT ||
     msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL_FOR_DEPLOYMENT ||
-    msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL ||
-    msg.kind === WebviewToHostMessageType.VIEW_PUBLISHING_LOG
+    msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL
   );
 }
 
@@ -180,6 +177,3 @@ export type NewCredentialForDeploymentMsg =
 
 export type NewCredentialMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.NEW_CREDENTIAL>;
-
-export type ViewPublishingLog =
-  AnyWebviewToHostMessage<WebviewToHostMessageType.VIEW_PUBLISHING_LOG>;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -223,8 +223,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         return this.showNewCredentialForDeployment();
       case WebviewToHostMessageType.NEW_CREDENTIAL:
         return this.showNewCredential();
-      case WebviewToHostMessageType.VIEW_PUBLISHING_LOG:
-        return this.showPublishingLog();
       default:
         window.showErrorMessage(
           `Internal Error: onConduitMessage unhandled msg: ${JSON.stringify(msg)}`,
@@ -964,10 +962,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     useBus().trigger("refreshCredentials", undefined);
   };
 
-  private showPublishingLog() {
-    return commands.executeCommand(Commands.Logs.Focus);
-  }
-
   private async showDeploymentQuickPick(
     contentRecordsSubset?: AllContentRecordTypes[],
     projectDir?: string,
@@ -1182,6 +1176,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     webviewView.webview.options = {
       // Enable JavaScript in the webview
       enableScripts: true,
+      // Enable command URIs as links to execute commands
+      enableCommandUris: true,
       // Restrict the webview to only load resources from these directories
       localResourceRoots: [
         Uri.joinPath(this.extensionUri, "dist"),

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -105,7 +105,7 @@
                 <a
                   class="webview-link"
                   role="button"
-                  @click="onViewPublishingLog"
+                  :href="`command:${Commands.Logs.Focus}`"
                   >View Log</a
                 >
               </p>
@@ -178,6 +178,7 @@ import {
 } from "../../../../src/api";
 import { WebviewToHostMessageType } from "../../../../src/types/messages/webviewToHostMessages";
 import { calculateTitle } from "../../../../src/utils/titles";
+import { Commands } from "../../../../src/constants";
 
 import { useHostConduitService } from "src/HostConduitService";
 import { useHomeStore } from "src/stores/home";
@@ -227,12 +228,6 @@ const onEditConfiguration = (fullPath: string) => {
     content: {
       configurationPath: fullPath,
     },
-  });
-};
-
-const onViewPublishingLog = () => {
-  hostConduit.sendMsg({
-    kind: WebviewToHostMessageType.VIEW_PUBLISHING_LOG,
   });
 };
 


### PR DESCRIPTION
This is a change to use `enableCommandUris` in our webview to use `href` commands to run registered commands in VSCode.

This allows us to remove messages when the messages were only running VSCode commands.

Some helpful documentation and references:
- https://code.visualstudio.com/api/extension-guides/command
- https://code.visualstudio.com/api/extension-guides/command
- https://www.eliostruyf.com/command-uri-vscode-webview-open-files-links/

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->