### PR TITLE
Passthrough callbacks with new `showProgressPassthrough`

### DIFF
--- a/extensions/vscode/src/utils/progress.ts
+++ b/extensions/vscode/src/utils/progress.ts
@@ -24,3 +24,27 @@ export async function showProgress(
     console.log(`Progress for "${title}" was displayed for ${duration}ms`);
   }
 }
+
+export async function showProgressPassthrough<T>(
+  title: string,
+  viewId: string,
+  until: () => Promise<T>,
+  trace = true,
+): Promise<T> {
+  const start = performance.now();
+
+  try {
+    return await window.withProgress(
+      {
+        title,
+        location: viewId ? { viewId } : ProgressLocation.Window,
+      },
+      until,
+    );
+  } finally {
+    if (trace) {
+      const duration = Math.round(Number(performance.now() - start));
+      console.log(`Progress for "${title}" was displayed for ${duration}ms`);
+    }
+  }
+}


### PR DESCRIPTION
This PR ensures that errors generated from fetching R or Python packages are caught to avoid creating uncaught exception logs in the debug console.

I plan to do a follow-up PR to merge `showProgressPassthrough` and `showProgress` and refactor other usages.

This should supersede #2183

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach was to pass the awaited function as the callback for `window.withProgress`, and use the fact that `window.withProgress` returns the "thenable the task-callback returned.".

This avoids creating a new callback and thus the uncaught exception error.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

To recreate the errors checkout `main` and open up the "Debug Console" while running VS Code in Extension Development Host mode.

- Create a Deployment for `shinyapp` in our `sample-content`
- Remove the `renv.lock` file if you have one,
- Once you don't have a `renv.lock` refresh the home view and you will see the unhandled exceptions

This PR should remove those errors.
