### PR TITLE
Decode 500 error's data string

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -14,6 +14,7 @@
         "async-mutex": "^0.5.0",
         "axios": "^1.7.4",
         "debounce": "^2.1.0",
+        "entities": "^5.0.0",
         "eventsource": "^2.0.2",
         "get-port": "5.1.1",
         "mutexify": "^1.4.0",
@@ -1823,6 +1824,18 @@
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/entities": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
+      "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -497,6 +497,7 @@
     "test": "npm run compile && node ./out/test/runTest.js"
   },
   "devDependencies": {
+    "@twbs/fantasticon": "^3.0.0",
     "@types/eventsource": "^1.1.15",
     "@types/mocha": "^10.0.2",
     "@types/mutexify": "^1.2.3",
@@ -510,7 +511,6 @@
     "esbuild": "^0.21.4",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^9.1.0",
-    "@twbs/fantasticon": "^3.0.0",
     "glob": "^10.3.3",
     "mocha": "^10.2.0",
     "typescript": "^5.2.2"
@@ -521,6 +521,7 @@
     "async-mutex": "^0.5.0",
     "axios": "^1.7.4",
     "debounce": "^2.1.0",
+    "entities": "^5.0.0",
     "eventsource": "^2.0.2",
     "get-port": "5.1.1",
     "mutexify": "^1.4.0",

--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 
 import { Credentials } from "./resources/Credentials";
 import { ContentRecords } from "./resources/ContentRecords";
@@ -8,6 +8,7 @@ import { Configurations } from "./resources/Configurations";
 import { Files } from "./resources/Files";
 import { Packages } from "./resources/Packages";
 import { EntryPoints } from "./resources/Entrypoints";
+import * as Entities from "entities";
 
 class PublishingClientApi {
   private client;
@@ -29,15 +30,20 @@ class PublishingClientApi {
       return request;
     });
 
-    this.client.interceptors.response.use((response) => {
-      const timestamp = response.config.ts;
-      if (timestamp) {
-        const request = response.request;
-        const duration = Math.round(Number(performance.now() - timestamp));
-        console.log(`Request: ${request.path} took ${duration}ms`);
-      }
-      return response;
-    });
+    this.client.interceptors.response.use(
+      (response) => {
+        this.logDuration(response);
+        return response;
+      },
+      (error) => {
+        // Decode data returned for 500 errors
+        if (error.response.status === 500) {
+          error.response.data = Entities.decodeHTML5(error.response.data);
+        }
+        this.logDuration(error.response);
+        return Promise.reject(error);
+      },
+    );
     this.apiServiceIsUp = apiServiceIsUp;
 
     this.configurations = new Configurations(this.client);
@@ -46,6 +52,16 @@ class PublishingClientApi {
     this.files = new Files(this.client);
     this.packages = new Packages(this.client);
     this.entrypoints = new EntryPoints(this.client);
+  }
+
+  logDuration(response: AxiosResponse<any, any>) {
+    const timestamp = response.config.ts;
+    if (timestamp) {
+      const request = response.request;
+      const duration = Math.round(Number(performance.now() - timestamp));
+      console.log(`Request: ${request.path} took ${duration}ms`);
+    }
+    return response;
   }
 
   setBaseUrl(url: string) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2176 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Brought in an HTML decoder which would decode the string that the agent encoded using the go package `html` (escapeString).

Performed this decoding for all responses that fail with a 500 error code, by updating the Axios client response interceptor. Only doing this for the response data field, as that is the only place it was applied on the agent within #2152.

ALSO determined that we were not outputting durations for error responses. I've gone ahead and included that change within this PR as well.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Easiest way to reproduce a 500 error is to invalidate a configuration file. For my testing, I changed the `[python]` section to be `[python2]`. Once you have done this, the error displayed in the lower-right corner error window should show the error without the quotes and other special characters being escaped out.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
