### PR TITLE
Show error and disable deployment when environment and secrets have duplicates

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -1,7 +1,12 @@
 <template>
   <vscode-button
     :data-automation="`deploy-button`"
-    :disabled="!haveResources || isConfigInError || home.publishInProgress"
+    :disabled="
+      !haveResources ||
+      isConfigInError ||
+      home.publishInProgress ||
+      home.duplicatedEnvironmentVariables.length
+    "
     @click="deploy"
   >
     Deploy Your Project

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -1,12 +1,7 @@
 <template>
   <vscode-button
     :data-automation="`deploy-button`"
-    :disabled="
-      !haveResources ||
-      isConfigInError ||
-      home.publishInProgress ||
-      home.duplicatedEnvironmentVariables.length
-    "
+    :disabled="!haveResources || isConfigInError || home.publishInProgress"
     @click="deploy"
   >
     Deploy Your Project

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -31,12 +31,13 @@
       <template v-if="home.duplicatedEnvironmentVariables.length">
         <p>
           <template v-if="home.duplicatedEnvironmentVariables.length === 1">
-            A duplicate name was
+            A variable was set as both a secret and environment variable. It
+            must only be set as one or the other.
           </template>
           <template v-if="home.duplicatedEnvironmentVariables.length > 1">
-            Duplicate names were
+            Variables were set as both secrets and environment variables. They
+            must only be set as one or the other.
           </template>
-          found in Secrets and Environment.
           <a
             class="webview-link"
             role="button"

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -28,6 +28,28 @@
         />
       </div>
 
+      <template v-if="home.duplicatedEnvironmentVariables.length">
+        <p>
+          <template v-if="home.duplicatedEnvironmentVariables.length === 1">
+            A duplicate name was
+          </template>
+          <template v-if="home.duplicatedEnvironmentVariables.length > 1">
+            Duplicate names were
+          </template>
+          found in Secrets and Environment.
+          <a
+            class="webview-link"
+            role="button"
+            @click="
+              onEditConfiguration(home.selectedConfiguration!.configurationPath)
+            "
+            >Edit the Configuration</a
+          >.
+        </p>
+        <p>{{ home.duplicatedEnvironmentVariables.join(", ") }}</p>
+        <p></p>
+      </template>
+
       <p v-if="home.config.active.isEntryMissing">
         No Config Entry in Deployment record -
         {{ home.selectedContentRecord?.saveName }}.

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -31,6 +31,33 @@ export const useHomeStore = defineStore("home", () => {
 
   const secrets = ref(new Map<string, string | undefined>());
 
+  const environment = computed((): Map<string, string> => {
+    const result = new Map<string, string>();
+    const config = selectedConfiguration.value;
+
+    if (config === undefined || isConfigurationError(config)) {
+      return result;
+    }
+
+    Object.entries(config.configuration.environment || {}).forEach(
+      ([name, value]) => {
+        result.set(name, value);
+      },
+    );
+
+    return result;
+  });
+
+  const duplicatedEnvironmentVariables = computed((): string[] => {
+    const result: string[] = [];
+    secrets.value.forEach((_, name) => {
+      if (environment.value.has(name)) {
+        result.push(name);
+      }
+    });
+    return result;
+  });
+
   const showDisabledOverlay = ref(false);
 
   const selectedContentRecord = ref<ContentRecord | PreContentRecord>();
@@ -375,6 +402,8 @@ export const useHomeStore = defineStore("home", () => {
     credentials,
     sortedCredentials,
     secrets,
+    environment,
+    duplicatedEnvironmentVariables,
     selectedContentRecord,
     selectedConfiguration,
     serverCredential,


### PR DESCRIPTION
This PR adds a new error that disables deployment - similar to a missing credential error in style - when there are names shared in Environment and Secrets in the selected Configuration.

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-10-01 at 16 15 42@2x](https://github.com/user-attachments/assets/ca031207-58b6-4660-8a40-538c185f9b64)

![CleanShot 2024-10-01 at 16 15 30@2x](https://github.com/user-attachments/assets/30ab36c8-72fb-41a4-b50b-8314633fe03c)

</details> 

The duplicated names are present in the error to make it easier to resolve, along with a link to edit the configuration similar to other errors.

## Intent

Resolves #2326 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->