### PR TITLE
update tests to get the new config name since they are no longer static

### DIFF
--- a/test/vscode-ui/test/helpers.ts
+++ b/test/vscode-ui/test/helpers.ts
@@ -41,3 +41,15 @@ export function runShellScript(scriptPath: string) {
     });
   });
 }
+
+export async function getConfigTitle(configName: RegExp) {
+  const workbench = await browser.getWorkbench();
+  const openEditorTitles = await workbench
+    .getEditorView()
+    .getOpenEditorTitles();
+  const fileNamePattern = configName;
+  const realFilename = openEditorTitles.find((title) =>
+    fileNamePattern.test(title),
+  );
+  return realFilename;
+}

--- a/test/vscode-ui/test/specs/fastapi.spec.ts
+++ b/test/vscode-ui/test/specs/fastapi.spec.ts
@@ -79,18 +79,23 @@ describe("VS Code Extension UI Test", () => {
     await browser.keys("\uE007");
   });
 
-  it("check config", async () => {
+  it("can check config", async () => {
     const workbench = await browser.getWorkbench();
-    await expect(
-      await workbench.getEditorView().getOpenEditorTitles(),
-    ).toContain("configuration-1.toml");
+    const openEditorTitles = await workbench
+      .getEditorView()
+      .getOpenEditorTitles();
+    const fileNamePattern = /^my fastapi app-.*$/;
+    const realFilename = openEditorTitles.find((title) =>
+      fileNamePattern.test(title),
+    );
+
     const filePath = path.resolve(
       __dirname,
-      "../../../sample-content/fastapi-simple/.posit/publish/configuration-1.toml",
+      "../../../sample-content/fastapi-simple/.posit/publish/" + realFilename,
     );
     const fileContent = fs.readFileSync(filePath, "utf8");
     await expect(fileContent).toContain(
-      "type = 'python-fastapi'\nentrypoint = 'simple.py'\nvalidate = true\nfiles = [\n  'simple.py',\n  'requirements.txt'\n]\ntitle = 'my fastapi app'",
+      "type = 'python-fastapi'\nentrypoint = 'simple.py'\nvalidate = true\nfiles = [\n  '/simple.py',\n  '/requirements.txt'\n]\ntitle = 'my fastapi app'",
     );
   });
 

--- a/test/vscode-ui/test/specs/fastapi.spec.ts
+++ b/test/vscode-ui/test/specs/fastapi.spec.ts
@@ -5,12 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
-
-import {
-  switchToSubframe,
-  waitForInputFields,
-  runShellScript,
-} from "../helpers.ts";
+import * as helper from "../helpers.ts";
 
 const connectServer = process.env.CONNECT_SERVER;
 const apiKey = process.env.CONNECT_API_KEY;
@@ -36,7 +31,7 @@ describe("VS Code Extension UI Test", () => {
   });
 
   it("can click add deployment button", async () => {
-    await switchToSubframe();
+    await helper.switchToSubframe();
     // initialize project via button
     const selectButton = (await $('[data-automation="select-deployment"]')).$(
       ".quick-pick-label",
@@ -65,14 +60,14 @@ describe("VS Code Extension UI Test", () => {
     await browser.keys("\uE007");
 
     // wait until the server responds
-    await waitForInputFields("The API key to be used");
+    await helper.waitForInputFields("The API key to be used");
 
     //set api key
     await input.setValue(apiKey);
     await browser.keys("\uE007");
 
     // wait for server validation
-    await waitForInputFields("Enter a Unique Nickname");
+    await helper.waitForInputFields("Enter a Unique Nickname");
 
     // set server name
     await input.setValue("my connect server");
@@ -80,14 +75,7 @@ describe("VS Code Extension UI Test", () => {
   });
 
   it("can check config", async () => {
-    const workbench = await browser.getWorkbench();
-    const openEditorTitles = await workbench
-      .getEditorView()
-      .getOpenEditorTitles();
-    const fileNamePattern = /^my fastapi app-.*$/;
-    const realFilename = openEditorTitles.find((title) =>
-      fileNamePattern.test(title),
-    );
+    const realFilename = await helper.getConfigTitle(/^my fastapi app-.*$/);
 
     const filePath = path.resolve(
       __dirname,
@@ -136,7 +124,7 @@ describe("VS Code Extension UI Test", () => {
       it("remove credentials", async () => {
         let scriptPath: string;
         scriptPath = "cd ../scripts && bash cleanup.bash";
-        await runShellScript(scriptPath);
+        await helper.runShellScript(scriptPath);
       });
     });
   });

--- a/test/vscode-ui/test/specs/nested-fastapi.spec.ts
+++ b/test/vscode-ui/test/specs/nested-fastapi.spec.ts
@@ -5,11 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
-import {
-  runShellScript,
-  switchToSubframe,
-  waitForInputFields,
-} from "../helpers.ts";
+import * as helper from "../helpers.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,7 +35,7 @@ describe("Nested Fast API Deployment", () => {
   });
 
   it("can add deployment", async () => {
-    await switchToSubframe();
+    await helper.switchToSubframe();
     // initialize project via button
     const selectButton = (await $('[data-automation="select-deployment"]')).$(
       ".quick-pick-label",
@@ -143,14 +139,14 @@ describe("Nested Fast API Deployment", () => {
     await browser.keys("\uE007");
 
     // wait until the server responds
-    await waitForInputFields("The API key to be used");
+    await helper.waitForInputFields("The API key to be used");
 
     //set api key
     await input.setValue(apiKey);
     await browser.keys("\uE007");
 
     // wait for server validation
-    await waitForInputFields("Enter a Unique Nickname");
+    await helper.waitForInputFields("Enter a Unique Nickname");
 
     // set server name
     await input.setValue("my connect server");
@@ -158,14 +154,7 @@ describe("Nested Fast API Deployment", () => {
   });
 
   it("can check config", async () => {
-    const workbench = await browser.getWorkbench();
-    const openEditorTitles = await workbench
-      .getEditorView()
-      .getOpenEditorTitles();
-    const fileNamePattern = /^my fastapi app-.*$/;
-    const realFilename = openEditorTitles.find((title) =>
-      fileNamePattern.test(title),
-    );
+    const realFilename = await helper.getConfigTitle(/^my fastapi app-.*$/);
 
     const filePath = path.resolve(
       __dirname,
@@ -214,7 +203,7 @@ describe("Nested Fast API Deployment", () => {
       it("remove credentials", async () => {
         let scriptPath: string;
         scriptPath = "cd ../scripts && bash cleanup.bash";
-        await runShellScript(scriptPath);
+        await helper.runShellScript(scriptPath);
       });
     });
   });

--- a/test/vscode-ui/test/specs/nested-fastapi.spec.ts
+++ b/test/vscode-ui/test/specs/nested-fastapi.spec.ts
@@ -18,6 +18,8 @@ const apiKey = process.env.CONNECT_API_KEY;
 
 const sep = path.sep;
 
+const title = "my fastapi app";
+
 describe("Nested Fast API Deployment", () => {
   let workbench: any;
   let input: any;
@@ -157,16 +159,21 @@ describe("Nested Fast API Deployment", () => {
 
   it("can check config", async () => {
     const workbench = await browser.getWorkbench();
-    await expect(
-      await workbench.getEditorView().getOpenEditorTitles(),
-    ).toContain("configuration-1.toml");
+    const openEditorTitles = await workbench
+      .getEditorView()
+      .getOpenEditorTitles();
+    const fileNamePattern = /^my fastapi app-.*$/;
+    const realFilename = openEditorTitles.find((title) =>
+      fileNamePattern.test(title),
+    );
+
     const filePath = path.resolve(
       __dirname,
-      "../../../sample-content/fastapi-simple/.posit/publish/configuration-1.toml",
+      "../../../sample-content/fastapi-simple/.posit/publish/" + realFilename,
     );
     const fileContent = fs.readFileSync(filePath, "utf8");
     await expect(fileContent).toContain(
-      "type = 'python-fastapi'\nentrypoint = 'simple.py'\nvalidate = true\nfiles = [\n  'simple.py',\n  'requirements.txt'\n]\ntitle = 'my fastapi app'",
+      "type = 'python-fastapi'\nentrypoint = 'simple.py'\nvalidate = true\nfiles = [\n  '/simple.py',\n  '/requirements.txt'\n]\ntitle = 'my fastapi app'",
     );
   });
 


### PR DESCRIPTION
Tests started failing last night because they look for the config name and check its contents. This PR uses a regex to find the filename opened in the editor and then checks the contents of that file.  

Tests are passing against this branch:

https://github.com/posit-dev/publisher/actions/runs/10599971513/job/29376369061

fixes: https://github.com/posit-dev/publisher/issues/2197