### PR TITLE
Adding some more debug lines to inspection and deployment

### DIFF
--- a/cmd/publisher/commands/deploy.go
+++ b/cmd/publisher/commands/deploy.go
@@ -69,5 +69,5 @@ func (cmd *DeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext)
 	if err != nil {
 		return err
 	}
-	return publisher.PublishDirectory(ctx.Logger)
+	return publisher.PublishDirectory()
 }

--- a/cmd/publisher/commands/redeploy.go
+++ b/cmd/publisher/commands/redeploy.go
@@ -55,5 +55,5 @@ func (cmd *RedeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContex
 	if err != nil {
 		return err
 	}
-	return publisher.PublishDirectory(ctx.Logger)
+	return publisher.PublishDirectory()
 }

--- a/internal/publish/bundle.go
+++ b/internal/publish/bundle.go
@@ -29,12 +29,11 @@ type uploadBundleSuccessData struct {
 func (p *defaultPublisher) createAndUploadBundle(
 	client connect.APIClient,
 	bundler bundles.Bundler,
-	contentID types.ContentID,
-	log logging.Logger) (types.BundleID, error) {
+	contentID types.ContentID) (types.BundleID, error) {
 
 	// Create Bundle step
 	op := events.PublishCreateBundleOp
-	prepareLog := log.WithArgs(logging.LogKeyOp, op)
+	prepareLog := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, createBundleStartData{}))
 	prepareLog.Info("Preparing files")
@@ -60,12 +59,13 @@ func (p *defaultPublisher) createAndUploadBundle(
 
 	// Upload Bundle step
 	op = events.PublishUploadBundleOp
-	uploadLog := log.WithArgs(logging.LogKeyOp, op)
+	uploadLog := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, uploadBundleStartData{}))
 	uploadLog.Info("Uploading files")
 
-	bundleID, err := client.UploadBundle(contentID, bundleFile, log)
+	bundleID, err := client.UploadBundle(contentID, bundleFile, p.log)
+	p.log.Debug("Bundle uploaded", "deployment", p.TargetName, "bundle_id", bundleID)
 	if err != nil {
 		return "", types.OperationError(op, err)
 	}
