### PR TITLE
Only show added decorator when file is new and included

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -24,7 +24,7 @@
       #postDecor
       v-if="
         file.isFile &&
-        file.reason?.source !== FileMatchSource.BUILT_IN &&
+        isFileIncluded(file) &&
         !home.flatFiles.lastDeployedFiles.has(file.rel)
       "
     >


### PR DESCRIPTION
This PR fixes the added decorator (the green A after files in the Project Files view) to only show if the file is new (not included in the last deployment) and included.

Previously any file that was new was being decorated.

## Intent

Resolves #2218

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->