### PR TITLE
Add support for insecure TLS connections to Connect Servers

### DIFF
--- a/cmd/publisher/commands/deploy.go
+++ b/cmd/publisher/commands/deploy.go
@@ -24,6 +24,7 @@ type DeployCmd struct {
 	SaveName    string            `name:"name" short:"n" help:"Save deployment with this name (in .posit/deployments/)"`
 	Account     *accounts.Account `kong:"-"`
 	Config      *config.Config    `kong:"-"`
+	// NOTE: Currently hardcoded to insecure = false. No CLI param added for now.
 }
 
 func (cmd *DeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
@@ -56,7 +57,7 @@ func (cmd *DeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext)
 	if err != nil {
 		return err
 	}
-	stateStore, err := state.New(absPath, cmd.AccountName, cmd.ConfigName, "", cmd.SaveName, ctx.Accounts, nil)
+	stateStore, err := state.New(absPath, cmd.AccountName, cmd.ConfigName, "", cmd.SaveName, ctx.Accounts, nil, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/publisher/commands/redeploy.go
+++ b/cmd/publisher/commands/redeploy.go
@@ -23,6 +23,7 @@ type RedeployCmd struct {
 	ConfigName string                 `name:"config" short:"c" help:"Configuration name (in .posit/publish/)"`
 	Config     *config.Config         `kong:"-"`
 	Target     *deployment.Deployment `kong:"-"`
+	// NOTE: Currently hardcoded to insecure = false. No CLI param added for now.
 }
 
 func (cmd *RedeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContext) error {
@@ -41,7 +42,7 @@ func (cmd *RedeployCmd) Run(args *cli_types.CommonArgs, ctx *cli_types.CLIContex
 	if err != nil {
 		return fmt.Errorf("invalid deployment name '%s': %w", cmd.TargetName, err)
 	}
-	stateStore, err := state.New(absPath, "", cmd.ConfigName, cmd.TargetName, "", ctx.Accounts, nil)
+	stateStore, err := state.New(absPath, "", cmd.ConfigName, cmd.TargetName, "", ctx.Accounts, nil, false)
 	if err != nil {
 		return err
 	}

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -33,6 +33,18 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": [
+      {
+        "title": "Posit Publisher",
+        "properties": {
+          "positPublisher.enableInsecureTLS": {
+            "markdownDescription": "Enable/disable skipping TLS certificate validation for connections to servers.\n\nWhen **disabled** (default), TLS connections initiated by Posit Publisher will only be established if the SSL certificate associated with the target server can be validated with the configured certificate authority. \n\nWhen **enabled**, the SSL certificate validation will be skipped. Only **enable** this setting if you are accessing fully trusted servers as it could introduce security vulnerabilities since server identity is not being verified.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "posit.publisher.init-project",

--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -11,6 +11,8 @@ import { Secrets } from "./resources/Secrets";
 import { EntryPoints } from "./resources/Entrypoints";
 import * as Entities from "entities";
 
+export type GetInsecureSettingFn = () => boolean;
+
 class PublishingClientApi {
   private client;
 
@@ -22,13 +24,28 @@ class PublishingClientApi {
   secrets: Secrets;
   apiServiceIsUp: Promise<boolean>;
   entrypoints: EntryPoints;
+  // In order to allow this object to be used both within the VSCode extension
+  // code as well as the hosted webview, we need to isolate imports which are
+  // not allowed in both. In this case, vscode functionality is needed to
+  // access the extension's configuration setting. So we'll initialize this
+  // object with a callback which can provide the separation, while maintaining
+  // our ability to have this object accessible from both "domains".
+  getInsecureSetting: GetInsecureSettingFn;
 
-  constructor(apiBaseUrl: string, apiServiceIsUp: Promise<boolean>) {
+  constructor(
+    getInsecureSettingFn: GetInsecureSettingFn,
+    apiBaseUrl: string,
+    apiServiceIsUp: Promise<boolean>,
+  ) {
     this.client = axios.create({
       baseURL: apiBaseUrl,
     });
     this.client.interceptors.request.use((request) => {
       request.ts = performance.now();
+      // request.params = {
+      //   ...request.params,
+      //   insecure: this.getInsecureSetting(),
+      // };
       return request;
     });
 
@@ -55,6 +72,7 @@ class PublishingClientApi {
     this.packages = new Packages(this.client);
     this.secrets = new Secrets(this.client);
     this.entrypoints = new EntryPoints(this.client);
+    this.getInsecureSetting = getInsecureSettingFn;
   }
 
   logDuration(response: AxiosResponse<any, any>) {
@@ -77,10 +95,11 @@ let api: PublishingClientApi | undefined = undefined;
 // NOTE: this function must be called ahead of useApi()
 // so that the class is properly instantiated.
 export const initApi = (
+  insecureSettingFn: GetInsecureSettingFn,
   apiServiceIsUp: Promise<boolean>,
   apiBaseUrl: string = "/api",
 ) => {
-  api = new PublishingClientApi(apiBaseUrl, apiServiceIsUp);
+  api = new PublishingClientApi(insecureSettingFn, apiBaseUrl, apiServiceIsUp);
 };
 
 // NOTE: initApi(...) must be called ahead of the first time

--- a/extensions/vscode/src/api/resources/ContentRecords.ts
+++ b/extensions/vscode/src/api/resources/ContentRecords.ts
@@ -71,6 +71,7 @@ export class ContentRecords {
     targetName: string,
     accountName: string,
     configName: string,
+    insecure: boolean,
     dir: string,
     secrets?: Record<string, string>,
   ) {
@@ -78,6 +79,7 @@ export class ContentRecords {
       account: accountName,
       config: configName,
       secrets: secrets,
+      insecure: insecure,
     };
     const encodedTarget = encodeURIComponent(targetName);
     return this.client.post<{ localId: string }>(

--- a/extensions/vscode/src/api/resources/Credentials.ts
+++ b/extensions/vscode/src/api/resources/Credentials.ts
@@ -55,10 +55,11 @@ export class Credentials {
   // for valid URL and invalid API key: no user, error in TestResult
   //   indicating that the API key is invalid
   // 404 - Agent not found...
-  test(url: string, apiKey?: string) {
+  test(url: string, insecure: boolean, apiKey?: string) {
     return this.client.post<TestResult>(`test-credentials`, {
       url,
       apiKey,
+      insecure,
     });
   }
 }

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -2,7 +2,7 @@
 
 import * as path from "path";
 
-import { ExtensionContext } from "vscode";
+import { ExtensionContext, Uri } from "vscode";
 
 import { HOST } from "src";
 
@@ -19,3 +19,8 @@ export const create = async (
 const getExecutableBinary = (context: ExtensionContext): string => {
   return path.join(context.extensionPath, "bin", "publisher");
 };
+
+const args = ["@ext:posit.publisher"];
+export const openConfigurationCommand = Uri.parse(
+  `command:workbench.action.openSettings?${encodeURIComponent(JSON.stringify(args))}`,
+);

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -7,7 +7,7 @@ import {
   assignStep,
 } from "./multiStepHelper";
 
-import { InputBoxValidationSeverity, Uri, window } from "vscode";
+import { InputBoxValidationSeverity, window } from "vscode";
 
 import { useApi, Credential } from "src/api";
 import {

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -570,7 +570,10 @@ export async function newDeployment(
             });
           }
           try {
-            const testResult = await api.credentials.test(input);
+            const testResult = await api.credentials.test(
+              input,
+              api.getInsecureSetting(),
+            );
             if (testResult.status !== 200) {
               return Promise.resolve({
                 message: `Error: Invalid URL (unable to validate connectivity with Server URL - API Call result: ${testResult.status} - ${testResult.statusText}).`,
@@ -643,7 +646,11 @@ export async function newDeployment(
             ? newDeploymentData.newCredentials.url
             : "";
           try {
-            const testResult = await api.credentials.test(serverUrl, input);
+            const testResult = await api.credentials.test(
+              serverUrl,
+              api.getInsecureSetting(),
+              input,
+            );
             if (testResult.status !== 200) {
               return Promise.resolve({
                 message: `Error: Invalid API Key (unable to validate API Key - API Call result: ${testResult.status} - ${testResult.statusText}).`,

--- a/extensions/vscode/src/services.ts
+++ b/extensions/vscode/src/services.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { ExtensionContext, Disposable } from "vscode";
+import { ExtensionContext, Disposable, workspace } from "vscode";
 
 import { HOST } from "src";
 import { initApi } from "src/api";
@@ -15,7 +15,7 @@ export class Service implements Disposable {
     this.context = context;
     this.agentURL = `http://${HOST}:${port}/api`;
     this.server = new Server(port);
-    initApi(this.isUp(), this.agentURL);
+    initApi(this.getInsecureSettingFn, this.isUp(), this.agentURL);
   }
 
   start = async () => {
@@ -39,5 +39,16 @@ export class Service implements Disposable {
     if (this.server) {
       this.server.outputChannel.show();
     }
+  }
+
+  getInsecureSettingFn(): boolean {
+    // set value from extension configuration - defaults to true
+    const configuration = workspace.getConfiguration("positPublisher");
+    const insecureTLS: boolean | undefined =
+      configuration.get<boolean>("enableInsecureTLS");
+    if (insecureTLS !== undefined) {
+      return insecureTLS;
+    }
+    return false;
   }
 }

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -2,12 +2,13 @@
 
 import { AxiosError, AxiosResponse, isAxiosError } from "axios";
 
-type ErrorCode =
+export type ErrorCode =
   | "unknown"
   | "resourceNotFound"
   | "invalidTOML"
   | "unknownTOMLKey"
-  | "invalidConfigFile";
+  | "invalidConfigFile"
+  | "errorCertificateVerification";
 
 export type axiosErrorWithJson<T = { code: ErrorCode; details: unknown }> =
   AxiosError & {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -258,6 +258,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         deploymentName,
         credentialName,
         configurationName,
+        api.getInsecureSetting(),
         projectDir,
         secrets,
       );

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -20,6 +20,7 @@ type PostDeploymentRequestBody struct {
 	AccountName string            `json:"account"`
 	ConfigName  string            `json:"config"`
 	Secrets     map[string]string `json:"secrets,omitempty"`
+	Insecure    bool              `json:"insecure"`
 }
 
 type PostDeploymentsReponse struct {
@@ -55,7 +56,7 @@ func PostDeploymentHandlerFunc(
 			InternalError(w, req, log, err)
 			return
 		}
-		newState, err := stateFactory(projectDir, b.AccountName, b.ConfigName, name, "", accountList, b.Secrets)
+		newState, err := stateFactory(projectDir, b.AccountName, b.ConfigName, name, "", accountList, b.Secrets, b.Insecure)
 		log.Debug("New account derived state created", "account", b.AccountName, "config", b.ConfigName)
 		if err != nil {
 			if errors.Is(err, accounts.ErrAccountNotFound) {

--- a/internal/services/api/post_deployment_test.go
+++ b/internal/services/api/post_deployment_test.go
@@ -68,7 +68,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 		`{
 			"account": "local",
 			"config": "default",
-			"insecure": false,
+			"insecure": false
 		}`))
 
 	publisher := &mockPublisher{}
@@ -171,7 +171,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWrongServe
 		`{
 			"account": "newAcct",
 			"config": "default",
-			"insecure": false,
+			"insecure": false
 		}`))
 
 	handler := PostDeploymentHandlerFunc(s.cwd, log, lister, events.NewNullEmitter())
@@ -236,7 +236,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentSubdir() {
 		`{
 			"account": "local",
 			"config": "default",
-			"insecure": false,
+			"insecure": false
 		}`))
 
 	publisher := &mockPublisher{}

--- a/internal/services/api/post_deployment_test.go
+++ b/internal/services/api/post_deployment_test.go
@@ -67,7 +67,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 	req.Body = io.NopCloser(strings.NewReader(
 		`{
 			"account": "local",
-			"config": "default"
+			"config": "default",
+			"insecure": false,
 		}`))
 
 	publisher := &mockPublisher{}
@@ -79,7 +80,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 		path util.AbsolutePath,
 		accountName, configName, targetName, saveName string,
 		accountList accounts.AccountList,
-		secrets map[string]string) (*state.State, error) {
+		secrets map[string]string,
+		insecure bool) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)
@@ -89,6 +91,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 
 		st := state.Empty()
 		st.Account = &accounts.Account{}
+		st.Account.Insecure = insecure
 		st.Target = deployment.New()
 		return st, nil
 	}
@@ -123,7 +126,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncStateErr()
 		path util.AbsolutePath,
 		accountName, configName, targetName, saveName string,
 		accountList accounts.AccountList,
-		secrets map[string]string) (*state.State, error) {
+		secrets map[string]string,
+		insecure bool) (*state.State, error) {
 		return nil, errors.New("test error from state factory")
 	}
 
@@ -166,7 +170,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWrongServe
 	req.Body = io.NopCloser(strings.NewReader(
 		`{
 			"account": "newAcct",
-			"config": "default"
+			"config": "default",
+			"insecure": false,
 		}`))
 
 	handler := PostDeploymentHandlerFunc(s.cwd, log, lister, events.NewNullEmitter())
@@ -182,13 +187,14 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncPublishErr
 	s.NoError(err)
 
 	lister := &accounts.MockAccountList{}
-	req.Body = io.NopCloser(strings.NewReader(`{"account": "local", "config": "default"}`))
+	req.Body = io.NopCloser(strings.NewReader(`{"account": "local", "config": "default", "insecure": false}`))
 
 	stateFactory = func(
 		path util.AbsolutePath,
 		accountName, configName, targetName, saveName string,
 		accountList accounts.AccountList,
-		secrets map[string]string) (*state.State, error) {
+		secrets map[string]string,
+		insecure bool) (*state.State, error) {
 
 		st := state.Empty()
 		st.Account = &accounts.Account{}
@@ -229,7 +235,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentSubdir() {
 	req.Body = io.NopCloser(strings.NewReader(
 		`{
 			"account": "local",
-			"config": "default"
+			"config": "default",
+			"insecure": false,
 		}`))
 
 	publisher := &mockPublisher{}
@@ -241,7 +248,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentSubdir() {
 		path util.AbsolutePath,
 		accountName, configName, targetName, saveName string,
 		accountList accounts.AccountList,
-		secrets map[string]string) (*state.State, error) {
+		secrets map[string]string,
+		insecure bool) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)
@@ -273,6 +281,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWithSecret
 		`{
 			"account": "local",
 			"config": "default",
+			"insecure": false,
 			"secrets": {
 				"API_KEY": "secret123",
 				"DB_PASSWORD": "password456"
@@ -289,7 +298,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWithSecret
 		path util.AbsolutePath,
 		accountName, configName, targetName, saveName string,
 		accountList accounts.AccountList,
-		secrets map[string]string) (*state.State, error) {
+		secrets map[string]string,
+		insecure bool) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -96,7 +96,7 @@ func Empty() *State {
 
 var ErrServerURLMismatch = errors.New("the account provided is for a different server; it must match the server for this deployment")
 
-func New(path util.AbsolutePath, accountName, configName, targetName string, saveName string, accountList accounts.AccountList, secrets map[string]string) (*State, error) {
+func New(path util.AbsolutePath, accountName, configName, targetName string, saveName string, accountList accounts.AccountList, secrets map[string]string, insecure bool) (*State, error) {
 	var target *deployment.Deployment
 	var account *accounts.Account
 	var cfg *config.Config
@@ -128,6 +128,11 @@ func New(path util.AbsolutePath, accountName, configName, targetName string, sav
 	if err != nil {
 		return nil, err
 	}
+
+	// we don't store insecure credential flag, instead we use a
+	// credential-wide configuration value which is passed in. 
+	// So we add that value before the account gets used
+	account.Insecure = insecure
 
 	if target.ServerURL != "" && target.ServerURL != account.URL {
 		return nil, ErrServerURLMismatch

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -296,7 +296,7 @@ func (s *StateSuite) TestNew() {
 
 	cfg := s.makeConfiguration("default")
 
-	state, err := New(s.cwd, "", "", "", "", accts, nil)
+	state, err := New(s.cwd, "", "", "", "", accts, nil, false)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(state.AccountName, "")
@@ -305,6 +305,7 @@ func (s *StateSuite) TestNew() {
 	s.Equal(&acct, state.Account)
 	s.Equal(cfg, state.Config)
 	s.Equal(map[string]string(nil), state.Secrets)
+	s.Equal(state.Account.Insecure, false)
 	// Target is never nil. We create a new target if no target ID was provided.
 	s.NotNil(state.Target)
 }
@@ -317,7 +318,7 @@ func (s *StateSuite) TestNewNonDefaultConfig() {
 	configName := "staging"
 	cfg := s.makeConfiguration(configName)
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, true)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -325,6 +326,7 @@ func (s *StateSuite) TestNewNonDefaultConfig() {
 	s.Equal("", state.TargetName)
 	s.Equal(&acct, state.Account)
 	s.Equal(cfg, state.Config)
+	s.Equal(state.Account.Insecure, true)
 	// Target is never nil. We create a new target if no target ID was provided.
 	s.NotNil(state.Target)
 }
@@ -334,7 +336,7 @@ func (s *StateSuite) TestNewConfigErr() {
 	acct := accounts.Account{}
 	accts.On("GetAllAccounts").Return([]accounts.Account{acct}, nil)
 
-	state, err := New(s.cwd, "", "", "", "", accts, nil)
+	state, err := New(s.cwd, "", "", "", "", accts, nil, false)
 	s.NotNil(err)
 	s.ErrorContains(err, "couldn't load configuration")
 	s.Nil(state)
@@ -372,7 +374,7 @@ func (s *StateSuite) TestNewWithTarget() {
 	err := d.WriteFile(targetPath)
 	s.NoError(err)
 
-	state, err := New(s.cwd, "", "", "myTargetName", "", accts, nil)
+	state, err := New(s.cwd, "", "", "myTargetName", "", accts, nil, false)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct1", state.AccountName)
@@ -381,6 +383,7 @@ func (s *StateSuite) TestNewWithTarget() {
 	s.Equal(&acct1, state.Account)
 	s.Equal(cfg, state.Config)
 	s.Equal(d, state.Target)
+	s.Equal(state.Account.Insecure, false)
 }
 
 func (s *StateSuite) TestNewWithTargetAndAccount() {
@@ -412,7 +415,7 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	err := d.WriteFile(targetPath)
 	s.NoError(err)
 
-	state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil)
+	state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, true)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct2", state.AccountName)
@@ -421,6 +424,7 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	s.Equal(&acct2, state.Account)
 	s.Equal(cfg, state.Config)
 	s.Equal(d, state.Target)
+	s.Equal(state.Account.Insecure, true)
 }
 
 func (s *StateSuite) TestNewWithSecrets() {
@@ -434,7 +438,7 @@ func (s *StateSuite) TestNewWithSecrets() {
 		"DB_PASSWORD": "password456",
 	}
 
-	state, err := New(s.cwd, "", "", "", "", accts, secrets)
+	state, err := New(s.cwd, "", "", "", "", accts, secrets, false)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(secrets, state.Secrets)
@@ -450,7 +454,7 @@ func (s *StateSuite) TestNewWithInvalidSecret() {
 		"INVALID_SECRET": "secret123",
 	}
 
-	state, err := New(s.cwd, "", "", "", "", accts, secrets)
+	state, err := New(s.cwd, "", "", "", "", accts, secrets, false)
 	s.NotNil(err)
 	s.ErrorContains(err, "secret 'INVALID_SECRET' is not in the configuration")
 	s.Nil(state)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -317,8 +317,10 @@ func (s *StateSuite) TestNewNonDefaultConfig() {
 
 	configName := "staging"
 	cfg := s.makeConfiguration(configName)
+	insecure := true
+	acct.Insecure = insecure
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil, true)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -415,7 +417,7 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	err := d.WriteFile(targetPath)
 	s.NoError(err)
 
-	state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, true)
+	state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, false)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct2", state.AccountName)
@@ -424,7 +426,6 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	s.Equal(&acct2, state.Account)
 	s.Equal(cfg, state.Config)
 	s.Equal(d, state.Target)
-	s.Equal(state.Account.Insecure, true)
 }
 
 func (s *StateSuite) TestNewWithSecrets() {

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -16,6 +16,7 @@ const (
 	ErrorUnknownTOMLKey               ErrorCode = "unknownTOMLKey"
 	ErrorInvalidConfigFiles           ErrorCode = "invalidConfigFiles"
 	ErrorCredentialServiceUnavailable ErrorCode = "credentialsServiceUnavailable"
+	ErrorCertificateVerification      ErrorCode = "errorCertificateVerification"
 	ErrorUnknown                      ErrorCode = "unknown"
 )
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This PR provides support for customer environments whose internal servers use self-signed SSL certificates, but for some reason, these certificates cannot be verified.

Resolves #2202

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

There are two agent APIs involved in the flows effected (`POST /test-credentials` and `POST /deployments/{target}`). The `test-credentials` API endpoint already supported an `insecure` option within it's body. I have replicated this into the `deployments/{target}` endpoint. The `insecure` option is now required for both APIs.

The credential object on the agent already supports an `insecure` attribute but it is not persisted. There was already code within the agent that implemented the insecure TLS functionality if set. Since we were looking for a global setting to enable `insecure TLS`, the API endpoint handlers each take the parameter passed in their body and update the memory copy of the account's insecure setting they are using to connect to the server. This allows this flag to be changed and immediately go into effect for the next test or deployment.

On the extension/UX side, a configuration setting for the Posit Publisher has been defined `Enable Insecure TLS`. You can access this setting within the settings UX for VSCode.
![2024-10-03 at 1 21 PM](https://github.com/user-attachments/assets/ac1bec86-1dec-4ec2-871a-b3578b7c52a9)

Access to the VSCode configuration setting is limited to the extension code (and is not available to the webview). It made most sense to have the current value available from the API client object, which is initialized by the extension code, but is available to the webview. It was not possible to simply add a method within the API client to retrieve the setting since both the extension and webview import the top-level `src/api` to access common types. While this can be changed in the future, I did not want to refactor the API to handle it within this PR. So instead, when the API client object is initialized, the extension passes in a callback which will return the current setting. 

As the appropriate API calls are made within the extension, they simply call the new method within the API client to retrieve the current value. Since there is no caching, the user should see the effect of a change immediately as long as the code retrieves this value at the last possible moment.

There are two scenarios in which you can see the effect of this PR.

The first is when creating a new credential. If validation of the server URL errors with a credential error, this error message is displayed with a link to the new configuration setting:
![2024-10-03 at 1 34 PM](https://github.com/user-attachments/assets/858f3b86-90af-4465-a9f4-3c4b410e73bc)

If the user clicks on the link within the error message, the multi-stepper stays open and the setting is made visible. They can alter this setting and then simply hit return within the multi-stepper to continue without TLS verification.
![2024-10-03 at 1 36 PM](https://github.com/user-attachments/assets/bfa18d01-1c48-479a-999e-b52cce7a3472)

If verification is successful, then the next step for the multi-stepper is shown as expected.

Once a user has the credential established, then deployment attempts will use the current setting value from the configuration.

If a user changes this setting back to `disabled` after it was required to be `enabled` to create credentials, then they will see a deployment error. Currently it is shown as follows (although there is a triage item to be evaluated to improve this message/functionality).
![2024-10-03 at 1 40 PM](https://github.com/user-attachments/assets/b081c296-c283-49ee-944f-07fedb11ef3f)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Automated tests have been updated on the agent. The area in which the functionality has been implemented is within the extension framework, which will require integration tests to be written for it.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

To setup a connect server which fails TLS certificate validation:
- Within the connect repo's `ssl` directory, run `just certificates`
- It will create an `alwayssecure.rsc.crt` file which you can open and add it to your keychain.
- Start with setting this certificate to `Trust Always`
- Update your `etc/hosts` file to include a definition of `alwayssecure.rsc` to be `127.0.0.1`
- From the root directory of the connect repo, run `just start`
- Use a browser to connect to `https://alwayssecure.rsc:3443/`, and you should be able to access the Connect dashboard without issue.
- Change the certificate to `Never Trust` within the keychain
- You'll need to open a new browser instance or window, but then attempt to connect to the connect server once again. You should see the warnings or stop pages for an insecure setting. Chrome will allow you bypass it, but Safari stops you cold (at least with my system settings).

Now you can create a credential within the publisher extension and verify the new functionality. Be sure to:
1. Create a credential to a different server than `alwayssecure.rsc`, to confirm regression
2. Create a credential to `alwayssecure.rsc` when it is not trusted. Validate the error is encountered during the new Credential flow, and confirm the link brings up the settings page. Enable the option and then press return on the multi-stepper, and it should proceed forward to the API key input. Complete the credential creation.
3. With a credential in place, try deploying a project with the `insecure TLS` option still enabled. It should deploy successfully.
4. Change the `insecure TLS` option to be disabled and try deploying once again. It should fail with the error displayed.

NOTE: if you have any issues with recreating an insecure server, check with either Bill or Kevin (who have set this up). Bill was unable to use YETI to do this, so you will need to use the direct starting of a server within the connect repo.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
