### PR TITLE
Use `file.id` comparison to match content record files list

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -28,7 +28,7 @@
         v-if="
           file.isFile &&
           isFileIncluded(file) &&
-          !home.flatFiles.lastDeployedFiles.has(file.rel)
+          !home.flatFiles.lastDeployedFiles.has(file.id)
         "
         class="text-git-added"
       >
@@ -38,7 +38,7 @@
         v-if="
           file.isFile &&
           !isFileIncluded(file) &&
-          home.flatFiles.lastDeployedFiles.has(file.rel)
+          home.flatFiles.lastDeployedFiles.has(file.id)
         "
         class="text-git-deleted"
       >


### PR DESCRIPTION
This PR fixes the windows path comparisons between the Content Record's `file` list and the files we get from the files API.

Previously I was using `file.rel` which was doing comparisons like:
```
'subdir\\subsubdir\\newtext.txt' == 'subdir/subsubdir/newtext.txt'
```

Instead of 
```
'subdir/subsubdir/newtext.txt' == 'subdir/subsubdir/newtext.txt'
```

`file.rel` in our files API gives the relative path with the OS's separators where `file.id` gives the same string that we expect in our content records and configuration files.

With that corrected this should address the issue of decorators showing up or not showing up correctly on Windows.

## Intent

Resolves #2112

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
