### PR TITLE
Add optional secrets arg to publish method

### DIFF
--- a/extensions/vscode/src/api/resources/ContentRecords.ts
+++ b/extensions/vscode/src/api/resources/ContentRecords.ts
@@ -72,10 +72,12 @@ export class ContentRecords {
     accountName: string,
     configName: string,
     dir: string,
+    secrets?: Record<string, string>,
   ) {
     const data = {
       account: accountName,
       config: configName,
+      secrets: secrets,
     };
     const encodedTarget = encodeURIComponent(targetName);
     return this.client.post<{ localId: string }>(


### PR DESCRIPTION
Nice and simple PR that adds the ability to send up the secrets in our `ContentRecords.publish()` method.

## Intent

Part of #2251