### PR TITLE
Only show select existing text if options exist

### DIFF
--- a/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
+++ b/extensions/vscode/src/multiStepInputs/selectNewOrExistingConfig.ts
@@ -126,7 +126,9 @@ export async function selectNewOrExistingConfig(
       configFileListItems.push({
         iconPath: new ThemeIcon("plus"),
         label: createNewConfigurationLabel,
-        detail: "(or pick one of the existing deployments below)",
+        detail: configurations.length
+          ? "(or pick one of the existing configurations below)"
+          : undefined,
         picked: configurations.length ? false : true,
       });
 

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1121,7 +1121,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       deploymentQuickPickList.push({
         iconPath: new ThemeIcon("plus"),
         label: createNewDeploymentLabel,
-        detail: "(or pick one of the existing deployments below)", // we're forcing a blank here, just to maintain height of selection
+        detail: includedContentRecords.length
+          ? "(or pick one of the existing deployments below)"
+          : undefined,
         lastMatch: includedContentRecords.length ? false : true,
       });
 


### PR DESCRIPTION
This PR corrects the details text for two of our `multiStepInputs` to only show the "pick one of the existing..." text when actual options exist to select. 

<details>
  <summary>Preview</summary>
  
![CleanShot 2024-10-01 at 16 39 03@2x](https://github.com/user-attachments/assets/bd7f706e-e7e7-4a22-809f-1a3237c357e8)
![CleanShot 2024-10-01 at 16 39 20@2x](https://github.com/user-attachments/assets/dc1e24c1-0247-4ced-b286-82d4ddbd6ae4)

</details> 

## Intent

Resolves #2241

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->