### PR TITLE
Add Secrets view and deploy with Secrets to extension

### DIFF
--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -96,6 +96,7 @@ export type DeployMsg = AnyWebviewToHostMessage<
     credentialName: string;
     configurationName: string;
     projectDir: string;
+    secrets?: Record<string, string>;
   }
 >;
 

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -248,6 +248,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     credentialName: string,
     configurationName: string,
     projectDir: string,
+    secrets?: Record<string, string>,
   ) {
     try {
       const api = await useApi();
@@ -256,6 +257,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         credentialName,
         configurationName,
         projectDir,
+        secrets,
       );
       deployProject(response.data.localId, this.stream);
     } catch (error: unknown) {
@@ -270,6 +272,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       msg.content.credentialName,
       msg.content.configurationName,
       msg.content.projectDir,
+      msg.content.secrets,
     );
   }
 
@@ -1397,15 +1400,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   public debounceSendRefreshedFilesLists = debounce(async () => {
     return await this.sendRefreshedFilesLists();
   }, DebounceDelaysMS.file);
-
-  public initiatePublish(target: PublishProcessParams) {
-    this.initiateDeployment(
-      target.deploymentName,
-      target.credentialName,
-      target.configurationName,
-      target.projectDir,
-    );
-  }
 
   public async handleFileInitiatedDeploymentSelection(uri: Uri) {
     // Guide the user to create a new Deployment with that file as the entrypoint

--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -6,6 +6,7 @@
       <EvenEasierDeploy class="easy-deploy-container" />
       <template v-if="home.selectedConfiguration">
         <ProjectFiles v-model:expanded="projectFilesExpanded" />
+        <Secrets />
         <PythonPackages />
         <RPackages />
         <Credentials />
@@ -21,6 +22,7 @@ import { ref } from "vue";
 import OverlayableView from "src/components/OverlayableView.vue";
 import EvenEasierDeploy from "src/components/EvenEasierDeploy.vue";
 import ProjectFiles from "src/components/views/projectFiles/ProjectFiles.vue";
+import Secrets from "src/components/views/secrets/Secrets.vue";
 import PythonPackages from "src/components/views/PythonPackages.vue";
 import RPackages from "src/components/views/RPackages.vue";
 import Credentials from "src/components/views/Credentials.vue";

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -159,6 +159,7 @@ const onPublishStartMsg = () => {
 };
 const onPublishFinishSuccessMsg = () => {
   const home = useHomeStore();
+  home.clearSecretValues();
   home.publishInProgress = false;
   home.lastContentRecordResult = `Last Deployment was Successful`;
   home.lastContentRecordMsg = "";

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -46,6 +46,14 @@ const deploy = () => {
     return;
   }
 
+  // Only send up secrets that have values
+  const secrets: Record<string, string> = {};
+  home.secrets.forEach((value, name) => {
+    if (value) {
+      secrets[name] = value;
+    }
+  });
+
   hostConduit.sendMsg({
     kind: WebviewToHostMessageType.DEPLOY,
     content: {
@@ -53,6 +61,7 @@ const deploy = () => {
       configurationName: home.selectedConfiguration.configurationName,
       credentialName: home.serverCredential.name,
       projectDir: home.selectedContentRecord.projectDir,
+      secrets: secrets,
     },
   });
 };

--- a/extensions/vscode/webviews/homeView/src/components/SidebarInput.vue
+++ b/extensions/vscode/webviews/homeView/src/components/SidebarInput.vue
@@ -1,0 +1,47 @@
+<template>
+  <input
+    v-model="model"
+    ref="input"
+    class="sidebar-input"
+    :aria-label="ariaLabel"
+    @keydown.prevent.enter="$emit('submit')"
+    @keydown.escape="$emit('cancel')"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+const model = defineModel();
+
+const props = defineProps<{
+  label: string;
+}>();
+
+defineEmits(["submit", "cancel"]);
+
+const input = ref<HTMLInputElement | null>(null);
+
+const ariaLabel = computed(
+  () => `${props.label}. Press Enter to confirm or Escape to cancel.`,
+);
+
+const select = () => {
+  input.value?.select();
+};
+
+defineExpose({ select });
+</script>
+
+<style lang="scss" scoped>
+.sidebar-input {
+  background-color: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  color: var(--vscode-input-foreground);
+  line-height: 20px;
+  padding: 0;
+  outline-color: var(--vscode-focusBorder);
+  outline-offset: -1px;
+  outline-style: solid;
+  outline-width: 1px;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItem.vue
@@ -36,7 +36,10 @@
       />
       <div class="tree-item-label-container">
         <span class="tree-item-title" data-automation="req">{{ title }}</span>
-        <span v-if="description" class="tree-item-description">
+        <span v-if="$slots.description" class="tree-item-description">
+          <slot name="description" />
+        </span>
+        <span v-else-if="description" class="tree-item-description">
           {{ description }}
         </span>
       </div>
@@ -79,6 +82,7 @@ withDefaults(defineProps<Props>(), {
 
 defineSlots<{
   default(props: { indentLevel: number }): any;
+  description(): any;
   postDecor(): any;
 }>();
 
@@ -151,6 +155,7 @@ const toggleExpanded = () => {
 
     .tree-item-label-container {
       flex: 1;
+      display: flex;
       min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -159,13 +164,24 @@ const toggleExpanded = () => {
         line-height: 22px;
         color: inherit;
         white-space: pre;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .tree-item-description {
+        line-height: 22px;
         font-size: 0.9em;
         margin-left: 0.5em;
-        opacity: 0.7;
+        flex-shrink: 100000;
         white-space: pre;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &:not(:has(input)) {
+          opacity: 0.7;
+        }
       }
     }
 

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -3,6 +3,7 @@
     :title="name"
     :actions="actions"
     codicon="codicon-lock-small"
+    :list-style="secretValue ? 'default' : 'deemphasized'"
     :tooltip="tooltip"
     align-icon-with-twisty
   >

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -1,0 +1,75 @@
+<template>
+  <form v-if="showInput" @submit.prevent="updateSecret">
+    <input
+      ref="input"
+      v-model="inputValue"
+      aria-label="Type secret value. Press Enter to confirm or Escape to cancel."
+      @keydown.escape="showInput = false"
+    />
+  </form>
+  <TreeItem
+    v-else
+    :title="name"
+    :description="value ? '••••••' : undefined"
+    :actions="actions"
+    codicon="codicon-lock-small"
+    :tooltip="tooltip"
+    align-icon-with-twisty
+    @click="inputSecret"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, nextTick } from "vue";
+
+import TreeItem from "src/components/tree/TreeItem.vue";
+import { useHomeStore } from "src/stores/home";
+import { ActionButton } from "src/components/ActionToolbar.vue";
+
+interface Props {
+  name: string;
+  value?: string;
+}
+
+const props = defineProps<Props>();
+
+const input = ref<HTMLInputElement | null>(null);
+const showInput = ref(false);
+const inputValue = ref(props.value);
+
+const home = useHomeStore();
+
+const inputSecret = () => {
+  showInput.value = true;
+  nextTick(() => input.value?.focus());
+};
+
+const updateSecret = () => {
+  home.secrets.set(props.name, inputValue.value);
+  showInput.value = false;
+};
+
+const tooltip = computed(() => {
+  if (props.value) {
+    return "On the next deploy the new value will be set for the deployment.";
+  }
+
+  return "No value has been set. The value will not change on the next deploy.";
+});
+
+const actions = computed<ActionButton[]>(() => {
+  const result = [];
+
+  if (props.value) {
+    result.push({
+      label: "Clear Value",
+      codicon: "codicon-x",
+      fn: () => {
+        home.secrets.set(props.name, undefined);
+      },
+    });
+  }
+
+  return result;
+});
+</script>

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -41,7 +41,7 @@ const home = useHomeStore();
 
 const inputSecret = () => {
   showInput.value = true;
-  nextTick(() => input.value?.focus());
+  nextTick(() => input.value?.select());
 };
 
 const updateSecret = () => {

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -3,7 +3,7 @@
     :title="name"
     :actions="actions"
     codicon="codicon-lock-small"
-    :list-style="secretValue ? 'default' : 'deemphasized'"
+    :list-style="secretValue || isEditing ? 'default' : 'deemphasized'"
     :tooltip="tooltip"
     align-icon-with-twisty
   >

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -81,7 +81,7 @@ const actions = computed<ActionButton[]>(() => {
   if (secretValue.value) {
     result.push({
       label: "Clear Value",
-      codicon: "codicon-x",
+      codicon: "codicon-remove",
       fn: () => {
         home.secrets.set(props.name, undefined);
       },

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -2,6 +2,7 @@
   <form v-if="showInput" @submit.prevent="updateSecret">
     <input
       ref="input"
+      class="secret-input"
       v-model="inputValue"
       aria-label="Type secret value. Press Enter to confirm or Escape to cancel."
       @keydown.escape="showInput = false"
@@ -77,3 +78,17 @@ const actions = computed<ActionButton[]>(() => {
   return result;
 });
 </script>
+
+<style lang="scss" scoped>
+.secret-input {
+  background-color: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  color: var(--vscode-input-foreground);
+  line-height: 20px;
+  padding: 0;
+  outline-color: var(--vscode-focusBorder);
+  outline-offset: -1px;
+  outline-style: solid;
+  outline-width: 1px;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -1,13 +1,12 @@
 <template>
-  <form v-if="showInput" @submit.prevent="updateSecret">
-    <input
-      ref="input"
-      class="secret-input"
-      v-model="inputValue"
-      aria-label="Type secret value. Press Enter to confirm or Escape to cancel."
-      @keydown.escape="showInput = false"
-    />
-  </form>
+  <SidebarInput
+    v-if="showInput"
+    ref="input"
+    v-model="inputValue"
+    label="Type secret value"
+    @submit="updateSecret"
+    @cancel="showInput = false"
+  />
   <TreeItem
     v-else
     :title="name"
@@ -24,6 +23,7 @@
 import { computed, ref, nextTick } from "vue";
 
 import TreeItem from "src/components/tree/TreeItem.vue";
+import SidebarInput from "src/components/SidebarInput.vue";
 import { useHomeStore } from "src/stores/home";
 import { ActionButton } from "src/components/ActionToolbar.vue";
 
@@ -33,7 +33,7 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const input = ref<HTMLInputElement | null>(null);
+const input = ref<InstanceType<typeof SidebarInput> | null>(null);
 const showInput = ref(false);
 const inputValue = ref<string>();
 
@@ -78,17 +78,3 @@ const actions = computed<ActionButton[]>(() => {
   return result;
 });
 </script>
-
-<style lang="scss" scoped>
-.secret-input {
-  background-color: var(--vscode-input-background);
-  border: 1px solid var(--vscode-input-border, transparent);
-  color: var(--vscode-input-foreground);
-  line-height: 20px;
-  padding: 0;
-  outline-color: var(--vscode-focusBorder);
-  outline-offset: -1px;
-  outline-style: solid;
-  outline-width: 1px;
-}
-</style>

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -10,7 +10,7 @@
   <TreeItem
     v-else
     :title="name"
-    :description="value ? '••••••' : undefined"
+    :description="secretValue ? '••••••' : undefined"
     :actions="actions"
     codicon="codicon-lock-small"
     :tooltip="tooltip"
@@ -28,19 +28,23 @@ import { ActionButton } from "src/components/ActionToolbar.vue";
 
 interface Props {
   name: string;
-  value?: string;
 }
 
 const props = defineProps<Props>();
 
 const input = ref<HTMLInputElement | null>(null);
 const showInput = ref(false);
-const inputValue = ref(props.value);
+const inputValue = ref<string>();
 
 const home = useHomeStore();
 
+const secretValue = computed(() => home.secrets.get(props.name));
+
 const inputSecret = () => {
+  // Update inputValue in case the secret value has changed or been cleared
+  inputValue.value = secretValue.value;
   showInput.value = true;
+  // Wait for next tick to ensure the input is rendered
   nextTick(() => input.value?.select());
 };
 
@@ -50,7 +54,7 @@ const updateSecret = () => {
 };
 
 const tooltip = computed(() => {
-  if (props.value) {
+  if (secretValue.value) {
     return "On the next deploy the new value will be set for the deployment.";
   }
 
@@ -60,7 +64,7 @@ const tooltip = computed(() => {
 const actions = computed<ActionButton[]>(() => {
   const result = [];
 
-  if (props.value) {
+  if (secretValue.value) {
     result.push({
       label: "Clear Value",
       codicon: "codicon-x",

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
@@ -27,7 +27,7 @@ const home = useHomeStore();
 const sectionActions = computed<ActionButton[]>(() => [
   {
     label: "Clear Values for all Secrets",
-    codicon: "codicon-x",
+    codicon: "codicon-clear-all",
     fn: () => {
       home.secrets.forEach((_, key) => {
         home.secrets.set(key, undefined);

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
@@ -1,5 +1,9 @@
 <template>
-  <TreeSection title="Secrets" :actions="sectionActions">
+  <TreeSection
+    title="Secrets"
+    :actions="sectionActions"
+    :count="home.secretsWithValueCount"
+  >
     <template v-if="home.secrets.size">
       <Secret v-for="[name] in home.secrets" :name="name" :key="name" />
     </template>

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
@@ -1,0 +1,38 @@
+<template>
+  <TreeSection title="Secrets" :actions="sectionActions">
+    <template v-if="home.secrets.size">
+      <Secret
+        v-for="[name, value] in home.secrets"
+        :name="name"
+        :value="value"
+      />
+    </template>
+    <WelcomeView v-else>
+      <p>No secrets have been added to the configuration.</p>
+    </WelcomeView>
+  </TreeSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { ActionButton } from "src/components/ActionToolbar.vue";
+import TreeSection from "src/components/tree/TreeSection.vue";
+import WelcomeView from "src/components/WelcomeView.vue";
+import { useHomeStore } from "src/stores/home";
+import Secret from "src/components/views/secrets/Secret.vue";
+
+const home = useHomeStore();
+
+const sectionActions = computed<ActionButton[]>(() => [
+  {
+    label: "Clear Values for all Secrets",
+    codicon: "codicon-x",
+    fn: () => {
+      home.secrets.forEach((_, key) => {
+        home.secrets.set(key, undefined);
+      });
+    },
+  },
+]);
+</script>

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
@@ -1,11 +1,7 @@
 <template>
   <TreeSection title="Secrets" :actions="sectionActions">
     <template v-if="home.secrets.size">
-      <Secret
-        v-for="[name, value] in home.secrets"
-        :name="name"
-        :value="value"
-      />
+      <Secret v-for="[name] in home.secrets" :name="name" :key="name" />
     </template>
     <WelcomeView v-else>
       <p>No secrets have been added to the configuration.</p>

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -226,6 +226,11 @@ export const useHomeStore = defineStore("home", () => {
     secrets.value = cleared;
   };
 
+  const secretsWithValueCount = computed(() => {
+    return Array.from(secrets.value.values()).filter((v) => v !== undefined)
+      .length;
+  });
+
   return {
     showDisabledOverlay,
     publishInProgress,
@@ -256,5 +261,6 @@ export const useHomeStore = defineStore("home", () => {
     updatePythonPackages,
     updateRPackages,
     clearSecretValues,
+    secretsWithValueCount,
   };
 });

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -10,8 +10,8 @@ import {
   Configuration,
   ContentRecordFile,
   ConfigurationError,
-  isConfigurationError,
 } from "../../../../src/api";
+import { isConfigurationError } from "../../../../src/api/types/configurations";
 import { WebviewToHostMessageType } from "../../../../src/types/messages/webviewToHostMessages";
 import { RPackage } from "../../../../src/api/types/packages";
 import { DeploymentSelector } from "../../../../src/types/shared";

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -215,6 +215,16 @@ export const useHomeStore = defineStore("home", () => {
     rVersion.value = version;
   };
 
+  const clearSecretValues = () => {
+    const cleared = new Map();
+
+    secrets.value.forEach((_, key) => {
+      cleared.set(key, undefined);
+    });
+
+    secrets.value = cleared;
+  };
+
   return {
     showDisabledOverlay,
     publishInProgress,
@@ -244,5 +254,6 @@ export const useHomeStore = defineStore("home", () => {
     updateParentViewSelectionState,
     updatePythonPackages,
     updateRPackages,
+    clearSecretValues,
   };
 });

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -66,7 +66,8 @@ export const useHomeStore = defineStore("home", () => {
       const result = new Map<string, string | undefined>();
 
       if (config === undefined || isConfigurationError(config)) {
-        return result;
+        secrets.value = result;
+        return;
       }
 
       const isSameContentRecord = Boolean(

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -8,6 +8,10 @@ body {
   padding: 0;
 }
 
+::selection {
+  background-color: rgba(195, 183, 184, 0.15);
+}
+
 .webview-link {
   pointer-events: auto;
   opacity: 1;


### PR DESCRIPTION
This PR adds a new Secrets section to the Home view.

Some new features:
- Secret values present are sent up on Deploy and added as environment variables on Connect. If the env var is present it's value is overwritten
- When changing Deployments the provided Secret values are cleared
- When a successful Deployment occurs the provided Secret values are cleared
- When a Configuration is changed, but the Deployment stays the same, the shared Secrets keep their values in the UI
- The number of Secrets with values is displayed as a Count badge on the Secrets section header to help the user know what is going to be sent up
- When editing a Secret the input will be selected so all of the value is highlighted for easy overwrite (similar to the rename functionality in VS Code)

<details>
  <summary>Preview</summary>
  
  https://github.com/user-attachments/assets/8134bad2-e327-4146-bbd8-a011c8e8e2b0
</details> 


## Intent

Resolves #2252, #2257, #2258

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to expand previously made components, and create new ones (when necessary) to allow for the new model of "editing" a Tree Item description.

In this case editing the value of the Secret items.

Actions are used to edit and clear Secrets. Instead of clicking directly the action button is more clear, and avoids issues with duplicated click events when the input field is already up.

When editing a Secret value the action buttons are removed from the UI until editing is complete. This was done to avoid confusing the user and dealing with tricky cases like what clicking "edit" or "clear" should do while the input is open. It also provides more space for the input field which is horizontally constrained.

## Directions for Reviewers

Ensure that Tree Item descriptions function and are styled as they previously were.

Ensure the new Tree Item with description input (the Secrets) function as expected.

Ensure that Secrets with values are sent up and are correct on the Connect Server. Secrets without values should remain the same across multiple re-deployments.