@@ -80,8 +80,11 @@ func (p *defaultPublisher) createAndUploadBundle(
 		if filename == "" {
 			filename = inspect.PythonRequirementsFilename
 		}
-		inspector := inspect.NewPythonInspector(p.Dir, util.Path{}, log)
+		p.log.Debug("Python configuration present", "filename", filename)
+
+		inspector := inspect.NewPythonInspector(p.Dir, util.Path{}, p.log)
 		requirements, err := inspector.ReadRequirementsFile(p.Dir.Join(filename))
+		p.log.Debug("Python requirements file in use", "requirements", requirements)
 		if err != nil {
 			return "", err
 		}
@@ -93,10 +96,12 @@ func (p *defaultPublisher) createAndUploadBundle(
 		if filename == "" {
 			filename = inspect.DefaultRenvLockfile
 		}
+		p.log.Debug("R configuration present", "filename", filename)
 		lockfile, err := renv.ReadLockfile(p.Dir.Join(filename))
 		if err != nil {
 			return "", err
 		}
+		p.log.Debug("Renv lockfile in use", "lockfile", lockfile)
 		p.Target.Renv = lockfile
 	}
 

--- a/internal/publish/check_configuration.go
+++ b/internal/publish/check_configuration.go
@@ -17,9 +17,9 @@ type checkConfigurationSuccessData struct{}
 
 var errTypeChanged = errors.New("configuration type cannot be changed once deployed; create a new destination to use a different type")
 
-func (p *defaultPublisher) checkConfiguration(client connect.APIClient, log logging.Logger) error {
+func (p *defaultPublisher) checkConfiguration(client connect.APIClient) error {
 	op := events.PublishCheckCapabilitiesOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, checkConfigurationStartData{}))
 	log.Info("Checking configuration against server capabilities")
@@ -31,10 +31,12 @@ func (p *defaultPublisher) checkConfiguration(client connect.APIClient, log logg
 	log.Info("Publishing with credentials", "username", user.Username, "email", user.Email)
 
 	if p.Target != nil {
+		log.Debug("Target found while checking configuration")
 		previousType := p.Target.Type
 		currentType := p.Config.Type
 
 		if previousType != "" && previousType != config.ContentTypeUnknown && currentType != previousType {
+			log.Debug("Content type mismatch between previous and new target", "previous_type", previousType, "current_type", currentType)
 			return types.OperationError(op, errTypeChanged)
 		}
 	}

--- a/internal/publish/create_deployment.go
+++ b/internal/publish/create_deployment.go
@@ -18,9 +18,9 @@ type createDeploymentSuccessData struct {
 	SaveName  string          `mapstructure:"saveName"`
 }
 
-func (p *defaultPublisher) createDeployment(client connect.APIClient, log logging.Logger) (types.ContentID, error) {
+func (p *defaultPublisher) createDeployment(client connect.APIClient) (types.ContentID, error) {
 	op := events.PublishCreateNewDeploymentOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, createDeploymentStartData{
 		SaveName: p.SaveName,

--- a/internal/publish/deploy_bundle.go
+++ b/internal/publish/deploy_bundle.go
@@ -17,11 +17,10 @@ type deployBundleSuccessData struct {
 func (p *defaultPublisher) deployBundle(
 	client connect.APIClient,
 	contentID types.ContentID,
-	bundleID types.BundleID,
-	log logging.Logger) (types.TaskID, error) {
+	bundleID types.BundleID) (types.TaskID, error) {
 
 	op := events.PublishDeployBundleOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, deployBundleStartData{}))
 	log.Info("Activating Deployment")

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -26,11 +26,12 @@ import (
 )
 
 type Publisher interface {
-	PublishDirectory(logging.Logger) error
+	PublishDirectory() error
 }
 
 type defaultPublisher struct {
 	*state.State
+	log            logging.Logger
 	emitter        events.Emitter
 	rPackageMapper renv.PackageMapper
 }
@@ -76,6 +77,7 @@ func NewFromState(s *state.State, emitter events.Emitter, log logging.Logger) (P
 	}
 	return &defaultPublisher{
 		State:          s,
+		log:            log,
 		emitter:        emitter,
 		rPackageMapper: renv.NewPackageMapper(s.Dir, util.Path{}),
 	}, nil
@@ -127,7 +129,7 @@ func (p *defaultPublisher) isDeployed() bool {
 	return p.Target != nil && p.Target.ID != ""
 }
 
-func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
+func (p *defaultPublisher) emitErrorEvents(err error) {
 	agentErr, ok := err.(*types.AgentError)
 	if !ok {
 		agentErr = types.NewAgentError(types.UnknownErrorCode, err, nil)
@@ -147,7 +149,7 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 		p.Target.Error = agentErr
 		writeErr := p.writeDeploymentRecord()
 		if writeErr != nil {
-			log.Warn("failed to write updated deployment record", "name", p.TargetName, "err", writeErr)
+			p.log.Warn("failed to write updated deployment record", "name", p.TargetName, "err", writeErr)
 		}
 		if p.isDeployed() {
 			// Provide URL in the event, if we got far enough in the deployment.
@@ -180,26 +182,26 @@ func (p *defaultPublisher) emitErrorEvents(err error, log logging.Logger) {
 		data))
 }
 
-func (p *defaultPublisher) PublishDirectory(log logging.Logger) error {
-	log.Info("Publishing from directory", logging.LogKeyOp, events.AgentOp, "path", p.Dir)
+func (p *defaultPublisher) PublishDirectory() error {
+	p.log.Info("Publishing from directory", logging.LogKeyOp, events.AgentOp, "path", p.Dir)
 	p.emitter.Emit(events.New(events.PublishOp, events.StartPhase, events.NoError, publishStartData{
 		Server: p.Account.URL,
 		Title:  p.Config.Title,
 	}))
-	log.Info("Starting deployment to server", "server", p.Account.URL)
+	p.log.Info("Starting deployment to server", "server", p.Account.URL)
 
 	// TODO: factory method to create client based on server type
 	// TODO: timeout option
-	client, err := connect.NewConnectClient(p.Account, 2*time.Minute, p.emitter, log)
+	client, err := connect.NewConnectClient(p.Account, 2*time.Minute, p.emitter, p.log)
 	if err != nil {
 		return err
 	}
-	err = p.publishWithClient(p.Account, client, log)
+	err = p.publishWithClient(p.Account, client)
 	if p.isDeployed() {
-		logAppInfo(os.Stderr, p.Account.URL, p.Target.ID, log, err)
+		logAppInfo(os.Stderr, p.Account.URL, p.Target.ID, p.log, err)
 	}
 	if err != nil {
-		p.emitErrorEvents(err, log)
+		p.emitErrorEvents(err)
 	} else {
 		p.emitter.Emit(events.New(events.PublishOp, events.SuccessPhase, events.NoError, publishSuccessData{
 			DashboardURL: getDashboardURL(p.Account.URL, p.Target.ID),
@@ -215,9 +217,11 @@ func (p *defaultPublisher) PublishDirectory(log logging.Logger) error {
 func (p *defaultPublisher) writeDeploymentRecord() error {
 	if p.SaveName == "" {
 		// Redeployment
+		p.log.Debug("No SaveName found in deployment. Redeploying.", "deployment", p.TargetName)
 		p.SaveName = p.TargetName
 	} else {
 		// Initial deployment
+		p.log.Debug("SaveName found in deployment. First deployment.", "deployment", p.SaveName)
 		p.TargetName = p.SaveName
 	}
 
@@ -227,6 +231,7 @@ func (p *defaultPublisher) writeDeploymentRecord() error {
 	p.Target.Configuration = p.Config
 
 	recordPath := deployment.GetDeploymentPath(p.Dir, p.SaveName)
+	p.log.Debug("Writing deployment record", "path", recordPath)
 	return p.Target.WriteFile(recordPath)
 }
 
@@ -278,25 +283,24 @@ func (p *defaultPublisher) createDeploymentRecord(
 
 func (p *defaultPublisher) publishWithClient(
 	account *accounts.Account,
-	client connect.APIClient,
-	log logging.Logger) error {
+	client connect.APIClient) error {
 
 	manifest := bundles.NewManifestFromConfig(p.Config)
-	log.Debug("Built manifest from config", "config", p.ConfigName)
+	p.log.Debug("Built manifest from config", "config", p.ConfigName)
 
 	if p.Config.R != nil {
-		rPackages, err := p.getRPackages(log)
+		rPackages, err := p.getRPackages()
 		if err != nil {
 			return err
 		}
 		manifest.Packages = rPackages
 	}
-	bundler, err := bundles.NewBundler(p.Dir, manifest, p.Config.Files, log)
+	bundler, err := bundles.NewBundler(p.Dir, manifest, p.Config.Files, p.log)
 	if err != nil {
 		return err
 	}
 
-	err = p.checkConfiguration(client, log)
+	err = p.checkConfiguration(client)
 	if err != nil {
 		return err
 	}
@@ -304,10 +308,10 @@ func (p *defaultPublisher) publishWithClient(
 	var contentID types.ContentID
 	if p.isDeployed() {
 		contentID = p.Target.ID
-		log.Info("Updating deployment", "content_id", contentID)
+		p.log.Info("Updating deployment", "content_id", contentID)
 	} else {
 		// Create a new deployment; we will update it with details later.
-		contentID, err = p.createDeployment(client, log)
+		contentID, err = p.createDeployment(client)
 		if err != nil {
 			return err
 		}
@@ -317,34 +321,34 @@ func (p *defaultPublisher) publishWithClient(
 		return types.OperationError(events.PublishCreateNewDeploymentOp, err)
 	}
 
-	bundleID, err := p.createAndUploadBundle(client, bundler, contentID, log)
+	bundleID, err := p.createAndUploadBundle(client, bundler, contentID)
 	if err != nil {
 		return err
 	}
 
-	err = p.updateContent(client, contentID, log)
+	err = p.updateContent(client, contentID)
 	if err != nil {
 		return err
 	}
 
-	err = p.setEnvVars(client, contentID, log)
+	err = p.setEnvVars(client, contentID)
 	if err != nil {
 		return err
 	}
 
-	taskID, err := p.deployBundle(client, contentID, bundleID, log)
+	taskID, err := p.deployBundle(client, contentID, bundleID)
 	if err != nil {
 		return err
 	}
 
-	taskLogger := log.WithArgs("source", "server.log")
+	taskLogger := p.log.WithArgs("source", "server.log")
 	err = client.WaitForTask(taskID, taskLogger)
 	if err != nil {
 		return err
 	}
 
 	if p.Config.Validate {
-		err = p.validateContent(client, contentID, log)
+		err = p.validateContent(client, contentID)
 		if err != nil {
 			return err
 		}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -282,6 +282,8 @@ func (p *defaultPublisher) publishWithClient(
 	log logging.Logger) error {
 
 	manifest := bundles.NewManifestFromConfig(p.Config)
+	log.Debug("Built manifest from config", "config", p.ConfigName)
+
 	if p.Config.R != nil {
 		rPackages, err := p.getRPackages(log)
 		if err != nil {

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -291,6 +291,7 @@ func (s *PublishSuite) publishWithClient(
 
 	publisher := &defaultPublisher{
 		State:   stateStore,
+		log:     s.log,
 		emitter: emitter,
 	}
 
@@ -302,14 +303,14 @@ func (s *PublishSuite) publishWithClient(
 	}
 	publisher.rPackageMapper = rPackageMapper
 
-	err := publisher.publishWithClient(account, client, s.log)
+	err := publisher.publishWithClient(account, client)
 	if expectedErr == nil {
 		s.NoError(err)
 	} else {
 		s.NotNil(err)
 		s.Equal(expectedErr.Error(), err.Error())
 
-		publisher.emitErrorEvents(err, s.log)
+		publisher.emitErrorEvents(err)
 	}
 	if target != nil {
 		// Creation date is not updated on deployment
@@ -362,10 +363,11 @@ func (s *PublishSuite) TestEmitErrorEventsNoTarget() {
 	emitter := events.NewCapturingEmitter()
 	publisher := &defaultPublisher{
 		State:   &state.State{},
+		log:     log,
 		emitter: emitter,
 	}
 
-	publisher.emitErrorEvents(expectedErr, log)
+	publisher.emitErrorEvents(expectedErr)
 
 	// We should emit a phase failure event and a publishing failure event.
 	s.Len(emitter.Events, 2)
@@ -397,10 +399,11 @@ func (s *PublishSuite) TestEmitErrorEventsWithTarget() {
 				ID: targetID,
 			},
 		},
+		log:     log,
 		emitter: emitter,
 	}
 
-	publisher.emitErrorEvents(expectedErr, log)
+	publisher.emitErrorEvents(expectedErr)
 
 	// We should emit a phase failure event and a publishing failure event.
 	s.Len(emitter.Events, 2)

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -12,9 +12,9 @@ import (
 type getRPackageDescriptionsStartData struct{}
 type getRPackageDescriptionsSuccessData struct{}
 
-func (p *defaultPublisher) getRPackages(log logging.Logger) (bundles.PackageMap, error) {
+func (p *defaultPublisher) getRPackages() (bundles.PackageMap, error) {
 	op := events.PublishGetRPackageDescriptionsOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, getRPackageDescriptionsStartData{}))
 	log.Info("Collecting R package descriptions")
@@ -25,6 +25,7 @@ func (p *defaultPublisher) getRPackages(log logging.Logger) (bundles.PackageMap,
 	}
 	lockfilePath := p.Dir.Join(lockfileString)
 
+	log.Debug("Collecting manifest R packages", "lockfile", lockfilePath)
 	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
 	if err != nil {
 		return nil, err

--- a/internal/publish/set_env_vars.go
+++ b/internal/publish/set_env_vars.go
@@ -14,8 +14,7 @@ type setEnvVarsSuccessData struct{}
 
 func (p *defaultPublisher) setEnvVars(
 	client connect.APIClient,
-	contentID types.ContentID,
-	log logging.Logger) error {
+	contentID types.ContentID) error {
 
 	env := p.Config.Environment
 	if len(env) == 0 {
@@ -23,7 +22,7 @@ func (p *defaultPublisher) setEnvVars(
 	}
 
 	op := events.PublishSetEnvVarsOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, setEnvVarsStartData{}))
 	log.Info("Setting environment variables")

--- a/internal/publish/update_content.go
+++ b/internal/publish/update_content.go
@@ -24,11 +24,10 @@ type DeploymentNotFoundErrorDetails struct {
 
 func (p *defaultPublisher) updateContent(
 	client connect.APIClient,
-	contentID types.ContentID,
-	log logging.Logger) error {
+	contentID types.ContentID) error {
 
 	op := events.PublishUpdateDeploymentOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, updateContentStartData{
 		ContentID: contentID,

--- a/internal/publish/validate.go
+++ b/internal/publish/validate.go
@@ -17,11 +17,10 @@ type validateSuccessData struct{}
 
 func (p *defaultPublisher) validateContent(
 	client connect.APIClient,
-	contentID types.ContentID,
-	log logging.Logger) error {
+	contentID types.ContentID) error {
 
 	op := events.PublishValidateDeploymentOp
-	log = log.WithArgs(logging.LogKeyOp, op)
+	log := p.log.WithArgs(logging.LogKeyOp, op)
 
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, validateStartData{
 		DirectURL: getDirectURL(p.Account.URL, p.Target.ID),

--- a/internal/services/api/api_helpers.go
+++ b/internal/services/api/api_helpers.go
@@ -51,6 +51,7 @@ var errProjectDirNotFound = errors.New("project directory not found")
 // Other errors return a 500.
 func ProjectDirFromRequest(base util.AbsolutePath, w http.ResponseWriter, req *http.Request, log logging.Logger) (util.AbsolutePath, util.RelativePath, error) {
 	dir := req.URL.Query().Get("dir")
+	log.Debug("Picking directory from request", "directory", dir)
 	projectDir, err := base.SafeJoin(dir)
 	if err != nil {
 		BadRequest(w, req, log, err)

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -78,6 +78,7 @@ func PostDeploymentHandlerFunc(
 		w.WriteHeader(http.StatusAccepted)
 		json.NewEncoder(w).Encode(response)
 
+		log := log.WithArgs("local_id", localID)
 		newState.LocalID = localID
 		publisher, err := publisherFactory(newState, emitter, log)
 		log.Debug("New publisher derived from state", "account", b.AccountName, "config", b.ConfigName)
@@ -87,8 +88,7 @@ func PostDeploymentHandlerFunc(
 		}
 
 		go func() {
-			log := log.WithArgs("local_id", localID)
-			err = publisher.PublishDirectory(log)
+			err = publisher.PublishDirectory()
 			if err != nil {
 				log.Error("Deployment failed", "error", err.Error())
 				return

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -55,6 +55,8 @@ func PostDeploymentHandlerFunc(
 			return
 		}
 		newState, err := stateFactory(projectDir, b.AccountName, b.ConfigName, name, "", accountList)
+		log.Debug("New account derived state created", "account", b.AccountName, "config", b.ConfigName)
+
 		if err != nil {
 			if errors.Is(err, accounts.ErrAccountNotFound) {
 				NotFound(w, log, err)
@@ -78,6 +80,7 @@ func PostDeploymentHandlerFunc(
 
 		newState.LocalID = localID
 		publisher, err := publisherFactory(newState, emitter, log)
+		log.Debug("New publisher derived from state", "account", b.AccountName, "config", b.ConfigName)
 		if err != nil {
 			InternalError(w, req, log, err)
 			return

--- a/internal/services/api/post_deployment_test.go
+++ b/internal/services/api/post_deployment_test.go
@@ -50,8 +50,8 @@ type mockPublisher struct {
 	mock.Mock
 }
 
-func (m *mockPublisher) PublishDirectory(log logging.Logger) error {
-	args := m.Called(log)
+func (m *mockPublisher) PublishDirectory() error {
+	args := m.Called()
 	return args.Error(0)
 }
 

--- a/internal/services/api/post_deployments.go
+++ b/internal/services/api/post_deployments.go
@@ -65,12 +65,14 @@ func PostDeploymentsHandlerFunc(
 			return
 		}
 		if exists {
+			log.Debug("Conflict found, deployment already exists", "path", path)
 			w.WriteHeader(http.StatusConflict)
 			return
 		}
 
 		if b.ConfigName != "" {
 			// Config must exist
+			log.Debug("Config name found in request", "config_name", b.ConfigName)
 			configPath := config.GetConfigPath(projectDir, b.ConfigName)
 			exists, err = configPath.Exists()
 			if err != nil {
@@ -89,6 +91,7 @@ func PostDeploymentsHandlerFunc(
 		d.ServerType = acct.ServerType
 		d.ConfigName = b.ConfigName
 
+		log.Debug("Writing deployment file", "path", path.String())
 		err = d.WriteFile(path)
 		if err != nil {
 			InternalError(w, req, log, err)


### PR DESCRIPTION
## Intent

Adding some more debug logs to the inspection and deployment areas of the backend.

Connected to #2153 

## Approach

- Some new `log.Debug` calls within the inspection and deployment.
- Adding a logger instance to `defaultPublisher` to do logging calls easier across this instance methods.

## Automated Tests

Updated a few unit tests related to expected logging instances.

## Directions for Reviewers

While inspecting and deploying, there should be more debug log lines in the output.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
