### PR TITLE
Add button to add a Secret to the config

### DIFF
--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -16,6 +16,7 @@ export enum WebviewToHostMessageType {
   REQUEST_FILES_LISTS = "requestFilesLists",
   REQUEST_CREDENTIALS = "requestCredentials",
   VSCODE_OPEN_RELATIVE = "VSCodeOpenRelativeMsg",
+  ADD_SECRET = "addSecret",
   REFRESH_PYTHON_PACKAGES = "RefreshPythonPackagesMsg",
   SCAN_PYTHON_PACKAGE_REQUIREMENTS = "ScanPythonPackageRequirementsMsg",
   REFRESH_R_PACKAGES = "RefreshRPackagesMsg",
@@ -50,6 +51,7 @@ export type WebviewToHostMessage =
   | ExcludeFileMsg
   | RequestFilesListsMsg
   | RequestCredentialsMsg
+  | AddSecretMsg
   | RefreshPythonPackagesMsg
   | VSCodeOpenRelativeMsg
   | ScanPythonPackageRequirementsMsg
@@ -75,6 +77,7 @@ export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
     msg.kind === WebviewToHostMessageType.EXCLUDE_FILE ||
     msg.kind === WebviewToHostMessageType.REQUEST_FILES_LISTS ||
     msg.kind === WebviewToHostMessageType.REQUEST_CREDENTIALS ||
+    msg.kind === WebviewToHostMessageType.ADD_SECRET ||
     msg.kind === WebviewToHostMessageType.REFRESH_PYTHON_PACKAGES ||
     msg.kind === WebviewToHostMessageType.VSCODE_OPEN_RELATIVE ||
     msg.kind === WebviewToHostMessageType.SCAN_PYTHON_PACKAGE_REQUIREMENTS ||
@@ -153,6 +156,9 @@ export type RequestFilesListsMsg =
 
 export type RequestCredentialsMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.REQUEST_CREDENTIALS>;
+
+export type AddSecretMsg =
+  AnyWebviewToHostMessage<WebviewToHostMessageType.ADD_SECRET>;
 
 export type RefreshPythonPackagesMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.REFRESH_PYTHON_PACKAGES>;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -200,6 +200,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         return await this.debounceRefreshPythonPackages();
       case WebviewToHostMessageType.REFRESH_R_PACKAGES:
         return await this.debounceRefreshRPackages();
+      case WebviewToHostMessageType.ADD_SECRET:
+        return await this.addSecret();
       case WebviewToHostMessageType.VSCODE_OPEN_RELATIVE:
         return await this.onRelativeOpenVSCode(msg);
       case WebviewToHostMessageType.SCAN_PYTHON_PACKAGE_REQUIREMENTS:
@@ -935,6 +937,50 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       });
     }
   }
+
+  private inputSecretName = async () => {
+    return await window.showInputBox({
+      title: "Add a Secret",
+      prompt: "Enter the name of the secret.",
+      ignoreFocusOut: true,
+      validateInput: (value: string) => {
+        if (value.length === 0) {
+          return "Secret names cannot be empty.";
+        }
+        return;
+      },
+    });
+  };
+
+  public addSecret = async () => {
+    const activeConfig = await this.state.getSelectedConfiguration();
+    if (activeConfig === undefined) {
+      console.error("homeView::addSecret: No active configuration.");
+      return;
+    }
+
+    const name = await this.inputSecretName();
+    if (name === undefined) {
+      // Cancelled by the user
+      return;
+    }
+
+    try {
+      await showProgress("Adding Secret", Views.HomeView, async () => {
+        const api = await useApi();
+        await api.secrets.add(
+          activeConfig.configurationName,
+          name,
+          activeConfig.projectDir,
+        );
+      });
+    } catch (error: unknown) {
+      const summary = getSummaryStringFromError("addSecret", error);
+      window.showInformationMessage(
+        `Failed to add secret to configuration. ${summary}`,
+      );
+    }
+  };
 
   public removeSecret = async (context: { name: string }) => {
     const activeConfig = await this.state.getSelectedConfiguration();

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secrets.vue
@@ -21,11 +21,25 @@ import TreeSection from "src/components/tree/TreeSection.vue";
 import WelcomeView from "src/components/WelcomeView.vue";
 import { useHomeStore } from "src/stores/home";
 import Secret from "src/components/views/secrets/Secret.vue";
+import { useHostConduitService } from "src/HostConduitService";
+
+import { WebviewToHostMessageType } from "../../../../../../src/types/messages/webviewToHostMessages";
 
 const home = useHomeStore();
+const { sendMsg } = useHostConduitService();
 
 const sectionActions = computed<ActionButton[]>(() => {
-  const result: ActionButton[] = [];
+  const result: ActionButton[] = [
+    {
+      label: "Add Secret",
+      codicon: "codicon-add",
+      fn: () => {
+        sendMsg({
+          kind: WebviewToHostMessageType.ADD_SECRET,
+        });
+      },
+    },
+  ];
 
   if (home.secretsWithValueCount > 0) {
     result.push({


### PR DESCRIPTION
This adds a new `+` button to the Secrets view header which will prompt for a name and add that name as a Secret to the selected Configuration.

<details>
  <summary>Preview</summary>
  
  
https://github.com/user-attachments/assets/8fe080f0-876d-4be9-aca8-f994b943eef7
</details> 

## Intent

Resolves #2305

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->