### PR TITLE
Add frontend Secrets API client resource

### DIFF
--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -7,6 +7,7 @@ import { ContentRecords } from "./resources/ContentRecords";
 import { Configurations } from "./resources/Configurations";
 import { Files } from "./resources/Files";
 import { Packages } from "./resources/Packages";
+import { Secrets } from "./resources/Secrets";
 import { EntryPoints } from "./resources/Entrypoints";
 import * as Entities from "entities";
 
@@ -18,6 +19,7 @@ class PublishingClientApi {
   contentRecords: ContentRecords;
   files: Files;
   packages: Packages;
+  secrets: Secrets;
   apiServiceIsUp: Promise<boolean>;
   entrypoints: EntryPoints;
 
@@ -51,6 +53,7 @@ class PublishingClientApi {
     this.contentRecords = new ContentRecords(this.client);
     this.files = new Files(this.client);
     this.packages = new Packages(this.client);
+    this.secrets = new Secrets(this.client);
     this.entrypoints = new EntryPoints(this.client);
   }
 

--- a/extensions/vscode/src/api/resources/Secrets.ts
+++ b/extensions/vscode/src/api/resources/Secrets.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import { AxiosInstance, AxiosResponse } from "axios";
+
+import { Configuration } from "../types/configurations";
+import { PostSecretBody, SecretAction } from "../types/secrets";
+
+export class Secrets {
+  private client: AxiosInstance;
+
+  constructor(client: AxiosInstance) {
+    this.client = client;
+  }
+
+  // Returns:
+  // 200 - success
+  // 400 - bad request
+  // 404 - not found
+  // 500 - internal server error
+  get(configName: string, dir: string) {
+    const encodedName = encodeURIComponent(configName);
+    return this.client.get<string[]>(`/configurations/${encodedName}/secrets`, {
+      params: { dir },
+    });
+  }
+
+  add(configName: string, secretName: string, dir: string) {
+    return this.update(configName, SecretAction.ADD, secretName, dir);
+  }
+
+  remove(configName: string, secretName: string, dir: string) {
+    return this.update(configName, SecretAction.REMOVE, secretName, dir);
+  }
+
+  // Returns:
+  // 200 - success
+  // 400 - bad request
+  // 404 - not found
+  // 500 - internal server error
+  update(
+    configName: string,
+    action: SecretAction,
+    secretName: string,
+    dir: string,
+  ) {
+    const encodedName = encodeURIComponent(configName);
+    const body = {
+      action,
+      secret: secretName,
+    };
+    return this.client.post<
+      Configuration,
+      AxiosResponse<Configuration>,
+      PostSecretBody
+    >(`/configurations/${encodedName}/secrets`, body, { params: { dir } });
+  }
+}

--- a/extensions/vscode/src/api/types/secrets.ts
+++ b/extensions/vscode/src/api/types/secrets.ts
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+export enum SecretAction {
+  ADD = "add",
+  REMOVE = "remove",
+}
+
+export type PostSecretBody = {
+  action: SecretAction;
+  secret: string;
+};


### PR DESCRIPTION
Adds the `Secrets` resource and associated types to the `api` module in the extension to use the two new APIs:
- `GET /api/configurations/$name/secrets`
- `POST /api/configurations/$name/secrets`

## Intent

Part of #2305

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
