### PR TITLE
Add secrets to config schema

### DIFF
--- a/internal/schema/schemas/config.toml
+++ b/internal/schema/schemas/config.toml
@@ -11,6 +11,7 @@ files = [
     "*.qmd",
     "requirements.txt",
 ]
+secrets = ["API_KEY", "DATABASE_PASSWORD"]
 
 [python]
 version = "3.11.3"

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -167,6 +167,14 @@
         }
       ]
     },
+    "secrets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Names of secrets required by the application. Injected as environment variables.",
+      "examples": ["API_KEY", "DATABASE_PASSWORD"]
+    },
     "connect": {
       "type": "object",
       "additionalProperties": false,

--- a/internal/schema/schemas/record.toml
+++ b/internal/schema/schemas/record.toml
@@ -22,6 +22,7 @@ files = [
     "*.qmd",
     "requirements.txt",
 ]
+secrets = ["API_KEY", "DATABASE_PASSWORD"]
 title = "Regional Quarterly Sales Report"
 description = "This is the quarterly sales report, broken down by region."
 


### PR DESCRIPTION
This PR adds `secrets` to our `posit-publishing-schema-v3.json` for Configuration files.

It is an array of strings to indicate the name (not value) of secrets that are available to be published alongside a deployment:

```
secrets = ['API_KEY', 'DATA_PASSWORD']
```

## Intent

Resolves #2251

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

~This doesn't include changes to the Content Record, but will be added in a future PR.~
After a bit more work on this I realized that isn't necessary.

A lot of file changes you may expect are missing from this PR since `secrets` was already in our Frontend and Backend types for Configuration details. We just didn't specify them in the schema.

I did not increase the schema version for this since older schemas are not made invalid since this is only adding an attribute.

## Automated Tests

No automated tests were added. The secrets attribute was already present, and TOML verification is already being tested.
