### PR TITLE
Switch to properly use `Uri.file()` rather than `Uri.parse()`.

### DIFF
--- a/extensions/vscode/src/utils/files.ts
+++ b/extensions/vscode/src/utils/files.ts
@@ -79,7 +79,7 @@ export async function openNewOrExistingFileInPreview(
   appendedContents?: string,
 ) {
   let fileExist = true;
-  const existingUri = Uri.parse(filePath);
+  const existingUri = Uri.file(filePath);
   const newUri = Uri.file(filePath).with({ scheme: "untitled" });
 
   try {
@@ -123,7 +123,7 @@ export async function updateNewOrExistingFile(
   openEditor = false,
 ) {
   let fileExist = true;
-  const uri = Uri.parse(filePath);
+  const uri = Uri.file(filePath);
 
   try {
     await workspace.fs.stat(uri);
@@ -263,7 +263,7 @@ export function relativePath(uri: Uri): string | undefined {
     return undefined;
   }
   const base = uriUtils.basename(uri);
-  const relativeFilePath = uriUtils.joinPath(Uri.parse(relativeDirPath), base);
+  const relativeFilePath = uriUtils.joinPath(Uri.file(relativeDirPath), base);
   let result = relativeFilePath.path;
   if (result.startsWith(path.sep)) {
     result = result.replace(path.sep, "");

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1673,7 +1673,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           if (config) {
             return await commands.executeCommand(
               "vscode.open",
-              Uri.parse(config.configurationPath),
+              Uri.file(config.configurationPath),
             );
           }
           console.error(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Corrects usage to proper function for file paths. 

Fixes: #2175 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

From the VSCode documentation: 
```
		 * The *difference* between {@link Uri.parse} and {@link Uri.file} is that the latter treats the argument
		 * as path, not as stringified-uri. E.g. `Uri.file(path)` is *not* the same as
		 * `Uri.parse('file://' + path)` because the path might contain characters that are
		 * interpreted (# and ?). See the following sample:
		 * ```ts
		 * const good = URI.file('/coding/c#/project1');
		 * good.scheme === 'file';
		 * good.path === '/coding/c#/project1';
		 * good.fragment === '';
		 *
		 * const bad = URI.parse('file://' + '/coding/c#/project1');
		 * bad.scheme === 'file';
		 * bad.path === '/coding/c'; // path is now broken
		 * bad.fragment === '/project1';
```

Based on this new learning, I searched the codebase and determined that our file utility was making the same mistake, so I've fixed it in here.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

The conditions around the referenced bug should be verified.
The other two methods that were updated with this change are currently unused, but it is desirable to keep them in the codebase.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
