### PR TITLE
End deployment filenames with unique characters

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -33,10 +33,7 @@ import {
   getMessageFromError,
   getSummaryStringFromError,
 } from "src/utils/errors";
-import {
-  newConfigFileNameFromTitle,
-  untitledContentRecordName,
-} from "src/utils/names";
+import { newDeploymentName, newConfigFileNameFromTitle } from "src/utils/names";
 import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
 import { DeploymentObjects } from "src/types/shared";
@@ -1340,7 +1337,7 @@ export async function newDeployment(
     if (!existingNames) {
       existingNames = [];
     }
-    const contentRecordName = untitledContentRecordName(existingNames);
+    const contentRecordName = newDeploymentName(existingNames);
     const response = await api.contentRecords.createNew(
       selectedInspectionResult.projectDir,
       finalCredentialName,

--- a/extensions/vscode/src/utils/names.ts
+++ b/extensions/vscode/src/utils/names.ts
@@ -5,24 +5,14 @@ import { InputBoxValidationSeverity } from "vscode";
 import { isValidFilename } from "src/utils/files";
 import filenamify from "filenamify";
 
-export function untitledContentRecordName(
-  existingContentRecordNames: string[],
-): string {
-  if (existingContentRecordNames.length === 0) {
-    return "deployment-1";
-  }
-
-  let id = 0;
-  let defaultName = "";
+export function newDeploymentName(existingNames: string[] = []): string {
+  // Generate unique name endings until we find a unique one
+  let result;
   do {
-    id += 1;
-    const trialName = `deployment-${id}`;
+    result = `deployment-${randomNameEnding(4)}`;
+  } while (!uniqueContentRecordName(result, existingNames));
 
-    if (uniqueContentRecordName(trialName, existingContentRecordNames)) {
-      defaultName = trialName;
-    }
-  } while (!defaultName);
-  return defaultName;
+  return result;
 }
 
 export function uniqueContentRecordName(


### PR DESCRIPTION
With #2182 configuration file names were named like `fastapi-simple-QSPH` based on the title of the content.

This PR uses the same 4 random, base32 string appending characters to create content record files - like `deployment-DEQ7` to avoid git conflicts with created deployments.

## Intent

Resolves #1818

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
