### PR TITLE
Credentials service with a logger

### DIFF
--- a/cmd/publisher/commands/credentials.go
+++ b/cmd/publisher/commands/credentials.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/posit-dev/publisher/internal/cli_types"
 	"github.com/posit-dev/publisher/internal/credentials"
+	"github.com/posit-dev/publisher/internal/logging"
 )
 
 type CredentialsCommand struct {
@@ -24,7 +25,7 @@ type CreateCredentialCommand struct {
 }
 
 func (cmd *CreateCredentialCommand) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
-	cs := credentials.CredentialsService{}
+	cs := credentials.NewCredentialsService(logging.NewDiscardLogger())
 	cred, err := cs.Set(cmd.Name, cmd.URL, cmd.ApiKey)
 	if err != nil {
 		return err
@@ -44,7 +45,7 @@ type DeleteCredentialCommand struct {
 }
 
 func (cmd *DeleteCredentialCommand) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
-	cs := credentials.CredentialsService{}
+	cs := credentials.NewCredentialsService(logging.NewDiscardLogger())
 	err := cs.Delete(cmd.GUID)
 	if err != nil {
 		return err
@@ -59,7 +60,7 @@ type GetCredentialCommand struct {
 }
 
 func (cmd *GetCredentialCommand) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
-	cs := credentials.CredentialsService{}
+	cs := credentials.NewCredentialsService(logging.NewDiscardLogger())
 	cred, err := cs.Get(cmd.GUID)
 	if err != nil {
 		return err
@@ -78,7 +79,7 @@ type ListCredentialsCommand struct {
 }
 
 func (cmd *ListCredentialsCommand) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
-	cs := credentials.CredentialsService{}
+	cs := credentials.NewCredentialsService(logging.NewDiscardLogger())
 	creds, err := cs.List()
 	if err != nil {
 		return err

--- a/internal/accounts/account_list.go
+++ b/internal/accounts/account_list.go
@@ -31,7 +31,7 @@ var _ AccountList = &defaultAccountList{}
 func NewAccountList(fs afero.Fs, log logging.Logger) *defaultAccountList {
 	return &defaultAccountList{
 		providers: []AccountProvider{
-			NewCredentialsProvider(),
+			NewCredentialsProvider(log),
 		},
 		log: log,
 	}

--- a/internal/accounts/provider_credentials.go
+++ b/internal/accounts/provider_credentials.go
@@ -2,14 +2,19 @@
 
 package accounts
 
-import "github.com/posit-dev/publisher/internal/credentials"
+import (
+	"github.com/posit-dev/publisher/internal/credentials"
+	"github.com/posit-dev/publisher/internal/logging"
+)
 
 type CredentialsProvider struct {
 	cs credentials.CredentialsService
 }
 
-func NewCredentialsProvider() *CredentialsProvider {
-	return &CredentialsProvider{cs: credentials.CredentialsService{}}
+func NewCredentialsProvider(log logging.Logger) *CredentialsProvider {
+	return &CredentialsProvider{
+		cs: credentials.NewCredentialsService(log),
+	}
 }
 
 func (p *CredentialsProvider) Load() ([]Account, error) {

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/pelletier/go-toml/v2"
+	"github.com/posit-dev/publisher/internal/logging/loggingtest"
 	"github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"github.com/zalando/go-keyring"
 )
 
@@ -26,7 +28,20 @@ var fileCred = Credential{
 	Name:   "connect.localtest.me",
 }
 
-func credentialsFilePath(afs afero.Fs) (util.AbsolutePath, error) {
+type CredentialsTestSuite struct {
+	utiltest.Suite
+	log *loggingtest.MockLogger
+}
+
+func TestCredentialsTestSuite(t *testing.T) {
+	suite.Run(t, new(CredentialsTestSuite))
+}
+
+func (s *CredentialsTestSuite) SetupTest() {
+	s.log = loggingtest.NewMockLogger()
+}
+
+func (s *CredentialsTestSuite) credentialsFilePath(afs afero.Fs) (util.AbsolutePath, error) {
 	homeDir, err := util.UserHomeDir(afs)
 	if err != nil {
 		return util.AbsolutePath{}, err
@@ -34,12 +49,12 @@ func credentialsFilePath(afs afero.Fs) (util.AbsolutePath, error) {
 	return homeDir.Join(".connect-credentials"), nil
 }
 
-func createFileCredentials(t *testing.T, cs *CredentialsService, errorCheck bool) {
-	path, err := credentialsFilePath(cs.afs)
-	assert.NoError(t, err)
+func (s *CredentialsTestSuite) createFileCredentials(cs *credentialsService, errorCheck bool) {
+	path, err := s.credentialsFilePath(cs.afs)
+	s.NoError(err)
 
 	f, err := path.Create()
-	assert.NoError(t, err)
+	s.NoError(err)
 	defer f.Close()
 
 	enc := toml.NewEncoder(f)
@@ -48,195 +63,210 @@ func createFileCredentials(t *testing.T, cs *CredentialsService, errorCheck bool
 		Key: fileCred.ApiKey,
 	}
 	err = enc.Encode(cred)
-	assert.NoError(t, err)
+	s.NoError(err)
 
 	if errorCheck {
 		res, err := cs.Get(fileCred.GUID)
-		assert.NoError(t, err)
+		s.NoError(err)
 		expected := Credential{
 			GUID:   fileCred.GUID,
 			Name:   fileCred.Name,
 			URL:    fileCred.URL,
 			ApiKey: fileCred.ApiKey,
 		}
-		assert.Equal(t, res, &expected)
+		s.Equal(res, &expected)
 	}
 }
 
-func clearFileCredentials(t *testing.T, cs *CredentialsService) {
-	path, err := credentialsFilePath(cs.afs)
-	assert.NoError(t, err)
+func (s *CredentialsTestSuite) clearFileCredentials(cs *credentialsService) {
+	path, err := s.credentialsFilePath(cs.afs)
+	s.NoError(err)
 	_ = path.Remove()
 }
 
-func TestSet(t *testing.T) {
+func (s *CredentialsTestSuite) TestSet() {
 	keyring.MockInit()
-	cs := CredentialsService{
+	cs := credentialsService{
 		afs: afero.NewMemMapFs(),
+		log: s.log,
 	}
-	clearFileCredentials(t, &cs)
+	s.clearFileCredentials(&cs)
 
 	cred, err := cs.Set("example", "https://example.com", "12345")
-	assert.NoError(t, err)
-	assert.NotNil(t, cred.GUID)
-	assert.Equal(t, cred.Name, "example")
-	assert.Equal(t, cred.URL, "https://example.com")
-	assert.Equal(t, cred.ApiKey, "12345")
+	s.NoError(err)
+	s.NotNil(cred.GUID)
+	s.Equal(cred.Name, "example")
+	s.Equal(cred.URL, "https://example.com")
+	s.Equal(cred.ApiKey, "12345")
 }
 
-func TestSetURLCollisionError(t *testing.T) {
+func (s *CredentialsTestSuite) TestSetURLCollisionError() {
 	keyring.MockInit()
-	cs := CredentialsService{
+	cs := credentialsService{
 		afs: afero.NewMemMapFs(),
+		log: s.log,
 	}
-	clearFileCredentials(t, &cs)
+	s.clearFileCredentials(&cs)
 
 	_, err := cs.Set("example", "https://example.com", "12345")
-	assert.NoError(t, err)
+	s.NoError(err)
 	_, err = cs.Set("example", "https://example.com", "12345")
-	assert.Error(t, err)
-	assert.IsType(t, &URLCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&URLCollisionError{}, err)
 
 	// validate collision with env var credentials
-	createFileCredentials(t, &cs, true)
+	s.createFileCredentials(&cs, true)
 
 	_, err = cs.Set("unique", fileCred.URL, "12345")
-	assert.Error(t, err)
-	assert.IsType(t, &EnvURLCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&EnvURLCollisionError{}, err)
 }
 
-func TestGet(t *testing.T) {
+func (s *CredentialsTestSuite) TestGet() {
 	keyring.MockInit()
-	cs := CredentialsService{
+	cs := credentialsService{
 		afs: afero.NewMemMapFs(),
+		log: s.log,
 	}
-	clearFileCredentials(t, &cs)
+	s.clearFileCredentials(&cs)
+	testGuid := "5ede880a-acd8-4206-b9fa-7d788c42fbe4"
 
 	// First test without any credentials in environment
+	s.log.On("Debug", "Credential does not exist", "credential", testGuid).Return()
 
 	// error if missing
-	_, err := cs.Get("example")
-	assert.Error(t, err)
+	_, err := cs.Get(testGuid)
+	s.Error(err)
+	s.log.AssertExpectations(s.T())
 
 	// pass if exists
 	cred, err := cs.Set("example", "https://example.com", "12345")
-	assert.NoError(t, err)
+	s.NoError(err)
 	res, err := cs.Get(cred.GUID)
-	assert.NoError(t, err)
-	assert.Equal(t, res, cred)
+	s.NoError(err)
+	s.Equal(res, cred)
 
 	// confirm environment credential not available
+	s.log.On("Debug", "Credential does not exist", "credential", fileCred.GUID).Return()
 	_, err = cs.Get(fileCred.GUID)
-	assert.Error(t, err)
+	s.Error(err)
+	s.log.AssertExpectations(s.T())
 
 	// Test with credentials in environment
-	createFileCredentials(t, &cs, true)
+	s.createFileCredentials(&cs, true)
 
 	// retest prior test
 	res, err = cs.Get(cred.GUID)
-	assert.NoError(t, err)
-	assert.Equal(t, res, cred)
+	s.NoError(err)
+	s.Equal(res, cred)
 
 	// request environment credentials
 	res, err = cs.Get(fileCred.GUID)
-	assert.NoError(t, err)
-	assert.Equal(t, res, &fileCred)
+	s.NoError(err)
+	s.Equal(res, &fileCred)
 
 	// Test for conflicts where credential was saved ahead of env variable
-	clearFileCredentials(t, &cs)
+	s.clearFileCredentials(&cs)
 	cred, err = cs.Set("env", fileCred.URL, "12345")
-	assert.NoError(t, err)
+	s.NoError(err)
 	_, err = cs.Get(cred.GUID)
-	assert.NoError(t, err)
+	s.NoError(err)
 
-	createFileCredentials(t, &cs, false)
+	s.log.On("Debug", "Conflict on credential record", "error", "CONNECT_SERVER URL value conflicts with existing credential (connect.localtest.me) URL: https://connect.localtest.me/rsc/dev-password-copy").Return()
+	s.createFileCredentials(&cs, false)
 	_, err = cs.Get(cred.GUID)
-	assert.Error(t, err)
-	assert.IsType(t, &EnvURLCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&EnvURLCollisionError{}, err)
+	s.log.AssertExpectations(s.T())
 }
 
-func TestNormalizedSet(t *testing.T) {
+func (s *CredentialsTestSuite) TestNormalizedSet() {
 	keyring.MockInit()
-	cs := CredentialsService{
+	cs := credentialsService{
 		afs: afero.NewMemMapFs(),
+		log: s.log,
 	}
-	clearFileCredentials(t, &cs)
+	s.clearFileCredentials(&cs)
 
 	// pass if no change (already normalized)
 	cred, err := cs.Set("example", "https://example.com", "12345")
-	assert.NoError(t, err)
+	s.NoError(err)
 	res, err := cs.Get(cred.GUID)
-	assert.NoError(t, err)
-	assert.Equal(t, res.URL, cred.URL)
+	s.NoError(err)
+	s.Equal(res.URL, cred.URL)
 
 	// pass if URL ends up normalized
 	cred, err = cs.Set("example2", "https://example.com///another/seg/", "12345")
-	assert.NoError(t, err)
-	assert.NotEqual(t, cred.URL, "https://example.com///another/seg/")
+	s.NoError(err)
+	s.NotEqual(cred.URL, "https://example.com///another/seg/")
 
 	res, err = cs.Get(cred.GUID)
-	assert.NoError(t, err)
-	assert.Equal(t, res.URL, "https://example.com/another/seg")
-	assert.Equal(t, cred.URL, res.URL)
+	s.NoError(err)
+	s.Equal(res.URL, "https://example.com/another/seg")
+	s.Equal(cred.URL, res.URL)
 }
 
-func TestSetCollisions(t *testing.T) {
+func (s *CredentialsTestSuite) TestSetCollisions() {
 	keyring.MockInit()
-	cs := CredentialsService{
+	cs := credentialsService{
 		afs: afero.NewMemMapFs(),
+		log: s.log,
 	}
 
 	// Add credentials into environment
-	createFileCredentials(t, &cs, true)
+	s.createFileCredentials(&cs, true)
 
 	// add a non-environment credential
 	_, err := cs.Set("example", "https://example.com", "12345")
-	assert.NoError(t, err)
+	s.NoError(err)
 
 	// non-environment name collision
 	_, err = cs.Set("example", "https://more_examples.com", "12345")
-	assert.Error(t, err)
-	assert.IsType(t, &NameCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&NameCollisionError{}, err)
 
 	// environment name collision
 	_, err = cs.Set(fileCred.Name, "https://more_examples2.com", "12345")
-	assert.Error(t, err)
-	assert.IsType(t, &EnvNameCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&EnvNameCollisionError{}, err)
 
 	// non-environment URL collision
 	_, err = cs.Set("another_example", "https://example.com", "12345")
-	assert.Error(t, err)
-	assert.IsType(t, &URLCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&URLCollisionError{}, err)
 
 	// environment URL collision
 	_, err = cs.Set("one_more", fileCred.URL, "12345")
-	assert.Error(t, err)
-	assert.IsType(t, &EnvURLCollisionError{}, err)
+	s.Error(err)
+	s.IsType(&EnvURLCollisionError{}, err)
 }
 
-func TestDelete(t *testing.T) {
+func (s *CredentialsTestSuite) TestDelete() {
 	keyring.MockInit()
-	cs := CredentialsService{
+	cs := credentialsService{
 		afs: afero.NewMemMapFs(),
+		log: s.log,
 	}
-	clearFileCredentials(t, &cs)
+	s.clearFileCredentials(&cs)
 
 	cred, err := cs.Set("example", "https://example.com", "12345")
-	assert.NoError(t, err)
+	s.NoError(err)
 
 	// no error if exists
 	err = cs.Delete(cred.GUID)
-	assert.NoError(t, err)
+	s.NoError(err)
 
 	// err if missing
+	s.log.On("Debug", "Credential does not exist", "credential", cred.GUID).Return()
 	err = cs.Delete(cred.GUID)
-	assert.Error(t, err)
+	s.Error(err)
+	s.log.AssertExpectations(s.T())
 
 	// Add credentials into environment
-	createFileCredentials(t, &cs, true)
+	s.createFileCredentials(&cs, true)
 
 	// err for our special GUID
 	err = cs.Delete(fileCred.GUID)
-	assert.Error(t, err)
-	assert.IsType(t, &EnvURLDeleteError{}, err)
+	s.Error(err)
+	s.IsType(&EnvURLDeleteError{}, err)
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -3,6 +3,7 @@ package logging
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"io"
 	"log/slog"
 )
 
@@ -35,4 +36,9 @@ func FromStdLogger(log *slog.Logger) Logger {
 
 func (l logger) WithArgs(args ...any) Logger {
 	return logger{l.BaseLogger.With(args...)}
+}
+
+func NewDiscardLogger() Logger {
+	discardLgr := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	return logger{discardLgr}
 }

--- a/internal/services/api/delete_credentials.go
+++ b/internal/services/api/delete_credentials.go
@@ -13,7 +13,7 @@ import (
 func DeleteCredentialHandlerFunc(log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		guid := mux.Vars(req)["guid"]
-		cs := credentials.CredentialsService{}
+		cs := credentials.NewCredentialsService(log)
 		err := cs.Delete(guid)
 		if err != nil {
 			switch e := err.(type) {

--- a/internal/services/api/delete_credentials_test.go
+++ b/internal/services/api/delete_credentials_test.go
@@ -34,8 +34,7 @@ func (s *DeleteCredentialsSuite) SetupTest() {
 }
 
 func (s *DeleteCredentialsSuite) Test204() {
-
-	cs := credentials.CredentialsService{}
+	cs := credentials.NewCredentialsService(s.log)
 	cred, err := cs.Set("example", "https://example.com", "12345")
 	s.NoError(err)
 

--- a/internal/services/api/get_credential.go
+++ b/internal/services/api/get_credential.go
@@ -14,7 +14,7 @@ import (
 func GetCredentialHandlerFunc(log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		guid := mux.Vars(req)["guid"]
-		cs := credentials.CredentialsService{}
+		cs := credentials.NewCredentialsService(log)
 		cred, err := cs.Get(guid)
 		if err != nil {
 			switch e := err.(type) {

--- a/internal/services/api/get_credentials.go
+++ b/internal/services/api/get_credentials.go
@@ -12,7 +12,7 @@ import (
 
 func GetCredentialsHandlerFunc(log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		cs := credentials.CredentialsService{}
+		cs := credentials.NewCredentialsService(log)
 		creds, err := cs.List()
 		if err != nil {
 			InternalError(w, req, log, err)

--- a/internal/services/api/post_credentials.go
+++ b/internal/services/api/post_credentials.go
@@ -30,7 +30,7 @@ func PostCredentialFuncHandler(log logging.Logger) http.HandlerFunc {
 			return
 		}
 
-		cs := credentials.CredentialsService{}
+		cs := credentials.NewCredentialsService(log)
 		cred, err := cs.Set(body.Name, body.URL, body.ApiKey)
 		if err != nil {
 			if _, ok := err.(*credentials.URLCollisionError); ok {

--- a/internal/services/api/post_credentials_test.go
+++ b/internal/services/api/post_credentials_test.go
@@ -60,7 +60,7 @@ func (s *PostCredentialTestSuite) Test409() {
 	url := "http://example.com"
 	ak := "12345"
 
-	cs := credentials.CredentialsService{}
+	cs := credentials.NewCredentialsService(s.log)
 	_, err := cs.Set(name, url, ak)
 	s.NoError(err)
 


### PR DESCRIPTION
## Intent

PR introduces quite simple changes for CredentialsService to have it's own logging instance, allowing to have further logging calls within credentials operations.

This is an initial work for #1831

### Adding a logger to credentials service

This PR adds a logger to `CredentialsService` which is now private - `credentialService` - such change for two reasons:
1. Continuity to #2153 - more debug logging where we are lacking
2. These changes help and are introductory work to #1831

### Why make credentials service private?

Making credentials service private is to prevent panics, since `credentialsService` will call a logger instance internally, making the struct private and the interface and constructor public, forces consumers of this service to pass a logger. E.g:

```go
// The following would bring a panic, program will compile with no issues but with the risk of runtime errors
// "runtime error: invalid memory address or nil pointer dereference"
cs := credentialsService{}
cs.Get(someGuid) // <- If logger is called for any reason within this method, program will panic
```

```go
// Using the private struct but a public constructor prevents that panic
cs := NewCredentialsService(lgr) // <- constructor expects and forces us to pass a logger for the resulting struct
cs.Get(someGuid) // Won't panic, no runtime errors
```

### No-op logger

The new no-op logger - `NewDiscardLogger` - is only used for the `cli`. Endpoints and any code related to the vscode extension is passing a proper logger.

I'm not going to bring more scope to this work. I agree that it'll be great to make the `cli` fully work, but that's not our priority at the moment. When we get to make the `cli` a priority we then can figure out a proper logging strategy for it.

## Type of Change

Enhancement on credentials operations for logging purposes.

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

- Have a `NewCredentialsService` constructor to force new instances to have a logger.
- Previous `CredentialService` is now a private package struct and we now have an interface for it.

## Automated Tests

Updated unit tests accordingly.

## Directions for Reviewers

Nothing specific, changes are pretty much repetitive

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
