### PR TITLE
Suppress calls to agent when active config is in error

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -338,7 +338,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return;
     }
     if (isConfigurationError(activeConfig)) {
-      console.log(
+      console.error(
         "homeView::updateFileList: Skipping - error in active configuration.",
       );
       return;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -337,6 +337,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       console.error("homeView::updateFileList: No active configuration.");
       return;
     }
+    if (isConfigurationError(activeConfig)) {
+      console.log(
+        "homeView::updateFileList: Skipping - error in active configuration.",
+      );
+      return;
+    }
     try {
       await showProgress("Updating File List", Views.HomeView, async () => {
         const api = await useApi();
@@ -958,6 +964,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       console.error("homeView::addSecret: No active configuration.");
       return;
     }
+    if (isConfigurationError(activeConfig)) {
+      console.error(
+        "homeView::addSecret: Unable to add secret into a configuration with error.",
+      );
+      return;
+    }
 
     const name = await this.inputSecretName();
     if (name === undefined) {
@@ -986,6 +998,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     const activeConfig = await this.state.getSelectedConfiguration();
     if (activeConfig === undefined) {
       console.error("homeView::removeSecret: No active configuration.");
+      return;
+    }
+    if (isConfigurationError(activeConfig)) {
+      console.error(
+        "homeView::removeSecret: Unable to remove secret from a configuration with error.",
+      );
       return;
     }
 
@@ -1456,7 +1474,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   public sendRefreshedFilesLists = async () => {
     const activeConfig = await this.state.getSelectedConfiguration();
-    if (activeConfig) {
+    if (activeConfig && !isConfigurationError(activeConfig)) {
       try {
         const response = await showProgress(
           "Refreshing Files",

--- a/extensions/vscode/webviews/homeView/src/App.vue
+++ b/extensions/vscode/webviews/homeView/src/App.vue
@@ -4,7 +4,12 @@
   <main>
     <OverlayableView :activateOverlay="home.showDisabledOverlay">
       <EvenEasierDeploy class="easy-deploy-container" />
-      <template v-if="home.selectedConfiguration">
+      <template
+        v-if="
+          home.selectedConfiguration &&
+          !isConfigurationError(home.selectedConfiguration)
+        "
+      >
         <ProjectFiles v-model:expanded="projectFilesExpanded" />
         <Secrets />
         <PythonPackages />
@@ -30,6 +35,7 @@ import HelpAndFeedback from "src/components/views/HelpAndFeedback.vue";
 
 import { useHostConduitService } from "src/HostConduitService";
 import { useHomeStore } from "./stores/home";
+import { isConfigurationError } from "../../../src/api";
 
 useHostConduitService();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This PR resolves the issue where API calls that depend on a valid configuration file are being called even if the configuration file is in error, which causes API failure notices to be displayed in VSCode.

Resolves #2323 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

There are a number of API calls that we know depend upon a valid configuration file (as we are required to pass in the name of the active configuration file). I have added checks (where missing) into the methods in which we get the active configuration file and return immediately if the active configuration is in error. This removes the reported error message, which was occurring off of file watcher actions.

I have also updated the homeView to not display the configuration-reliant sections (files, python, r) when the selected configuration is in error.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Edit the active configuration to have an invalid TOML field. Saving the file should not cause a 500 error to be displayed in the lower-right corner of VSCode. Confirm the sections `files`, `r packages` and `python packages` are hidden after save.

Make other changes directly to the configuration which are valid, and upon save, you should see the appropriate updates to the UX where previously expected. Confirm the sections `files`, `r packages` and `python packages` are visible after save.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
