### PR TITLE
Allow deploy when the config is in error

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -1,7 +1,7 @@
 <template>
   <vscode-button
     :data-automation="`deploy-button`"
-    :disabled="!haveResources || isConfigInError || home.publishInProgress"
+    :disabled="!haveResources || home.publishInProgress"
     @click="deploy"
   >
     Deploy Your Project
@@ -11,7 +11,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { isConfigurationError } from "../../../../src/api";
 import { useHomeStore } from "src/stores/home";
 import { useHostConduitService } from "src/HostConduitService";
 
@@ -26,13 +25,6 @@ const haveResources = computed(
     Boolean(home.selectedConfiguration) &&
     Boolean(home.serverCredential),
 );
-
-const isConfigInError = computed(() => {
-  return Boolean(
-    home.selectedConfiguration &&
-      isConfigurationError(home.selectedConfiguration),
-  );
-});
 
 const deploy = () => {
   if (


### PR DESCRIPTION
This PR removes the disable state for the Deploy button when the configuration is in error.

There isn't anything preventing us from calling the Deploy API when this occurs. The warning is still present telling the user that their configuration is indeed in error, but now they can attempt a deploy and get an error message.

That looks something like this:

![image](https://github.com/user-attachments/assets/c01a0f59-135c-499c-8643-da288400abc7)

Our `ValidateTOMLFile` function will error when the Configuration doesn't match the schema, and has an error like the example above.

https://github.com/posit-dev/publisher/blob/7830e62c2bfe119d8d47c3dcc9dce19bacef5371/internal/schema/schema.go#L83

## Intent

Resolves #2345 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->