### PR TITLE
Be quiet for symlink walking errors

### DIFF
--- a/internal/bundles/bundle_test.go
+++ b/internal/bundles/bundle_test.go
@@ -396,6 +396,8 @@ func (s *BundlerSuite) TestNewBundleFromDirectorySymlinks() {
 	}, s.getTarFileNames(dest))
 }
 
+// We log the issues with symbolic links but not return them to not polute the user with error notifications
+// when another piece of software is dealing with the same directory.
 func (s *BundlerSuite) TestNewBundleFromDirectoryMissingSymlinkTarget() {
 	// afero's MemFs doesn't have symlink support, so we
 	// are using a fixture directory under ./testdata.
@@ -407,6 +409,6 @@ func (s *BundlerSuite) TestNewBundleFromDirectoryMissingSymlinkTarget() {
 	bundler, err := NewBundler(dirPath, NewManifest(), nil, log)
 	s.Nil(err)
 	manifest, err := bundler.CreateBundle(dest)
-	s.ErrorIs(err, os.ErrNotExist)
-	s.Nil(manifest)
+	s.NoError(err)
+	s.NotNil(manifest)
 }

--- a/internal/bundles/matcher/walker.go
+++ b/internal/bundles/matcher/walker.go
@@ -85,6 +85,10 @@ func (i *matchingWalker) Walk(base util.AbsolutePath, fn util.AbsoluteWalkFunc) 
 			i.log.Warn("permission error; skipping", "path", path)
 			return nil
 		}
+		if err != nil {
+			i.log.Warn("Unknown error while accessing file", "path", path, "error", err.Error())
+			return nil
+		}
 		return fn(path, info, err)
 	})
 }

--- a/internal/services/api/files/services.go
+++ b/internal/services/api/files/services.go
@@ -52,7 +52,8 @@ func (s filesService) GetFile(p util.AbsolutePath, matchList matcher.MatchList) 
 				s.log.Warn("permission error; skipping", "path", path)
 				return nil
 			} else {
-				return err
+				s.log.Warn("Unknown error while accesing file", "path", path)
+				return nil
 			}
 		}
 		match := matchList.Match(path)

--- a/internal/util/symlink_walker.go
+++ b/internal/util/symlink_walker.go
@@ -3,7 +3,6 @@ package util
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -45,14 +44,15 @@ func (w *symlinkWalker) visit(fn AbsoluteWalkFunc) AbsoluteWalkFunc {
 				// like Emacs which creates symbolic files for unsaved modifications to files.
 				// We'll log the behavior but not return errors to not polute the user with error notifications
 				// when another piece of software is dealing with the same directory.
-				w.log.Debug("Error following symlink, ignoring file", "filepath", path, "error", err.Error())
+				w.log.Warn("Error following symlink, ignoring file", "filepath", path, "error", err.Error())
 				return nil
 			}
 
 			targetPath := NewPath(linkTarget, path.Fs())
 			targetInfo, err := targetPath.Stat()
 			if err != nil {
-				return fmt.Errorf("error getting target info for symlink %s: %w", targetPath, err)
+				w.log.Warn("Error getting info for symlink", "filepath", targetPath, "error", err.Error())
+				return nil
 			}
 			// Visit symlink target info but use the path to the link.
 			err = w.visit(fn)(path, targetInfo, nil)

