### PR TITLE
Avoid height changes in Tree Items due to `line-height`

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItem.vue
@@ -162,7 +162,6 @@ const toggleExpanded = () => {
       }
 
       .tree-item-description {
-        line-height: 22px;
         font-size: 0.9em;
         margin-left: 0.5em;
         opacity: 0.7;

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
@@ -160,7 +160,6 @@ const toggleExpanded = () => {
       }
 
       .tree-item-description {
-        line-height: 22px;
         font-size: 0.9em;
         margin-left: 0.5em;
         opacity: 0.7;


### PR DESCRIPTION
In `TreeItem` and `TreeItemCheckbox` there was a height difference depending on if a description was rendered. This was not very noticeable unless the description was toggled causing a `1px` layout shift.

The reason this was occurring was due to the `line-height` set on the `span` element containing the description:

> On block-level elements in horizontal writing modes, it (`line-height`) specifies the preferred height of line boxes within the element, and on non-[replaced](https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element) inline elements, it specifies the height that is used to calculate line box height.

`line-height` did not have any affect on the rendering of the description but did seem to adjust the height when that element was included in the DOM. Removing it fixed this issue.

<details>
  <summary>Recording of the layout shift</summary>
  
https://github.com/user-attachments/assets/364a6650-bbf1-48ad-a5ac-764cb13213a6


</details>

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->