### PR TITLE
Add support for optional codicon in TreeSection

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
@@ -11,6 +11,11 @@
           class="twisty-container codicon"
           :class="expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'"
         />
+        <span
+          v-if="codicon"
+          class="tree-section-icon codicon"
+          :class="codicon"
+        />
         <h3 class="title">{{ title }}</h3>
         <span v-if="$slots.description" class="description">
           <slot name="description" />
@@ -37,6 +42,7 @@ const expanded = defineModel("expanded", { required: false, default: false });
 defineProps<{
   title: string;
   description?: string;
+  codicon?: string;
   actions?: ActionButton[];
 }>();
 
@@ -99,6 +105,11 @@ const toggleExpanded = () => {
       margin: 0 2px;
       font-size: 16px;
       color: var(--vscode-icon-foreground);
+    }
+
+    .tree-section-icon {
+      font-size: 13px;
+      margin-right: 4px;
     }
 
     .title {


### PR DESCRIPTION
This PR adds a new optional prop to `TreeSection` allowing a codicon string to be passed. When passed the codicon will appear to the left of the title, and the right of the twisty for the section.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-08-29 at 16 40 39@2x](https://github.com/user-attachments/assets/24f75d70-477c-431f-be46-75853621cb02)

The icon is small to match the title font size, and is the same muted color. 

</details> 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->