### PR TITLE
inotify linux link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,13 +59,13 @@ Or install a specific version with:
 ```
 
 > [!WARNING]
-> Linux users need to have `inotify-tools` installed for the VSCode filewatcher to work properly.
-> This impacts how the extension presents file-specific data.
+> [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't propagating in the Publisher extension, ensure you have `inotify` installed.
 > To install `inotify` on Debian, use the following command:<br />
 >
 > ```
 > apt install inotify-tools
 > ```
+
 
 ## Optional: Install Quarto
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,7 +58,9 @@ Or install a specific version with:
 ./install-publisher.bash 1.0.beta1
 ```
 
-> [!WARNING] > [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't propagating in the Publisher extension, ensure you have `inotify` installed.
+> [!WARNING]
+>
+> [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't propagating in the Publisher extension, ensure you have `inotify` installed.
 > To install `inotify` on Debian, use the following command:<br />
 >
 > ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,7 +60,7 @@ Or install a specific version with:
 
 > [!WARNING]
 >
-> [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't propagating in the Publisher extension, ensure you have `inotify` installed.
+> [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't updating the Publisher extension, ensure you have `inotify` installed.
 > To install `inotify` on Debian, use the following command:<br />
 >
 > ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,14 +58,12 @@ Or install a specific version with:
 ./install-publisher.bash 1.0.beta1
 ```
 
-> [!WARNING]
-> [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't propagating in the Publisher extension, ensure you have `inotify` installed.
+> [!WARNING] > [VSCode uses inotify](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues) on Linux installations. If file changes aren't propagating in the Publisher extension, ensure you have `inotify` installed.
 > To install `inotify` on Debian, use the following command:<br />
 >
 > ```
 > apt install inotify-tools
 > ```
-
 
 ## Optional: Install Quarto
 


### PR DESCRIPTION
To address Jon's comment here:
https://github.com/posit-dev/publisher/pull/2332#discussion_r1787634361

This updates the `inotify` warning with a link to [VSCode File Watcher Issues doc](https://github.com/microsoft/vscode/wiki/File-Watcher-Issues). While the doc doesn't explicitly state that `inotify` will need to be installed, it does mention that it is used for File Watching.

I had to manually install `inotify-tools` to get this working in my ubuntu22 VM.

Fixes: https://github.com/posit-dev/publisher/issues/1216