### PR TITLE
Add PyShiny entrypoint to Files list

### DIFF
--- a/internal/inspect/detectors/pyshiny.go
+++ b/internal/inspect/detectors/pyshiny.go
@@ -85,6 +85,8 @@ func (d *pyShinyDetector) InferType(base util.AbsolutePath, entrypoint util.Rela
 		} else {
 			cfg.Entrypoint = relEntrypoint.String()
 		}
+		cfg.Files = append(cfg.Files, relEntrypoint.String())
+
 		cfg.Type = config.ContentTypePythonShiny
 		// indicate that Python inspection is needed
 		cfg.Python = &config.Python{}

--- a/internal/inspect/detectors/pyshiny_test.go
+++ b/internal/inspect/detectors/pyshiny_test.go
@@ -41,7 +41,7 @@ func (s *PyShinySuite) TestInferType() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{},
+		Files:      []string{filename},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -66,7 +66,7 @@ func (s *PyShinySuite) TestInferTypeShinyExpress() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: "shiny.express.app:app_2e_py",
 		Validate:   true,
-		Files:      []string{},
+		Files:      []string{filename},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -95,7 +95,7 @@ func (s *PyShinySuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{},
+		Files:      []string{filename},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -123,7 +123,7 @@ func (s *PyShinySuite) TestInferTypeWithExtraFile() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{},
+		Files:      []string{filename},
 		Python:     &config.Python{},
 	}, configs[0])
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR ensures that the entrypoint file for a Shiny Express app is included in the Files list. Since the entrypoint is in module:object format, the generic config generation wasn't including it.

Fixes #2137 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Add the entrypoint file in the `pyShinyDetector`.

## Automated Tests

Updated existing tests to verify the files list is correct.

<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

Inspect a Shiny Express app, and verify that the entrypoint file appears in the Files list.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
