### PR TITLE
Updates to New Deployment Multi-Stepper

### DIFF
--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -97,7 +97,8 @@ export const contentTypeStrings = {
   [ContentType.RMD_SHINY]:
     "render with rmarkdown/knitr and run embedded Shiny app",
   [ContentType.RMD]: "render with rmarkdown/knitr",
-  [ContentType.UNKNOWN]: "unknown content type; cannot deploy this item",
+  [ContentType.UNKNOWN]:
+    "unknown content type; manual selection needed to deploy",
 };
 
 export type ConfigurationDetails = {

--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -24,6 +24,19 @@ export type ConfigurationInspectionResult = {
   projectDir: string;
 };
 
+export const areInspectionResultsSimilarEnough = (
+  inspect1: ConfigurationInspectionResult,
+  inspect2: ConfigurationInspectionResult,
+) => {
+  // Not comparing ALL attributes, just enough to maintain uniqueness and
+  // confidence that this is a "similar" inspection result
+  return (
+    inspect1.projectDir === inspect2.projectDir &&
+    inspect1.configuration.entrypoint === inspect2.configuration.entrypoint &&
+    inspect1.configuration.type === inspect2.configuration.type
+  );
+};
+
 export function isConfigurationError(
   cfg: Configuration | ConfigurationError,
 ): cfg is ConfigurationError {
@@ -48,6 +61,24 @@ export enum ContentType {
   RMD = "rmd",
   UNKNOWN = "unknown",
 }
+
+export const allValidContentTypes: ContentType[] = [
+  ContentType.HTML,
+  ContentType.JUPYTER_NOTEBOOK,
+  ContentType.JUPYTER_VOILA,
+  ContentType.PYTHON_BOKEH,
+  ContentType.PYTHON_DASH,
+  ContentType.PYTHON_FASTAPI,
+  ContentType.PYTHON_FLASK,
+  ContentType.PYTHON_SHINY,
+  ContentType.PYTHON_STREAMLIT,
+  ContentType.QUARTO_SHINY,
+  ContentType.QUARTO,
+  ContentType.R_PLUMBER,
+  ContentType.R_SHINY,
+  ContentType.RMD_SHINY,
+  ContentType.RMD,
+];
 
 export const contentTypeStrings = {
   [ContentType.HTML]: "serve pre-rendered HTML",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -11,6 +11,7 @@ export const DEFAULT_PYTHON_PACKAGE_FILE = "requirements.txt";
 export const DEFAULT_R_PACKAGE_FILE = "renv.lock";
 
 // pulled from /internal/services/api/get_entrypoints.go
+// should all be lowercase!
 export const ENTRYPOINT_FILE_EXTENSIONS = [
   ".htm",
   ".html",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -10,6 +10,17 @@ export const DEPLOYMENTS_PATTERN = "**/.posit/publish/deployments/*.toml";
 export const DEFAULT_PYTHON_PACKAGE_FILE = "requirements.txt";
 export const DEFAULT_R_PACKAGE_FILE = "renv.lock";
 
+// pulled from /internal/services/api/get_entrypoints.go
+export const ENTRYPOINT_FILE_EXTENSIONS = [
+  ".htm",
+  ".html",
+  ".ipynb",
+  ".py",
+  ".qmd",
+  ".r",
+  ".rmd",
+];
+
 const baseCommands = {
   InitProject: "posit.publisher.init-project",
   ShowOutputChannel: "posit.publisher.showOutputChannel",

--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -1,5 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
+import { ConfigurationInspectionResult } from "src/api";
 import {
   QuickPickItem,
   window,
@@ -21,6 +22,9 @@ export function isQuickPickItem(d: QuickPickItem | string): d is QuickPickItem {
 }
 
 export type QuickPickItemWithIndex = QuickPickItem & { index: number };
+export type QuickPickItemWithInspectionResult = QuickPickItem & {
+  inspectionResult?: ConfigurationInspectionResult;
+};
 
 export function isQuickPickItemWithIndex(
   d: QuickPickItem | string,
@@ -28,12 +32,23 @@ export function isQuickPickItemWithIndex(
   return (d as QuickPickItemWithIndex).index !== undefined;
 }
 
+export function isQuickPickItemWithInspectionResult(
+  d: QuickPickItem | string,
+): d is QuickPickItemWithInspectionResult {
+  return (
+    (d as QuickPickItemWithInspectionResult).inspectionResult !== undefined
+  );
+}
+
 export interface MultiStepState {
   title: string;
   step: number;
   lastStep: number;
   totalSteps: number;
-  data: Record<string, QuickPickItem | string | undefined>;
+  data: Record<
+    string,
+    QuickPickItem | QuickPickItemWithInspectionResult | string | undefined
+  >;
   promptStepNumbers: Record<string, number>;
 }
 

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -46,388 +46,6 @@ import { showProgress } from "src/utils/progress";
 import { relativeDir, relativePath, vscodeOpenFiles } from "src/utils/files";
 import { ENTRYPOINT_FILE_EXTENSIONS } from "src/constants";
 
-// type stepInfo = {
-//   step: number;
-//   totalSteps: number;
-// };
-
-// type possibleSteps = {
-//   noCredentials: {
-//     singleEntryPoint: stepInfo;
-//     multipleEntryPoints: {
-//       singleContentType: stepInfo;
-//       multipleContentTypes: stepInfo;
-//     };
-//   };
-//   newCredentials: {
-//     singleEntryPoint: stepInfo;
-//     multipleEntryPoints: {
-//       singleContentType: stepInfo;
-//       multipleContentTypes: stepInfo;
-//     };
-//   };
-//   existingCredentials: {
-//     singleEntryPoint: stepInfo;
-//     multipleEntryPoints: {
-//       singleContentType: stepInfo;
-//       multipleContentTypes: stepInfo;
-//     };
-//   };
-// };
-
-// const steps: Record<string, possibleSteps | undefined> = {
-//   inputEntryPointFileSelection: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 0, // not yet shown
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 1,
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 1,
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 0, // not yet shown
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 1,
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 1,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 0, // not yet shown
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 1,
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 1,
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-//   inputEntryPointContentTypeSelection: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 0, // still 0
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 1, // not shown
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 2,
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 0, // still 0
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 1, // not shown
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 2,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 0, // still 0
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 1, // not shown
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 2,
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-//   inputTitle: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 1,
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 2,
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 3,
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 1,
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 2,
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 3,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 1,
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 2,
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 3,
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-//   pickCredentials: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 1, // not shown
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 2, // not shown
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 3, // not shown
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 2,
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 3,
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 4,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 2,
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 3,
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 4,
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-//   inputServerUrl: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 2,
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 3,
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 4,
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 3,
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 4,
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 5,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 2, // not shown
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 3, // not shown
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 4, // not shown
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-//   inputAPIKey: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 3,
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 4,
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 5,
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 4,
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 5,
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 6,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 2, // not shown
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 3, // not shown
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 4, // not shown
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-//   inputCredentialName: {
-//     noCredentials: {
-//       singleEntryPoint: {
-//         step: 4,
-//         totalSteps: 4,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 5,
-//           totalSteps: 5,
-//         },
-//         multipleContentTypes: {
-//           step: 6,
-//           totalSteps: 6,
-//         },
-//       },
-//     },
-//     newCredentials: {
-//       singleEntryPoint: {
-//         step: 5,
-//         totalSteps: 5,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 6,
-//           totalSteps: 6,
-//         },
-//         multipleContentTypes: {
-//           step: 7,
-//           totalSteps: 7,
-//         },
-//       },
-//     },
-//     existingCredentials: {
-//       singleEntryPoint: {
-//         step: 2, // not shown
-//         totalSteps: 2,
-//       },
-//       multipleEntryPoints: {
-//         singleContentType: {
-//           step: 3, // not shown
-//           totalSteps: 3,
-//         },
-//         multipleContentTypes: {
-//           step: 4, // not shown
-//           totalSteps: 4,
-//         },
-//       },
-//     },
-//   },
-// };
-
 export async function newDeployment(
   viewId: string,
   projectDir = ".",
@@ -475,13 +93,6 @@ export async function newDeployment(
     newCredentials: {},
   };
 
-  // let selectedEntrypoint: SelectedEntrypoint = {};
-  // let newtitle: string | undefined = undefined;
-  // let existingCredentialName: string | undefined = undefined;
-  // let newCredentialURL: string | undefined = undefined;
-  // let newCredentialName: string | undefined = undefined;
-  // let newCredentialAPIKey: string | undefined = undefined;
-
   const newCredentialForced = (state?: MultiStepState): boolean => {
     if (!state) {
       return false;
@@ -501,55 +112,6 @@ export async function newDeployment(
   const newCredentialByAnyMeans = (state?: MultiStepState): boolean => {
     return newCredentialForced(state) || newCredentialSelected(state);
   };
-
-  // const hasMultiplePossibleEntryPointFiles = () => {
-  //   return inspectionResults.length > 1;
-  // };
-
-  // const hasMultipleContentTypesForSelectedEntryPoint = () => {
-  //   return inspectionResults.length > 1;
-  // };
-
-  // const getStepInfo = (
-  //   stepId: string,
-  //   multiStepState: MultiStepState,
-  // ): stepInfo | undefined => {
-  //   const step = steps[stepId];
-  //   if (!step) {
-  //     // if we have not covered the step, then don't number it.
-  //     return {
-  //       step: 0,
-  //       totalSteps: 0,
-  //     };
-  //   }
-  //   if (newCredentialForced(multiStepState)) {
-  //     if (hasMultiplePossibleEntryPointFiles()) {
-  //       if (hasMultipleContentTypesForSelectedEntryPoint()) {
-  //         return step.noCredentials.multipleEntryPoints.multipleContentTypes;
-  //       }
-  //       return step.noCredentials.multipleEntryPoints.singleContentType;
-  //     }
-  //     return step.noCredentials.singleEntryPoint;
-  //   }
-  //   if (newCredentialSelected(multiStepState)) {
-  //     if (hasMultiplePossibleEntryPointFiles()) {
-  //       if (hasMultipleContentTypesForSelectedEntryPoint()) {
-  //         return step.newCredentials.multipleEntryPoints.multipleContentTypes;
-  //       }
-  //       return step.newCredentials.multipleEntryPoints.singleContentType;
-  //     }
-  //     return step.newCredentials.singleEntryPoint;
-  //   }
-  //   // else it has to be existing credential selected
-  //   if (hasMultiplePossibleEntryPointFiles()) {
-  //     if (hasMultipleContentTypesForSelectedEntryPoint()) {
-  //       return step.existingCredentials.multipleEntryPoints
-  //         .multipleContentTypes;
-  //     }
-  //     return step.existingCredentials.multipleEntryPoints.singleContentType;
-  //   }
-  //   return step.existingCredentials.singleEntryPoint;
-  // };
 
   const getConfigurationInspectionQuickPicks = (
     relEntryPoint: EntryPointPath,
@@ -739,6 +301,7 @@ export async function newDeployment(
 
   // Select the entrypoint, if there is more than one
   // Select the content type, if there is more than one
+  // Select the content type for anything selected which has a content type of UNKNOWN
   // Prompt for Title
   // If no credentials, then skip to create new credential
   // If some credentials, select either use of existing or creation of a new one
@@ -776,8 +339,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #1 - maybe?:
-  // Select the entrypoint to be used w/ the contentRecord
+  // Step: Select the entrypoint to be used w/ the contentRecord
   // ***************************************************************
   async function inputEntryPointFileSelection(
     input: MultiStepInput,
@@ -790,14 +352,6 @@ export async function newDeployment(
 
     // show only if we were not passed in a file
     if (entryPointFile === undefined) {
-      // const step = getStepInfo("inputEntryPointFileSelection", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::inputEntryPointFileSelection step info not found.",
-      //   );
-      //   return;
-      // }
-
       if (newDeploymentData.entrypoint.filePath) {
         entryPointListItems.forEach((item) => {
           item.picked = item.label === newDeploymentData.entrypoint.filePath;
@@ -806,8 +360,8 @@ export async function newDeployment(
 
       const pick = await input.showQuickPick({
         title: state.title,
-        step: 0, // step.step,
-        totalSteps: 0, // step.totalSteps,
+        step: 0,
+        totalSteps: 0,
         placeholder:
           "Select entrypoint file. This is your main file for your project. (Use this field to filter selections.)",
         items: entryPointListItems,
@@ -872,8 +426,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #2 - maybe?:
-  // Select the content inspection result should use
+  // Step: Select the content inspection result should use
   // ***************************************************************
   async function inputEntryPointInspectionResultSelection(
     input: MultiStepInput,
@@ -894,14 +447,6 @@ export async function newDeployment(
 
     // skip if we only have one choice.
     if (inspectionQuickPicks.length > 1) {
-      // const step = getStepInfo("inputEntryPointContentTypeSelection", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::inputEntryPointContentTypeSelection step info not found.",
-      //   );
-      //   return undefined;
-      // }
-
       if (newDeploymentData.entrypoint.inspectionResult) {
         inspectionQuickPicks.forEach((pick) => {
           if (
@@ -918,9 +463,9 @@ export async function newDeployment(
 
       const pick = await input.showQuickPick({
         title: state.title,
-        step: 0, // step.step,
-        totalSteps: 0, // step.totalSteps,
-        placeholder: `Select the content type for your entrypoint file (${entryPointFile}).`,
+        step: 0,
+        totalSteps: 0,
+        placeholder: `Select the content type for your entrypoint file (${newDeploymentData.entrypoint.filePath}).`,
         items: inspectionQuickPicks,
         buttons: [],
         shouldResume: () => Promise.resolve(false),
@@ -942,8 +487,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #?
-  // Input the Content Type, if needed
+  // Step: Input the Content Type, if inspection returns UNKNOWN content type
   // ***************************************************************
   async function inputContentType(
     input: MultiStepInput,
@@ -967,19 +511,11 @@ export async function newDeployment(
         });
       });
 
-      // const step = getStepInfo("inputContentType", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::inputContentType step info not found.",
-      //   );
-      //   return;
-      // }
-
       const pick = await input.showQuickPick({
         title: state.title,
-        step: 0, // state.step,
-        totalSteps: 0, // state.totalSteps,
-        placeholder: `Select the content type for your entrypoint file (${entryPointFile}).`,
+        step: 0,
+        totalSteps: 0,
+        placeholder: `Select the content type for your entrypoint file (${newDeploymentData.entrypoint.filePath}).`,
         items: quickPicks,
         buttons: [],
         shouldResume: () => Promise.resolve(false),
@@ -1005,21 +541,13 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #2 - maybe
-  // Input the Title
+  // Step: Input the Title
   // ***************************************************************
   async function inputTitle(input: MultiStepInput, state: MultiStepState) {
     // in case we have backed up from the subsequent check, we need to reset
     // the selection that it will update. This will allow steps to be the minimum number
     // as long as we don't know for certain it will take more steps.
 
-    // const step = getStepInfo("inputTitle", state);
-    // if (!step) {
-    //   window.showErrorMessage(
-    //     "Internal Error: newDeployment::inputTitle step info not found.",
-    //   );
-    //   return;
-    // }
     let initialValue = "";
     if (newDeploymentData.entrypoint.inspectionResult) {
       const detail =
@@ -1031,8 +559,8 @@ export async function newDeployment(
 
     const title = await input.showInputBox({
       title: state.title,
-      step: 0, // step.step,
-      totalSteps: 0, // step.totalSteps,
+      step: 0,
+      totalSteps: 0,
       value: newDeploymentData.title ? newDeploymentData.title : initialValue,
       prompt: "Enter a title for your content or application.",
       validate: (value) => {
@@ -1053,18 +581,10 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #3 - maybe
-  // Select the credentials to be used
+  // Step #3: Select the credentials to be used
   // ***************************************************************
   async function pickCredentials(input: MultiStepInput, state: MultiStepState) {
     if (!newCredentialForced(state)) {
-      // const step = getStepInfo("pickCredentials", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::pickCredentials step info not found.",
-      //   );
-      //   return;
-      // }
       if (newDeploymentData.existingCredentialName) {
         credentialListItems.forEach((credential) => {
           credential.picked =
@@ -1073,8 +593,8 @@ export async function newDeployment(
       }
       const pick = await input.showQuickPick({
         title: state.title,
-        step: 0, // step.step,
-        totalSteps: 0, // step.totalSteps,
+        step: 0,
+        totalSteps: 0,
         placeholder:
           "Select the credential you want to use to deploy. (Use this field to filter selections.)",
         items: credentialListItems,
@@ -1090,8 +610,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #4 - maybe?:
-  // Get the server url
+  // Step: New Credentials - Get the server url
   // ***************************************************************
   async function inputServerUrl(input: MultiStepInput, state: MultiStepState) {
     if (newCredentialByAnyMeans(state)) {
@@ -1099,18 +618,10 @@ export async function newDeployment(
         ? newDeploymentData.newCredentials.url
         : "";
 
-      // const step = getStepInfo("inputServerUrl", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::inputServerUrl step info not found.",
-      //   );
-      //   return;
-      // }
-
       const url = await input.showInputBox({
         title: state.title,
-        step: 0, // step.step,
-        totalSteps: 0, // step.totalSteps,
+        step: 0,
+        totalSteps: 0,
         value: currentURL,
         prompt: "Enter the Public URL of the Posit Connect Server",
         placeholder: "example: https://servername.com:3939",
@@ -1184,8 +695,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #5 - maybe?:
-  // Enter the API Key
+  // Step: New Credentials - Enter the API Key
   // ***************************************************************
   async function inputAPIKey(input: MultiStepInput, state: MultiStepState) {
     if (newCredentialByAnyMeans(state)) {
@@ -1193,18 +703,10 @@ export async function newDeployment(
         ? newDeploymentData.newCredentials.apiKey
         : "";
 
-      // const step = getStepInfo("inputAPIKey", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::inputAPIKey step info not found.",
-      //   );
-      //   return;
-      // }
-
       const apiKey = await input.showInputBox({
         title: state.title,
-        step: 0, // step.step,
-        totalSteps: 0, // step.totalSteps,
+        step: 0,
+        totalSteps: 0,
         password: true,
         value: currentAPIKey,
         prompt: `The API key to be used to authenticate with Posit Connect.
@@ -1266,8 +768,7 @@ export async function newDeployment(
   }
 
   // ***************************************************************
-  // Step #6 - maybe?:
-  // Name the credential
+  // Step: New Credentials - Name the credential
   // ***************************************************************
   async function inputCredentialName(
     input: MultiStepInput,
@@ -1278,18 +779,10 @@ export async function newDeployment(
         ? newDeploymentData.newCredentials.name
         : "";
 
-      // const step = getStepInfo("inputCredentialName", state);
-      // if (!step) {
-      //   window.showErrorMessage(
-      //     "Internal Error: newDeployment::inputCredentialName step info not found.",
-      //   );
-      //   return;
-      // }
-
       const name = await input.showInputBox({
         title: state.title,
-        step: 0, // step.step,
-        totalSteps: 0, // step.totalSteps,
+        step: 0,
+        totalSteps: 0,
         value: currentName,
         prompt: "Enter a Unique Nickname for your Credential.",
         placeholder: "example: Posit Connect",

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -209,7 +209,7 @@ export async function newDeployment(
     const filteredOpenFileList: string[] = [];
     rawOpenFileList.forEach((openFilePath) => {
       const parsedPath = path.parse(openFilePath);
-      if (ENTRYPOINT_FILE_EXTENSIONS.includes(parsedPath.ext)) {
+      if (ENTRYPOINT_FILE_EXTENSIONS.includes(parsedPath.ext.toLowerCase())) {
         filteredOpenFileList.push(openFilePath);
       }
     });

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -5,8 +5,9 @@ import {
   MultiStepInput,
   MultiStepState,
   QuickPickItemWithIndex,
-  isQuickPickItem,
+  QuickPickItemWithInspectionResult,
   isQuickPickItemWithIndex,
+  isQuickPickItemWithInspectionResult,
 } from "src/multiStepInputs/multiStepHelper";
 
 import {
@@ -17,6 +18,7 @@ import {
   Uri,
   commands,
   window,
+  workspace,
 } from "vscode";
 
 import {
@@ -27,6 +29,9 @@ import {
   contentTypeStrings,
   ConfigurationInspectionResult,
   EntryPointPath,
+  areInspectionResultsSimilarEnough,
+  ContentType,
+  allValidContentTypes,
 } from "src/api";
 import { getPythonInterpreterPath } from "src/utils/config";
 import {
@@ -38,389 +43,390 @@ import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
 import { DeploymentObjects } from "src/types/shared";
 import { showProgress } from "src/utils/progress";
-import { vscodeOpenFiles } from "src/utils/files";
+import { relativeDir, relativePath, vscodeOpenFiles } from "src/utils/files";
+import { ENTRYPOINT_FILE_EXTENSIONS } from "src/constants";
 
-type stepInfo = {
-  step: number;
-  totalSteps: number;
-};
+// type stepInfo = {
+//   step: number;
+//   totalSteps: number;
+// };
 
-type possibleSteps = {
-  noCredentials: {
-    singleEntryPoint: stepInfo;
-    multipleEntryPoints: {
-      singleContentType: stepInfo;
-      multipleContentTypes: stepInfo;
-    };
-  };
-  newCredentials: {
-    singleEntryPoint: stepInfo;
-    multipleEntryPoints: {
-      singleContentType: stepInfo;
-      multipleContentTypes: stepInfo;
-    };
-  };
-  existingCredentials: {
-    singleEntryPoint: stepInfo;
-    multipleEntryPoints: {
-      singleContentType: stepInfo;
-      multipleContentTypes: stepInfo;
-    };
-  };
-};
+// type possibleSteps = {
+//   noCredentials: {
+//     singleEntryPoint: stepInfo;
+//     multipleEntryPoints: {
+//       singleContentType: stepInfo;
+//       multipleContentTypes: stepInfo;
+//     };
+//   };
+//   newCredentials: {
+//     singleEntryPoint: stepInfo;
+//     multipleEntryPoints: {
+//       singleContentType: stepInfo;
+//       multipleContentTypes: stepInfo;
+//     };
+//   };
+//   existingCredentials: {
+//     singleEntryPoint: stepInfo;
+//     multipleEntryPoints: {
+//       singleContentType: stepInfo;
+//       multipleContentTypes: stepInfo;
+//     };
+//   };
+// };
 
-const steps: Record<string, possibleSteps | undefined> = {
-  inputEntryPointFileSelection: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 0, // not yet shown
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 1,
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 1,
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 0, // not yet shown
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 1,
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 1,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 0, // not yet shown
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 1,
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 1,
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-  inputEntryPointContentTypeSelection: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 0, // still 0
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 1, // not shown
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 2,
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 0, // still 0
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 1, // not shown
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 2,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 0, // still 0
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 1, // not shown
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 2,
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-  inputTitle: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 1,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 2,
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 3,
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 1,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 2,
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 3,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 1,
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 2,
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 3,
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-  pickCredentials: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 1, // not shown
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 2, // not shown
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 3, // not shown
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 2,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 3,
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 4,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 2,
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 3,
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 4,
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-  inputServerUrl: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 2,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 3,
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 4,
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 3,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 4,
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 5,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 2, // not shown
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 3, // not shown
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 4, // not shown
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-  inputAPIKey: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 3,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 4,
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 5,
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 4,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 5,
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 6,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 2, // not shown
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 3, // not shown
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 4, // not shown
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-  inputCredentialName: {
-    noCredentials: {
-      singleEntryPoint: {
-        step: 4,
-        totalSteps: 4,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 5,
-          totalSteps: 5,
-        },
-        multipleContentTypes: {
-          step: 6,
-          totalSteps: 6,
-        },
-      },
-    },
-    newCredentials: {
-      singleEntryPoint: {
-        step: 5,
-        totalSteps: 5,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 6,
-          totalSteps: 6,
-        },
-        multipleContentTypes: {
-          step: 7,
-          totalSteps: 7,
-        },
-      },
-    },
-    existingCredentials: {
-      singleEntryPoint: {
-        step: 2, // not shown
-        totalSteps: 2,
-      },
-      multipleEntryPoints: {
-        singleContentType: {
-          step: 3, // not shown
-          totalSteps: 3,
-        },
-        multipleContentTypes: {
-          step: 4, // not shown
-          totalSteps: 4,
-        },
-      },
-    },
-  },
-};
+// const steps: Record<string, possibleSteps | undefined> = {
+//   inputEntryPointFileSelection: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 0, // not yet shown
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 1,
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 1,
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 0, // not yet shown
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 1,
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 1,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 0, // not yet shown
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 1,
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 1,
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+//   inputEntryPointContentTypeSelection: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 0, // still 0
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 1, // not shown
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 2,
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 0, // still 0
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 1, // not shown
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 2,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 0, // still 0
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 1, // not shown
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 2,
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+//   inputTitle: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 1,
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 2,
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 3,
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 1,
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 2,
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 3,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 1,
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 2,
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 3,
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+//   pickCredentials: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 1, // not shown
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 2, // not shown
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 3, // not shown
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 2,
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 3,
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 4,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 2,
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 3,
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 4,
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+//   inputServerUrl: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 2,
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 3,
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 4,
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 3,
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 4,
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 5,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 2, // not shown
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 3, // not shown
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 4, // not shown
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+//   inputAPIKey: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 3,
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 4,
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 5,
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 4,
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 5,
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 6,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 2, // not shown
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 3, // not shown
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 4, // not shown
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+//   inputCredentialName: {
+//     noCredentials: {
+//       singleEntryPoint: {
+//         step: 4,
+//         totalSteps: 4,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 5,
+//           totalSteps: 5,
+//         },
+//         multipleContentTypes: {
+//           step: 6,
+//           totalSteps: 6,
+//         },
+//       },
+//     },
+//     newCredentials: {
+//       singleEntryPoint: {
+//         step: 5,
+//         totalSteps: 5,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 6,
+//           totalSteps: 6,
+//         },
+//         multipleContentTypes: {
+//           step: 7,
+//           totalSteps: 7,
+//         },
+//       },
+//     },
+//     existingCredentials: {
+//       singleEntryPoint: {
+//         step: 2, // not shown
+//         totalSteps: 2,
+//       },
+//       multipleEntryPoints: {
+//         singleContentType: {
+//           step: 3, // not shown
+//           totalSteps: 3,
+//         },
+//         multipleContentTypes: {
+//           step: 4, // not shown
+//           totalSteps: 4,
+//         },
+//       },
+//     },
+//   },
+// };
 
 export async function newDeployment(
   viewId: string,
@@ -435,8 +441,7 @@ export async function newDeployment(
   let credentials: Credential[] = [];
   let credentialListItems: QuickPickItem[] = [];
 
-  let discoveredEntryPoints: string[] = [];
-  let entryPointListItems: QuickPickItem[] = [];
+  let entryPointListItems: QuickPickItemWithInspectionResult[] = [];
   let inspectionResults: ConfigurationInspectionResult[] = [];
   let contentRecordNames = new Map<string, string[]>();
 
@@ -445,6 +450,37 @@ export async function newDeployment(
   let newContentRecord: PreContentRecord | undefined;
 
   const createNewCredentialLabel = "Create a New Credential";
+  const browseForEntrypointLabel = "Open...";
+
+  // Collected Data
+  type SelectedEntrypoint = {
+    filePath?: string;
+    inspectionResult?: ConfigurationInspectionResult;
+    contentType?: ContentType;
+  };
+  type NewCredentialAttrs = {
+    url?: string;
+    name?: string;
+    apiKey?: string;
+  };
+  type NewDeploymentData = {
+    entrypoint: SelectedEntrypoint;
+    title?: string;
+    existingCredentialName?: string;
+    newCredentials: NewCredentialAttrs;
+  };
+
+  let newDeploymentData: NewDeploymentData = {
+    entrypoint: {},
+    newCredentials: {},
+  };
+
+  // let selectedEntrypoint: SelectedEntrypoint = {};
+  // let newtitle: string | undefined = undefined;
+  // let existingCredentialName: string | undefined = undefined;
+  // let newCredentialURL: string | undefined = undefined;
+  // let newCredentialName: string | undefined = undefined;
+  // let newCredentialAPIKey: string | undefined = undefined;
 
   const newCredentialForced = (state?: MultiStepState): boolean => {
     if (!state) {
@@ -458,9 +494,7 @@ export async function newDeployment(
       return false;
     }
     return Boolean(
-      state.data.credentialName &&
-        isQuickPickItem(state.data.credentialName) &&
-        state.data.credentialName.label === createNewCredentialLabel,
+      newDeploymentData?.existingCredentialName === createNewCredentialLabel,
     );
   };
 
@@ -468,103 +502,105 @@ export async function newDeployment(
     return newCredentialForced(state) || newCredentialSelected(state);
   };
 
-  const hasMultiplePossibleEntryPointFiles = () => {
-    return inspectionResults.length > 1;
-  };
+  // const hasMultiplePossibleEntryPointFiles = () => {
+  //   return inspectionResults.length > 1;
+  // };
 
-  const hasMultipleContentTypesForSelectedEntryPoint = () => {
-    return inspectionResults.length > 1;
-  };
+  // const hasMultipleContentTypesForSelectedEntryPoint = () => {
+  //   return inspectionResults.length > 1;
+  // };
 
-  const getStepInfo = (
-    stepId: string,
-    multiStepState: MultiStepState,
-  ): stepInfo | undefined => {
-    const step = steps[stepId];
-    if (!step) {
-      // if we have not covered the step, then don't number it.
-      return {
-        step: 0,
-        totalSteps: 0,
-      };
-    }
-    if (newCredentialForced(multiStepState)) {
-      if (hasMultiplePossibleEntryPointFiles()) {
-        if (hasMultipleContentTypesForSelectedEntryPoint()) {
-          return step.noCredentials.multipleEntryPoints.multipleContentTypes;
-        }
-        return step.noCredentials.multipleEntryPoints.singleContentType;
-      }
-      return step.noCredentials.singleEntryPoint;
-    }
-    if (newCredentialSelected(multiStepState)) {
-      if (hasMultiplePossibleEntryPointFiles()) {
-        if (hasMultipleContentTypesForSelectedEntryPoint()) {
-          return step.newCredentials.multipleEntryPoints.multipleContentTypes;
-        }
-        return step.newCredentials.multipleEntryPoints.singleContentType;
-      }
-      return step.newCredentials.singleEntryPoint;
-    }
-    // else it has to be existing credential selected
-    if (hasMultiplePossibleEntryPointFiles()) {
-      if (hasMultipleContentTypesForSelectedEntryPoint()) {
-        return step.existingCredentials.multipleEntryPoints
-          .multipleContentTypes;
-      }
-      return step.existingCredentials.multipleEntryPoints.singleContentType;
-    }
-    return step.existingCredentials.singleEntryPoint;
-  };
+  // const getStepInfo = (
+  //   stepId: string,
+  //   multiStepState: MultiStepState,
+  // ): stepInfo | undefined => {
+  //   const step = steps[stepId];
+  //   if (!step) {
+  //     // if we have not covered the step, then don't number it.
+  //     return {
+  //       step: 0,
+  //       totalSteps: 0,
+  //     };
+  //   }
+  //   if (newCredentialForced(multiStepState)) {
+  //     if (hasMultiplePossibleEntryPointFiles()) {
+  //       if (hasMultipleContentTypesForSelectedEntryPoint()) {
+  //         return step.noCredentials.multipleEntryPoints.multipleContentTypes;
+  //       }
+  //       return step.noCredentials.multipleEntryPoints.singleContentType;
+  //     }
+  //     return step.noCredentials.singleEntryPoint;
+  //   }
+  //   if (newCredentialSelected(multiStepState)) {
+  //     if (hasMultiplePossibleEntryPointFiles()) {
+  //       if (hasMultipleContentTypesForSelectedEntryPoint()) {
+  //         return step.newCredentials.multipleEntryPoints.multipleContentTypes;
+  //       }
+  //       return step.newCredentials.multipleEntryPoints.singleContentType;
+  //     }
+  //     return step.newCredentials.singleEntryPoint;
+  //   }
+  //   // else it has to be existing credential selected
+  //   if (hasMultiplePossibleEntryPointFiles()) {
+  //     if (hasMultipleContentTypesForSelectedEntryPoint()) {
+  //       return step.existingCredentials.multipleEntryPoints
+  //         .multipleContentTypes;
+  //     }
+  //     return step.existingCredentials.multipleEntryPoints.singleContentType;
+  //   }
+  //   return step.existingCredentials.singleEntryPoint;
+  // };
 
   const getConfigurationInspectionQuickPicks = (
     relEntryPoint: EntryPointPath,
   ) => {
-    return new Promise<QuickPickItemWithIndex[]>(async (resolve, reject) => {
-      const inspectionListItems: QuickPickItemWithIndex[] = [];
+    return new Promise<QuickPickItemWithInspectionResult[]>(
+      async (resolve, reject) => {
+        const inspectionListItems: QuickPickItemWithInspectionResult[] = [];
 
-      try {
-        const python = await getPythonInterpreterPath();
-        const relEntryPointDir = path.dirname(relEntryPoint);
-        const relEntryPointFile = path.basename(relEntryPoint);
+        try {
+          const python = await getPythonInterpreterPath();
+          const relEntryPointDir = path.dirname(relEntryPoint);
+          const relEntryPointFile = path.basename(relEntryPoint);
 
-        const inspectResponse = await api.configurations.inspect(
-          relEntryPointDir,
-          python,
-          {
-            entrypoint: relEntryPointFile,
-          },
-        );
+          const inspectResponse = await api.configurations.inspect(
+            relEntryPointDir,
+            python,
+            {
+              entrypoint: relEntryPointFile,
+            },
+          );
 
-        inspectionResults = inspectResponse.data;
-        inspectionResults.forEach((result, i) => {
-          const config = result.configuration;
-          if (config.entrypoint) {
-            inspectionListItems.push({
-              iconPath: new ThemeIcon("gear"),
-              label: config.type.toString(),
-              description: `(${contentTypeStrings[config.type]})`,
-              index: i,
-            });
-          }
-        });
-      } catch (error: unknown) {
-        const summary = getSummaryStringFromError(
-          "newDeployment, configurations.inspect",
-          error,
-        );
-        window.showErrorMessage(
-          `Unable to continue with project inspection failure for ${entryPointFile}. ${summary}`,
-        );
-        return reject();
-      }
-      if (!inspectionListItems.length) {
-        const msg = `Unable to continue with no project entrypoints found during inspection for ${entryPointFile}.`;
-        window.showErrorMessage(msg);
-        return reject();
-      }
-      return resolve(inspectionListItems);
-    });
+          inspectionResults = inspectResponse.data;
+          inspectionResults.forEach((result) => {
+            const config = result.configuration;
+            if (config.entrypoint) {
+              inspectionListItems.push({
+                iconPath: new ThemeIcon("gear"),
+                label: config.type.toString(),
+                description: `(${contentTypeStrings[config.type]})`,
+                inspectionResult: result,
+              });
+            }
+          });
+        } catch (error: unknown) {
+          const summary = getSummaryStringFromError(
+            "newDeployment, configurations.inspect",
+            error,
+          );
+          window.showErrorMessage(
+            `Unable to continue with project inspection failure for ${entryPointFile}. ${summary}`,
+          );
+          return reject();
+        }
+        if (!inspectionListItems.length) {
+          const msg = `Unable to continue with no project entrypoints found during inspection for ${entryPointFile}.`;
+          window.showErrorMessage(msg);
+          return reject();
+        }
+        return resolve(inspectionListItems);
+      },
+    );
   };
 
   const getCredentials = new Promise<void>(async (resolve, reject) => {
@@ -588,88 +624,80 @@ export async function newDeployment(
       window.showErrorMessage(
         `Unable to continue with a failed API response. ${summary}`,
       );
-      return reject();
+      return reject(summary);
     }
     return resolve();
   });
 
   const getEntrypoints = new Promise<void>(async (resolve, reject) => {
-    try {
-      if (entryPointFile) {
-        // we were passed in a specific entrypoint file.
-        // while we don't need it, we'll still provide the results
-        // in the same way.
-        const entryPointPath = path.join(projectDir, entryPointFile);
-        entryPointListItems.push({
-          iconPath: new ThemeIcon("file"),
-          label: entryPointPath,
-        });
-        discoveredEntryPoints.push(entryPointPath);
-        return resolve();
-      }
-      const entrypointFilesOpened: string[] = [];
-      const entrypointFilesUnopened: string[] = [];
-
-      // rely upon the backend to tell us what are valid entrypoints
-      const entryPointsResponse = await api.entrypoints.get(projectDir);
-      discoveredEntryPoints = entryPointsResponse.data;
-
-      // build up a list of open files, relative to the opened workspace folder
-      const openFileList: string[] = vscodeOpenFiles();
-
-      // loop through and now separate possible entrypoints into open or not
-      discoveredEntryPoints.forEach((entrypointFile) => {
-        if (
-          openFileList.find(
-            (f) => f.toLowerCase() === entrypointFile.toLowerCase(),
-          )
-        ) {
-          entrypointFilesOpened.push(entrypointFile);
-        } else {
-          entrypointFilesUnopened.push(entrypointFile);
-        }
+    if (entryPointFile) {
+      // we were passed in a specific entrypoint file.
+      // while we don't need it, we'll still provide the results
+      // in the same way.
+      const entryPointPath = path.join(projectDir, entryPointFile);
+      entryPointListItems.push({
+        iconPath: new ThemeIcon("file"),
+        label: entryPointPath,
       });
+      return resolve();
+    }
 
-      // build the entrypointList
-      if (entrypointFilesOpened.length) {
-        entryPointListItems.push({
-          label: "Open Files",
-          kind: QuickPickItemKind.Separator,
-        });
-        entrypointFilesOpened.forEach((entryPointFile) => {
-          entryPointListItems.push({
-            iconPath: new ThemeIcon("file"),
-            label: entryPointFile,
-          });
-        });
+    // build up a list of open files, relative to the opened workspace folder
+    const rawOpenFileList: string[] = vscodeOpenFiles();
+    const filteredOpenFileList: string[] = [];
+    rawOpenFileList.forEach((openFilePath) => {
+      const parsedPath = path.parse(openFilePath);
+      if (ENTRYPOINT_FILE_EXTENSIONS.includes(parsedPath.ext)) {
+        filteredOpenFileList.push(openFilePath);
       }
-      if (entrypointFilesUnopened.length) {
-        entryPointListItems.push({
-          label: "Discovered Entrypoints",
-          kind: QuickPickItemKind.Separator,
-        });
-        entrypointFilesUnopened.forEach((entryPointFile) => {
-          entryPointListItems.push({
-            iconPath: new ThemeIcon("file"),
-            label: entryPointFile,
+    });
+    filteredOpenFileList.sort();
+
+    // build the entrypointList
+    if (filteredOpenFileList.length) {
+      entryPointListItems.push({
+        label: "Open Files",
+        kind: QuickPickItemKind.Separator,
+      });
+      const python = await getPythonInterpreterPath();
+      for (const openFile of filteredOpenFileList) {
+        // inspect each file type
+        try {
+          const relEntryPointDir = path.dirname(openFile);
+          const relEntryPointFile = path.basename(openFile);
+
+          const inspectResponse = await api.configurations.inspect(
+            relEntryPointDir,
+            python,
+            {
+              entrypoint: relEntryPointFile,
+            },
+          );
+          inspectionResults = inspectResponse.data;
+          inspectionResults.forEach((result) => {
+            const config = result.configuration;
+            entryPointListItems.push({
+              iconPath: new ThemeIcon("file"),
+              label: openFile,
+              detail: `${config.type.toString()} (${contentTypeStrings[config.type]})`,
+              inspectionResult: result,
+            });
           });
-        });
+        } catch (error: unknown) {
+          // pass up the rejection
+          reject(error);
+        }
       }
-    } catch (error: unknown) {
-      const summary = getSummaryStringFromError(
-        "newDeployment, entrypoints.get",
-        error,
-      );
-      window.showErrorMessage(
-        `Unable to continue with project entrypoint detection failure. ${summary}`,
-      );
-      return reject();
     }
-    if (!discoveredEntryPoints.length) {
-      const msg = `Unable to continue with no project entrypoints found.`;
-      window.showErrorMessage(msg);
-      return reject();
-    }
+    entryPointListItems.push({
+      label: "Other",
+      kind: QuickPickItemKind.Separator,
+    });
+    entryPointListItems.push({
+      iconPath: new ThemeIcon("file"),
+      label: browseForEntrypointLabel,
+      detail: "Use the File Open Dialog to select your entrypoint file. ",
+    });
     return resolve();
   });
 
@@ -736,17 +764,7 @@ export async function newDeployment(
       step: 0,
       lastStep: 0,
       totalSteps: 0,
-      data: {
-        // each attribute is initialized to undefined
-        // to be returned when it has not been cancelled to assist type guards
-        entryPointPath: undefined, // eventual type is QuickPickItem
-        entryPoint: undefined, // eventual type is QuickPickItemWithIndex
-        title: undefined, // eventual type is string
-        credentialName: undefined, // eventual type is either a string or QuickPickItem
-        url: undefined, // eventual type is string
-        name: undefined, // eventual type is string
-        apiKey: undefined, // eventual type is string
-      },
+      data: {},
       promptStepNumbers: {},
     };
 
@@ -770,20 +788,26 @@ export async function newDeployment(
     // as long as we don't know it will take another one.
     inspectionResults = [];
 
-    // show only if we have more than one potential entrypoint discovered
-    if (discoveredEntryPoints.length > 1) {
-      const step = getStepInfo("inputEntryPointFileSelection", state);
-      if (!step) {
-        window.showErrorMessage(
-          "Internal Error: newDeployment::inputEntryPointFileSelection step info not found.",
-        );
-        return;
+    // show only if we were not passed in a file
+    if (entryPointFile === undefined) {
+      // const step = getStepInfo("inputEntryPointFileSelection", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::inputEntryPointFileSelection step info not found.",
+      //   );
+      //   return;
+      // }
+
+      if (newDeploymentData.entrypoint.filePath) {
+        entryPointListItems.forEach((item) => {
+          item.picked = item.label === newDeploymentData.entrypoint.filePath;
+        });
       }
 
       const pick = await input.showQuickPick({
         title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
+        step: 0, // step.step,
+        totalSteps: 0, // step.totalSteps,
         placeholder:
           "Select entrypoint file. This is your main file for your project. (Use this field to filter selections.)",
         items: entryPointListItems,
@@ -791,64 +815,190 @@ export async function newDeployment(
         shouldResume: () => Promise.resolve(false),
         ignoreFocusOut: true,
       });
-      state.data.entryPointPath = pick.label;
+
+      let selectedEntrypointFile: string | undefined = undefined;
+      if (pick.label === browseForEntrypointLabel) {
+        let baseUri = Uri.parse(".");
+        const workspaceFolders = workspace.workspaceFolders;
+        if (workspaceFolders !== undefined) {
+          baseUri = workspaceFolders[0].uri;
+        }
+        selectedEntrypointFile = undefined;
+        do {
+          const fileUris = await window.showOpenDialog({
+            defaultUri: baseUri,
+            openLabel: "Select",
+            canSelectFolders: false,
+            canSelectMany: false,
+            title: "Select Entrypoint File (main file for your project)",
+          });
+          if (!fileUris || !fileUris[0]) {
+            // cancelled.
+            return;
+          }
+          const fileUri = fileUris[0];
+
+          if (relativeDir(fileUri)) {
+            selectedEntrypointFile = relativePath(fileUri);
+          } else {
+            window.showErrorMessage(
+              `Entrypoint files must be located within the folder opened by VSCode. 
+							File ${fileUri.fsPath} is not located within the VSCode Workspace: ${baseUri.fsPath}.`,
+              {
+                modal: true,
+              },
+            );
+            selectedEntrypointFile = undefined;
+          }
+        } while (!selectedEntrypointFile);
+        newDeploymentData.entrypoint.filePath = selectedEntrypointFile;
+        newDeploymentData.entrypoint.inspectionResult = undefined;
+      } else {
+        if (isQuickPickItemWithInspectionResult(pick)) {
+          newDeploymentData.entrypoint.filePath = pick.label;
+          newDeploymentData.entrypoint.inspectionResult = pick.inspectionResult;
+        } else {
+          return;
+        }
+      }
       return (input: MultiStepInput) =>
-        inputEntryPointContentTypeSelection(input, state);
+        inputEntryPointInspectionResultSelection(input, state);
     } else {
-      state.data.entryPointPath = discoveredEntryPoints[0];
+      // We were passed in a specific file, so set and continue to inspection
+      newDeploymentData.entrypoint.filePath = entryPointFile;
       // We're skipping this step, so we must silently just jump to the next step
-      return inputEntryPointContentTypeSelection(input, state);
+      return inputEntryPointInspectionResultSelection(input, state);
     }
   }
 
   // ***************************************************************
   // Step #2 - maybe?:
-  // Select the content type of the entrypoint
+  // Select the content inspection result should use
   // ***************************************************************
-  async function inputEntryPointContentTypeSelection(
+  async function inputEntryPointInspectionResultSelection(
     input: MultiStepInput,
     state: MultiStepState,
   ) {
-    if (!state.data.entryPointPath) {
+    if (!newDeploymentData.entrypoint.filePath) {
       return;
     }
-
-    // always relative
-    const entryPointPath = isQuickPickItem(state.data.entryPointPath)
-      ? state.data.entryPointPath.label
-      : state.data.entryPointPath;
+    // Have to create a copy of the guarded value, to keep language service happy
+    // within anonymous function below
+    const entryPointFile = newDeploymentData.entrypoint.filePath;
 
     const inspectionQuickPicks = await showProgress(
       "Scanning::newDeployment",
       viewId,
-      async () => await getConfigurationInspectionQuickPicks(entryPointPath),
+      async () => await getConfigurationInspectionQuickPicks(entryPointFile),
     );
 
     // skip if we only have one choice.
     if (inspectionQuickPicks.length > 1) {
-      const step = getStepInfo("inputEntryPointContentTypeSelection", state);
-      if (!step) {
-        window.showErrorMessage(
-          "Internal Error: newDeployment::inputEntryPointContentTypeSelection step info not found.",
-        );
-        return;
+      // const step = getStepInfo("inputEntryPointContentTypeSelection", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::inputEntryPointContentTypeSelection step info not found.",
+      //   );
+      //   return undefined;
+      // }
+
+      if (newDeploymentData.entrypoint.inspectionResult) {
+        inspectionQuickPicks.forEach((pick) => {
+          if (
+            pick.inspectionResult &&
+            newDeploymentData.entrypoint.inspectionResult
+          ) {
+            pick.picked = areInspectionResultsSimilarEnough(
+              pick.inspectionResult,
+              newDeploymentData.entrypoint.inspectionResult,
+            );
+          }
+        });
       }
 
       const pick = await input.showQuickPick({
         title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
-        placeholder: `Select the content type for your entrypoint file (${entryPointPath}).`,
+        step: 0, // step.step,
+        totalSteps: 0, // step.totalSteps,
+        placeholder: `Select the content type for your entrypoint file (${entryPointFile}).`,
         items: inspectionQuickPicks,
         buttons: [],
         shouldResume: () => Promise.resolve(false),
         ignoreFocusOut: true,
       });
 
-      state.data.entryPoint = pick;
+      if (!pick || !isQuickPickItemWithInspectionResult(pick)) {
+        return;
+      }
+
+      newDeploymentData.entrypoint.inspectionResult = pick.inspectionResult;
+      return (input: MultiStepInput) => inputContentType(input, state);
+    } else {
+      newDeploymentData.entrypoint.inspectionResult =
+        inspectionQuickPicks[0].inspectionResult;
+      // We're skipping this step, so we must silently just jump to the next step
+      return inputContentType(input, state);
+    }
+  }
+
+  // ***************************************************************
+  // Step #?
+  // Input the Content Type, if needed
+  // ***************************************************************
+  async function inputContentType(
+    input: MultiStepInput,
+    state: MultiStepState,
+  ) {
+    if (!newDeploymentData.entrypoint.inspectionResult) {
+      return;
+    }
+    if (
+      newDeploymentData.entrypoint.inspectionResult.configuration.type ===
+      ContentType.UNKNOWN
+    ) {
+      // have to prompt user for a content type, since we were unable to determine it.
+      const quickPicks: QuickPickItemWithIndex[] = [];
+      allValidContentTypes.forEach((contentType, index) => {
+        quickPicks.push({
+          label: contentType,
+          detail: contentTypeStrings[contentType],
+          picked: newDeploymentData.entrypoint.contentType === contentType,
+          index,
+        });
+      });
+
+      // const step = getStepInfo("inputContentType", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::inputContentType step info not found.",
+      //   );
+      //   return;
+      // }
+
+      const pick = await input.showQuickPick({
+        title: state.title,
+        step: 0, // state.step,
+        totalSteps: 0, // state.totalSteps,
+        placeholder: `Select the content type for your entrypoint file (${entryPointFile}).`,
+        items: quickPicks,
+        buttons: [],
+        shouldResume: () => Promise.resolve(false),
+        ignoreFocusOut: true,
+      });
+
+      if (!pick) {
+        return;
+      }
+      if (!isQuickPickItemWithIndex(pick)) {
+        return;
+      }
+      newDeploymentData.entrypoint.contentType =
+        allValidContentTypes[pick.index];
+
       return (input: MultiStepInput) => inputTitle(input, state);
     } else {
-      state.data.entryPoint = inspectionQuickPicks[0];
+      newDeploymentData.entrypoint.contentType =
+        newDeploymentData.entrypoint.inspectionResult.configuration.type;
       // We're skipping this step, so we must silently just jump to the next step
       return inputTitle(input, state);
     }
@@ -862,22 +1012,18 @@ export async function newDeployment(
     // in case we have backed up from the subsequent check, we need to reset
     // the selection that it will update. This will allow steps to be the minimum number
     // as long as we don't know for certain it will take more steps.
-    state.data.credentialName = undefined;
 
-    const step = getStepInfo("inputTitle", state);
-    if (!step) {
-      window.showErrorMessage(
-        "Internal Error: newDeployment::inputTitle step info not found.",
-      );
-      return;
-    }
+    // const step = getStepInfo("inputTitle", state);
+    // if (!step) {
+    //   window.showErrorMessage(
+    //     "Internal Error: newDeployment::inputTitle step info not found.",
+    //   );
+    //   return;
+    // }
     let initialValue = "";
-    if (
-      state.data.entryPoint &&
-      isQuickPickItemWithIndex(state.data.entryPoint)
-    ) {
+    if (newDeploymentData.entrypoint.inspectionResult) {
       const detail =
-        inspectionResults[state.data.entryPoint.index].configuration.title;
+        newDeploymentData.entrypoint.inspectionResult.configuration.title;
       if (detail) {
         initialValue = detail;
       }
@@ -885,10 +1031,9 @@ export async function newDeployment(
 
     const title = await input.showInputBox({
       title: state.title,
-      step: step.step,
-      totalSteps: step.totalSteps,
-      value:
-        typeof state.data.title === "string" ? state.data.title : initialValue,
+      step: 0, // step.step,
+      totalSteps: 0, // step.totalSteps,
+      value: newDeploymentData.title ? newDeploymentData.title : initialValue,
       prompt: "Enter a title for your content or application.",
       validate: (value) => {
         if (value.length < 3) {
@@ -903,7 +1048,7 @@ export async function newDeployment(
       ignoreFocusOut: true,
     });
 
-    state.data.title = title;
+    newDeploymentData.title = title;
     return (input: MultiStepInput) => pickCredentials(input, state);
   }
 
@@ -913,29 +1058,31 @@ export async function newDeployment(
   // ***************************************************************
   async function pickCredentials(input: MultiStepInput, state: MultiStepState) {
     if (!newCredentialForced(state)) {
-      const step = getStepInfo("pickCredentials", state);
-      if (!step) {
-        window.showErrorMessage(
-          "Internal Error: newDeployment::pickCredentials step info not found.",
-        );
-        return;
+      // const step = getStepInfo("pickCredentials", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::pickCredentials step info not found.",
+      //   );
+      //   return;
+      // }
+      if (newDeploymentData.existingCredentialName) {
+        credentialListItems.forEach((credential) => {
+          credential.picked =
+            credential.label === newDeploymentData.existingCredentialName;
+        });
       }
       const pick = await input.showQuickPick({
         title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
+        step: 0, // step.step,
+        totalSteps: 0, // step.totalSteps,
         placeholder:
           "Select the credential you want to use to deploy. (Use this field to filter selections.)",
         items: credentialListItems,
-        activeItem:
-          typeof state.data.credentialName !== "string"
-            ? state.data.credentialName
-            : undefined,
         buttons: [],
         shouldResume: () => Promise.resolve(false),
         ignoreFocusOut: true,
       });
-      state.data.credentialName = pick;
+      newDeploymentData.existingCredentialName = pick.label;
 
       return (input: MultiStepInput) => inputServerUrl(input, state);
     }
@@ -948,23 +1095,22 @@ export async function newDeployment(
   // ***************************************************************
   async function inputServerUrl(input: MultiStepInput, state: MultiStepState) {
     if (newCredentialByAnyMeans(state)) {
-      const currentURL =
-        typeof state.data.url === "string" && state.data.url.length
-          ? state.data.url
-          : "";
+      const currentURL = newDeploymentData.newCredentials.url
+        ? newDeploymentData.newCredentials.url
+        : "";
 
-      const step = getStepInfo("inputServerUrl", state);
-      if (!step) {
-        window.showErrorMessage(
-          "Internal Error: newDeployment::inputServerUrl step info not found.",
-        );
-        return;
-      }
+      // const step = getStepInfo("inputServerUrl", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::inputServerUrl step info not found.",
+      //   );
+      //   return;
+      // }
 
       const url = await input.showInputBox({
         title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
+        step: 0, // step.step,
+        totalSteps: 0, // step.totalSteps,
         value: currentURL,
         prompt: "Enter the Public URL of the Posit Connect Server",
         placeholder: "example: https://servername.com:3939",
@@ -1031,7 +1177,7 @@ export async function newDeployment(
         ignoreFocusOut: true,
       });
 
-      state.data.url = formatURL(url.trim());
+      newDeploymentData.newCredentials.url = formatURL(url.trim());
       return (input: MultiStepInput) => inputAPIKey(input, state);
     }
     return inputAPIKey(input, state);
@@ -1043,28 +1189,27 @@ export async function newDeployment(
   // ***************************************************************
   async function inputAPIKey(input: MultiStepInput, state: MultiStepState) {
     if (newCredentialByAnyMeans(state)) {
-      const currentAPIKey =
-        typeof state.data.apiKey === "string" && state.data.apiKey.length
-          ? state.data.apiKey
-          : "";
+      const currentAPIKey = newDeploymentData.newCredentials.apiKey
+        ? newDeploymentData.newCredentials.apiKey
+        : "";
 
-      const step = getStepInfo("inputAPIKey", state);
-      if (!step) {
-        window.showErrorMessage(
-          "Internal Error: newDeployment::inputAPIKey step info not found.",
-        );
-        return;
-      }
+      // const step = getStepInfo("inputAPIKey", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::inputAPIKey step info not found.",
+      //   );
+      //   return;
+      // }
 
       const apiKey = await input.showInputBox({
         title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
+        step: 0, // step.step,
+        totalSteps: 0, // step.totalSteps,
         password: true,
         value: currentAPIKey,
         prompt: `The API key to be used to authenticate with Posit Connect.
-        See the [User Guide](https://docs.posit.co/connect/user/api-keys/index.html#api-keys-creating)
-        for further information.`,
+			See the [User Guide](https://docs.posit.co/connect/user/api-keys/index.html#api-keys-creating)
+			for further information.`,
         validate: (input: string) => {
           if (input.includes(" ")) {
             return Promise.resolve({
@@ -1085,8 +1230,9 @@ export async function newDeployment(
           }
           // url should always be defined by the time we get to this step
           // but we have to type guard it for the API
-          const serverUrl =
-            typeof state.data.url === "string" ? state.data.url : "";
+          const serverUrl = newDeploymentData.newCredentials.url
+            ? newDeploymentData.newCredentials.url
+            : "";
           try {
             const testResult = await api.credentials.test(serverUrl, input);
             if (testResult.status !== 200) {
@@ -1113,7 +1259,7 @@ export async function newDeployment(
         ignoreFocusOut: true,
       });
 
-      state.data.apiKey = apiKey;
+      newDeploymentData.newCredentials.apiKey = apiKey;
       return (input: MultiStepInput) => inputCredentialName(input, state);
     }
     return inputCredentialName(input, state);
@@ -1128,23 +1274,22 @@ export async function newDeployment(
     state: MultiStepState,
   ) {
     if (newCredentialByAnyMeans(state)) {
-      const currentName =
-        typeof state.data.name === "string" && state.data.name.length
-          ? state.data.name
-          : "";
+      const currentName = newDeploymentData.newCredentials.name
+        ? newDeploymentData.newCredentials.name
+        : "";
 
-      const step = getStepInfo("inputCredentialName", state);
-      if (!step) {
-        window.showErrorMessage(
-          "Internal Error: newDeployment::inputCredentialName step info not found.",
-        );
-        return;
-      }
+      // const step = getStepInfo("inputCredentialName", state);
+      // if (!step) {
+      //   window.showErrorMessage(
+      //     "Internal Error: newDeployment::inputCredentialName step info not found.",
+      //   );
+      //   return;
+      // }
 
       const name = await input.showInputBox({
         title: state.title,
-        step: step.step,
-        totalSteps: step.totalSteps,
+        step: 0, // step.step,
+        totalSteps: 0, // step.totalSteps,
         value: currentName,
         prompt: "Enter a Unique Nickname for your Credential.",
         placeholder: "example: Posit Connect",
@@ -1176,7 +1321,7 @@ export async function newDeployment(
         ignoreFocusOut: true,
       });
 
-      state.data.name = name.trim();
+      newDeploymentData.newCredentials.name = name.trim();
     }
     // last step
   }
@@ -1197,7 +1342,7 @@ export async function newDeployment(
     );
   } catch {
     // errors have already been displayed by the underlying promises..
-    return;
+    return undefined;
   }
   const state = await collectInputs();
 
@@ -1205,15 +1350,14 @@ export async function newDeployment(
   // before completing the steps. This also serves as a type guard on
   // our state data vars down to the actual type desired
   if (
-    (!newCredentialForced(state) && state.data.credentialName === undefined) ||
-    // credentialName can be either type
-    state.data.entryPoint === undefined ||
-    !isQuickPickItemWithIndex(state.data.entryPoint) ||
-    state.data.title === undefined ||
-    typeof state.data.title !== "string"
+    !newDeploymentData.entrypoint.filePath ||
+    !newDeploymentData.entrypoint.contentType ||
+    !newDeploymentData.entrypoint.inspectionResult ||
+    !newDeploymentData.title ||
+    !newDeploymentData.existingCredentialName
   ) {
     console.log("User has aborted flow. Exiting.");
-    return;
+    return undefined;
   }
 
   // Maybe create a new credential?
@@ -1221,72 +1365,70 @@ export async function newDeployment(
     // have to type guard here, will protect us against
     // cancellation.
     if (
-      state.data.url === undefined ||
-      isQuickPickItem(state.data.url) ||
-      state.data.name === undefined ||
-      isQuickPickItem(state.data.name) ||
-      state.data.apiKey === undefined ||
-      isQuickPickItem(state.data.apiKey)
+      !newDeploymentData.newCredentials.url ||
+      !newDeploymentData.newCredentials.apiKey ||
+      !newDeploymentData.newCredentials.name
     ) {
       window.showErrorMessage(
         "Internal Error: NewDeployment Unexpected type guard failure @1",
       );
-      return;
+      return undefined;
     }
     try {
       // NEED an credential to be returned from this API
       // and assigned to newOrExistingCredential
       const response = await api.credentials.create(
-        state.data.name,
-        state.data.url,
-        state.data.apiKey,
+        newDeploymentData.newCredentials.name,
+        newDeploymentData.newCredentials.url,
+        newDeploymentData.newCredentials.apiKey,
       );
       newOrSelectedCredential = response.data;
     } catch (error: unknown) {
       const summary = getSummaryStringFromError("credentials::add", error);
       window.showInformationMessage(summary);
     }
-  } else if (state.data.credentialName) {
-    // If not creating, then we need to retrieve the one we're using.
-    let targetName: string | undefined = undefined;
-    if (isQuickPickItem(state.data.credentialName)) {
-      targetName = state.data.credentialName.label;
-    }
-    if (targetName) {
-      newOrSelectedCredential = credentials.find(
-        (credential) => credential.name === targetName,
+  } else if (newDeploymentData.existingCredentialName) {
+    newOrSelectedCredential = credentials.find(
+      (credential) =>
+        credential.name === newDeploymentData.existingCredentialName,
+    );
+    if (!newOrSelectedCredential) {
+      window.showErrorMessage(
+        `Internal Error: NewDeployment Unable to find credential: ${newDeploymentData.existingCredentialName}`,
       );
+      return undefined;
     }
   } else {
     // we are not creating a credential but also do not have a required existing value
     window.showErrorMessage(
       "Internal Error: NewDeployment Unexpected type guard failure @2",
     );
-    return;
+    return undefined;
   }
 
   // Create the Config File
   let configName: string | undefined;
-  const selectedInspectionResult =
-    inspectionResults[state.data.entryPoint.index];
-  if (!selectedInspectionResult) {
-    window.showErrorMessage(
-      `Unable to proceed creating configuration. Error retrieving config for ${state.data.entryPoint.label}, index = ${state.data.entryPoint.index}`,
-    );
-    return;
-  }
-  selectedInspectionResult.configuration.title = state.data.title;
+
+  newDeploymentData.entrypoint.inspectionResult.configuration.title =
+    newDeploymentData.title;
+  newDeploymentData.entrypoint.inspectionResult.configuration.type =
+    newDeploymentData.entrypoint.contentType;
 
   try {
     const existingNames = (
-      await api.configurations.getAll(selectedInspectionResult.projectDir)
+      await api.configurations.getAll(
+        newDeploymentData.entrypoint.inspectionResult.projectDir,
+      )
     ).data.map((config) => config.configurationName);
 
-    configName = newConfigFileNameFromTitle(state.data.title, existingNames);
+    configName = newConfigFileNameFromTitle(
+      newDeploymentData.title,
+      existingNames,
+    );
     const createResponse = await api.configurations.createOrUpdate(
       configName,
-      selectedInspectionResult.configuration,
-      selectedInspectionResult.projectDir,
+      newDeploymentData.entrypoint.inspectionResult.configuration,
+      newDeploymentData.entrypoint.inspectionResult.projectDir,
     );
     const fileUri = Uri.file(createResponse.data.configurationPath);
     newConfig = createResponse.data;
@@ -1297,50 +1439,21 @@ export async function newDeployment(
       error,
     );
     window.showErrorMessage(`Failed to create config file. ${summary}`);
-    return;
-  }
-
-  let finalCredentialName = <string | undefined>undefined;
-  if (
-    newCredentialForced(state) &&
-    state.data.name &&
-    !isQuickPickItem(state.data.name)
-  ) {
-    finalCredentialName = state.data.name;
-  } else if (!state.data.credentialName) {
-    window.showErrorMessage(
-      "Internal Error: NewDeployment Unexpected type guard failure @3",
-    );
-    return;
-  } else if (
-    newCredentialSelected(state) &&
-    state.data.name &&
-    !isQuickPickItem(state.data.name)
-  ) {
-    finalCredentialName = state.data.name;
-  } else if (isQuickPickItem(state.data.credentialName)) {
-    finalCredentialName = state.data.credentialName.label;
-  }
-  if (!finalCredentialName) {
-    // should have assigned it by now. Logic error!
-    window.showErrorMessage(
-      "Internal Error: NewDeployment Unexpected type guard failure @4",
-    );
-    return;
+    return undefined;
   }
 
   // Create the PreContentRecord File
   try {
     let existingNames = contentRecordNames.get(
-      selectedInspectionResult.projectDir,
+      newDeploymentData.entrypoint.inspectionResult.projectDir,
     );
     if (!existingNames) {
       existingNames = [];
     }
     const contentRecordName = newDeploymentName(existingNames);
     const response = await api.contentRecords.createNew(
-      selectedInspectionResult.projectDir,
-      finalCredentialName,
+      newDeploymentData.entrypoint.inspectionResult.projectDir,
+      newOrSelectedCredential?.name,
       configName,
       contentRecordName,
     );
@@ -1353,13 +1466,13 @@ export async function newDeployment(
     window.showErrorMessage(
       `Failed to create pre-deployment record. ${summary}`,
     );
-    return;
+    return undefined;
   }
   if (!newOrSelectedCredential) {
     window.showErrorMessage(
       "Internal Error: NewDeployment Unexpected type guard failure @5",
     );
-    return;
+    return undefined;
   }
   return {
     contentRecord: newContentRecord,

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -437,12 +437,16 @@ export async function newDeployment(
     }
     // Have to create a copy of the guarded value, to keep language service happy
     // within anonymous function below
-    const entryPointFile = newDeploymentData.entrypoint.filePath;
+    const entryPointFilePath = path.join(
+      projectDir,
+      newDeploymentData.entrypoint.filePath,
+    );
 
     const inspectionQuickPicks = await showProgress(
       "Scanning::newDeployment",
       viewId,
-      async () => await getConfigurationInspectionQuickPicks(entryPointFile),
+      async () =>
+        await getConfigurationInspectionQuickPicks(entryPointFilePath),
     );
 
     // skip if we only have one choice.

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -44,7 +44,12 @@ import { getNonce } from "src/utils/getNonce";
 import { getUri } from "src/utils/getUri";
 import { deployProject } from "src/views/deployProgress";
 import { WebviewConduit } from "src/utils/webviewConduit";
-import { fileExists, relativeDir, isRelativePathRoot } from "src/utils/files";
+import {
+  fileExists,
+  relativeDir,
+  isRelativePathRoot,
+  relativePath,
+} from "src/utils/files";
 import { Utils as uriUtils } from "vscode-uri";
 import { newDeployment } from "src/multiStepInputs/newDeployment";
 import type {
@@ -990,6 +995,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   private async showDeploymentQuickPick(
     contentRecordsSubset?: AllContentRecordTypes[],
     projectDir?: string,
+    entrypointFile?: string,
   ): Promise<PublishProcessParams | undefined> {
     try {
       // disable our home view, we are initiating a multi-step sequence
@@ -1153,7 +1159,11 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
       // If user selected create new, then switch over to that flow
       if (deployment?.label === createNewDeploymentLabel) {
-        return this.showNewDeploymentMultiStep(Views.HomeView);
+        return this.showNewDeploymentMultiStep(
+          Views.HomeView,
+          projectDir,
+          entrypointFile,
+        );
       }
 
       let deploymentSelector: DeploymentSelector | undefined;
@@ -1415,6 +1425,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return undefined;
     }
     const entrypointFile = uriUtils.basename(uri);
+    const entrypointRelPath = relativePath(uri);
 
     const api = await useApi();
 
@@ -1567,6 +1578,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const selected = await this.showDeploymentQuickPick(
         compatibleContentRecords,
         entrypointDir,
+        entrypointFile,
       );
       return selected;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2237 
Resolves #2200 

This PR addresses the performance issue with a recursive inspection behavior from VSCode's workspace root, when creating a new deployment. It also solves the problem when the user picks an entrypoint for which our inspection cannot determine the content type.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The first step of the new Deployment multi-stepper now displays a list of the open files that have one of the file extensions we recognize as entrypoints, performs inspection only on these files, and then offers the ability to use VSCode's file open dialog to select any other file. 

If the file selected has several options for deployment content type, a choice between the config types is presented.

If a config is selected with an UNKNOWN content type, a list of content types is presented for the user to tell us what type of project it is.

In another scenario, if a known type of entrypoint file has its publisher button clicked, and there are multiple deployments, then selecting a new deployment from the list will now maintain the file selected as the entrypoint file through the new deployment multi-stepper.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

The UX tests are being updated to handle these changes.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

To validate the functionality, you'll need to validate:

1. Clicking the plus sign when there are no files open within VSCode, should start the new Deployment multi-stepper off with just an option to open the file dialog.
-  Selecting a file outside of the VSCode workspace should display an error and then return to the file dialog.
- Clicking cancel from the File Dialog should abort the flow
- Clicking a valid entrypoint should proceed as expected. Use an RMD file to display multiple content types and other valid entrypoints which will not need to prompt for type.
2. Open a valid entrypoint file along with some others. Click the plus sign to confirm that only the valid entrypoint is shown.
3. Create multiple deployments for the entrypoint that you have open. Then click the file publisher button and confirm that you see a selection dialog to chose between the existing deployments or create a new one. Creating a new one should build a new deployment for the entrypoint you triggered the button from, without you having to select it.
4. Create a simple hello-world.py file, which is not currently supported as content. Browse or open the file and initiate a new deployment. Select it and confirm that you are forced to select a content type, and that the configuration file created properly reflects the choices you made. Deployment success/failure does not need to be confirmed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
