### PR TITLE
Default included files to the relative root dir

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -324,7 +324,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const api = await useApi();
       const apiRequest = api.files.updateFileList(
         activeConfig.configurationName,
-        uri,
+        `/${uri}`,
         action,
         activeConfig.projectDir,
       );

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -133,7 +133,7 @@ func normalizeConfig(
 	// The inspector may populate the file list.
 	// If it doesn't, default to just the entrypoint file.
 	if len(cfg.Files) == 0 {
-		cfg.Files = []string{cfg.Entrypoint}
+		cfg.Files = []string{fmt.Sprint("/", cfg.Entrypoint)}
 	}
 	needPython, err := requiresPython(cfg, base)
 	if err != nil {
@@ -146,7 +146,7 @@ func normalizeConfig(
 			return err
 		}
 		cfg.Python = pyConfig
-		cfg.Files = append(cfg.Files, cfg.Python.PackageFile)
+		cfg.Files = append(cfg.Files, fmt.Sprint("/", cfg.Python.PackageFile))
 	}
 	needR, err := requiresR(cfg, base, rExecutable)
 	if err != nil {
@@ -159,7 +159,7 @@ func normalizeConfig(
 			return err
 		}
 		cfg.R = rConfig
-		cfg.Files = append(cfg.Files, cfg.R.PackageFile)
+		cfg.Files = append(cfg.Files, fmt.Sprint("/", cfg.R.PackageFile))
 	}
 	cfg.Comments = strings.Split(initialComment, "\n")
 

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -170,7 +170,7 @@ func (s *InitializeSuite) TestGetPossibleConfigs() {
 	s.Len(configs, 2)
 	s.Equal(config.ContentTypePythonFlask, configs[0].Type)
 	s.Equal("app.py", configs[0].Entrypoint)
-	s.Equal([]string{"app.py", "requirements.txt"}, configs[0].Files)
+	s.Equal([]string{"/app.py", "/requirements.txt"}, configs[0].Files)
 	s.Equal(expectedPyConfig, configs[0].Python)
 
 	s.Equal(config.ContentTypeHTML, configs[1].Type)


### PR DESCRIPTION
This PR changes two things:
- when include or excluding a file in the extension UI a `/` is prepended to the file URI when it is sent to the API
- when a file is included in the created Configuration a `/` is prepended to them

This restricts the include to only the directory and _not_ its subdirectories avoiding some confusion when using the Project Files view.

## Intent

Resolves #2159

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

Ensure newly created Configurations work as expected
Ensure that the include and exclude actions in the Project Files view work as expected