### PR TITLE
Display configuration error w/ TOML parsing details

### DIFF
--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -27,5 +27,7 @@ export const isInvalidTOMLFileCode = (
   if (!agentError) {
     return false;
   }
-  return agentError.code === "invalidTOML";
+  return (
+    agentError.code === "invalidTOML" || agentError.code === "unknownTOMLKey"
+  );
 };

--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -8,3 +8,24 @@ export type AgentError = {
     [key: string]: unknown;
   };
 };
+
+export type InvalidTOMLFileCodeError = {
+  code: string;
+  msg: string;
+  operation: string;
+  data: {
+    problem: string;
+    file: string;
+    line: string;
+    column: string;
+  };
+};
+
+export const isInvalidTOMLFileCode = (
+  agentError: AgentError | undefined,
+): agentError is InvalidTOMLFileCodeError => {
+  if (!agentError) {
+    return false;
+  }
+  return agentError.code === "invalidTOML";
+};

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -71,6 +71,7 @@ export type ErrInvalidTOMLFile = MkErrorDataType<
     filename: string;
     line: number;
     column: number;
+    problem: string;
   }
 >;
 export const isErrInvalidTOMLFile =

--- a/extensions/vscode/webviews/homeView/src/components/configErrors/ConfigErrors.vue
+++ b/extensions/vscode/webviews/homeView/src/components/configErrors/ConfigErrors.vue
@@ -1,0 +1,100 @@
+<!-- Copyright (C) 2024 by Posit Software, PBC. -->
+
+<template>
+  <EntryMissing
+    v-if="ifEntryMissingError"
+    :config-selection-prompt="promptForConfigSelection"
+    @select-configuration="selectConfiguration"
+  />
+  <FileMissing
+    v-if="ifFileMissingError"
+    :config-selection-prompt="promptForConfigSelection"
+    @select-configuration="selectConfiguration"
+  />
+  <InvalidTOMLFile
+    v-if="ifInvalidTOMLFileError"
+    :error="invalidTOMLFileError"
+    @edit-active-configuration="onEditActiveConfiguration"
+  />
+  <UnhandledError v-if="ifUnhandledError" :error="configError" />
+</template>
+<script setup lang="ts">
+import { useHostConduitService } from "src/HostConduitService";
+import { useHomeStore } from "src/stores/home";
+import { computed } from "vue";
+import { WebviewToHostMessageType } from "../../../../../src/types/messages/webviewToHostMessages";
+import { isConfigurationError } from "../../../../../src/api";
+import {
+  AgentError,
+  InvalidTOMLFileCodeError,
+  isInvalidTOMLFileCode,
+} from "../../../../../src/api/types/error";
+
+import InvalidTOMLFile from "./InvalidTOMLFile.vue";
+import EntryMissing from "./EntryMissing.vue";
+import FileMissing from "./FileMissing.vue";
+import UnhandledError from "./UnhandledError.vue";
+
+const home = useHomeStore();
+const hostConduit = useHostConduitService();
+
+const ifEntryMissingError = computed(() => {
+  return home.config.active.isEntryMissing;
+});
+
+const ifFileMissingError = computed(() => {
+  return home.config.active.isMissing;
+});
+
+const ifInvalidTOMLFileError = computed(() => {
+  return invalidTOMLFileError.value;
+});
+
+const ifUnhandledError = computed(() => {
+  return (
+    !ifEntryMissingError.value &&
+    !ifFileMissingError.value &&
+    !ifInvalidTOMLFileError.value
+  );
+});
+
+const invalidTOMLFileError = computed(
+  (): InvalidTOMLFileCodeError | undefined => {
+    if (configError.value && isInvalidTOMLFileCode(configError.value)) {
+      return configError.value;
+    }
+    return undefined;
+  },
+);
+
+const promptForConfigSelection = computed((): string => {
+  return home.config.active.matchingConfigs.length > 0
+    ? "Select a Configuration"
+    : "Create a Configuration";
+});
+
+const onEditActiveConfiguration = () => {
+  hostConduit.sendMsg({
+    kind: WebviewToHostMessageType.EDIT_CONFIGURATION,
+    content: {
+      configurationPath: home.selectedConfiguration!.configurationPath,
+    },
+  });
+};
+
+const selectConfiguration = () => {
+  hostConduit.sendMsg({
+    kind: WebviewToHostMessageType.SHOW_SELECT_CONFIGURATION,
+  });
+};
+
+const configError = computed((): AgentError | undefined => {
+  if (
+    home.selectedConfiguration &&
+    isConfigurationError(home.selectedConfiguration)
+  ) {
+    return home.selectedConfiguration.error;
+  }
+  return undefined;
+});
+</script>

