### PR TITLE
Suppress permission errors

### DIFF
--- a/extensions/vscode/src/api/types/files.ts
+++ b/extensions/vscode/src/api/types/files.ts
@@ -25,6 +25,7 @@ export type ContentRecordFile = {
 export enum FileMatchSource {
   FILE = "file",
   BUILT_IN = "built-in",
+  PERMISSIONS_ERROR = "permissions",
 }
 
 export type FileMatch = {

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -4,7 +4,10 @@
     :key="file.id"
     :title="file.base"
     :checked="isFileIncluded(file)"
-    :disabled="file.reason?.source === 'built-in'"
+    :disabled="
+      file.reason?.source === 'built-in' ||
+      file.reason?.source === 'permissions'
+    "
     :list-style="isFileIncluded(file) ? 'default' : 'deemphasized'"
     :tooltip="
       isFileIncluded(file)

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -16,7 +16,7 @@
     @check="includeFile(file)"
     @uncheck="excludeFile(file)"
   >
-    <template v-if="file.files.length" #default="{ indentLevel }">
+    <template v-if="file.isDir" #default="{ indentLevel }">
       <TreeProjectFiles :files="file.files" :indentLevel="indentLevel" />
     </template>
 

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
@@ -13,6 +13,8 @@ export function excludedFileTooltip(file: ContentRecordFile) {
   if (file.reason) {
     if (file.reason.source === FileMatchSource.BUILT_IN) {
       tooltip += `\nThis is a built-in exclusion for the pattern: '${file.reason.pattern}' and cannot be overridden.`;
+    } else if (file.reason.source === FileMatchSource.PERMISSIONS_ERROR) {
+      tooltip += "\nYou don't have permission to access this directory.";
     } else {
       tooltip += `\nThe configuration file ${file.reason?.fileName} is excluding it with the pattern '${file.reason?.pattern}'`;
     }

--- a/internal/bundles/matcher/match_list.go
+++ b/internal/bundles/matcher/match_list.go
@@ -1,9 +1,6 @@
 package matcher
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/posit-dev/publisher/internal/util"
 )
 
@@ -12,7 +9,6 @@ import (
 type MatchList interface {
 	AddFromFile(base util.AbsolutePath, filePath util.AbsolutePath, patterns []string) error
 	Match(path util.AbsolutePath) *Pattern
-	Walk(root util.AbsolutePath, fn util.AbsoluteWalkFunc) error
 }
 
 type defaultMatchList struct {
@@ -55,23 +51,4 @@ func (l *defaultMatchList) Match(filePath util.AbsolutePath) *Pattern {
 		}
 	}
 	return match
-}
-
-func (l *defaultMatchList) Walk(root util.AbsolutePath, fn util.AbsoluteWalkFunc) error {
-	return root.Walk(
-		func(path util.AbsolutePath, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if path != root {
-				m := l.Match(path)
-				if m == nil || m.Exclude {
-					if info.IsDir() {
-						return filepath.SkipDir
-					}
-					return nil
-				}
-			}
-			return fn(path, info, err)
-		})
 }

--- a/internal/bundles/matcher/mock_match_list.go
+++ b/internal/bundles/matcher/mock_match_list.go
@@ -21,9 +21,4 @@ func (m *MockMatchList) Match(path util.AbsolutePath) *Pattern {
 	return args.Get(0).(*Pattern)
 }
 
-func (m *MockMatchList) Walk(root util.AbsolutePath, fn util.AbsoluteWalkFunc) error {
-	args := m.Called(root, fn)
-	return args.Error(0)
-}
-
 var _ MatchList = &MockMatchList{}

--- a/internal/bundles/matcher/pattern.go
+++ b/internal/bundles/matcher/pattern.go
@@ -11,6 +11,7 @@ import (
 type MatchSource string
 
 const MatchSourceFile MatchSource = "file"
+const MatchSourcePermissionsError MatchSource = "permissions"
 const MatchSourceBuiltIn MatchSource = "built-in"
 
 type Pattern struct {

--- a/internal/bundles/matcher/walker.go
+++ b/internal/bundles/matcher/walker.go
@@ -3,7 +3,9 @@ package matcher
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
 
 	"github.com/posit-dev/publisher/internal/logging"
@@ -78,6 +80,10 @@ func (i *matchingWalker) Walk(base util.AbsolutePath, fn util.AbsoluteWalkFunc) 
 					return nil
 				}
 			}
+		}
+		if errors.Is(err, os.ErrPermission) {
+			i.log.Warn("permission error; skipping", "path", path)
+			return nil
 		}
 		return fn(path, info, err)
 	})

--- a/internal/services/api/files/files.go
+++ b/internal/services/api/files/files.go
@@ -101,7 +101,7 @@ func (f *File) CalculateInclusions() {
 	}
 }
 
-func (f *File) insert(root util.AbsolutePath, path util.AbsolutePath, matchList matcher.MatchList) (*File, error) {
+func (f *File) insert(root util.AbsolutePath, path util.AbsolutePath, match *matcher.Pattern) (*File, error) {
 
 	// if the path is the same as the file's absolute path
 	if f.Abs == path.String() {
@@ -122,8 +122,6 @@ func (f *File) insert(root util.AbsolutePath, path util.AbsolutePath, matchList 
 		}
 
 		// otherwise, create it
-		match := matchList.Match(path)
-
 		child, err := CreateFile(root, path, match)
 		if err != nil || child == nil {
 			return nil, err
@@ -135,11 +133,11 @@ func (f *File) insert(root util.AbsolutePath, path util.AbsolutePath, matchList 
 	}
 
 	// otherwise, create the parent file
-	parent, err := f.insert(root, pathdir, matchList)
+	parent, err := f.insert(root, pathdir, match)
 	if err != nil || parent == nil {
 		return nil, err
 	}
 
 	// then insert this into the parent
-	return parent.insert(root, path, matchList)
+	return parent.insert(root, path, match)
 }

--- a/internal/services/api/files/services.go
+++ b/internal/services/api/files/services.go
@@ -46,6 +46,10 @@ func (s filesService) GetFile(p util.AbsolutePath, matchList matcher.MatchList) 
 	err = walker.Walk(p, func(path util.AbsolutePath, info fs.FileInfo, err error) error {
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
+				// File was deleted since readdir() was called
+				return nil
+			} else if errors.Is(err, os.ErrPermission) {
+				s.log.Warn("permission error; skipping", "path", path)
 				return nil
 			} else {
 				return err


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This PR adds handling for permission errors during directory traversal.

Fixes #2135 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The `MatchingWalker` and `filesService` suppress permission errors.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

Deny read permissions to files or directories in your project (`chmod 000 $PATH`).

* Directories that can't be read will show up as empty in the Project Files view. 
* Files that can't be read will show up in the Project Files view. If you exclude them, you can deploy without error. If you include them, an error will be raised during deployment.

This is similar to the VSCode file tree behavior.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
