### PR TITLE
Add contextual notification alert icons to section headers

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -28,7 +28,7 @@
         />
       </div>
 
-      <p v-if="isConfigEntryMissing">
+      <p v-if="home.isConfigEntryMissing">
         No Config Entry in Deployment record -
         {{ home.selectedContentRecord?.saveName }}.
         <a class="webview-link" role="button" @click="selectConfiguration">{{
@@ -36,14 +36,14 @@
         }}</a
         >.
       </p>
-      <p v-if="isConfigMissing">
+      <p v-if="home.isConfigMissing">
         The last Configuration used for this Deployment was not found.
         <a class="webview-link" role="button" @click="selectConfiguration">{{
           promptForConfigSelection
         }}</a
         >.
       </p>
-      <p v-if="isConfigInError">
+      <p v-if="home.isConfigInError">
         The selected Configuration has an error.
         <a
           class="webview-link"
@@ -55,7 +55,7 @@
         >.
       </p>
 
-      <p v-if="isCredentialMissing">
+      <p v-if="home.isCredentialMissingInConfig">
         A Credential for the Deployment's server URL was not found.
         <a class="webview-link" role="button" @click="newCredential"
           >Create a new Credential</a
@@ -246,19 +246,6 @@ const onViewPublishingLog = () => {
   });
 };
 
