### PR TITLE
Preprend slash in config files for all types

### DIFF
--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -175,7 +175,7 @@ func (s *InitializeSuite) TestGetPossibleConfigs() {
 
 	s.Equal(config.ContentTypeHTML, configs[1].Type)
 	s.Equal("index.html", configs[1].Entrypoint)
-	s.Equal([]string{"index.html"}, configs[1].Files)
+	s.Equal([]string{"/index.html"}, configs[1].Files)
 	s.Nil(configs[1].Python)
 }
 

--- a/internal/inspect/detectors/all_test.go
+++ b/internal/inspect/detectors/all_test.go
@@ -46,7 +46,7 @@ func (s *AllSuite) TestInferTypeDirectory() {
 		Type:       config.ContentTypeHTML,
 		Entrypoint: "index.html",
 		Validate:   true,
-		Files:      []string{"index.html"},
+		Files:      []string{"/index.html"},
 	}, configs[0])
 	s.Equal(&config.Config{
 		Schema:     schema.ConfigSchemaURL,
@@ -113,7 +113,7 @@ func (s *AllSuite) TestInferAll() {
 			Type:       config.ContentTypeHTML,
 			Entrypoint: "myfile.html",
 			Validate:   true,
-			Files:      []string{"myfile.html"},
+			Files:      []string{"/myfile.html"},
 			Python:     nil,
 		},
 	}, t)

--- a/internal/inspect/detectors/html.go
+++ b/internal/inspect/detectors/html.go
@@ -3,6 +3,8 @@ package detectors
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"fmt"
+
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/util"
 )
@@ -49,7 +51,7 @@ func (d *StaticHTMLDetector) InferType(base util.AbsolutePath, entrypoint util.R
 		cfg.Type = config.ContentTypeHTML
 		cfg.Entrypoint = relEntrypoint.String()
 		cfg.Files = []string{
-			relEntrypoint.String(),
+			fmt.Sprint("/", relEntrypoint.String()),
 		}
 		extraDirs := []string{"_site", relEntrypoint.WithoutExt().String() + "_files"}
 		for _, filename := range extraDirs {
@@ -59,7 +61,7 @@ func (d *StaticHTMLDetector) InferType(base util.AbsolutePath, entrypoint util.R
 				return nil, err
 			}
 			if exists {
-				cfg.Files = append(cfg.Files, filename)
+				cfg.Files = append(cfg.Files, fmt.Sprint("/", filename))
 			}
 		}
 		configs = append(configs, cfg)

--- a/internal/inspect/detectors/html_test.go
+++ b/internal/inspect/detectors/html_test.go
@@ -3,6 +3,7 @@ package detectors
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/posit-dev/publisher/internal/config"
@@ -46,14 +47,14 @@ func (s *StaticHTMLDetectorSuite) TestInferType() {
 		Type:       config.ContentTypeHTML,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{filename},
+		Files:      []string{fmt.Sprintf("/%s", filename)},
 	}, configs[0])
 	s.Equal(&config.Config{
 		Schema:     schema.ConfigSchemaURL,
 		Type:       config.ContentTypeHTML,
 		Entrypoint: otherFilename,
 		Validate:   true,
-		Files:      []string{otherFilename},
+		Files:      []string{fmt.Sprintf("/%s", otherFilename)},
 	}, configs[1])
 }
 
@@ -83,6 +84,6 @@ func (s *StaticHTMLDetectorSuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypeHTML,
 		Entrypoint: otherFilename,
 		Validate:   true,
-		Files:      []string{otherFilename},
+		Files:      []string{fmt.Sprintf("/%s", otherFilename)},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/pyshiny.go
+++ b/internal/inspect/detectors/pyshiny.go
@@ -85,7 +85,7 @@ func (d *pyShinyDetector) InferType(base util.AbsolutePath, entrypoint util.Rela
 		} else {
 			cfg.Entrypoint = relEntrypoint.String()
 		}
-		cfg.Files = append(cfg.Files, relEntrypoint.String())
+		cfg.Files = append(cfg.Files, fmt.Sprint("/", relEntrypoint.String()))
 
 		cfg.Type = config.ContentTypePythonShiny
 		// indicate that Python inspection is needed

--- a/internal/inspect/detectors/pyshiny_test.go
+++ b/internal/inspect/detectors/pyshiny_test.go
@@ -3,6 +3,7 @@ package detectors
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/posit-dev/publisher/internal/config"
@@ -41,7 +42,7 @@ func (s *PyShinySuite) TestInferType() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{filename},
+		Files:      []string{fmt.Sprintf("/%s", filename)},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -66,7 +67,7 @@ func (s *PyShinySuite) TestInferTypeShinyExpress() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: "shiny.express.app:app_2e_py",
 		Validate:   true,
-		Files:      []string{filename},
+		Files:      []string{fmt.Sprintf("/%s", filename)},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -95,7 +96,7 @@ func (s *PyShinySuite) TestInferTypeWithEntrypoint() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{filename},
+		Files:      []string{fmt.Sprintf("/%s", filename)},
 		Python:     &config.Python{},
 	}, configs[0])
 }
@@ -123,7 +124,7 @@ func (s *PyShinySuite) TestInferTypeWithExtraFile() {
 		Type:       config.ContentTypePythonShiny,
 		Entrypoint: filename,
 		Validate:   true,
-		Files:      []string{filename},
+		Files:      []string{fmt.Sprintf("/%s", filename)},
 		Python:     &config.Python{},
 	}, configs[0])
 }

--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -288,7 +288,7 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath, entrypoint util.Relat
 			} else {
 				relPath = inputFile
 			}
