### PR TITLE
Deployment preflight errors due to bad content GUID

### DIFF
--- a/extensions/vscode/src/api/types/events.ts
+++ b/extensions/vscode/src/api/types/events.ts
@@ -1,5 +1,7 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
+import { ErrorCode } from "../../utils/errorTypes";
+
 export enum EventSourceReadyState {
   CONNECTING = 0,
   OPEN = 1,
@@ -298,10 +300,11 @@ export function getLocalId(arg: EventStreamMessage) {
   return arg.data.localId;
 }
 
-export interface EventStreamMessage {
+export interface EventStreamMessage<T = Record<string, string>> {
   type: EventSubscriptionTarget;
   time: string;
-  data: Record<string, string>;
+  data: T;
+  errCode?: ErrorCode;
   error?: string;
 }
 

--- a/extensions/vscode/src/eventErrors.test.ts
+++ b/extensions/vscode/src/eventErrors.test.ts
@@ -1,0 +1,95 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import { describe, expect, test } from "vitest";
+import { EventStreamMessage } from "./api";
+import {
+  EventStreamMessageErrorCoded,
+  isCodedEventErrorMessage,
+  isEvtErrTargetNotFound,
+  isEvtErrTargetForbidden,
+  handleEventCodedError,
+} from "./eventErrors";
+import { ErrorCode } from "./utils/errorTypes";
+
+const mkEventStreamMsg = (
+  data = {},
+  errCode?: ErrorCode,
+): EventStreamMessage => {
+  return {
+    type: "publish/failure",
+    time: "Tue Oct 01 2024 10:00:00 GMT-0600",
+    data,
+    errCode,
+    error: "failed to publish",
+  };
+};
+
+describe("Event errors", () => {
+  test("isCodedEventErrorMessage", () => {
+    // Message without error code
+    let streamMsg = mkEventStreamMsg();
+    let result = isCodedEventErrorMessage(streamMsg);
+    expect(result).toBe(false);
+
+    // Message with error code
+    streamMsg = mkEventStreamMsg({}, "deploymentTargetNotFound");
+    result = isCodedEventErrorMessage(streamMsg);
+    expect(result).toBe(true);
+  });
+
+  test("isEvtErrTargetNotFound", () => {
+    // Message with another error code
+    let streamMsg = mkEventStreamMsg({}, "unknown");
+    let result = isEvtErrTargetNotFound(
+      streamMsg as EventStreamMessageErrorCoded,
+    );
+    expect(result).toBe(false);
+
+    // Message with error code
+    streamMsg = mkEventStreamMsg({}, "deploymentTargetNotFound");
+    result = isEvtErrTargetNotFound(streamMsg as EventStreamMessageErrorCoded);
+    expect(result).toBe(true);
+  });
+
+  test("isEvtErrTargetForbidden", () => {
+    // Message with another error code
+    let streamMsg = mkEventStreamMsg({}, "unknown");
+    let result = isEvtErrTargetForbidden(
+      streamMsg as EventStreamMessageErrorCoded,
+    );
+    expect(result).toBe(false);
+
+    // Message with error code
+    streamMsg = mkEventStreamMsg({}, "deploymentTargetIsForbidden");
+    result = isEvtErrTargetForbidden(streamMsg as EventStreamMessageErrorCoded);
+    expect(result).toBe(true);
+  });
+
+  test("handleEventCodedError", () => {
+    const msgData = {
+      dashboardUrl: "https://here.it.is/content/abcdefg",
+      error: "A possum on the fridge",
+    };
+    let streamMsg = mkEventStreamMsg(msgData, "unknown");
+    let resultMsg = handleEventCodedError(
+      streamMsg as EventStreamMessageErrorCoded,
+    );
+    expect(resultMsg).toBe("Unknown error: A possum on the fridge");
+
+    streamMsg = mkEventStreamMsg(msgData, "deploymentTargetNotFound");
+    resultMsg = handleEventCodedError(
+      streamMsg as EventStreamMessageErrorCoded,
+    );
+    expect(resultMsg).toBe(
+      `Content at https://here.it.is/content/abcdefg could not be found. Please, verify the content "id" is accurate.`,
+    );
+
+    streamMsg = mkEventStreamMsg(msgData, "deploymentTargetIsForbidden");
+    resultMsg = handleEventCodedError(
+      streamMsg as EventStreamMessageErrorCoded,
+    );
+    expect(resultMsg).toBe(
+      "You don't have enough permissions to deploy to https://here.it.is/content/abcdefg. Please, verify the credentials in use.",
+    );
+  });
+});

--- a/extensions/vscode/src/eventErrors.ts
+++ b/extensions/vscode/src/eventErrors.ts
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import { EventStreamMessage } from "./api/types/events";
+import { ErrorCode } from "./utils/errorTypes";
+
+export interface EventStreamMessageErrorCoded<T = Record<string, string>>
+  extends EventStreamMessage<T> {
+  errCode: ErrorCode;
+}
+
+export function isCodedEventErrorMessage(
+  msg: EventStreamMessage,
+): msg is EventStreamMessageErrorCoded {
+  return msg.errCode !== undefined;
+}
+
+type deploymentEvtErr = {
+  dashboardUrl: string;
+  localId: string;
+  error: string;
+};
+
+export const isEvtErrTargetNotFound = (
+  emsg: EventStreamMessageErrorCoded,
+): emsg is EventStreamMessageErrorCoded<deploymentEvtErr> => {
+  return emsg.errCode === "deploymentTargetNotFound";
+};
+
+export const isEvtErrTargetForbidden = (
+  emsg: EventStreamMessageErrorCoded,
+): emsg is EventStreamMessageErrorCoded<deploymentEvtErr> => {
+  return emsg.errCode === "deploymentTargetIsForbidden";
+};
+
+export const handleEventCodedError = (
+  emsg: EventStreamMessageErrorCoded,
+): string => {
+  if (isEvtErrTargetNotFound(emsg)) {
+    return `Content at ${emsg.data.dashboardUrl} could not be found. Please, verify the content "id" is accurate.`;
+  }
+  if (isEvtErrTargetForbidden(emsg)) {
+    return `You don't have enough permissions to deploy to ${emsg.data.dashboardUrl}. Please, verify the credentials in use.`;
+  }
+  const unknownErrMsg = emsg.data.error || emsg.data.message;
+  return `Unknown error: ${unknownErrMsg}`;
+};

--- a/extensions/vscode/src/eventErrors.ts
+++ b/extensions/vscode/src/eventErrors.ts
@@ -17,30 +17,23 @@ export function isCodedEventErrorMessage(
 type deploymentEvtErr = {
   dashboardUrl: string;
   localId: string;
+  message: string;
   error: string;
 };
 
-export const isEvtErrTargetNotFound = (
+export const isEvtErrDeploymentFailed = (
   emsg: EventStreamMessageErrorCoded,
 ): emsg is EventStreamMessageErrorCoded<deploymentEvtErr> => {
-  return emsg.errCode === "deploymentTargetNotFound";
-};
-
-export const isEvtErrTargetForbidden = (
-  emsg: EventStreamMessageErrorCoded,
-): emsg is EventStreamMessageErrorCoded<deploymentEvtErr> => {
-  return emsg.errCode === "deploymentTargetIsForbidden";
+  return emsg.errCode === "deployFailed";
 };
 
 export const handleEventCodedError = (
   emsg: EventStreamMessageErrorCoded,
 ): string => {
-  if (isEvtErrTargetNotFound(emsg)) {
-    return `Content at ${emsg.data.dashboardUrl} could not be found. Please, verify the content "id" is accurate.`;
+  if (isEvtErrDeploymentFailed(emsg)) {
+    return emsg.data.message;
   }
-  if (isEvtErrTargetForbidden(emsg)) {
-    return `You don't have enough permissions to deploy to ${emsg.data.dashboardUrl}. Please, verify the credentials in use.`;
-  }
+
   const unknownErrMsg = emsg.data.error || emsg.data.message;
   return `Unknown error: ${unknownErrMsg}`;
 };

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -2,12 +2,15 @@
 
 import { AxiosError, AxiosResponse, isAxiosError } from "axios";
 
-type ErrorCode =
+export type ErrorCode =
   | "unknown"
   | "resourceNotFound"
   | "invalidTOML"
   | "unknownTOMLKey"
-  | "invalidConfigFile";
+  | "invalidConfigFile"
+  | "deploymentTargetNotFound"
+  | "deploymentTargetIsForbidden"
+  | "deploymentTargetUnreachable";
 
 export type axiosErrorWithJson<T = { code: ErrorCode; details: unknown }> =
   AxiosError & {

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -8,9 +8,7 @@ export type ErrorCode =
   | "invalidTOML"
   | "unknownTOMLKey"
   | "invalidConfigFile"
-  | "deploymentTargetNotFound"
-  | "deploymentTargetIsForbidden"
-  | "deploymentTargetUnreachable";
+  | "deployFailed";
 
 export type axiosErrorWithJson<T = { code: ErrorCode; details: unknown }> =
   AxiosError & {

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -16,6 +16,10 @@ import {
 } from "vscode";
 
 import { EventStream, displayEventStreamMessage } from "src/events";
+import {
+  isCodedEventErrorMessage,
+  handleEventCodedError,
+} from "src/eventErrors";
 
 import {
   EventStreamMessage,
@@ -195,12 +199,16 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       if (enhancedError && enhancedError.buttonStr) {
         options.push(enhancedError.buttonStr);
       }
-      const selection = await window.showErrorMessage(
-        msg.data.cancelled === "true"
-          ? `Deployment cancelled: ${msg.data.message}`
-          : `Deployment failed: ${msg.data.message}`,
-        ...options,
-      );
+      let errorMessage = "";
+      if (isCodedEventErrorMessage(msg)) {
+        errorMessage = handleEventCodedError(msg);
+      } else {
+        errorMessage =
+          msg.data.cancelled === "true"
+            ? `Deployment cancelled: ${msg.data.message}`
+            : `Deployment failed: ${msg.data.message}`;
+      }
+      const selection = await window.showErrorMessage(errorMessage, ...options);
       if (selection === showLogsOption) {
         await commands.executeCommand(Commands.Logs.Focus);
       } else if (selection === enhancedError?.buttonStr) {

--- a/internal/clients/connect/client.go
+++ b/internal/clients/connect/client.go
@@ -22,6 +22,7 @@ type User struct {
 
 type APIClient interface {
 	TestAuthentication(logging.Logger) (*User, error)
+	ContentDetails(contentID types.ContentID, body *ConnectContent, log logging.Logger) error
 	CreateDeployment(*ConnectContent, logging.Logger) (types.ContentID, error)
 	UpdateDeployment(types.ContentID, *ConnectContent, logging.Logger) error
 	SetEnvVars(types.ContentID, config.Environment, logging.Logger) error

--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -179,6 +179,11 @@ type connectGetContentDTO struct {
 	// Owner        *ownerOutputDTO   `json:"owner,omitempty"`
 }
 
+func (c *ConnectClient) ContentDetails(contentID types.ContentID, body *ConnectContent, log logging.Logger) error {
+	url := fmt.Sprintf("/__api__/v1/content/%s", contentID)
+	return c.client.Get(url, body, log)
+}
+
 func (c *ConnectClient) CreateDeployment(body *ConnectContent, log logging.Logger) (types.ContentID, error) {
 	content := connectGetContentDTO{}
 	err := c.client.Post("/__api__/v1/content", body, &content, log)

--- a/internal/clients/connect/client_connect_test.go
+++ b/internal/clients/connect/client_connect_test.go
@@ -568,3 +568,25 @@ func (s *ConnectClientSuite) TestTestAuthenticationNotPublisher() {
 	s.NotNil(err)
 	s.ErrorContains(err, "user account bob with role 'viewer' does not have permission to publish content")
 }
+
+func (s *ConnectClientSuite) TestContentDetails() {
+	lgr := logging.New()
+	content := &ConnectContent{}
+	httpClient := &http_client.MockHTTPClient{}
+	httpClient.On("Get", "/__api__/v1/content/e8922765-4880-43cd-abc0-d59fe59b8b4b", content, lgr).Return(nil)
+
+	client := &ConnectClient{
+		client: httpClient,
+	}
+
+	err := client.ContentDetails("e8922765-4880-43cd-abc0-d59fe59b8b4b", content, lgr)
+	s.NoError(err)
+	httpClient.AssertExpectations(s.T())
+
+	expectedErr := errors.New("unreachable")
+	httpClient.On("Get", "/__api__/v1/content/cf3d3afe-2076-4812-825a-28237252030b", content, lgr).Return(expectedErr)
+
+	err = client.ContentDetails("cf3d3afe-2076-4812-825a-28237252030b", content, lgr)
+	s.ErrorIs(err, expectedErr)
+	httpClient.AssertExpectations(s.T())
+}

--- a/internal/clients/connect/content.go
+++ b/internal/clients/connect/content.go
@@ -3,6 +3,8 @@ package connect
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"fmt"
+
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/types"
 )
@@ -10,6 +12,7 @@ import (
 type ConnectContent struct {
 	Name                           types.ContentName `json:"name"`
 	Title                          string            `json:"title,omitempty"`
+	GUID                           string            `json:"guid,omitempty"`
 	Description                    string            `json:"description,omitempty"`
 	AccessType                     string            `json:"access_type,omitempty"`
 	ConnectionTimeout              *int32            `json:"connection_timeout,omitempty"`
@@ -32,6 +35,15 @@ type ConnectContent struct {
 	DefaultImageName               string            `json:"default_image_name,omitempty"`
 	DefaultREnvironmentManagement  *bool             `json:"default_r_environment_management,omitempty"`
 	DefaultPyEnvironmentManagement *bool             `json:"default_py_environment_management,omitempty"`
+	Locked                         bool              `json:"locked,omitempty"`
+}
+
+// Returns and error if content is locked
+func (c *ConnectContent) LockedError() error {
+	if c.Locked {
+		return fmt.Errorf("content with ID %s is locked", c.GUID)
+	}
+	return nil
 }
 
 func copy[T any](src *T) *T {

--- a/internal/clients/connect/mock_client.go
+++ b/internal/clients/connect/mock_client.go
@@ -38,6 +38,11 @@ func (m *MockClient) TestAuthentication(log logging.Logger) (*User, error) {
 }
 
 func (m *MockClient) ContentDetails(id types.ContentID, s *ConnectContent, log logging.Logger) error {
+	// Updates content as locked when needed
+	if id == "myLockedContentID" {
+		s.GUID = "myLockedContentID"
+		s.Locked = true
+	}
 	args := m.Called(id, s, log)
 	return args.Error(0)
 }

--- a/internal/clients/connect/mock_client.go
+++ b/internal/clients/connect/mock_client.go
@@ -37,6 +37,11 @@ func (m *MockClient) TestAuthentication(log logging.Logger) (*User, error) {
 	}
 }
 
+func (m *MockClient) ContentDetails(id types.ContentID, s *ConnectContent, log logging.Logger) error {
+	args := m.Called(id, s, log)
+	return args.Error(0)
+}
+
 func (m *MockClient) CreateDeployment(s *ConnectContent, log logging.Logger) (types.ContentID, error) {
 	args := m.Called(s, log)
 	return args.Get(0).(types.ContentID), args.Error(1)

--- a/internal/clients/http_client/http_client.go
+++ b/internal/clients/http_client/http_client.go
@@ -241,3 +241,12 @@ func NewHTTPClientForAccount(account *accounts.Account, timeout time.Duration, l
 		Transport: authTransport,
 	}, nil
 }
+
+func IsHTTPAgentErrorStatusOf(err error, status int) (*types.AgentError, bool) {
+	if aerr, isAgentErr := err.(*types.AgentError); isAgentErr {
+		if httperr, isHttpErr := aerr.Err.(*HTTPError); isHttpErr {
+			return aerr, httperr.Status == status
+		}
+	}
+	return nil, false
+}

--- a/internal/clients/http_client/http_client_test.go
+++ b/internal/clients/http_client/http_client_test.go
@@ -1,0 +1,44 @@
+package http_client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/stretchr/testify/suite"
+)
+
+// Copyright (C) 2024 by Posit Software, PBC.
+
+type HttpClientSuite struct {
+	utiltest.Suite
+}
+
+func TestHttpClientSuite(t *testing.T) {
+	suite.Run(t, new(HttpClientSuite))
+}
+
+func (s *HttpClientSuite) TestIsHTTPAgentErrorStatusOf() {
+	agentErr := types.NewAgentError(
+		types.ErrorDeploymentTargetNotFound,
+		NewHTTPError("", "", http.StatusNotFound),
+		nil,
+	)
+
+	// With a true agent error
+	resultingErr, yesItIs := IsHTTPAgentErrorStatusOf(agentErr, http.StatusNotFound)
+	s.Equal(yesItIs, true)
+	s.Equal(agentErr, resultingErr)
+
+	// With a true agent error, but a status that it is not
+	resultingErr, yesItIs = IsHTTPAgentErrorStatusOf(agentErr, http.StatusBadGateway)
+	s.Equal(yesItIs, false)
+	s.Equal(agentErr, resultingErr)
+
+	// With a non agent error
+	resultingErr, yesItIs = IsHTTPAgentErrorStatusOf(errors.New("nope"), http.StatusNotFound)
+	s.Equal(yesItIs, false)
+	s.Nil(resultingErr)
+}

--- a/internal/clients/http_client/http_client_test.go
+++ b/internal/clients/http_client/http_client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/posit-dev/publisher/internal/events"
 	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/stretchr/testify/suite"
@@ -22,7 +23,7 @@ func TestHttpClientSuite(t *testing.T) {
 
 func (s *HttpClientSuite) TestIsHTTPAgentErrorStatusOf() {
 	agentErr := types.NewAgentError(
-		types.ErrorDeploymentTargetNotFound,
+		events.DeploymentFailedCode,
 		NewHTTPError("", "", http.StatusNotFound),
 		nil,
 	)

--- a/internal/events/cli_emitter.go
+++ b/internal/events/cli_emitter.go
@@ -91,7 +91,7 @@ func (e *cliEmitter) Emit(event *Event) error {
 		fmt.Fprintln(e.writer, "[OK]", formatEventData(event.Data))
 	case FailurePhase:
 		e.writer.NeedNewline = false
-		fmt.Fprintln(e.writer, "[ERROR]", event.errCode, formatEventData(event.Data))
+		fmt.Fprintln(e.writer, "[ERROR]", event.ErrCode, formatEventData(event.Data))
 	}
 	return nil
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -17,13 +17,13 @@ type EventData = types.ErrorData
 var NoData = struct{}{}
 
 type Event struct {
-	Time time.Time
-	Type EventType
-	Data EventData
+	Time    time.Time
+	Type    EventType
+	Data    EventData
+	ErrCode ErrorCode
 
-	op      Operation
-	phase   Phase
-	errCode ErrorCode
+	op    Operation
+	phase Phase
 }
 
 // We use Operation and Phase to construct the event Type.
@@ -72,9 +72,9 @@ func New(op Operation, phase Phase, errCode ErrorCode, data any) *Event {
 		Time:    time.Now(),
 		Type:    EventTypeOf(op, phase),
 		Data:    eventData,
+		ErrCode: errCode,
 		op:      op,
 		phase:   phase,
-		errCode: errCode,
 	}
 }
 

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -11,11 +11,14 @@ type ErrorData map[string]any
 type Operation string
 
 const (
-	ErrorResourceNotFound   ErrorCode = "resourceNotFound"
-	ErrorInvalidTOML        ErrorCode = "invalidTOML"
-	ErrorUnknownTOMLKey     ErrorCode = "unknownTOMLKey"
-	ErrorInvalidConfigFiles ErrorCode = "invalidConfigFiles"
-	ErrorUnknown            ErrorCode = "unknown"
+	ErrorResourceNotFound            ErrorCode = "resourceNotFound"
+	ErrorInvalidTOML                 ErrorCode = "invalidTOML"
+	ErrorUnknownTOMLKey              ErrorCode = "unknownTOMLKey"
+	ErrorInvalidConfigFiles          ErrorCode = "invalidConfigFiles"
+	ErrorDeploymentTargetNotFound    ErrorCode = "deploymentTargetNotFound"
+	ErrorDeploymentTargetIsForbidden ErrorCode = "deploymentTargetIsForbidden"
+	ErrorDeploymentTargetUnreachable ErrorCode = "deploymentTargetUnreachable"
+	ErrorUnknown                     ErrorCode = "unknown"
 )
 
 type EventableError interface {

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -16,9 +16,6 @@ const (
 	ErrorUnknownTOMLKey               ErrorCode = "unknownTOMLKey"
 	ErrorInvalidConfigFiles           ErrorCode = "invalidConfigFiles"
 	ErrorCredentialServiceUnavailable ErrorCode = "credentialsServiceUnavailable"
-	ErrorDeploymentTargetNotFound     ErrorCode = "deploymentTargetNotFound"
-	ErrorDeploymentTargetIsForbidden  ErrorCode = "deploymentTargetIsForbidden"
-	ErrorDeploymentTargetUnreachable  ErrorCode = "deploymentTargetUnreachable"
 	ErrorUnknown                      ErrorCode = "unknown"
 )
 
@@ -101,4 +98,14 @@ func OperationError(op Operation, err error) EventableError {
 	}
 	e.SetOperation(op)
 	return e
+}
+
+// Evaluate if a given error is an AgentError
+// returning the error as AgentError type when it is
+// and a bool flag of the comparison result.
+func IsAgentError(err error) (*AgentError, bool) {
+	if aerr, ok := err.(*AgentError); ok {
+		return aerr, ok
+	}
+	return nil, false
 }

--- a/internal/types/error_test.go
+++ b/internal/types/error_test.go
@@ -67,3 +67,20 @@ func (s *ErrorSuite) TestNewAgentError() {
 		Data:    make(ErrorData),
 	})
 }
+
+func (s *ErrorSuite) TestIsAgentError() {
+	originalError := errors.New("shattered glass!")
+	aerr, isIt := IsAgentError(originalError)
+	s.Equal(isIt, false)
+	s.Nil(aerr)
+
+	aTrueAgentError := NewAgentError(ErrorInvalidTOML, originalError, nil)
+	aerr, isIt = IsAgentError(aTrueAgentError)
+	s.Equal(isIt, true)
+	s.Equal(aerr, &AgentError{
+		Message: "shattered glass!",
+		Code:    ErrorInvalidTOML,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+}


### PR DESCRIPTION
## Intent

**Main intent:**
Better error messaging on deployment errors due to bad content ID on deployment toml

**Common errors handled by this PR**
- The GUID does not match the content or does not exist - 404
<img width="1441" alt="Screen Shot 2024-10-03 at 15 03 51" src="https://github.com/user-attachments/assets/eb317674-55cb-49a8-9c1c-2c68afb81b58">

- The user does not have permissions anymore to the content - 403
<img width="1343" alt="Screen Shot 2024-10-03 at 15 09 55" src="https://github.com/user-attachments/assets/6bb74f9c-f0b5-4e2b-b86c-823e2a4dc834">

- Content is locked
<img width="1441" alt="Screen Shot 2024-10-03 at 15 03 31" src="https://github.com/user-attachments/assets/b4357b21-5b99-4dac-a427-1af5ec61f9ef">

- Unknown error
<img width="1537" alt="Screen Shot 2024-10-03 at 15 56 55" src="https://github.com/user-attachments/assets/0382171e-02c1-48b2-b118-2fcfdfb28f6b">

Fixes #2287 

## Type of Change

Adding an extra step on the backend when deploying. Before building the bundle and doing any further operations, we will do a preflight check, trying to query the content target to validate that it can be reached, it exists and the user has permissions over it.

Returning an error with enough details to be handled by the extension code.

The changes are taking a similar approach to the http Axios errors but in this case these are messages sent by via SSE, so this is another area of the product where we are now filtering by error codes to provide a more meaningful message.

## Automated Tests

Created and updated unit tests accordingly.

## Directions for Reviewers

- [ ] For an existing content already deployed, change the `id` within the `deployment-*.toml` to:
    - [ ] To a content GUID that you don't have permissions to (or use a new credential without enough permissions to that content)
    - [ ] To a GUID for some content that does not exist

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
