### PR TITLE
Add ability to remove a Secret name in the UI

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -59,6 +59,12 @@
         "category": "Posit Publisher"
       },
       {
+        "command": "posit.publisher.homeView.removeSecret",
+        "title": "Remove Secret from Configuration",
+        "icon": "$(trash)",
+        "category": "Posit Publisher"
+      },
+      {
         "command": "posit.publisher.files.refresh",
         "title": "Refresh Deployment Files",
         "icon": "$(refresh)",
@@ -248,6 +254,10 @@
           "when": "posit.publish.state == 'initialized'"
         },
         {
+          "command": "posit.publisher.homeView.removeSecret",
+          "when": "false"
+        },
+        {
           "command": "posit.publisher.files.refresh",
           "when": "posit.publish.state == 'initialized'"
         },
@@ -346,6 +356,10 @@
         {
           "command": "posit.publisher.homeView.deleteCredential",
           "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'credentials-tree-item'"
+        },
+        {
+          "command": "posit.publisher.homeView.removeSecret",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'secrets-tree-item'"
         }
       ]
     },

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -73,6 +73,7 @@ const homeViewCommands = {
   AddCredential: "posit.publisher.homeView.addCredential",
   DeleteCredential: "posit.publisher.homeView.deleteCredential",
   RefreshCredentials: "posit.publisher.homeView.refreshCredentials",
+  RemoveSecret: "posit.publisher.homeView.removeSecret",
   EditCurrentConfiguration: "posit.publisher.homeView.edit.Configuration",
   // Added automatically by VSCode with view registration
   Focus: "posit.publisher.homeView.focus",

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -936,6 +936,30 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
   }
 
+  public removeSecret = async (context: { name: string }) => {
+    const activeConfig = await this.state.getSelectedConfiguration();
+    if (activeConfig === undefined) {
+      console.error("homeView::removeSecret: No active configuration.");
+      return;
+    }
+
+    try {
+      await showProgress("Removing Secret", Views.HomeView, async () => {
+        const api = await useApi();
+        await api.secrets.remove(
+          activeConfig.configurationName,
+          context.name,
+          activeConfig.projectDir,
+        );
+      });
+    } catch (error: unknown) {
+      const summary = getSummaryStringFromError("removeSecret", error);
+      window.showInformationMessage(
+        `Failed to remove secret from configuration. ${summary}`,
+      );
+    }
+  };
+
   private async showNewCredential() {
     return await commands.executeCommand(Commands.HomeView.AddCredential);
   }
@@ -1787,6 +1811,13 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           Uri.parse("https://github.com/posit-dev/publisher/discussions"),
         );
       }),
+    );
+
+    this.context.subscriptions.push(
+      commands.registerCommand(
+        Commands.HomeView.RemoveSecret,
+        this.removeSecret,
+      ),
     );
 
     this.context.subscriptions.push(

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -6,6 +6,7 @@
     :list-style="secretValue || isEditing ? 'default' : 'deemphasized'"
     :tooltip="tooltip"
     align-icon-with-twisty
+    :data-vscode-context="vscodeContext"
   >
     <template #description>
       <SidebarInput
@@ -90,5 +91,13 @@ const actions = computed<ActionButton[]>(() => {
   }
 
   return result;
+});
+
+const vscodeContext = computed(() => {
+  return JSON.stringify({
+    name: props.name,
+    webviewSection: "secrets-tree-item",
+    preventDefaultContextMenuItems: true,
+  });
 });
 </script>


### PR DESCRIPTION
Adds the ability to remove a Secret name from the selected Configuration in the UI.

To do this you can right-click a Secret to bring up a context menu, similar to the removal of Credentials.

<details>
  <summary>Preview</summary>

https://github.com/user-attachments/assets/f879e7fd-ebf7-4a28-a972-c7bc77609bf3


</details> 

## Intent

Part of #2305

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->