### PR TITLE
Check if an environment variable exists when validating added secret

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -964,7 +964,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           return "Secret names cannot be empty.";
         }
         if (existingKeys.has(value)) {
-          return "There is already an environment variable with this name. Secrets and environment variable cannot share a name.";
+          return "There is already an environment variable with this name. Secrets and environment variable names must be unique.";
         }
         return;
       },

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -35,6 +35,7 @@ import {
   isPreContentRecordWithConfig,
   useApi,
   AllContentRecordTypes,
+  EnvironmentConfig,
 } from "src/api";
 import { useBus } from "src/bus";
 import { EventStream } from "src/events";
@@ -944,7 +945,16 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
   }
 
-  private inputSecretName = async () => {
+  private inputSecretName = async (
+    environment: EnvironmentConfig | undefined,
+  ) => {
+    const existingKeys = new Set();
+    if (environment) {
+      for (const secret in environment) {
+        existingKeys.add(secret);
+      }
+    }
+
     return await window.showInputBox({
       title: "Add a Secret",
       prompt: "Enter the name of the secret.",
@@ -952,6 +962,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       validateInput: (value: string) => {
         if (value.length === 0) {
           return "Secret names cannot be empty.";
+        }
+        if (existingKeys.has(value)) {
+          return "There is already an environment variable with this name. Secrets and environment variable cannot share a name.";
         }
         return;
       },
@@ -971,7 +984,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return;
     }
 
-    const name = await this.inputSecretName();
+    const name = await this.inputSecretName(
+      activeConfig.configuration.environment,
+    );
     if (name === undefined) {
       // Cancelled by the user
       return;

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -114,6 +115,13 @@ func (cfg *Config) AddSecret(secret string) error {
 			return nil // Secret already exists, no need to add
 		}
 	}
+	// Check if the secret name already exists in the environment
+	for e := range cfg.Environment {
+		if e == secret {
+			return errors.New("secret name already exists in environment")
+		}
+	}
+
 	cfg.Secrets = append(cfg.Secrets, secret)
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -182,6 +182,14 @@ func (s *ConfigSuite) TestApplySecretActionAddNoDuplicates() {
 	s.Equal([]string{"existingSecret1", "existingSecret2"}, cfg.Secrets)
 }
 
+func (s *ConfigSuite) TestApplySecretActionAddExitingEnvVar() {
+	cfg := New()
+	cfg.Environment = map[string]string{"existingEnvVar": "value"}
+	cfg.Secrets = []string{}
+	err := cfg.AddSecret("existingEnvVar")
+	s.NotNil(err)
+}
+
 func (s *ConfigSuite) TestApplySecretActionRemove() {
 	cfg := New()
 	cfg.Secrets = []string{"secret1", "secret2"}


### PR DESCRIPTION
This adds a small bit of validation code to our `addSecret` flow that checks to see if an environment variable already exists with the input name, and prevents the user from inputting it.

This is added at the VS Code input level, and on the API endpoint.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-10-01 at 15 09 42@2x](https://github.com/user-attachments/assets/69d3e6a5-37f8-43c1-8388-2e5612c2d1ff)

</details> 

## Intent

Part of #2326

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Automated tests were included for the Go code.

## Directions for Reviewers

1. Add a Secret via the UI
2. Attempt to add a Secret via the UI that has the same name as an environment variable already in the Configuration
