### PR TITLE
Refactor `showProgress` to passthrough callback return

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -16,7 +16,7 @@ import {
 } from "src/utils/errors";
 import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
-import { showProgress } from "src/utils/progress";
+import { showProgressPassthrough } from "src/utils/progress";
 
 const createNewCredentialLabel = "Create a New Credential";
 
@@ -29,27 +29,6 @@ export async function newCredential(
   // ***************************************************************
   const api = await useApi();
   let credentials: Credential[] = [];
-
-  const getCredentials = new Promise<void>(async (resolve, reject) => {
-    try {
-      const response = await api.credentials.list();
-      if (response.data) {
-        credentials = response.data;
-      }
-    } catch (error: unknown) {
-      const summary = getSummaryStringFromError(
-        "newCredentials, credentials.list",
-        error,
-      );
-      window.showInformationMessage(
-        `Unable to query existing credentials. ${summary}`,
-      );
-      return reject();
-    }
-    return resolve();
-  });
-
-  showProgress("Initializing::newCredential", getCredentials, viewId);
 
   // ***************************************************************
   // Order of all steps
@@ -302,19 +281,31 @@ export async function newCredential(
   }
 
   // ***************************************************************
-  // Wait for the api promise to complete
+  // Wait for the api promise to complete while showing progress
   // Kick off the input collection
   // and await until it completes.
   // This is a promise which returns the state data used to
   // collect the info.
   // ***************************************************************
-
   try {
-    await getCredentials;
-  } catch {
-    // errors have already been displayed by the underlying promises..
-    return;
+    await showProgressPassthrough(
+      "Initializing::newCredential",
+      viewId,
+      async () => {
+        const response = await api.credentials.list();
+        credentials = response.data;
+      },
+    );
+  } catch (error: unknown) {
+    const summary = getSummaryStringFromError(
+      "newCredentials, credentials.list",
+      error,
+    );
+    window.showInformationMessage(
+      `Unable to query existing credentials. ${summary}`,
+    );
   }
+
   const state = await collectInputs();
 
   // make sure user has not hit escape or moved away from the window

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -16,7 +16,7 @@ import {
 } from "src/utils/errors";
 import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
-import { showProgressPassthrough } from "src/utils/progress";
+import { showProgress } from "src/utils/progress";
 
 const createNewCredentialLabel = "Create a New Credential";
 
@@ -288,14 +288,10 @@ export async function newCredential(
   // collect the info.
   // ***************************************************************
   try {
-    await showProgressPassthrough(
-      "Initializing::newCredential",
-      viewId,
-      async () => {
-        const response = await api.credentials.list();
-        credentials = response.data;
-      },
-    );
+    await showProgress("Initializing::newCredential", viewId, async () => {
+      const response = await api.credentials.list();
+      credentials = response.data;
+    });
   } catch (error: unknown) {
     const summary = getSummaryStringFromError(
       "newCredentials, credentials.list",

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -40,7 +40,7 @@ import {
 import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
 import { DeploymentObjects } from "src/types/shared";
-import { showProgressPassthrough } from "src/utils/progress";
+import { showProgress } from "src/utils/progress";
 import { vscodeOpenFiles } from "src/utils/files";
 
 type stepInfo = {
@@ -821,7 +821,7 @@ export async function newDeployment(
       ? state.data.entryPointPath.label
       : state.data.entryPointPath;
 
-    const inspectionQuickPicks = await showProgressPassthrough(
+    const inspectionQuickPicks = await showProgress(
       "Scanning::newDeployment",
       viewId,
       async () => await getConfigurationInspectionQuickPicks(entryPointPath),
@@ -1192,7 +1192,7 @@ export async function newDeployment(
   // collect the info.
   // ***************************************************************
   try {
-    await showProgressPassthrough(
+    await showProgress(
       "Initializing::newDeployment",
       viewId,
       async () =>

--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -387,7 +387,7 @@ export async function selectNewOrExistingConfig(
 
   try {
     await showProgress(
-      "Initializing::collectInputs",
+      "Initializing::selectNewOrExistingConfig",
       viewId,
       async () =>
         await Promise.all([getConfigurations, getConfigurationInspections]),

--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -37,7 +37,7 @@ import {
   filterInspectionResultsToType,
   filterConfigurationsToValidAndType,
 } from "src/utils/filters";
-import { showProgressPassthrough } from "src/utils/progress";
+import { showProgress } from "src/utils/progress";
 import { isRelativePathRoot } from "src/utils/files";
 import { newConfigFileNameFromTitle } from "src/utils/names";
 
@@ -386,7 +386,7 @@ export async function selectNewOrExistingConfig(
   // ***************************************************************
 
   try {
-    await showProgressPassthrough(
+    await showProgress(
       "Initializing::collectInputs",
       viewId,
       async () =>

--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -37,7 +37,7 @@ import {
   filterInspectionResultsToType,
   filterConfigurationsToValidAndType,
 } from "src/utils/filters";
-import { showProgress } from "src/utils/progress";
+import { showProgressPassthrough } from "src/utils/progress";
 import { isRelativePathRoot } from "src/utils/files";
 import { newConfigFileNameFromTitle } from "src/utils/names";
 
@@ -216,15 +216,6 @@ export async function selectNewOrExistingConfig(
     },
   );
 
-  // wait for all of them to complete
-  const apisComplete = Promise.all([
-    getConfigurations,
-    getConfigurationInspections,
-  ]);
-
-  // Start the progress indicator and have it stop when the API calls are complete
-  showProgress("Initializing::selectNewOrExistingConfig", apisComplete, viewId);
-
   // ***************************************************************
   // Order of all steps
   // NOTE: This multi-stepper is used for multiple commands
@@ -387,14 +378,20 @@ export async function selectNewOrExistingConfig(
   }
 
   // ***************************************************************
-  // Wait for the api promise to complete
+  // Wait for the api promise to complete while showing progress
   // Kick off the input collection
   // and await until it completes.
   // This is a promise which returns the state data used to
   // collect the info.
   // ***************************************************************
+
   try {
-    await apisComplete;
+    await showProgressPassthrough(
+      "Initializing::collectInputs",
+      viewId,
+      async () =>
+        await Promise.all([getConfigurations, getConfigurationInspections]),
+    );
   } catch {
     // errors have already been displayed by the underlying promises..
     return;

--- a/extensions/vscode/src/utils/progress.ts
+++ b/extensions/vscode/src/utils/progress.ts
@@ -2,29 +2,6 @@
 
 import { ProgressLocation, window } from "vscode";
 
-export async function showProgress(
-  title: string,
-  until: Promise<any>,
-  viewId: string,
-  trace = true,
-) {
-  const start = performance.now();
-  window.withProgress(
-    {
-      title,
-      location: viewId ? { viewId } : ProgressLocation.Window,
-    },
-    () => {
-      return until;
-    },
-  );
-  await until;
-  if (trace) {
-    const duration = Math.round(Number(performance.now() - start));
-    console.log(`Progress for "${title}" was displayed for ${duration}ms`);
-  }
-}
-
 export async function showProgressPassthrough<T>(
   title: string,
   viewId: string,

--- a/extensions/vscode/src/utils/progress.ts
+++ b/extensions/vscode/src/utils/progress.ts
@@ -2,7 +2,7 @@
 
 import { ProgressLocation, window } from "vscode";
 
-export async function showProgressPassthrough<T>(
+export async function showProgress<T>(
   title: string,
   viewId: string,
   until: () => Promise<T>,

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -69,7 +69,7 @@ import { RPackage, RVersionConfig } from "src/api/types/packages";
 import { calculateTitle } from "src/utils/titles";
 import { ConfigWatcherManager, WatcherManager } from "src/watchers";
 import { Commands, Contexts, DebounceDelaysMS, Views } from "src/constants";
-import { showProgressPassthrough } from "src/utils/progress";
+import { showProgress } from "src/utils/progress";
 import { newCredential } from "src/multiStepInputs/newCredential";
 import { PublisherState } from "src/state";
 import { throttleWithLastPending } from "src/utils/throttle";
@@ -321,19 +321,15 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return;
     }
     try {
-      await showProgressPassthrough(
-        "Updating File List",
-        Views.HomeView,
-        async () => {
-          const api = await useApi();
-          await api.files.updateFileList(
-            activeConfig.configurationName,
-            `/${uri}`,
-            action,
-            activeConfig.projectDir,
-          );
-        },
-      );
+      await showProgress("Updating File List", Views.HomeView, async () => {
+        const api = await useApi();
+        await api.files.updateFileList(
+          activeConfig.configurationName,
+          `/${uri}`,
+          action,
+          activeConfig.projectDir,
+        );
+      });
     } catch (error: unknown) {
       const summary = getSummaryStringFromError(
         "homeView::updateFileList",
@@ -369,7 +365,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   private async refreshContentRecordData() {
     try {
-      await showProgressPassthrough(
+      await showProgress(
         "Refreshing Deployments",
         Views.HomeView,
         async () => await this.state.refreshContentRecords(),
@@ -386,7 +382,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   private async refreshConfigurationData() {
     try {
-      await showProgressPassthrough(
+      await showProgress(
         "Refreshing Configurations",
         Views.HomeView,
         async () => await this.state.refreshConfigurations(),
@@ -408,7 +404,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   private async refreshCredentialData() {
     try {
-      await showProgressPassthrough(
+      await showProgress(
         "Refreshing Credentials",
         Views.HomeView,
         async () => await this.state.refreshCredentials(),
@@ -511,7 +507,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           packageFile = pythonSection.packageFile;
           packageMgr = pythonSection.packageManager;
 
-          const response = await showProgressPassthrough(
+          const response = await showProgress(
             "Refreshing Python Packages",
             Views.HomeView,
             async () => {
@@ -579,7 +575,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           packageFile = rSection.packageFile;
           packageMgr = rSection.packageManager;
 
-          const response = await showProgressPassthrough(
+          const response = await showProgress(
             "Refreshing R Packages",
             Views.HomeView,
             async () =>
@@ -680,7 +676,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
 
     try {
-      const response = await showProgressPassthrough(
+      const response = await showProgress(
         "Refreshing Python Requirements File",
         Views.HomeView,
         async () => {
@@ -747,7 +743,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
 
     try {
-      await showProgressPassthrough(
+      await showProgress(
         "Creating R Requirements File",
         Views.HomeView,
         async () => {
@@ -804,18 +800,14 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         await this.state.getSelectedConfiguration(),
       );
       if (config) {
-        await showProgressPassthrough(
-          "Updating Config",
-          Views.HomeView,
-          async () => {
-            const api = await useApi();
-            await api.contentRecords.patch(
-              targetContentRecord.deploymentName,
-              config.configurationName,
-              targetContentRecord.projectDir,
-            );
-          },
-        );
+        await showProgress("Updating Config", Views.HomeView, async () => {
+          const api = await useApi();
+          await api.contentRecords.patch(
+            targetContentRecord.deploymentName,
+            config.configurationName,
+            targetContentRecord.projectDir,
+          );
+        });
 
         // now select the new, updated or existing deployment
         const deploymentSelector: DeploymentSelector = {
@@ -1302,19 +1294,15 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     includeSavedState?: boolean,
   ) => {
     try {
-      await showProgressPassthrough(
-        "Refreshing Data",
-        Views.HomeView,
-        async () => {
-          const apis: Promise<void>[] = [this.refreshCredentialData()];
-          if (forceAll) {
-            // we have been told to refresh everything
-            apis.push(this.refreshContentRecordData());
-            apis.push(this.refreshConfigurationData());
-          }
-          return await Promise.all(apis);
-        },
-      );
+      await showProgress("Refreshing Data", Views.HomeView, async () => {
+        const apis: Promise<void>[] = [this.refreshCredentialData()];
+        if (forceAll) {
+          // we have been told to refresh everything
+          apis.push(this.refreshContentRecordData());
+          apis.push(this.refreshConfigurationData());
+        }
+        return await Promise.all(apis);
+      });
     } catch (error: unknown) {
       const summary = getSummaryStringFromError(
         "refreshAll::Promise.all",
@@ -1372,7 +1360,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     const activeConfig = await this.state.getSelectedConfiguration();
     if (activeConfig) {
       try {
-        const response = await showProgressPassthrough(
+        const response = await showProgress(
           "Refreshing Files",
           Views.HomeView,
           async () => {
@@ -1492,7 +1480,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     });
 
     try {
-      await showProgressPassthrough(
+      await showProgress(
         "Initializing::handleFileInitiatedDeployment",
         Views.HomeView,
         async () => {


### PR DESCRIPTION
Follow-up to #2194 that refactors all `showProgress` usage to use the new passthrough callback return method to ensure that errors are caught.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->