--- a/extensions/vscode/webviews/homeView/src/components/configErrors/EntryMissing.vue
+++ b/extensions/vscode/webviews/homeView/src/components/configErrors/EntryMissing.vue
@@ -1,0 +1,38 @@
+<!-- Copyright (C) 2024 by Posit Software, PBC. -->
+
+<template>
+  <div class="error-block">
+    Configuration Error!
+    <ul class="bullets">
+      <li>No Config Entry in Deployment record</li>
+    </ul>
+    <a
+      class="webview-link"
+      role="button"
+      @click="emit(`select-configuration`)"
+      >{{ configSelectionPrompt }}</a
+    >
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHomeStore } from "src/stores/home";
+
+const home = useHomeStore();
+
+const emit = defineEmits(["select-configuration"]);
+
+const props = defineProps<{
+  configSelectionPrompt: string;
+}>();
+</script>
+<style lang="scss" scoped>
+.bullets {
+  margin: 0;
+  padding: 0 0 3px 15px;
+}
+.error-block {
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/configErrors/FileMissing.vue
+++ b/extensions/vscode/webviews/homeView/src/components/configErrors/FileMissing.vue
@@ -1,0 +1,39 @@
+<!-- Copyright (C) 2024 by Posit Software, PBC. -->
+
+<template>
+  <div class="error-block">
+    Configuration Error!
+    <ul class="bullets">
+      <li>File Missing</li>
+      <li>The last Configuration used for this Deployment was not found.</li>
+    </ul>
+    <a
+      class="webview-link"
+      role="button"
+      @click="emit(`select-configuration`)"
+      >{{ configSelectionPrompt }}</a
+    >
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHomeStore } from "src/stores/home";
+
+const home = useHomeStore();
+
+const emit = defineEmits(["select-configuration"]);
+
+const props = defineProps<{
+  configSelectionPrompt: string;
+}>();
+</script>
+<style lang="scss" scoped>
+.bullets {
+  margin: 0;
+  padding: 0 0 3px 15px;
+}
+.error-block {
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/configErrors/InvalidTOMLFile.vue
+++ b/extensions/vscode/webviews/homeView/src/components/configErrors/InvalidTOMLFile.vue
@@ -1,0 +1,44 @@
+<!-- Copyright (C) 2024 by Posit Software, PBC. -->
+
+<template>
+  <div v-if="error" class="error-block">
+    Configuration Error!
+    <ul class="bullets">
+      <li>Invalid TOML</li>
+      <li>
+        {{ error.data.problem }}
+      </li>
+      <li>
+        line: {{ error.data.line }}, column:
+        {{ error.data.column }}
+      </li>
+    </ul>
+    <a
+      class="webview-link"
+      role="button"
+      @click="emit(`edit-active-configuration`)"
+      >Edit the Configuration</a
+    >
+  </div>
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import { InvalidTOMLFileCodeError } from "../../../../../src/api/types/error";
+
+const emit = defineEmits(["edit-active-configuration"]);
+
+const props = defineProps<{
+  error: InvalidTOMLFileCodeError | undefined;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.bullets {
+  margin: 0;
+  padding: 0 0 3px 15px;
+}
+.error-block {
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/configErrors/UnhandledError.vue
+++ b/extensions/vscode/webviews/homeView/src/components/configErrors/UnhandledError.vue
@@ -3,9 +3,14 @@
 <template>
   <div v-if="error" class="error-block">
     Configuration Error!
-    <ul class="bullets">
+    <ul v-if="isDataAvailable" class="bullets">
       <li v-for="key in Object.keys(error.data)">
         {{ key }}: {{ error.data[key] }}
+      </li>
+    </ul>
+    <ul v-else class="bullets">
+      <li>
+        {{ error.msg }}
       </li>
     </ul>
     <a
@@ -17,13 +22,18 @@
   </div>
 </template>
 <script setup lang="ts">
+import { computed } from "vue";
 import { AgentError } from "../../../../../src/api/types/error";
 
 const emit = defineEmits(["edit-active-configuration"]);
 
-defineProps<{
+const props = defineProps<{
   error: AgentError | undefined;
 }>();
+
+const isDataAvailable = computed(() => {
+  return props.error && Object.keys(props.error.data).length > 0;
+});
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/vscode/webviews/homeView/src/components/configErrors/UnhandledError.vue
+++ b/extensions/vscode/webviews/homeView/src/components/configErrors/UnhandledError.vue
@@ -1,0 +1,38 @@
+<!-- Copyright (C) 2024 by Posit Software, PBC. -->
+
+<template>
+  <div v-if="error" class="error-block">
+    Configuration Error!
+    <ul class="bullets">
+      <li v-for="key in Object.keys(error.data)">
+        {{ key }}: {{ error.data[key] }}
+      </li>
+    </ul>
+    <a
+      class="webview-link"
+      role="button"
+      @click="emit(`edit-active-configuration`)"
+      >Edit the Configuration</a
+    >
+  </div>
+</template>
+<script setup lang="ts">
+import { AgentError } from "../../../../../src/api/types/error";
+
+const emit = defineEmits(["edit-active-configuration"]);
+
+defineProps<{
+  error: AgentError | undefined;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.bullets {
+  margin: 0;
+  padding: 0 0 3px 15px;
+}
+.error-block {
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -16,6 +16,7 @@ import { WebviewToHostMessageType } from "../../../../src/types/messages/webview
 import { RPackage } from "../../../../src/api/types/packages";
 import { DeploymentSelector } from "../../../../src/types/shared";
 import { splitFilesOnInclusion } from "src/utils/files";
+import { filterConfigurationsToValidAndType } from "../../../../src/utils/filters";
 
 export const useHomeStore = defineStore("home", () => {
   const platformFileSeparator = ref<string>("/");
@@ -360,6 +361,13 @@ export const useHomeStore = defineStore("home", () => {
           config.active.isMissing.value ||
           config.active.isError.value ||
           config.active.isCredentialMissing.value
+        );
+      }),
+
+      matchingConfigs: computed((): Configuration[] => {
+        return filterConfigurationsToValidAndType(
+          configurations.value,
+          selectedContentRecord.value?.type,
         );
       }),
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

The changes present within this PR will display the error details present within `ConfigurationError`s. Previously, the details were not shown and only a generic message was provided to the user, with no details on what to fix. A great example of this was when a TOML parsing error was returned within a ConfigurationError object. The AgentError includes specific error data for this type of error (invalidTOML).

Resolves #2330 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The UX currently detects some errors associated with the configuration file. I first extracted those out into a new `ConfigErrors` component, with each of the existing being subcomponents to display their own details. 

I then defined a new type declaration for the Agent Error which contained the invalidTOML error, and created a subcomponent to display within the `ConfigErrors` component.

I also added a generic subcomponent that displays the information present within the AgentError, if the error had not been handled by another subcomponent.

Screenshots:

Existing Configuration Errors
- Missing Configuration Error:
![2024-09-30 at 4 27 PM](https://github.com/user-attachments/assets/4f32f72f-85b9-4b07-8468-9e323a069331)

- No configuration file entry in deployment file
![2024-09-30 at 4 30 PM](https://github.com/user-attachments/assets/ade4780b-647e-464f-85f5-82d6dbe2e0e8)

- Invalid TOML Error - Parsing error reported
(added abc to file)
![2024-09-30 at 4 32 PM](https://github.com/user-attachments/assets/c720a955-6011-4336-aefe-c65de5eed7a2)

- Invalid TOML Error (actually UnknownTOMLKey from agent, but handled as invalidTOML error)
(changed `entrypoint =` to `entrypoint2 =`)
![2024-10-01 at 9 03 AM](https://github.com/user-attachments/assets/0e86828e-0dc6-416d-850c-f03d007a09b7)

- Invalid TOML Error
(Changed `files = []` to `files = "abc"`)
![2024-10-01 at 9 08 AM](https://github.com/user-attachments/assets/1ee37c12-0b6f-40d1-a48c-9f11eaf1f68d)

- Invalid TOML Error
(Deleted value after = sign)
![2024-10-01 at 9 22 AM](https://github.com/user-attachments/assets/6163d7c3-e451-465c-b3ae-1e04a7161a17)

- Invalid TOML Error
(Removed last quote for key)
![2024-10-01 at 9 23 AM](https://github.com/user-attachments/assets/e7c03d90-f5d7-4188-88de-7865f333eb60)

- Generic Handled Error - Error not returned as specific error from agent
(duplicated one key to another).
![2024-10-01 at 9 54 AM](https://github.com/user-attachments/assets/5e8bb334-b751-4bfc-9792-20e4cab56586)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Conditions for reproducing the errors above are listed. Simply recreate them and validate that you see the updated UX.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
