### PR TITLE
Reword Credential nickname prompt and placeholder

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -246,8 +246,8 @@ export async function newCredential(
       step: thisStepNumber,
       totalSteps: state.totalSteps,
       value: currentName,
-      prompt: "Enter a Unique Nickname for your Credential.",
-      placeholder: "example: Posit Connect",
+      prompt: "Enter a unique nickname for this server.",
+      placeholder: "Posit Connect",
       finalValidation: (input: string) => {
         input = input.trim();
         if (input === "") {

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -691,8 +691,8 @@ export async function newDeployment(
         step: 0,
         totalSteps: 0,
         value: currentName,
-        prompt: "Enter a Unique Nickname for your Credential.",
-        placeholder: "example: Posit Connect",
+        prompt: "Enter a unique nickname for this server.",
+        placeholder: "Posit Connect",
         finalValidation: (input: string) => {
           input = input.trim();
           if (input === "") {

--- a/test/vscode-ui/test/specs/extension.spec.ts
+++ b/test/vscode-ui/test/specs/extension.spec.ts
@@ -93,7 +93,7 @@ describe("VS Code Extension UI Test", () => {
     await browser.keys("\uE007");
 
     // wait for validation
-    await waitForInputFields("Enter a Unique Nickname");
+    await waitForInputFields("Enter a unique nickname for this server");
 
     // set server name
     await input.setValue("my connect server");

--- a/test/vscode-ui/test/specs/fastapi.spec.ts
+++ b/test/vscode-ui/test/specs/fastapi.spec.ts
@@ -72,7 +72,7 @@ describe("VS Code Extension UI Test", () => {
     await browser.keys("\uE007");
 
     // wait for server validation
-    await helper.waitForInputFields("Enter a Unique Nickname");
+    await helper.waitForInputFields("Enter a unique nickname for this server");
 
     // set server name
     await input.setValue("my connect server");

--- a/test/vscode-ui/test/specs/nested-fastapi-configuration.spec.ts
+++ b/test/vscode-ui/test/specs/nested-fastapi-configuration.spec.ts
@@ -86,7 +86,7 @@ describe("Nested Fast API Configuration", () => {
     await browser.keys("\uE007");
 
     // wait for server validation
-    await helper.waitForInputFields("Enter a Unique Nickname");
+    await helper.waitForInputFields("Enter a unique nickname for this server");
 
     // set server name
     await input.setValue("my connect server");


### PR DESCRIPTION
A nice and simple reword for the Credential `multiStepInputs`:

From: Enter a Unique Nickname for your Credential.
To: Enter a unique nickname for this server and API key combination.

`Example: ` was also removed from the placeholder text to make it more similar to other VS Code inputs.

## Intent

Resolves #2265