### PR TITLE
Show `indeterminate` state in Project Files view based on inclusions

### DIFF
--- a/extensions/vscode/src/api/types/files.ts
+++ b/extensions/vscode/src/api/types/files.ts
@@ -20,6 +20,8 @@ export type ContentRecordFile = {
   size: number;
   fileCount: number;
   abs: string;
+  allIncluded: boolean;
+  allExcluded: boolean;
 };
 
 export enum FileMatchSource {

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
@@ -29,6 +29,7 @@
       <vscode-checkbox
         :checked="checked"
         :disabled="disabled"
+        :indeterminate="indeterminate"
         class="tree-item-checkbox"
         @click="checked ? $emit('uncheck') : $emit('check')"
       >
@@ -61,6 +62,7 @@ const expanded = defineModel("expanded", { required: false, default: false });
 interface Props {
   title: string;
   checked: boolean;
+  indeterminate?: boolean;
   disabled?: boolean;
   listStyle?: TreeItemStyle;
   description?: string;

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -4,6 +4,7 @@
     :key="file.id"
     :title="file.base"
     :checked="isFileIncluded(file)"
+    :indeterminate="isFileIndeterminate(file)"
     :disabled="
       file.reason?.source === 'built-in' ||
       file.reason?.source === 'permissions'
@@ -60,7 +61,7 @@ import { useHostConduitService } from "src/HostConduitService";
 import PostDecor from "src/components/tree/PostDecor.vue";
 import { ActionButton } from "src/components/ActionToolbar.vue";
 
-import { ContentRecordFile, FileMatchSource } from "../../../../../../src/api";
+import { ContentRecordFile } from "../../../../../../src/api";
 import { WebviewToHostMessageType } from "../../../../../../src/types/messages/webviewToHostMessages";
 
 interface Props {
@@ -114,5 +115,21 @@ const fileActions = (file: ContentRecordFile): ActionButton[] => {
   }
 
   return actions;
+};
+
+const isFileIndeterminate = (file: ContentRecordFile) => {
+  if (!file.isDir) {
+    return false;
+  }
+
+  if (isFileIncluded(file)) {
+    return file.allIncluded ? false : true;
+  }
+
+  if (file.allExcluded) {
+    return false;
+  }
+
+  return true;
 };
 </script>


### PR DESCRIPTION
This PR adds an `indeterminate` state to the checkboxes in the tree Project Files view based on inclusion and the new `allIncluded` and `allExcluded` attributes.

## Intent

Resolves #2219

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

You can see the different states by:
- including a directory, but not one of its children
- excluding a directory, but including one of its children

Keep in mind that the include/exclude files API doesn't handle directories perfectly. I'd recommend looking closely at the files attribute in the Configuration while testing this feature to ensure erroneous includes are being added.
