### PR TITLE
Add support for count badge to TreeSection

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/CountBadge.vue
+++ b/extensions/vscode/webviews/homeView/src/components/CountBadge.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="count-badge">{{ count }}</div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  count: number;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.count-badge {
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  border: 1px solid var(--vscode-badge-foreground);
+
+  border-radius: 11px;
+  box-sizing: border-box;
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 11px;
+  min-height: 18px;
+  min-width: 18px;
+  padding: 3px 6px;
+  text-align: center;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
@@ -27,6 +27,9 @@
       <div v-if="actions" class="actions">
         <ActionToolbar :title="title" :actions="actions" />
       </div>
+      <div v-if="count" class="count">
+        <CountBadge :count="count" />
+      </div>
     </div>
     <div v-show="expanded" class="pane-body">
       <slot />
@@ -36,6 +39,7 @@
 
 <script setup lang="ts">
 import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
+import CountBadge from "src/components/CountBadge.vue";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 
@@ -44,6 +48,7 @@ defineProps<{
   description?: string;
   codicon?: string;
   actions?: ActionButton[];
+  count?: number;
 }>();
 
 const toggleExpanded = () => {
@@ -140,6 +145,12 @@ const toggleExpanded = () => {
 
   & :deep(.action-item) {
     margin-right: 4px;
+  }
+
+  .count {
+    display: flex;
+    margin-left: 2px;
+    padding-right: 12px;
   }
 }
 


### PR DESCRIPTION
This PR adds a new prop `count` to `TreeSection` that enables showing a `CountBadge` similar to other sections in VS Code.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-09-19 at 13 24 22@2x](https://github.com/user-attachments/assets/757b3389-3111-426e-8b1a-6c02098b1ece)

Note the "real" VS Code count badge in the Source Control section on the left, and the "fake" count badge on the right in the Secrets view.

</details> 

## Intent

Part of #2252

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->