--- a/internal/util/symlink_walker.go
+++ b/internal/util/symlink_walker.go
@@ -40,7 +40,6 @@ func (w *symlinkWalker) visit(fn AbsoluteWalkFunc) AbsoluteWalkFunc {
 		if info.Mode().Type()&os.ModeSymlink != 0 {
 			w.log.Info("Following symlink", "path", path)
 			linkTarget, err := filepath.EvalSymlinks(path.String())
-			targetPath := NewPath(linkTarget, path.Fs())
 			if err != nil {
 				// There's software that creates symbolic links to files which do not exist,
 				// like Emacs which creates symbolic files for unsaved modifications to files.
@@ -49,6 +48,8 @@ func (w *symlinkWalker) visit(fn AbsoluteWalkFunc) AbsoluteWalkFunc {
 				w.log.Debug("Error following symlink, ignoring file", "filepath", path, "error", err.Error())
 				return nil
 			}
+
+			targetPath := NewPath(linkTarget, path.Fs())
 			targetInfo, err := targetPath.Stat()
 			if err != nil {
 				return fmt.Errorf("error getting target info for symlink %s: %w", targetPath, err)

--- a/internal/util/symlink_walker_test.go
+++ b/internal/util/symlink_walker_test.go
@@ -131,7 +131,7 @@ func (s *SymlinkWalkerSuite) TestNewBundleFromDirectoryMissingSymlinkTarget() {
 	})
 
 	log.On("Info", "Following symlink", "path", symlinkPathMatcher).Return()
-	log.On("Debug", "Error following symlink, ignoring file", "filepath", symlinkPathMatcher, "error", mock.Anything).Return()
+	log.On("Warn", "Error following symlink, ignoring file", "filepath", symlinkPathMatcher, "error", mock.Anything).Return()
 
 	underlyingWalker := &FSWalker{}
 	walker := NewSymlinkWalker(underlyingWalker, log)

--- a/internal/util/symlink_walker_test.go
+++ b/internal/util/symlink_walker_test.go
@@ -127,7 +127,7 @@ func (s *SymlinkWalkerSuite) TestNewBundleFromDirectoryMissingSymlinkTarget() {
 	log := loggingtest.NewMockLogger()
 
 	symlinkPathMatcher := mock.MatchedBy(func(path AbsolutePath) bool {
-		return strings.Contains(path.String(), "/symlink_test/link_target_missing/badlink")
+		return strings.Contains(path.String(), "badlink")
 	})
 
 	log.On("Info", "Following symlink", "path", symlinkPathMatcher).Return()

--- a/internal/util/symlink_walker_test.go
+++ b/internal/util/symlink_walker_test.go
@@ -5,13 +5,14 @@ package util
 import (
 	"errors"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/logging/loggingtest"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
@@ -116,17 +117,27 @@ func (s *SymlinkWalkerSuite) TestNewBundleFromDirectorySymlinks() {
 	}, fileList)
 }
 
+// We log the issues with symbolic links but not return them to not polute the user with error notifications
+// when another piece of software is dealing with the same directory.
 func (s *SymlinkWalkerSuite) TestNewBundleFromDirectoryMissingSymlinkTarget() {
 	// afero's MemFs doesn't have symlink support, so we
 	// are using a fixture directory under ./testdata.
 	realFS := afero.NewOsFs()
 	dirPath := NewAbsolutePath(s.cwd.String(), realFS).Join("testdata", "symlink_test", "link_target_missing")
-	log := logging.New()
+	log := loggingtest.NewMockLogger()
+
+	symlinkPathMatcher := mock.MatchedBy(func(path AbsolutePath) bool {
+		return strings.Contains(path.String(), "/symlink_test/link_target_missing/badlink")
+	})
+
+	log.On("Info", "Following symlink", "path", symlinkPathMatcher).Return()
+	log.On("Debug", "Error following symlink, ignoring file", "filepath", symlinkPathMatcher, "error", mock.Anything).Return()
 
 	underlyingWalker := &FSWalker{}
 	walker := NewSymlinkWalker(underlyingWalker, log)
 	err := walker.Walk(dirPath, func(path AbsolutePath, info fs.FileInfo, err error) error {
 		return nil
 	})
-	s.ErrorIs(err, os.ErrNotExist)
+	s.NoError(err)
+	log.AssertExpectations(s.T())
 }


### PR DESCRIPTION
## Intent

This PR aims to not pollute VSCode with notification errors about symlinks that do not exist. 

When a directory being watched by the Publisher extension is being modified by other software, there's the chance for symbolic links to be created to files that do not exist, like Emacs which creates symbolic files for unsaved modifications.

With this PR changes, we'll log the behavior and errors for symbolic links but won't show error notifications.

<img width="2038" alt="Screen Shot 2024-10-01 at 13 54 59" src="https://github.com/user-attachments/assets/23a51429-d83b-4045-be6a-fb6645cd2fa2">

Fixes #2267 

## Approach

Log symbolic link walking errors, do not bubble them up to the extension code as errors.

## Automated Tests

Updated unit tests accordingly.

## Directions for Reviewers

Creating a symbolic link to a file that does not exist should show the `"Error following symlink" ... "no such file or directory"`  debug log but not notification error should show up.

E.g: 
`ln -s foo bar` should show something like
```
time=2024-10-01T14:45:03.224-06:00 level=DEBUG msg="Error following symlink, ignoring file" filepath=/Users/mn/Posit/_ide/top-5-income-share-streamlit/bar error="lstat /Users/mn/Posit/_ide/top-5-income-share-streamlit/foo: no such file or directory"
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
