### PR TITLE
Fixes for Nightly job

### DIFF
--- a/.github/workflows/contract.yaml
+++ b/.github/workflows/contract.yaml
@@ -133,7 +133,7 @@ jobs:
           unzip dist/*-darwin-amd64.vsix -d dist/ext
         if: matrix.runs-on == 'macos-latest'
       - run: chmod -R +x ./bin
-      - run: echo "${FUZZBUCKET_SSH_KEY}" > test/fuzzbucket-ssh-key && chmod 600 test/fuzzbucket-ssh-key
+      - run: echo "${FUZZBUCKET_SSH_KEY}" > test/setup/fuzzbucket-ssh-key && chmod 600 test/setup/fuzzbucket-ssh-key
 
       # vscode ui tests
       - run: just vscode configure

--- a/.github/workflows/contract.yaml
+++ b/.github/workflows/contract.yaml
@@ -64,7 +64,7 @@ jobs:
         if: matrix.runs-on == 'macos-latest'
 
       - run: chmod -R +x ./bin
-      - run: echo "${FUZZBUCKET_SSH_KEY}" > test/fuzzbucket-ssh-key && chmod 600 test/fuzzbucket-ssh-key
+      - run: echo "${FUZZBUCKET_SSH_KEY}" > test/setup/fuzzbucket-ssh-key && chmod 600 test/setup/fuzzbucket-ssh-key
       - run: just bats install
       - run: just bats test common
       - run: just bats test init

--- a/.github/workflows/contract.yaml
+++ b/.github/workflows/contract.yaml
@@ -130,7 +130,7 @@ jobs:
         if: matrix.runs-on == 'windows-latest'
       - name: Extract dist on macos
         run: |
-          unzip dist/*-darwin-amd64.vsix -d dist/ext
+          unzip dist/*-darwin-arm64.vsix -d dist/ext
         if: matrix.runs-on == 'macos-latest'
       - run: chmod -R +x ./bin
       - run: echo "${FUZZBUCKET_SSH_KEY}" > test/setup/fuzzbucket-ssh-key && chmod 600 test/setup/fuzzbucket-ssh-key

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,6 +19,7 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
   package:
+    needs: build
     uses: ./.github/workflows/package.yaml
   contract-deps:
     secrets: inherit

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,6 +18,8 @@ jobs:
     uses: ./.github/workflows/agent.yaml
   build:
     uses: ./.github/workflows/build.yaml
+  package:
+    uses: ./.github/workflows/package.yaml
   contract-deps:
     secrets: inherit
     uses: ./.github/workflows/contract-deps.yaml


### PR DESCRIPTION
When I updated the nightly tests to run against specific packages I made a couple mistakes.

1. Forgot to include the `package` job as a dependency
2. Used the amd build for macOS, GH Actions uses the arm build so it was causing failures
3. Added a fix for some flakiness around the fuzzbucket ssh key I create in an earlier step

All tests are now passing:
https://github.com/posit-dev/publisher/actions/runs/11145196437