-const isConfigInErrorList = (configName?: string): boolean => {
-  if (!configName) {
-    return false;
-  }
-  return Boolean(
-    home.configurationsInError.find(
-      (config) =>
-        config.configurationName ===
-        home.selectedContentRecord?.configurationName,
-    ),
-  );
-};
-
 const filteredConfigs = computed((): Configuration[] => {
   return filterConfigurationsToValidAndType(
     home.configurations,
@@ -283,28 +270,6 @@ const contextMenuVSCodeContext = computed((): string => {
     isPreContentRecord(home.selectedContentRecord)
     ? "homeview-active-contentRecord-more-menu"
     : "homeview-last-contentRecord-more-menu";
-});
-
-const isConfigEntryMissing = computed((): boolean => {
-  return Boolean(
-    home.selectedContentRecord && !home.selectedContentRecord.configurationName,
-  );
-});
-
-const isConfigMissing = computed((): boolean => {
-  return Boolean(
-    home.selectedContentRecord &&
-      !home.selectedConfiguration &&
-      !isConfigInErrorList(home.selectedContentRecord?.configurationName) &&
-      !isConfigEntryMissing.value,
-  );
-});
-
-const isConfigInError = computed((): boolean => {
-  return Boolean(
-    home.selectedConfiguration &&
-      isConfigurationError(home.selectedConfiguration),
-  );
 });
 
 const deploymentTitle = computed(() => {
@@ -348,17 +313,13 @@ const entrypointSubTitle = computed(() => {
       if (contentRecord.projectDir !== ".") {
         subTitle = `${contentRecord.projectDir}${home.platformFileSeparator}`;
       }
-      if (!isConfigInError.value) {
+      if (!home.isConfigInError) {
         subTitle += config.configuration.entrypoint;
       }
       return subTitle;
     }
   }
   return "ProjectDir and Entrypoint not determined";
-});
-
-const isCredentialMissing = computed((): boolean => {
-  return Boolean(home.selectedContentRecord && !home.serverCredential);
 });
 
 const selectConfiguration = () => {

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -28,7 +28,7 @@
         />
       </div>
 
-      <p v-if="home.isConfigEntryMissing">
+      <p v-if="home.config.active.isEntryMissing">
         No Config Entry in Deployment record -
         {{ home.selectedContentRecord?.saveName }}.
         <a class="webview-link" role="button" @click="selectConfiguration">{{
@@ -36,14 +36,14 @@
         }}</a
         >.
       </p>
-      <p v-if="home.isConfigMissing">
+      <p v-if="home.config.active.isMissing">
         The last Configuration used for this Deployment was not found.
         <a class="webview-link" role="button" @click="selectConfiguration">{{
           promptForConfigSelection
         }}</a
         >.
       </p>
-      <p v-if="home.isConfigInError">
+      <p v-if="home.config.active.isError">
         The selected Configuration has an error.
         <a
           class="webview-link"
@@ -55,7 +55,7 @@
         >.
       </p>
 
-      <p v-if="home.isCredentialMissingInConfig">
+      <p v-if="home.config.active.isCredentialMissing">
         A Credential for the Deployment's server URL was not found.
         <a class="webview-link" role="button" @click="newCredential"
           >Create a new Credential</a
@@ -313,7 +313,7 @@ const entrypointSubTitle = computed(() => {
       if (contentRecord.projectDir !== ".") {
         subTitle = `${contentRecord.projectDir}${home.platformFileSeparator}`;
       }
-      if (!home.isConfigInError) {
+      if (!home.config.active.isError) {
         subTitle += config.configuration.entrypoint;
       }
       return subTitle;

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
@@ -11,15 +11,21 @@
           class="twisty-container codicon"
           :class="expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'"
         />
-        <h3 class="title">{{ title }}</h3>
-        <span v-if="$slots.description" class="description">
-          <slot name="description" />
-        </span>
-        <span v-else-if="description" class="description">
-          {{ description }}
-        </span>
+        <div style="display: flex; justify-content: space-between">
+          <h3 class="title">{{ title }}</h3>
+          <span v-if="$slots.description" class="description">
+            <slot name="description" />
+          </span>
+          <span v-else-if="description" class="description">
+            {{ description }}
+          </span>
+          <div
+            v-if="codicon && !expanded"
+            class="tree-section-icon codicon"
+            :class="codicon"
+          />
+        </div>
       </div>
-      <div v-if="codicon" class="tree-section-icon codicon" :class="codicon" />
       <div v-if="actions" class="actions">
         <ActionToolbar :title="title" :actions="actions" />
       </div>
@@ -62,17 +68,11 @@ const toggleExpanded = () => {
   .tree-section-icon {
     font-size: 13px;
     margin-right: 4px;
-    display: initial;
   }
 
   &.expanded:hover .actions,
   &.expanded:focus-within .actions {
     display: initial;
-  }
-
-  &.expanded .tree-section-icon {
-    display: none;
-    margin-left: auto;
   }
 
   &.expanded:hover

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
@@ -11,20 +11,18 @@
           class="twisty-container codicon"
           :class="expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'"
         />
-        <div style="display: flex; justify-content: space-between">
-          <h3 class="title">{{ title }}</h3>
-          <span v-if="$slots.description" class="description">
-            <slot name="description" />
-          </span>
-          <span v-else-if="description" class="description">
-            {{ description }}
-          </span>
-          <div
-            v-if="codicon && !expanded"
-            class="tree-section-icon codicon"
-            :class="codicon"
-          />
-        </div>
+        <h3 class="title">{{ title }}</h3>
+        <span v-if="$slots.description" class="description">
+          <slot name="description" />
+        </span>
+        <span v-else-if="description" class="description">
+          {{ description }}
+        </span>
+        <div
+          v-if="codicon && !expanded"
+          class="tree-section-icon codicon"
+          :class="codicon"
+        />
       </div>
       <div v-if="actions" class="actions">
         <ActionToolbar :title="title" :actions="actions" />
@@ -68,6 +66,7 @@ const toggleExpanded = () => {
   .tree-section-icon {
     font-size: 13px;
     margin-right: 4px;
+    margin-left: auto;
   }
 
   &.expanded:hover .actions,

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
@@ -27,6 +27,9 @@
       <div v-if="actions" class="actions">
         <ActionToolbar :title="title" :actions="actions" />
       </div>
+      <div v-if="headerActions" class="header-actions">
+        <ActionToolbar :title="title" :actions="headerActions" />
+      </div>
       <div v-if="count" class="count">
         <CountBadge :count="count" />
       </div>
@@ -40,20 +43,27 @@
 <script setup lang="ts">
 import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
 import CountBadge from "src/components/CountBadge.vue";
+import { watch } from "vue";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 
-defineProps<{
+const props = defineProps<{
   title: string;
   description?: string;
   codicon?: string;
+  headerActions?: ActionButton[];
   actions?: ActionButton[];
   count?: number;
+  expanded?: boolean;
 }>();
 
 const toggleExpanded = () => {
   expanded.value = !expanded.value;
 };
+
+watch([props.expanded], () => {
+  expanded.value = props.expanded;
+});
 </script>
 
 <style lang="scss" scoped>
@@ -62,10 +72,18 @@ const toggleExpanded = () => {
     display: none;
     margin-left: auto;
   }
+  .header-actions {
+    display: initial;
+  }
 
   &.expanded:hover .actions,
   &.expanded:focus-within .actions {
     display: initial;
+  }
+
+  &.expanded .header-actions {
+    display: none;
+    margin-left: auto;
   }
 
   &.expanded:hover

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeSection.vue
@@ -11,11 +11,6 @@
           class="twisty-container codicon"
           :class="expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'"
         />
-        <span
-          v-if="codicon"
-          class="tree-section-icon codicon"
-          :class="codicon"
-        />
         <h3 class="title">{{ title }}</h3>
         <span v-if="$slots.description" class="description">
           <slot name="description" />
@@ -24,11 +19,9 @@
           {{ description }}
         </span>
       </div>
+      <div v-if="codicon" class="tree-section-icon codicon" :class="codicon" />
       <div v-if="actions" class="actions">
         <ActionToolbar :title="title" :actions="actions" />
-      </div>
-      <div v-if="headerActions" class="header-actions">
-        <ActionToolbar :title="title" :actions="headerActions" />
       </div>
       <div v-if="count" class="count">
         <CountBadge :count="count" />
@@ -43,27 +36,20 @@
 <script setup lang="ts">
 import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
 import CountBadge from "src/components/CountBadge.vue";
-import { watch } from "vue";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 
-const props = defineProps<{
+defineProps<{
   title: string;
   description?: string;
   codicon?: string;
-  headerActions?: ActionButton[];
   actions?: ActionButton[];
   count?: number;
-  expanded?: boolean;
 }>();
 
 const toggleExpanded = () => {
   expanded.value = !expanded.value;
 };
-
-watch([props.expanded], () => {
-  expanded.value = props.expanded;
-});
 </script>
 
 <style lang="scss" scoped>
@@ -72,7 +58,10 @@ watch([props.expanded], () => {
     display: none;
     margin-left: auto;
   }
-  .header-actions {
+
+  .tree-section-icon {
+    font-size: 13px;
+    margin-right: 4px;
     display: initial;
   }
 
@@ -81,7 +70,7 @@ watch([props.expanded], () => {
     display: initial;
   }
 
-  &.expanded .header-actions {
+  &.expanded .tree-section-icon {
     display: none;
     margin-left: auto;
   }
@@ -128,11 +117,6 @@ watch([props.expanded], () => {
       margin: 0 2px;
       font-size: 16px;
       color: var(--vscode-icon-foreground);
-    }
-
-    .tree-section-icon {
-      font-size: 13px;
-      margin-right: 4px;
     }
 
     .title {

--- a/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
@@ -3,12 +3,10 @@
     title="Credentials"
     data-automation="credentials"
     :actions="sectionActions"
-    :codicon="home.credentialsAlert ? `codicon-alert` : ``"
+    :codicon="home.credential.active.isAlertActive ? `codicon-alert` : ``"
   >
-    <WelcomeView v-if="showWelcomeView">
-      <template v-if="home.credentialsAlert">
-        <p>No credentials have been added yet.</p>
-      </template>
+    <WelcomeView v-if="!home.credential.isAvailable">
+      <p>No credentials have been added yet.</p>
     </WelcomeView>
     <TreeItem
       v-else
@@ -63,10 +61,6 @@ const sectionActions = computed(() => {
       },
     },
   ];
-});
-
-const showWelcomeView = computed(() => {
-  return home.alertNoCredentials;
 });
 
 const vscodeContext = (credential: Credential) => {

--- a/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
@@ -2,10 +2,14 @@
   <TreeSection
     title="Credentials"
     data-automation="credentials"
+    :header-actions="credentialsHeaderActions"
     :actions="sectionActions"
+    :expanded="sectionExpanded"
   >
-    <WelcomeView v-if="home.sortedCredentials.length === 0">
-      <p>No credentials have been added yet.</p>
+    <WelcomeView v-if="showWelcomeView">
+      <template v-if="home.credentialsAlert">
+        <p>No credentials have been added yet.</p>
+      </template>
     </WelcomeView>
     <TreeItem
       v-else
@@ -25,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 import TreeSection from "src/components/tree/TreeSection.vue";
 import TreeItem from "src/components/tree/TreeItem.vue";
@@ -36,9 +40,29 @@ import { useHostConduitService } from "src/HostConduitService";
 import { Credential } from "../../../../../src/api";
 import { CredentialGUIs } from "../../../../../src/constants";
 import { WebviewToHostMessageType } from "../../../../../src/types/messages/webviewToHostMessages";
+import { ActionButton } from "../ActionToolbar.vue";
 
 const home = useHomeStore();
+const sectionExpanded = ref<boolean>(false);
+
 const { sendMsg } = useHostConduitService();
+
+const onClickAlert = () => {
+  sectionExpanded.value = true;
+};
+
+const credentialsHeaderActions = computed((): ActionButton[] => {
+  if (home.credentialsAlert) {
+    return [
+      {
+        label: "Action Required!",
+        codicon: "codicon-alert",
+        fn: onClickAlert,
+      },
+    ];
+  }
+  return [];
+});
 
 const sectionActions = computed(() => {
   return [
@@ -59,6 +83,10 @@ const sectionActions = computed(() => {
       },
     },
   ];
+});
+
+const showWelcomeView = computed(() => {
+  return home.alertNoCredentials;
 });
 
 const vscodeContext = (credential: Credential) => {

--- a/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
@@ -2,9 +2,8 @@
   <TreeSection
     title="Credentials"
     data-automation="credentials"
-    :header-actions="credentialsHeaderActions"
     :actions="sectionActions"
-    :expanded="sectionExpanded"
+    :codicon="home.credentialsAlert ? `codicon-alert` : ``"
   >
     <WelcomeView v-if="showWelcomeView">
       <template v-if="home.credentialsAlert">
@@ -43,26 +42,8 @@ import { WebviewToHostMessageType } from "../../../../../src/types/messages/webv
 import { ActionButton } from "../ActionToolbar.vue";
 
 const home = useHomeStore();
-const sectionExpanded = ref<boolean>(false);
 
 const { sendMsg } = useHostConduitService();
-
-const onClickAlert = () => {
-  sectionExpanded.value = true;
-};
-
-const credentialsHeaderActions = computed((): ActionButton[] => {
-  if (home.credentialsAlert) {
-    return [
-      {
-        label: "Action Required!",
-        codicon: "codicon-alert",
-        fn: onClickAlert,
-      },
-    ];
-  }
-  return [];
-});
 
 const sectionActions = computed(() => {
   return [

--- a/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import TreeSection from "src/components/tree/TreeSection.vue";
 import TreeItem from "src/components/tree/TreeItem.vue";
@@ -39,7 +39,6 @@ import { useHostConduitService } from "src/HostConduitService";
 import { Credential } from "../../../../../src/api";
 import { CredentialGUIs } from "../../../../../src/constants";
 import { WebviewToHostMessageType } from "../../../../../src/types/messages/webviewToHostMessages";
-import { ActionButton } from "../ActionToolbar.vue";
 
 const home = useHomeStore();
 

--- a/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
@@ -2,9 +2,8 @@
   <TreeSection
     title="Python Packages"
     data-automation="python-packages"
-    :header-actions="pythonPackageHeaderActions"
     :actions="pythonPackageActions"
-    :expanded="sectionExpanded"
+    :codicon="home.pythonAlert ? `codicon-alert` : ``"
   >
     <WelcomeView v-if="showWelcomeView">
       <template v-if="home.alertPythonMissingRequirements">
@@ -59,8 +58,6 @@ import { WebviewToHostMessageType } from "../../../../../src/types/messages/webv
 import { ActionButton } from "../ActionToolbar.vue";
 
 const home = useHomeStore();
-const sectionExpanded = ref<boolean>(false);
-
 const hostConduit = useHostConduitService();
 
 const onRefresh = () => {
@@ -86,23 +83,6 @@ const onEditRequirementsFile = () => {
     },
   });
 };
-
-const onClickAlert = () => {
-  sectionExpanded.value = true;
-};
-
-const pythonPackageHeaderActions = computed((): ActionButton[] => {
-  if (home.pythonAlert) {
-    return [
-      {
-        label: "Action Required!",
-        codicon: "codicon-alert",
-        fn: onClickAlert,
-      },
-    ];
-  }
-  return [];
-});
 
 const pythonPackageActions = computed((): ActionButton[] => {
   const result: ActionButton[] = [];

--- a/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
@@ -3,10 +3,10 @@
     title="Python Packages"
     data-automation="python-packages"
     :actions="pythonPackageActions"
-    :codicon="home.pythonAlert ? `codicon-alert` : ``"
+    :codicon="home.python.active.isAlertActive ? `codicon-alert` : ``"
   >
     <WelcomeView v-if="showWelcomeView">
-      <template v-if="home.alertPythonMissingRequirements">
+      <template v-if="home.python.active.isMissingRequirements">
         <p>
           To deploy Python content, you need a package file listing any package
           dependencies, but the file does not exist. Click Scan to create one
@@ -16,13 +16,13 @@
           Scan
         </vscode-button>
       </template>
-      <template v-if="home.isNotPythonProject">
+      <template v-if="!home.python.active.isInProject">
         <p>
           This project is not configured to use Python. To configure Python, add
           a [python] section to your configuration file.
         </p>
       </template>
-      <template v-if="home.alertPythonEmptyRequirements">
+      <template v-if="home.python.active.isEmptyRequirements">
         <p>
           This project currently has no Python package requirements. If this is
           not accurate, click Scan to update based on the files in your project
@@ -111,9 +111,9 @@ const pythonPackageActions = computed((): ActionButton[] => {
 
 const showWelcomeView = computed(() => {
   return (
-    home.isNotPythonProject ||
-    home.alertPythonEmptyRequirements ||
-    home.alertPythonMissingRequirements
+    !home.python.active.isInProject ||
+    home.python.active.isEmptyRequirements ||
+    home.python.active.isMissingRequirements
   );
 });
 </script>

--- a/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/PythonPackages.vue
@@ -50,7 +50,7 @@ import TreeItem from "src/components/tree/TreeItem.vue";
 import TreeSection from "src/components/tree/TreeSection.vue";
 import WelcomeView from "src/components/WelcomeView.vue";
 
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import { useHomeStore } from "src/stores/home";
 import { useHostConduitService } from "src/HostConduitService";

--- a/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
@@ -2,9 +2,8 @@
   <TreeSection
     title="R Packages"
     data-automation="r-packages"
-    :header-actions="rPackageHeaderActions"
     :actions="rPackageActions"
-    :expanded="sectionExpanded"
+    :codicon="home.rAlert ? `codicon-alert` : ``"
   >
     <WelcomeView v-if="showWelcomeView">
       <template v-if="home.alertRMissingPackageFile">
@@ -91,23 +90,6 @@ const onEditRequirementsFile = () => {
     },
   });
 };
-
-const onClickAlert = () => {
-  sectionExpanded.value = true;
-};
-
-const rPackageHeaderActions = computed((): ActionButton[] => {
-  if (home.rAlert) {
-    return [
-      {
-        label: "Action Required!",
-        codicon: "codicon-alert",
-        fn: onClickAlert,
-      },
-    ];
-  }
-  return [];
-});
 
 const rPackageActions = computed((): ActionButton[] => {
   const result: ActionButton[] = [];

--- a/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
@@ -55,7 +55,7 @@ import TreeItem from "src/components/tree/TreeItem.vue";
 import TreeSection from "src/components/tree/TreeSection.vue";
 import WelcomeView from "src/components/WelcomeView.vue";
 
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import { useHomeStore } from "src/stores/home";
 import { useHostConduitService } from "src/HostConduitService";
@@ -63,7 +63,6 @@ import { WebviewToHostMessageType } from "../../../../../src/types/messages/webv
 import { ActionButton } from "../ActionToolbar.vue";
 
 const home = useHomeStore();
-const sectionExpanded = ref<boolean>(false);
 
 const hostConduit = useHostConduitService();
 

--- a/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
@@ -3,10 +3,10 @@
     title="R Packages"
     data-automation="r-packages"
     :actions="rPackageActions"
-    :codicon="home.rAlert ? `codicon-alert` : ``"
+    :codicon="home.r.active.isAlertActive ? `codicon-alert` : ``"
   >
     <WelcomeView v-if="showWelcomeView">
-      <template v-if="home.alertRMissingPackageFile">
+      <template v-if="home.r.active.isMissingPackageFile">
         <p>
           To deploy R content, you need a package file listing any package
           dependencies, but the file does not exist or is invalid. Use
@@ -19,13 +19,13 @@
           Scan
         </vscode-button>
       </template>
-      <template v-if="isNotRProject">
+      <template v-if="!home.r.active.isInProject">
         <p data-automation="r-not-configured">
           This project is not configured to use R. To configure R, add an [r]
           section to your configuration file.
         </p>
       </template>
-      <template v-if="home.alertREmptyRequirements">
+      <template v-if="home.r.active.isEmptyRequirements">
         <p>
           This project currently has no R package requirements (file ({{
             home.rPackageFile
@@ -117,14 +117,9 @@ const rPackageActions = computed((): ActionButton[] => {
 
 const showWelcomeView = computed(() => {
   return (
-    isNotRProject.value ||
-    home.alertREmptyRequirements ||
-    home.alertRMissingPackageFile
+    !home.r.active.isInProject ||
+    home.r.active.isEmptyRequirements ||
+    home.r.active.isMissingPackageFile
   );
-});
-
-// not considered an alert
-const isNotRProject = computed(() => {
-  return !home.rProject;
 });
 </script>

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -232,6 +232,111 @@ export const useHomeStore = defineStore("home", () => {
       .length;
   });
 
+  // Not considered an alert at this time.
+  const isNotPythonProject = computed(() => {
+    return !pythonProject.value;
+  });
+
+  const alertPythonEmptyRequirements = computed(() => {
+    return (
+      pythonProject.value &&
+      pythonPackageFile.value &&
+      pythonPackages.value &&
+      pythonPackages.value.length === 0
+    );
+  });
+
+  const alertPythonMissingRequirements = computed(() => {
+    return pythonProject.value && !pythonPackageFile.value;
+  });
+
+  const pythonAlert = computed(() => {
+    return (
+      alertPythonEmptyRequirements.value || alertPythonMissingRequirements.value
+    );
+  });
+
+  const alertRMissingPackageFile = computed(() => {
+    return rProject.value && !rPackageFile.value;
+  });
+
+  const alertREmptyRequirements = computed(() => {
+    return (
+      rProject.value &&
+      rPackageFile.value &&
+      rPackages.value &&
+      rPackages.value.length === 0
+    );
+  });
+
+  const rAlert = computed(() => {
+    return alertRMissingPackageFile.value || alertREmptyRequirements.value;
+  });
+
+  const alertNoCredentials = computed(() => {
+    return !Boolean(sortedCredentials.value.length);
+  });
+
+  const credentialsAlert = computed(() => {
+    return alertNoCredentials.value;
+  });
+
+  const anyActiveAlerts = computed(() => {
+    return (
+      !configAlert.value &&
+      (credentialsAlert.value || rAlert.value || pythonAlert.value)
+    );
+  });
+
+  const isConfigEntryMissing = computed(() => {
+    return Boolean(
+      selectedContentRecord.value &&
+        !selectedContentRecord.value.configurationName,
+    );
+  });
+
+  const isConfigMissing = computed((): boolean => {
+    return Boolean(
+      selectedContentRecord.value &&
+        !selectedConfiguration.value &&
+        !isConfigInErrorList(selectedContentRecord.value?.configurationName) &&
+        !isConfigEntryMissing.value,
+    );
+  });
+
+  const isConfigInError = computed((): boolean => {
+    return Boolean(
+      selectedConfiguration.value &&
+        isConfigurationError(selectedConfiguration.value),
+    );
+  });
+
+  const isConfigInErrorList = (configName?: string): boolean => {
+    if (!configName) {
+      return false;
+    }
+    return Boolean(
+      configurationsInError.value.find(
+        (config) =>
+          config.configurationName ===
+          selectedContentRecord.value?.configurationName,
+      ),
+    );
+  };
+
+  const isCredentialMissingInConfig = computed((): boolean => {
+    return Boolean(selectedContentRecord.value && !serverCredential.value);
+  });
+
+  const configAlert = computed(() => {
+    return (
+      isConfigEntryMissing.value ||
+      isConfigMissing.value ||
+      isConfigInError.value ||
+      isCredentialMissingInConfig.value
+    );
+  });
+
   return {
     platformFileSeparator,
     showDisabledOverlay,
@@ -254,9 +359,19 @@ export const useHomeStore = defineStore("home", () => {
     pythonPackages,
     pythonPackageFile,
     pythonPackageManager,
+    isNotPythonProject,
+    alertPythonEmptyRequirements,
+    alertPythonMissingRequirements,
+    pythonAlert,
     rProject,
     rPackages,
     rPackageFile,
+    alertRMissingPackageFile,
+    alertREmptyRequirements,
+    rAlert,
+    alertNoCredentials,
+    credentialsAlert,
+    anyActiveAlerts,
     updateSelectedContentRecordBySelector,
     updateSelectedContentRecordByObject,
     updateParentViewSelectionState,
@@ -264,5 +379,11 @@ export const useHomeStore = defineStore("home", () => {
     updateRPackages,
     clearSecretValues,
     secretsWithValueCount,
+    isConfigEntryMissing,
+    isConfigMissing,
+    isConfigInError,
+    isConfigInErrorList,
+    isCredentialMissingInConfig,
+    configAlert,
   };
 });


### PR DESCRIPTION
…ion when alerting

<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This PR adds action indicators to section headers to indicate that attention is needed.

resolves #2245 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Business logic that determined the display of actionable messages was moved into the central store for `EvenEasierDeploy.vue`, `Credentials.vue`, `RPackages.vue` and `PythonPackages.vue`. Existing logic was maintained, which was easy since each of these methods were already using the store to perform their computations.

`TreeSection.vue` component was updated to allow the specification of a `headerActions` prop, which is shown when the section is collapsed (vs. the `actions` prop which is only shown when the section is expanded. Also had to support an `expanded` prop, to allow the actions (who's logic is implemented in the parent component) to be able to expand the section.

Screenshot:
![2024-09-25 at 11 05 AM](https://github.com/user-attachments/assets/da8094b9-fc49-45ce-95c2-74d49a2ee9e7)

## Directions for Reviewers

Each of the updated sections (credentials, python packages, and r packages) will show the alert icon when collapsed under the same conditions as they would display their "welcome" messages when expanded.

To reproduce some of these:
- for a python project:
    - remove your `requirements.txt` file
    - empty the `requirements.txt` file
- for an R project:
    - remove your `renv.lock` file 
    - empty your `renv.lock` file

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