-			cfg.Files = append(cfg.Files, relPath)
+			cfg.Files = append(cfg.Files, fmt.Sprint("/", relPath))
 		}
 		extraFiles := []string{"_quarto.yml", "_metadata.yaml"}
 		for _, filename := range extraFiles {
@@ -298,7 +298,7 @@ func (d *QuartoDetector) InferType(base util.AbsolutePath, entrypoint util.Relat
 				return nil, err
 			}
 			if exists {
-				cfg.Files = append(cfg.Files, filename)
+				cfg.Files = append(cfg.Files, fmt.Sprint("/", filename))
 			}
 		}
 		configs = append(configs, cfg)

--- a/internal/inspect/detectors/quarto_test.go
+++ b/internal/inspect/detectors/quarto_test.go
@@ -104,7 +104,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownProject() {
 		Entrypoint: "quarto-proj-none.qmd",
 		Title:      "quarto-proj-none",
 		Validate:   true,
-		Files:      []string{"quarto-proj-none.qmd", "_quarto.yml"},
+		Files:      []string{"/quarto-proj-none.qmd", "/_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -124,7 +124,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownProjectWindows() {
 		Entrypoint: "quarto-proj-none.qmd",
 		Title:      "quarto-proj-none",
 		Validate:   true,
-		Files:      []string{"quarto-proj-none.qmd", "_quarto.yml"},
+		Files:      []string{"/quarto-proj-none.qmd", "/_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -144,7 +144,7 @@ func (s *QuartoDetectorSuite) TestInferTypePythonProject() {
 		Entrypoint: "quarto-proj-py.qmd",
 		Title:      "quarto-proj-py",
 		Validate:   true,
-		Files:      []string{"quarto-proj-py.qmd", "_quarto.yml"},
+		Files:      []string{"/quarto-proj-py.qmd", "/_quarto.yml"},
 		Python:     &config.Python{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -165,7 +165,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRProject() {
 		Entrypoint: "quarto-proj-r.qmd",
 		Title:      "quarto-proj-r",
 		Validate:   true,
-		Files:      []string{"quarto-proj-r.qmd", "_quarto.yml"},
+		Files:      []string{"/quarto-proj-r.qmd", "/_quarto.yml"},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -186,7 +186,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRAndPythonProject() {
 		Entrypoint: "quarto-proj-r-py.qmd",
 		Title:      "quarto-proj-r-py",
 		Validate:   true,
-		Files:      []string{"quarto-proj-r-py.qmd", "_quarto.yml"},
+		Files:      []string{"/quarto-proj-r-py.qmd", "/_quarto.yml"},
 		Python:     &config.Python{},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
@@ -208,7 +208,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRShinyProject() {
 		Entrypoint: "quarto-proj-r-shiny.qmd",
 		Title:      "quarto-proj-r-shiny",
 		Validate:   true,
-		Files:      []string{"quarto-proj-r-shiny.qmd", "_quarto.yml"},
+		Files:      []string{"/quarto-proj-r-shiny.qmd", "/_quarto.yml"},
 		R:          &config.R{},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
@@ -229,7 +229,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 		Entrypoint: "about.qmd",
 		Title:      "About",
 		Validate:   true,
-		Files:      []string{"index.qmd", "about.qmd", "_quarto.yml"},
+		Files:      []string{"/index.qmd", "/about.qmd", "/_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -241,7 +241,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 		Entrypoint: "index.qmd",
 		Title:      "quarto-website-none",
 		Validate:   true,
-		Files:      []string{"index.qmd", "about.qmd", "_quarto.yml"},
+		Files:      []string{"/index.qmd", "/about.qmd", "/_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -282,7 +282,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMultidocProject() {
 		Entrypoint: "document1.qmd",
 		Title:      "quarto-proj-none-multidocument",
 		Validate:   true,
-		Files:      []string{"document1.qmd", "document2.qmd", "_quarto.yml"},
+		Files:      []string{"/document1.qmd", "/document2.qmd", "/_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -294,7 +294,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMultidocProject() {
 		Entrypoint: "document2.qmd",
 		Title:      "quarto-proj-none-multidocument",
 		Validate:   true,
-		Files:      []string{"document1.qmd", "document2.qmd", "_quarto.yml"},
+		Files:      []string{"/document1.qmd", "/document2.qmd", "/_quarto.yml"},
 		Quarto: &config.Quarto{
 			Version: "1.4.553",
 			Engines: []string{"markdown"},
@@ -314,7 +314,7 @@ func (s *QuartoDetectorSuite) TestInferTypeNotebook() {
 		Entrypoint: "stock-report-jupyter.ipynb",
 		Title:      "Stock Report: TSLA",
 		Validate:   true,
-		Files:      []string{"stock-report-jupyter.ipynb"},
+		Files:      []string{"/stock-report-jupyter.ipynb"},
 		Python:     &config.Python{},
 		Quarto: &config.Quarto{
 			Version: "1.5.54",
@@ -335,7 +335,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRevalJSQuartoShiny() {
 		Entrypoint: "dashboard.qmd",
 		Title:      "posit::conf(2024)",
 		Validate:   true,
-		Files:      []string{"dashboard.qmd"},
+		Files:      []string{"/dashboard.qmd"},
 		Quarto: &config.Quarto{
 			Version: "1.5.54",
 			Engines: []string{"knitr"},


### PR DESCRIPTION
This PR ensures that we prepend the `/` to avoid accidentaly including files with the same name as the entrypoint in subdirectories for the configuration files we generate.

This is a follow-up to #2174 that applies this to all types of Deployments - HTML, Quarto, Shiny Express, etc

## Intent

Resolves #2211 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->