### PR TITLE
Add decoration for removed files in Project Files

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -23,15 +23,27 @@
       <TreeProjectFiles :files="file.files" :indentLevel="indentLevel" />
     </template>
 
-    <template
-      #postDecor
-      v-if="
-        file.isFile &&
-        isFileIncluded(file) &&
-        !home.flatFiles.lastDeployedFiles.has(file.rel)
-      "
-    >
-      <PostDecor class="text-git-added">A</PostDecor>
+    <template #postDecor>
+      <PostDecor
+        v-if="
+          file.isFile &&
+          isFileIncluded(file) &&
+          !home.flatFiles.lastDeployedFiles.has(file.rel)
+        "
+        class="text-git-added"
+      >
+        A
+      </PostDecor>
+      <PostDecor
+        v-if="
+          file.isFile &&
+          !isFileIncluded(file) &&
+          home.flatFiles.lastDeployedFiles.has(file.rel)
+        "
+        class="text-git-deleted"
+      >
+        R
+      </PostDecor>
     </template>
   </TreeItemCheckbox>
 </template>


### PR DESCRIPTION
This PR adds an additional file decoration for files that were included in the last deployment, but are excluded for the next. They are now marked with a red `R` for removal.

The source control VS Code extension uses a red `D` for deletion, but that didn't feel quite right since the file is just being excluded (or removed from the next deployment).

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-08-29 at 12 45 24](https://github.com/user-attachments/assets/0fd8e9e6-d47e-4688-b71c-6b7ee41b7c98)

</details> 

## Intent

Resolves #2222

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here is extremely similar to the green `A` with a different `v-if`

## Directions for Reviewers

To see this in action:
- make a deployment
- unselect files previously deployed in the Project Files view