### PR TITLE
Use titles to name configuration files in addition to short hash

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.7.4",
         "debounce": "^2.1.0",
         "eventsource": "^2.0.2",
+        "filenamify": "^6.0.0",
         "get-port": "5.1.1",
         "mutexify": "^1.4.0",
         "retry": "^0.13.1",
@@ -2185,6 +2186,31 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -497,6 +497,7 @@
     "test": "npm run compile && node ./out/test/runTest.js"
   },
   "devDependencies": {
+    "@twbs/fantasticon": "^3.0.0",
     "@types/eventsource": "^1.1.15",
     "@types/mocha": "^10.0.2",
     "@types/mutexify": "^1.2.3",
@@ -510,7 +511,6 @@
     "esbuild": "^0.21.4",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^9.1.0",
-    "@twbs/fantasticon": "^3.0.0",
     "glob": "^10.3.3",
     "mocha": "^10.2.0",
     "typescript": "^5.2.2"
@@ -522,6 +522,7 @@
     "axios": "^1.7.4",
     "debounce": "^2.1.0",
     "eventsource": "^2.0.2",
+    "filenamify": "^6.0.0",
     "get-port": "5.1.1",
     "mutexify": "^1.4.0",
     "retry": "^0.13.1",

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -1290,7 +1290,11 @@ export async function newDeployment(
   selectedInspectionResult.configuration.title = state.data.title;
 
   try {
-    configName = newConfigFileNameFromTitle(state.data.title);
+    const existingNames = (
+      await api.configurations.getAll(selectedInspectionResult.projectDir)
+    ).data.map((config) => config.configurationName);
+
+    configName = newConfigFileNameFromTitle(state.data.title, existingNames);
     const createResponse = await api.configurations.createOrUpdate(
       configName,
       selectedInspectionResult.configuration,

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -34,7 +34,7 @@ import {
   getSummaryStringFromError,
 } from "src/utils/errors";
 import {
-  untitledConfigurationName,
+  newConfigFileNameFromTitle,
   untitledContentRecordName,
 } from "src/utils/names";
 import { formatURL, normalizeURL } from "src/utils/url";
@@ -1290,9 +1290,7 @@ export async function newDeployment(
   selectedInspectionResult.configuration.title = state.data.title;
 
   try {
-    configName = await untitledConfigurationName(
-      selectedInspectionResult.projectDir,
-    );
+    configName = newConfigFileNameFromTitle(state.data.title);
     const createResponse = await api.configurations.createOrUpdate(
       configName,
       selectedInspectionResult.configuration,

--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -436,7 +436,15 @@ export async function selectNewOrExistingConfig(
         );
         return;
       }
-      const configName = newConfigFileNameFromTitle(state.data.title);
+
+      const existingNames = (
+        await api.configurations.getAll(selectedInspectionResult.projectDir)
+      ).data.map((config) => config.configurationName);
+
+      const configName = newConfigFileNameFromTitle(
+        state.data.title,
+        existingNames,
+      );
       selectedInspectionResult.configuration.title = state.data.title;
       const createResponse = await api.configurations.createOrUpdate(
         configName,

--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -32,7 +32,6 @@ import {
   isQuickPickItem,
   isQuickPickItemWithIndex,
 } from "src/multiStepInputs/multiStepHelper";
-import { untitledConfigurationName } from "src/utils/names";
 import { calculateTitle } from "src/utils/titles";
 import {
   filterInspectionResultsToType,
@@ -40,6 +39,7 @@ import {
 } from "src/utils/filters";
 import { showProgress } from "src/utils/progress";
 import { isRelativePathRoot } from "src/utils/files";
+import { newConfigFileNameFromTitle } from "src/utils/names";
 
 export async function selectNewOrExistingConfig(
   activeDeployment: ContentRecord | PreContentRecord,
@@ -436,9 +436,7 @@ export async function selectNewOrExistingConfig(
         );
         return;
       }
-      const configName = await untitledConfigurationName(
-        selectedInspectionResult.projectDir,
-      );
+      const configName = newConfigFileNameFromTitle(state.data.title);
       selectedInspectionResult.configuration.title = state.data.title;
       const createResponse = await api.configurations.createOrUpdate(
         configName,

--- a/extensions/vscode/src/utils/names.ts
+++ b/extensions/vscode/src/utils/names.ts
@@ -2,38 +2,8 @@
 
 import { InputBoxValidationSeverity } from "vscode";
 
-import { useApi } from "src/api";
 import { isValidFilename } from "src/utils/files";
-
-export async function untitledConfigurationName(
-  projectDir: string,
-): Promise<string> {
-  const api = await useApi();
-  const existingConfigurations = (await api.configurations.getAll(projectDir))
-    .data;
-
-  if (existingConfigurations.length === 0) {
-    return "configuration-1";
-  }
-
-  let id = 0;
-  let defaultName = "";
-  do {
-    id += 1;
-    const trialName = `configuration-${id}`;
-
-    if (
-      !existingConfigurations.find((config) => {
-        return (
-          config.configurationName.toLowerCase() === trialName.toLowerCase()
-        );
-      })
-    ) {
-      defaultName = trialName;
-    }
-  } while (!defaultName);
-  return defaultName;
-}
+import filenamify from "filenamify";
 
 export function untitledContentRecordName(
   existingContentRecordNames: string[],
@@ -81,4 +51,34 @@ export function contentRecordNameValidator(
     }
     return undefined;
   };
+}
+
+/**
+ * Creates a semi-unique configuration name from a content title.
+ *
+ * @param title The title of the content to create a filename from
+ * @returns A filename that is safe to use in the filesystem with a unique 4
+ * character ending to avoid Git conflicts.
+ */
+export function newConfigFileNameFromTitle(title: string): string {
+  const filename = filenamify(title, {
+    replacement: "-",
+    maxLength: 95,
+  });
+  const uniqueEnding = randomNameEnding(4);
+  return `${filename}-${uniqueEnding}`;
+}
+
+/**
+ * Generates a random, uppercase, base 32 string of the given length.
+ *
+ * @param length [4] The length of the resulting string
+ * @returns A random base 32 string of the given length
+ */
+export function randomNameEnding(length: number = 4): string {
+  return Array.from({ length: length }, () =>
+    Math.floor(Math.random() * 32)
+      .toString(32)
+      .toUpperCase(),
+  ).join("");
 }

--- a/extensions/vscode/src/utils/names.ts
+++ b/extensions/vscode/src/utils/names.ts
@@ -68,7 +68,7 @@ export function newConfigFileNameFromTitle(
 ): string {
   const filename = filenamify(title, {
     replacement: "-",
-    maxLength: 95,
+    maxLength: 30,
   });
 
   // Generate unique name endings until we find a unique one

--- a/extensions/vscode/src/utils/names.ts
+++ b/extensions/vscode/src/utils/names.ts
@@ -57,16 +57,28 @@ export function contentRecordNameValidator(
  * Creates a semi-unique configuration name from a content title.
  *
  * @param title The title of the content to create a filename from
+ * @param existingNames [[]] An array of existing configuration names to ensure
+ *   uniqueness
  * @returns A filename that is safe to use in the filesystem with a unique 4
  * character ending to avoid Git conflicts.
  */
-export function newConfigFileNameFromTitle(title: string): string {
+export function newConfigFileNameFromTitle(
+  title: string,
+  existingNames: string[] = [],
+): string {
   const filename = filenamify(title, {
     replacement: "-",
     maxLength: 95,
   });
-  const uniqueEnding = randomNameEnding(4);
-  return `${filename}-${uniqueEnding}`;
+
+  // Generate unique name endings until we find a unique one
+  let result;
+  do {
+    const uniqueEnding = randomNameEnding(4);
+    result = `${filename}-${uniqueEnding}`;
+  } while (existingNames.includes(result));
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
This PR introduces a new naming setup for configuration files where they are named after the provided title of the content.

The file names also include a short unique string of base 32 characters for example: `fastapi-simple-AU9Q` to avoid collisions with collaborations via Git.

## Intent

Resolves #2067

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to avoid enumerating configurations and start using the title. To achieve file name safety a new dependency was brought in - [filenamify](https://github.com/sindresorhus/filenamify).

The random characters are created with `Math.random()` since we do not need cryptographic security on these. They then are converted from numbers to strings with the radix `32`.

## Directions for Reviewers

Test out the two ways we have to create configurations:
- the add Deployment flow
- the Select Active Configuration for Deployment flow, Create a New Configuration option
