### PR TITLE
Add GUID to POST /deployments and create new api skeleton for POST /inspect/remote/{GUID}

### DIFF
--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -27,9 +27,9 @@ type Deployment struct {
 	CreatedAt     string              `toml:"created_at" json:"createdAt"`
 	Type          config.ContentType  `toml:"type" json:"type"`
 	ConfigName    string              `toml:"configuration_name" json:"configurationName"`
+	ID            types.ContentID     `toml:"id,omitempty" json:"id"`
 
 	// Full deployment fields
-	ID            types.ContentID   `toml:"id,omitempty" json:"id"`
 	DeployedAt    string            `toml:"deployed_at,omitempty" json:"deployedAt"`
 	BundleID      types.BundleID    `toml:"bundle_id,omitempty" json:"bundleId"`
 	BundleURL     string            `toml:"bundle_url,omitempty" json:"bundleUrl"`

--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -82,6 +82,10 @@ func RouterHandlerFunc(base util.AbsolutePath, lister accounts.AccountList, log 
 	r.Handle(ToPath("inspect"), PostInspectHandlerFunc(base, log)).
 		Methods(http.MethodPost)
 
+	// POST /api/inspect/remote/$GUID
+	r.Handle(ToPath("inspect", "remote", "{guid}"), PostInspectRemoteHandlerFunc(base, log, lister)).
+		Methods(http.MethodPost)
+
 	// GET /api/credentials
 	r.Handle(ToPath("credentials"), GetCredentialsHandlerFunc(log)).
 		Methods(http.MethodGet)

--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -82,8 +82,8 @@ func RouterHandlerFunc(base util.AbsolutePath, lister accounts.AccountList, log 
 	r.Handle(ToPath("inspect"), PostInspectHandlerFunc(base, log)).
 		Methods(http.MethodPost)
 
-	// POST /api/inspect/remote/$GUID
-	r.Handle(ToPath("inspect", "remote", "{guid}"), PostInspectRemoteHandlerFunc(base, log, lister)).
+	// POST /api/inspect/remote/$accountName/$guid
+	r.Handle(ToPath("inspect", "remote", "{name}", "{guid}"), PostInspectRemoteHandlerFunc(base, log, lister)).
 		Methods(http.MethodPost)
 
 	// GET /api/credentials

--- a/internal/services/api/deployment_dto.go
+++ b/internal/services/api/deployment_dto.go
@@ -35,6 +35,7 @@ type preDeploymentDTO struct {
 	ConfigName string              `json:"configurationName,omitempty"`
 	ConfigPath string              `json:"configurationPath,omitempty"`
 	Error      *types.AgentError   `json:"deploymentError,omitempty"`
+	ID         types.ContentID     `json:"id,omitempty"`
 }
 
 type fullDeploymentDTO struct {

--- a/internal/services/api/post_deployments.go
+++ b/internal/services/api/post_deployments.go
@@ -10,15 +10,17 @@ import (
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/deployment"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 )
 
 // Copyright (C) 2023 by Posit Software, PBC.
 
 type PostDeploymentsRequestBody struct {
-	AccountName string `json:"account"`
-	ConfigName  string `json:"config"`
-	SaveName    string `json:"saveName"`
+	AccountName string          `json:"account"`
+	ConfigName  string          `json:"config"`
+	SaveName    string          `json:"saveName"`
+	ID          types.ContentID `json:"id"`
 }
 
 func PostDeploymentsHandlerFunc(
@@ -88,6 +90,11 @@ func PostDeploymentsHandlerFunc(
 		d.ServerURL = acct.URL
 		d.ServerType = acct.ServerType
 		d.ConfigName = b.ConfigName
+
+		if b.ID != "" {
+			d.ID = b.ID
+			log.Info("Post Deployment - Existing ID passed in", b.ID)
+		}
 
 		err = d.WriteFile(path)
 		if err != nil {

--- a/internal/services/api/post_deployments_test.go
+++ b/internal/services/api/post_deployments_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/posit-dev/publisher/internal/accounts"
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/spf13/afero"
@@ -84,6 +85,55 @@ func (s *PostDeploymentsSuite) TestPostDeployments() {
 	s.Equal(accounts.ServerTypeConnect, res.ServerType)
 	s.Equal(acct.URL, res.ServerURL)
 	s.Equal(deploymentStateNew, res.State)
+}
+
+func (s *PostDeploymentsSuite) TestPostDeploymentsWithID() {
+	lister := &accounts.MockAccountList{}
+	acct := &accounts.Account{
+		Name:       "myAccount",
+		URL:        "https://connect.example.com",
+		ServerType: accounts.ServerTypeConnect,
+	}
+	lister.On("GetAccountByName", "myAccount").Return(acct, nil)
+
+	h := PostDeploymentsHandlerFunc(s.cwd, logging.New(), lister)
+
+	cfg := config.New()
+	err := cfg.WriteFile(config.GetConfigPath(s.cwd, "myConfig"))
+	s.NoError(err)
+
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(`{
+		"account": "myAccount",
+		"config": "myConfig",
+		"saveName": "newDeployment",
+		"id": "abc"
+	}`)
+	req, err := http.NewRequest("POST", "/api/deployments", body)
+	s.NoError(err)
+	h(rec, req)
+
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	res := fullDeploymentDTO{}
+	dec := json.NewDecoder(rec.Body)
+	dec.DisallowUnknownFields()
+	s.NoError(dec.Decode(&res))
+
+	actualPath, err := util.NewPath(res.Path, s.cwd.Fs()).Rel(s.cwd)
+	s.NoError(err)
+	s.Equal(filepath.Join(".posit", "publish", "deployments", "newDeployment.toml"), actualPath.String())
+
+	s.Equal("newDeployment", res.Name)
+	s.Equal("newDeployment", res.SaveName)
+	s.Equal(".", res.ProjectDir)
+	s.Equal("myConfig", res.ConfigName)
+	s.Equal("myConfig.toml", filepath.Base(res.ConfigPath))
+	s.Equal(accounts.ServerTypeConnect, res.ServerType)
+	s.Equal(acct.URL, res.ServerURL)
+	s.Equal(deploymentStateDeployed, res.State)
+	s.Equal(types.ContentID("abc"), res.ID)
 }
 
 func (s *PostDeploymentsSuite) TestPostDeploymentsNoConfig() {

--- a/internal/services/api/post_inspect_remote.go
+++ b/internal/services/api/post_inspect_remote.go
@@ -1,0 +1,74 @@
+package api
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/posit-dev/publisher/internal/accounts"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/util"
+)
+
+type postInspectRemoteRequestBody struct {
+	AccountName string `json:"account"`
+}
+
+type postInspectRemoteResponseBody struct {
+	// Configuration *config.Config `json:"configuration"`
+	ProjectDir string          `json:"projectDir"`
+	ServerURL  string          `json:"serverUrl"`
+	ID         types.ContentID `json:"id,omitempty"`
+}
+
+func PostInspectRemoteHandlerFunc(
+	base util.AbsolutePath,
+	log logging.Logger,
+	accountList accounts.AccountList,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		guid := mux.Vars(req)["guid"]
+		_, relProjectDir, err := ProjectDirFromRequest(base, w, req, log)
+		if err != nil {
+			// Response already returned by ProjectDirFromRequest
+			return
+		}
+		dec := json.NewDecoder(req.Body)
+		dec.DisallowUnknownFields()
+		var b postInspectRemoteRequestBody
+		err = dec.Decode(&b)
+		if err != nil {
+			BadRequest(w, req, log, err)
+			return
+		}
+		log.Info("POST inspect/remote was passed in", "ID", guid, "AccountName", b.AccountName)
+
+		acct, err := accountList.GetAccountByName(b.AccountName)
+		if err != nil {
+			if errors.Is(err, accounts.ErrAccountNotFound) {
+				NotFound(w, log, err)
+				return
+			} else {
+				InternalError(w, req, log, err)
+				return
+			}
+		}
+
+		response := postInspectRemoteResponseBody{}
+
+		// send what we know now.
+		response = postInspectRemoteResponseBody{
+			ProjectDir: relProjectDir.String(),
+			ServerURL:  acct.URL,
+			ID:         types.ContentID(guid),
+		}
+
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}
+}

--- a/internal/services/api/post_inspect_remote.go
+++ b/internal/services/api/post_inspect_remote.go
@@ -14,10 +14,6 @@ import (
 	"github.com/posit-dev/publisher/internal/util"
 )
 
-type postInspectRemoteRequestBody struct {
-	AccountName string `json:"account"`
-}
-
 type postInspectRemoteResponseBody struct {
 	// Configuration *config.Config `json:"configuration"`
 	ProjectDir string          `json:"projectDir"`

--- a/internal/services/api/post_inspect_remote.go
+++ b/internal/services/api/post_inspect_remote.go
@@ -31,23 +31,18 @@ func PostInspectRemoteHandlerFunc(
 	accountList accounts.AccountList,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		guid := mux.Vars(req)["guid"]
+		vars := mux.Vars(req)
+		guid := vars["guid"]
+		accountName := vars["name"]
+
 		_, relProjectDir, err := ProjectDirFromRequest(base, w, req, log)
 		if err != nil {
 			// Response already returned by ProjectDirFromRequest
 			return
 		}
-		dec := json.NewDecoder(req.Body)
-		dec.DisallowUnknownFields()
-		var b postInspectRemoteRequestBody
-		err = dec.Decode(&b)
-		if err != nil {
-			BadRequest(w, req, log, err)
-			return
-		}
-		log.Info("POST inspect/remote was passed in", "ID", guid, "AccountName", b.AccountName)
+		log.Info("POST inspect/remote was passed in", "ID", guid, "AccountName", accountName)
 
-		acct, err := accountList.GetAccountByName(b.AccountName)
+		acct, err := accountList.GetAccountByName(accountName)
 		if err != nil {
 			if errors.Is(err, accounts.ErrAccountNotFound) {
 				NotFound(w, log, err)
@@ -58,10 +53,8 @@ func PostInspectRemoteHandlerFunc(
 			}
 		}
 
-		response := postInspectRemoteResponseBody{}
-
 		// send what we know now.
-		response = postInspectRemoteResponseBody{
+		response := postInspectRemoteResponseBody{
 			ProjectDir: relProjectDir.String(),
 			ServerURL:  acct.URL,
 			ID:         types.ContentID(guid),

--- a/internal/services/api/post_inspect_remote_test.go
+++ b/internal/services/api/post_inspect_remote_test.go
@@ -1,0 +1,79 @@
+package api
+
+// Copyright (C) 2023 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/posit-dev/publisher/internal/accounts"
+	"github.com/posit-dev/publisher/internal/config"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+)
+
+type PostInspectRemoteSuite struct {
+	utiltest.Suite
+	cwd util.AbsolutePath
+}
+
+func TestPostInspectRemoteSuite(t *testing.T) {
+	suite.Run(t, new(PostInspectRemoteSuite))
+}
+
+func (s *PostInspectRemoteSuite) SetupTest() {
+	fs := afero.NewMemMapFs()
+	cwd, err := util.Getwd(fs)
+	s.Nil(err)
+	s.cwd = cwd
+	s.cwd.MkdirAll(0700)
+}
+
+func (s *PostInspectRemoteSuite) TestPostInspectRemote() {
+	lister := &accounts.MockAccountList{}
+	acct := &accounts.Account{
+		Name:       "myAccount",
+		URL:        "https://connect.example.com",
+		ServerType: accounts.ServerTypeConnect,
+	}
+	lister.On("GetAccountByName", "myAccount").Return(acct, nil)
+
+	h := PostInspectRemoteHandlerFunc(s.cwd, logging.New(), lister)
+
+	cfg := config.New()
+	err := cfg.WriteFile(config.GetConfigPath(s.cwd, "myConfig"))
+	s.NoError(err)
+
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(`{
+		"account": "myAccount"
+	}`)
+	guid := "abc"
+	path, err := url.JoinPath("/api/inspect/remote/", guid)
+	s.NoError(err)
+	req, err := http.NewRequest("POST", path, body)
+	s.NoError(err)
+	req = mux.SetURLVars(req, map[string]string{"guid": guid})
+	h(rec, req)
+
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	res := postInspectRemoteResponseBody{}
+	dec := json.NewDecoder(rec.Body)
+	dec.DisallowUnknownFields()
+	s.NoError(dec.Decode(&res))
+
+	s.Equal(acct.URL, res.ServerURL)
+	s.Equal(types.ContentID("abc"), res.ID)
+	s.Equal(".", res.ProjectDir)
+}

--- a/internal/services/api/post_inspect_remote_test.go
+++ b/internal/services/api/post_inspect_remote_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -54,15 +53,13 @@ func (s *PostInspectRemoteSuite) TestPostInspectRemote() {
 	s.NoError(err)
 
 	rec := httptest.NewRecorder()
-	body := strings.NewReader(`{
-		"account": "myAccount"
-	}`)
+	account := "myAccount"
 	guid := "abc"
-	path, err := url.JoinPath("/api/inspect/remote/", guid)
+	path, err := url.JoinPath("/api/inspect/remote", account, guid)
 	s.NoError(err)
-	req, err := http.NewRequest("POST", path, body)
+	req, err := http.NewRequest("POST", path, nil)
 	s.NoError(err)
-	req = mux.SetURLVars(req, map[string]string{"guid": guid})
+	req = mux.SetURLVars(req, map[string]string{"name": account, "guid": guid})
 	h(rec, req)
 
 	s.Equal(http.StatusOK, rec.Result().StatusCode)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2224 
Resolves #2250

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

POST /api/deployments now allows for an optional data attribute `id`, which will set the GUID within the pre-deployment record. Pre-deployment DTO has been modified to include the `id` field.

POST /api/inspect/remote/{account}/{GUID} is now available and simply validates the account passed in and prints out the GUID (as part of a skeleton implementation).

Unit tests have been updated/created for both.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->
Unit tests validate:
- for POST /api/deployments: that the ID is optional and functions as expected when provided
- for POST /api/inspect/remote: that the API is handled and the GUID is pulled correctly out of the request

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Validation is done by the unit tests, however, you can execute the code with something similar to:

**previous functionality**
```
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s -XPOST -d '{"account":"dev-password","config":"configuration-1","saveName":"file1"}' 'localhost:9001/api/deployments?dir=test/sample-content/fastapi-simple'
```

**new functionality** - passing in an id, which is saved in file2
```
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s -XPOST -d '{"account":"dev-password","config":"configuration-1","saveName":"file2","id":"abc"}' 'localhost:9001/api/deployments?dir=test/sample-content/fastapi-simple'
```

**new endpoint**
```
$(just executable-path) ui -vv --listen=localhost:9001 &
curl -s -XPOST 'localhost:9001/api/inspect/remote/dev-password/abc'
```
