### PR TITLE
File credentials service (unplugged at the moment)

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -53,6 +53,16 @@ type Credential struct {
 
 type CredentialV0 = Credential
 
+func (c *Credential) ConflictCheck(compareWith Credential) error {
+	if compareWith.URL == c.URL {
+		return NewURLCollisionError(c.Name, c.URL)
+	}
+	if compareWith.Name == c.Name {
+		return NewNameCollisionError(c.Name, c.URL)
+	}
+	return nil
+}
+
 type CredentialRecord struct {
 	GUID    string          `json:"guid"`
 	Version uint            `json:"version"`
@@ -95,7 +105,7 @@ func NewCredentialsService(log logging.Logger) *credentialsService {
 // FileCredentialRecordFactory creates a Credential based on the presence of the
 // a file containing CONNECT_SERVER and CONNECT_API_KEY.
 
-type fileCredential struct {
+type deprcfileCredential struct {
 	URL string `toml:"url"`
 	Key string `toml:"key"`
 }
@@ -113,7 +123,7 @@ func (cs *credentialsService) FileCredentialRecordFactory() (*CredentialRecord, 
 	if !exists {
 		return nil, nil
 	}
-	var credential fileCredential
+	var credential deprcfileCredential
 	err = util.ReadTOMLFile(filePath, &credential)
 	if err != nil {
 		return nil, err

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -58,7 +58,7 @@ func (s *CredentialsTestSuite) createFileCredentials(cs *credentialsService, err
 	defer f.Close()
 
 	enc := toml.NewEncoder(f)
-	cred := fileCredential{
+	cred := deprcfileCredential{
 		URL: fileCred.URL,
 		Key: fileCred.ApiKey,
 	}

--- a/internal/credentials/errors.go
+++ b/internal/credentials/errors.go
@@ -8,6 +8,10 @@ type CorruptedError struct {
 	GUID string
 }
 
+func NewCorruptedError(guid string) *CorruptedError {
+	return &CorruptedError{guid}
+}
+
 func (e *CorruptedError) Error() string {
 	return fmt.Sprintf("credential '%s' is corrupted", e.GUID)
 }
@@ -16,12 +20,20 @@ type LoadError struct {
 	Err error
 }
 
+func NewLoadError(err error) *LoadError {
+	return &LoadError{err}
+}
+
 func (e *LoadError) Error() string {
 	return fmt.Sprintf("failed to load credentials: %v", e.Err)
 }
 
 type NotFoundError struct {
 	GUID string
+}
+
+func NewNotFoundError(guid string) *NotFoundError {
+	return &NotFoundError{GUID: guid}
 }
 
 func (e *NotFoundError) Error() string {
@@ -34,6 +46,10 @@ type URLCollisionError struct {
 	URL  string
 }
 
+func NewURLCollisionError(name, url string) *URLCollisionError {
+	return &URLCollisionError{name, url}
+}
+
 func (e *URLCollisionError) Error() string {
 	return fmt.Sprintf("URL value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
 }
@@ -42,6 +58,10 @@ func (e *URLCollisionError) Error() string {
 type EnvURLCollisionError struct {
 	Name string
 	URL  string
+}
+
+func NewEnvURLCollisionError(name, url string) *EnvURLCollisionError {
+	return &EnvURLCollisionError{name, url}
 }
 
 func (e *EnvURLCollisionError) Error() string {
@@ -54,6 +74,10 @@ type NameCollisionError struct {
 	URL  string
 }
 
+func NewNameCollisionError(name, url string) *NameCollisionError {
+	return &NameCollisionError{name, url}
+}
+
 func (e *NameCollisionError) Error() string {
 	return fmt.Sprintf("Name value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
 }
@@ -62,6 +86,10 @@ func (e *NameCollisionError) Error() string {
 type EnvNameCollisionError struct {
 	Name string
 	URL  string
+}
+
+func NewEnvNameCollisionError(name, url string) *EnvNameCollisionError {
+	return &EnvNameCollisionError{name, url}
 }
 
 func (e *EnvNameCollisionError) Error() string {
@@ -73,6 +101,10 @@ type EnvURLDeleteError struct {
 	GUID string
 }
 
+func NewEnvURLDeleteError(guid string) *EnvURLDeleteError {
+	return &EnvURLDeleteError{guid}
+}
+
 func (e *EnvURLDeleteError) Error() string {
 	return fmt.Sprintf("DELETING an environment credential is not allowed. (GUID=%s)", e.GUID)
 }
@@ -81,6 +113,20 @@ type VersionError struct {
 	Version uint
 }
 
+func NewVersionError(v uint) *VersionError {
+	return &VersionError{v}
+}
+
 func (e *VersionError) Error() string {
 	return fmt.Sprintf("credential version not supported: %d", e.Version)
+}
+
+type IncompleteCredentialError struct{}
+
+func NewIncompleteCredentialError() *IncompleteCredentialError {
+	return &IncompleteCredentialError{}
+}
+
+func (e *IncompleteCredentialError) Error() string {
+	return "New credentials require non-empty Name, URL and Api Key fields"
 }

--- a/internal/credentials/file.go
+++ b/internal/credentials/file.go
@@ -101,6 +101,10 @@ func (c *fileCredentialsService) Set(name, url, ak string) (*Credential, error) 
 	}
 
 	creds, err := c.load()
+	if err != nil {
+		return nil, err
+	}
+
 	normalizedUrl, err := util.NormalizeServerURL(url)
 	if err != nil {
 		return nil, err

--- a/internal/credentials/file.go
+++ b/internal/credentials/file.go
@@ -1,0 +1,269 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/spf13/afero"
+)
+
+const ondiskFilename = ".connect-credentials"
+
+type fileCredential struct {
+	GUID    string `toml:"guid"`
+	Version uint   `toml:"version"`
+	URL     string `toml:"url"`
+	ApiKey  string `toml:"api_key"`
+}
+
+func (cr *fileCredential) IsValid() bool {
+	return cr.URL != "" && cr.ApiKey != ""
+}
+
+type fileCredentials struct {
+	Credentials map[string]fileCredential `toml:"credentials"`
+}
+
+func (fcs *fileCredentials) CredentialsList() []Credential {
+	var list []Credential
+	for credName, fileCred := range fcs.Credentials {
+		list = append(list, Credential{
+			Name:   credName,
+			GUID:   fileCred.GUID,
+			URL:    fileCred.URL,
+			ApiKey: fileCred.ApiKey,
+		})
+	}
+	return list
+}
+
+func (fcs *fileCredentials) CredentialByGuid(guid string) (Credential, error) {
+	var cred Credential
+	for credName, fileCred := range fcs.Credentials {
+		if fileCred.GUID == guid {
+			cred = Credential{
+				Name:   credName,
+				GUID:   fileCred.GUID,
+				URL:    fileCred.URL,
+				ApiKey: fileCred.ApiKey,
+			}
+			return cred, nil
+		}
+	}
+	return Credential{}, NewNotFoundError(guid)
+}
+
+func (fcs *fileCredentials) RemoveByName(name string) {
+	delete(fcs.Credentials, name)
+}
+
+type fileCredentialsService struct {
+	mu            sync.Mutex
+	afs           afero.Fs
+	log           logging.Logger
+	credsFilepath util.AbsolutePath
+}
+
+func NewFileCredentialsService(log logging.Logger) (*fileCredentialsService, error) {
+	fservice := &fileCredentialsService{
+		log: log,
+	}
+
+	// Set home dir credentials file path
+	homeDir, err := util.UserHomeDir(fservice.afs)
+	if err != nil {
+		return nil, err
+	}
+	fservice.credsFilepath = homeDir.Join(ondiskFilename)
+
+	// Verify file can be modified, will create if not exists
+	err = fservice.setup()
+	if err != nil {
+		return nil, err
+	}
+
+	return fservice, nil
+}
+
+func (c *fileCredentialsService) Set(name, url, ak string) (*Credential, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if name == "" || url == "" || ak == "" {
+		return nil, NewIncompleteCredentialError()
+	}
+
+	creds, err := c.load()
+	normalizedUrl, err := util.NormalizeServerURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	guid := uuid.New().String()
+	cred := Credential{
+		GUID:   guid,
+		Name:   name,
+		URL:    normalizedUrl,
+		ApiKey: ak,
+	}
+
+	err = c.checkForConflicts(creds, cred)
+	if err != nil {
+		c.log.Debug("Conflicts storing new credential to file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return nil, err
+	}
+
+	creds.Credentials[name] = fileCredential{
+		GUID:    guid,
+		Version: CurrentVersion,
+		URL:     normalizedUrl,
+		ApiKey:  ak,
+	}
+
+	err = c.saveFile(creds)
+	if err != nil {
+		c.log.Debug("Could not update credentials file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return nil, err
+	}
+
+	return &cred, nil
+}
+
+func (c *fileCredentialsService) Get(guid string) (*Credential, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	creds, err := c.load()
+	if err != nil {
+		c.log.Debug("Error loading credentials from file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return nil, err
+	}
+
+	credential, err := creds.CredentialByGuid(guid)
+	if err != nil {
+		c.log.Debug("Could not find credential in file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return nil, err
+	}
+
+	return &credential, nil
+}
+
+func (c *fileCredentialsService) List() ([]Credential, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	creds, err := c.load()
+	if err != nil {
+		c.log.Debug("Error loading credentials from file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return nil, err
+	}
+
+	return creds.CredentialsList(), nil
+}
+
+func (c *fileCredentialsService) Delete(guid string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// First verify that credential exists
+	creds, err := c.load()
+	if err != nil {
+		c.log.Debug("Cannot delete credential, error loading credentials from file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return err
+	}
+
+	credential, err := creds.CredentialByGuid(guid)
+	if err != nil {
+		c.log.Debug("Cannot delete credential that does not exist", "error", err.Error(), "filename", c.credsFilepath.String())
+		return err
+	}
+
+	creds.RemoveByName(credential.Name)
+
+	err = c.saveFile(creds)
+	if err != nil {
+		c.log.Debug("Could not update credentials file", "error", err.Error(), "filename", c.credsFilepath.String())
+		return err
+	}
+
+	return nil
+}
+
+func (c *fileCredentialsService) setup() error {
+	_, err := c.credsFilepath.Stat()
+	if os.IsNotExist(err) {
+		file, err := c.credsFilepath.Create()
+		if err != nil {
+			return err
+		}
+		file.Close()
+		return nil
+	}
+
+	_, err = c.load()
+	if err != nil {
+		return NewLoadError(err)
+	}
+
+	return nil
+}
+
+func (c *fileCredentialsService) load() (fileCredentials, error) {
+	var creds fileCredentials
+	err := util.ReadTOMLFile(c.credsFilepath, &creds)
+	if err != nil {
+		return creds, NewLoadError(err)
+	}
+	c.normalizeAll(&creds)
+	return creds, nil
+}
+
+func (c *fileCredentialsService) saveFile(credsData fileCredentials) error {
+	credsFile, err := c.credsFilepath.OpenFile(os.O_TRUNC|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer credsFile.Close()
+	enc := toml.NewEncoder(credsFile)
+	return enc.Encode(credsData)
+}
+
+func (c *fileCredentialsService) normalizeCred(cred *fileCredential) error {
+	if cred.IsValid() {
+		normalizedUrl, err := util.NormalizeServerURL(cred.URL)
+		if err != nil {
+			return fmt.Errorf("Error normalizing file based credential URL: %s %v", cred.URL, err)
+		}
+		cred.URL = normalizedUrl
+	}
+	return nil
+}
+
+func (c *fileCredentialsService) normalizeAll(creds *fileCredentials) error {
+	for name, cred := range creds.Credentials {
+		err := c.normalizeCred(&cred)
+		if err != nil {
+			return err
+		}
+		creds.Credentials[name] = cred
+	}
+	return nil
+}
+
+func (c *fileCredentialsService) checkForConflicts(creds fileCredentials, newCred Credential) error {
+	// Check if URL or name are already used by another credential
+	for _, cred := range creds.CredentialsList() {
+		err := cred.ConflictCheck(newCred)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/credentials/file_test.go
+++ b/internal/credentials/file_test.go
@@ -1,0 +1,478 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+package credentials
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/logging/loggingtest"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type FileCredentialsServiceSuite struct {
+	utiltest.Suite
+	testdata   util.AbsolutePath
+	loggerMock *loggingtest.MockLogger
+}
+
+func TestFileCredentialsServiceSuite(t *testing.T) {
+	suite.Run(t, new(FileCredentialsServiceSuite))
+}
+
+func (s *FileCredentialsServiceSuite) fileSetupDeleteTest() {
+	fileData := []byte(`
+[credentials.tokeep]
+guid = "18cd5640-bee5-4b2a-992a-a2725ab6103d"
+version = 0
+url = "https://a1.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh000"
+
+[credentials.willdelete]
+guid = "79077898-7e26-4909-9eb7-596d1a6d0b6f"
+version = 0
+url = "hTTps://b2.CONNECT-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh002"
+
+[credentials.alsotokeep]
+guid = "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc"
+version = 0
+url = "https://c3.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh003"
+`)
+
+	err := os.WriteFile(s.testdata.Join("testdelete.toml").String(), fileData, 0644)
+	s.NoError(err)
+}
+
+func (s *FileCredentialsServiceSuite) fileSetupNewCredsTest() {
+	fileData := []byte(`
+[credentials.preexistent]
+guid = "18cd5640-bee5-4b2a-992a-a2725ab6103d"
+version = 0
+url = "https://a1.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh000"
+`)
+
+	err := os.WriteFile(s.testdata.Join("testset.toml").String(), fileData, 0644)
+	s.NoError(err)
+}
+
+func (s *FileCredentialsServiceSuite) SetupTest() {
+	_, filename, _, ok := runtime.Caller(0)
+	s.True(ok)
+	dir := util.NewAbsolutePath(filename, nil).Dir()
+	s.testdata = dir.Join("testdata", "toml")
+	s.loggerMock = loggingtest.NewMockLogger()
+	s.fileSetupDeleteTest()
+	s.fileSetupNewCredsTest()
+}
+
+func (s *FileCredentialsServiceSuite) TestSetupService() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("goodcreds.toml"),
+	}
+
+	err := cs.setup()
+	s.NoError(err)
+}
+
+func (s *FileCredentialsServiceSuite) TestSetupService_FileNotExists() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("do-not-exist-must-create.toml"),
+	}
+
+	_, err := cs.credsFilepath.Stat()
+	s.ErrorIs(err, os.ErrNotExist)
+
+	err = cs.setup()
+	s.NoError(err)
+
+	_, err = cs.credsFilepath.Stat()
+	s.NoError(err)
+
+	// Delete file for, green field for test runs
+	cs.credsFilepath.Remove()
+	s.NoError(err)
+}
+
+func (s *FileCredentialsServiceSuite) TestLoadFile() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("goodcreds.toml"),
+	}
+
+	creds, err := cs.load()
+	s.NoError(err)
+
+	s.Equal(creds, fileCredentials{
+		Credentials: map[string]fileCredential{
+			"hugo": {
+				GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+				Version: 0,
+				URL:     "https://a1.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+			},
+			"rick": {
+				GUID:    "79077898-7e26-4909-9eb7-596d1a6d0b6f",
+				Version: 0,
+				URL:     "https://b2.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+			},
+			"jane": {
+				GUID:    "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc",
+				Version: 0,
+				URL:     "https://c3.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh003",
+			},
+			"frank sinatra": {
+				GUID:    "bcdd57dd-6a68-4dcc-9877-d3ab2f512a04",
+				Version: 0,
+				URL:     "https://c4.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh004",
+			},
+		},
+	})
+}
+
+func (s *FileCredentialsServiceSuite) TestGet() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("goodcreds.toml"),
+	}
+
+	cred, err := cs.Get("79077898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.NoError(err)
+	s.Equal(cred, &Credential{
+		Name:   "rick",
+		GUID:   "79077898-7e26-4909-9eb7-596d1a6d0b6f",
+		URL:    "https://b2.connect-server:3939/connect",
+		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+	})
+}
+
+func (s *FileCredentialsServiceSuite) TestGet_CannotLoadErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("non-existent.toml"),
+	}
+
+	s.loggerMock.On("Debug", "Error loading credentials from file", "error", mock.Anything, "filename", cs.credsFilepath.String()).Return()
+
+	_, err := cs.Get("79077898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.Error(err)
+	s.loggerMock.AssertExpectations(s.T())
+}
+
+func (s *FileCredentialsServiceSuite) TestGet_NotFoundErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("goodcreds.toml"),
+	}
+
+	s.loggerMock.On("Debug", "Could not find credential in file", "error", mock.Anything, "filename", cs.credsFilepath.String()).Return()
+
+	_, err := cs.Get("00000898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.Error(err)
+	s.Equal(err.Error(), "credential not found: 00000898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.loggerMock.AssertExpectations(s.T())
+}
+
+func (s *FileCredentialsServiceSuite) TestList() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("goodcreds.toml"),
+	}
+
+	creds, err := cs.List()
+	s.NoError(err)
+
+	s.Contains(creds, Credential{
+		Name:   "hugo",
+		GUID:   "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+		URL:    "https://a1.connect-server:3939/connect",
+		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+	})
+	s.Contains(creds, Credential{
+		Name:   "rick",
+		GUID:   "79077898-7e26-4909-9eb7-596d1a6d0b6f",
+		URL:    "https://b2.connect-server:3939/connect",
+		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+	})
+	s.Contains(creds, Credential{
+		Name:   "jane",
+		GUID:   "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc",
+		URL:    "https://c3.connect-server:3939/connect",
+		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh003",
+	})
+	s.Contains(creds, Credential{
+		Name:   "frank sinatra",
+		GUID:   "bcdd57dd-6a68-4dcc-9877-d3ab2f512a04",
+		URL:    "https://c4.connect-server:3939/connect",
+		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh004",
+	})
+}
+
+func (s *FileCredentialsServiceSuite) TestList_CannotLoadErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("non-existent.toml"),
+	}
+
+	s.loggerMock.On("Debug", "Error loading credentials from file", "error", mock.Anything, "filename", cs.credsFilepath.String()).Return()
+
+	_, err := cs.Get("79077898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.Error(err)
+	s.loggerMock.AssertExpectations(s.T())
+}
+
+func (s *FileCredentialsServiceSuite) TestDelete() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("testdelete.toml"),
+	}
+
+	creds, err := cs.load()
+	s.NoError(err)
+
+	// Data generated on test setup
+	s.Equal(creds, fileCredentials{
+		Credentials: map[string]fileCredential{
+			"tokeep": {
+				GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+				Version: 0,
+				URL:     "https://a1.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+			},
+			"willdelete": {
+				GUID:    "79077898-7e26-4909-9eb7-596d1a6d0b6f",
+				Version: 0,
+				URL:     "https://b2.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+			},
+			"alsotokeep": {
+				GUID:    "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc",
+				Version: 0,
+				URL:     "https://c3.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh003",
+			},
+		},
+	})
+
+	err = cs.Delete("79077898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.NoError(err)
+
+	creds, err = cs.load()
+	s.NoError(err)
+
+	// Data generated on test setup
+	s.Equal(creds, fileCredentials{
+		Credentials: map[string]fileCredential{
+			"tokeep": {
+				GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+				Version: 0,
+				URL:     "https://a1.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+			},
+			"alsotokeep": {
+				GUID:    "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc",
+				Version: 0,
+				URL:     "https://c3.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh003",
+			},
+		},
+	})
+}
+
+func (s *FileCredentialsServiceSuite) TestDelete_CannotLoadErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("non-existent.toml"),
+	}
+
+	s.loggerMock.On("Debug", "Cannot delete credential, error loading credentials from file", "error", mock.Anything, "filename", cs.credsFilepath.String()).Return()
+
+	err := cs.Delete("79077898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.Error(err)
+	s.loggerMock.AssertExpectations(s.T())
+}
+
+func (s *FileCredentialsServiceSuite) TestDelete_NotFoundErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("testdelete.toml"),
+	}
+
+	s.loggerMock.On("Debug", "Cannot delete credential that does not exist", "error", mock.Anything, "filename", cs.credsFilepath.String()).Return()
+
+	err := cs.Delete("00000898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.Error(err)
+	s.Equal(err.Error(), "credential not found: 00000898-7e26-4909-9eb7-596d1a6d0b6f")
+	s.loggerMock.AssertExpectations(s.T())
+}
+
+func (s *FileCredentialsServiceSuite) TestSet() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("testset.toml"),
+	}
+
+	creds, err := cs.load()
+	s.NoError(err)
+
+	// Data generated on test setup
+	s.Equal(creds, fileCredentials{
+		Credentials: map[string]fileCredential{
+			"preexistent": {
+				GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+				Version: 0,
+				URL:     "https://a1.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+			},
+		},
+	})
+
+	newcred, err := cs.Set("newcred", "https://b2.connect-server:3939/connect", "abcdeC2aqbh7dg8TO43XPu7r56YDh002")
+	s.NoError(err)
+
+	s.Equal(newcred.Name, "newcred")
+	s.Equal(newcred.URL, "https://b2.connect-server:3939/connect")
+	s.Equal(newcred.ApiKey, "abcdeC2aqbh7dg8TO43XPu7r56YDh002")
+
+	creds, err = cs.load()
+	s.NoError(err)
+
+	// Data generated on test setup
+	s.Equal(creds, fileCredentials{
+		Credentials: map[string]fileCredential{
+			"preexistent": {
+				GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+				Version: 0,
+				URL:     "https://a1.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+			},
+			"newcred": {
+				GUID:    newcred.GUID,
+				Version: 0,
+				URL:     "https://b2.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+			},
+		},
+	})
+
+	newcred2, err := cs.Set("brand new cred wspaces", "https://b3.connect-server:3939/connect", "abcdeC2aqbh7dg8TO43XPu7r56YDh003")
+	s.NoError(err)
+
+	s.Equal(newcred2.Name, "brand new cred wspaces")
+	s.Equal(newcred2.URL, "https://b3.connect-server:3939/connect")
+	s.Equal(newcred2.ApiKey, "abcdeC2aqbh7dg8TO43XPu7r56YDh003")
+
+	creds, err = cs.load()
+	s.NoError(err)
+
+	// Data generated on test setup
+	s.Equal(creds, fileCredentials{
+		Credentials: map[string]fileCredential{
+			"preexistent": {
+				GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+				Version: 0,
+				URL:     "https://a1.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+			},
+			"newcred": {
+				GUID:    newcred.GUID,
+				Version: 0,
+				URL:     "https://b2.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+			},
+			"brand new cred wspaces": {
+				GUID:    newcred2.GUID,
+				Version: 0,
+				URL:     "https://b3.connect-server:3939/connect",
+				ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh003",
+			},
+		},
+	})
+}
+
+func (s *FileCredentialsServiceSuite) TestSet_BlankDataErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("testset.toml"),
+	}
+
+	testCases := map[string][3]string{
+		"empty credential": {"", "https://b2.connect-server:3939/connect", "abcdeC2aqbh7dg8TO43XPu7r56YDh002"},
+		"empty URL":        {"newcred", "", "abcdeC2aqbh7dg8TO43XPu7r56YDh002"},
+		"empty key":        {"newcred", "https://b2.connect-server:3939/connect", ""},
+	}
+
+	for _, params := range testCases {
+		_, err := cs.Set(params[0], params[1], params[2])
+		s.Error(err)
+		s.Equal(err.Error(), "New credentials require non-empty Name, URL and Api Key fields")
+
+		creds, err := cs.load()
+		s.NoError(err)
+
+		// File is intact
+		s.Equal(creds, fileCredentials{
+			Credentials: map[string]fileCredential{
+				"preexistent": {
+					GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+					Version: 0,
+					URL:     "https://a1.connect-server:3939/connect",
+					ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+				},
+			},
+		})
+	}
+}
+
+func (s *FileCredentialsServiceSuite) TestSet_ConflictErr() {
+	cs := &fileCredentialsService{
+		log:           s.loggerMock,
+		credsFilepath: s.testdata.Join("testset.toml"),
+	}
+
+	testCases := map[string][4]string{
+		"conflict with Name": {
+			"preexistent", "https://b2.connect-server:3939/connect", "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+			"Name value conflicts with existing credential (preexistent) URL: https://a1.connect-server:3939/connect",
+		},
+		"conflict with URL": {
+			"defanewnamehere", "https://a1.connect-server:3939/connect", "abcdeC2aqbh7dg8TO43XPu7r56YDh002",
+			"URL value conflicts with existing credential (preexistent) URL: https://a1.connect-server:3939/connect",
+		},
+	}
+
+	for _, params := range testCases {
+		expectedErrMessage := params[3]
+		s.loggerMock.On("Debug", "Conflicts storing new credential to file", "error", expectedErrMessage, "filename", cs.credsFilepath.String()).Return()
+
+		_, err := cs.Set(params[0], params[1], params[2])
+		s.Error(err)
+		s.loggerMock.AssertExpectations(s.T())
+
+		creds, err := cs.load()
+		s.NoError(err)
+
+		// File is intact
+		s.Equal(creds, fileCredentials{
+			Credentials: map[string]fileCredential{
+				"preexistent": {
+					GUID:    "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+					Version: 0,
+					URL:     "https://a1.connect-server:3939/connect",
+					ApiKey:  "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
+				},
+			},
+		})
+	}
+}

--- a/internal/credentials/testdata/toml/goodcreds.toml
+++ b/internal/credentials/testdata/toml/goodcreds.toml
@@ -1,0 +1,23 @@
+[credentials.hugo]
+guid = "18cd5640-bee5-4b2a-992a-a2725ab6103d"
+version = 0
+url = "https://a1.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh000"
+
+[credentials.rick]
+guid = "79077898-7e26-4909-9eb7-596d1a6d0b6f"
+version = 0
+url = "hTTps://b2.CONNECT-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh002"
+
+[credentials.jane]
+guid = "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc"
+version = 0
+url = "https://c3.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh003"
+
+[credentials."frank sinatra"]
+guid = "bcdd57dd-6a68-4dcc-9877-d3ab2f512a04"
+version = 0
+url = "https://c4.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh004"

--- a/internal/credentials/testdata/toml/testdelete.toml
+++ b/internal/credentials/testdata/toml/testdelete.toml
@@ -1,0 +1,18 @@
+
+[credentials.tokeep]
+guid = "18cd5640-bee5-4b2a-992a-a2725ab6103d"
+version = 0
+url = "https://a1.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh000"
+
+[credentials.willdelete]
+guid = "79077898-7e26-4909-9eb7-596d1a6d0b6f"
+version = 0
+url = "hTTps://b2.CONNECT-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh002"
+
+[credentials.alsotokeep]
+guid = "3bb375e4-6f01-4fd6-942a-ac32a5e4d7cc"
+version = 0
+url = "https://c3.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh003"

--- a/internal/credentials/testdata/toml/testset.toml
+++ b/internal/credentials/testdata/toml/testset.toml
@@ -1,0 +1,6 @@
+
+[credentials.preexistent]
+guid = "18cd5640-bee5-4b2a-992a-a2725ab6103d"
+version = 0
+url = "https://a1.connect-server:3939/connect"
+api_key = "abcdeC2aqbh7dg8TO43XPu7r56YDh000"


### PR DESCRIPTION
## Intent

Incremental work pushed for #1831 

This PR adds a new credentials service and it's constructor, which will handle cases where a system keyring service is unavailable.

- `fileCredentialsService`
- `NewFileCredentialsService(log logging.Logger) (*fileCredentialsService, error)`

This new file credentials service is unplugged in this PR, meant to facilitate incremental review of the file credentials work.

A subsequent PR will be created pointing to this one (at least until this one is merged).

Main points of this new file credentials service:
- Has a setup step that runs within the constructor to verify if the `.connect-credentials` file exists, creates it when needed.
- Implements the methods of the existing credentials service that uses the keyring provider. To allow plugging it in and be swapped when needed. (More on this on the sub-sequent PR)
```
Set(name, url, ak string) (*Credential, error)
Get(guid string) (*Credential, error)
List() ([]Credential, error)
Delete(guid string) error
```

Unit tests of this service serve as an example on how the `.connect-credentials` file will updated, while actually testing read and write actions to a TOML format file.

## Type of Change

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests

Unit tests for this new service included

## Directions for Reviewers

No manual actions needed at this moment, unit tests verify that the file service can read and write credentials to the provided file.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
