### PR TITLE
Only show clear secrets button when values present

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
@@ -24,15 +24,21 @@ import Secret from "src/components/views/secrets/Secret.vue";
 
 const home = useHomeStore();
 
-const sectionActions = computed<ActionButton[]>(() => [
-  {
-    label: "Clear Values for all Secrets",
-    codicon: "codicon-clear-all",
-    fn: () => {
-      home.secrets.forEach((_, key) => {
-        home.secrets.set(key, undefined);
-      });
-    },
-  },
-]);
+const sectionActions = computed<ActionButton[]>(() => {
+  const result: ActionButton[] = [];
+
+  if (home.secretsWithValueCount > 0) {
+    result.push({
+      label: "Clear Values for all Secrets",
+      codicon: "codicon-clear-all",
+      fn: () => {
+        home.secrets.forEach((_, key) => {
+          home.secrets.set(key, undefined);
+        });
+      },
+    });
+  }
+
+  return result;
+});
 </script>


### PR DESCRIPTION
Small change that hides the "Clear Values for all Secrets" button in the Secrets view until there are secrets with values to clear.

## Intent

Resolves #2304

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->