### PR TITLE
Show some details for a TOML parsing error

### DIFF
--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -26,8 +26,8 @@ export type AgentErrorInvalidTOML = AgentErrorBase & {
   data: {
     problem: string;
     file: string;
-    line: string;
-    column: string;
+    line: number;
+    column: number;
   };
 };
 

--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -1,10 +1,38 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
-export type AgentError = {
+type AgentErrorBase = {
   code: string;
   msg: string;
   operation: string;
+};
+
+export type AgentError = AgentErrorTypeUnknown | AgentErrorInvalidTOML;
+
+export type AgentErrorTypeUnknown = AgentErrorBase & {
   data: {
     [key: string]: unknown;
   };
+};
+
+// This represents the Agent Errors we haven't been able to
+// narrow down to a specific type.
+export const isAgentErrorTypeUnknown = (
+  e: AgentError,
+): e is AgentErrorTypeUnknown => {
+  return !isAgentErrorInvalidTOML(e);
+};
+
+export type AgentErrorInvalidTOML = AgentErrorBase & {
+  data: {
+    problem: string;
+    file: string;
+    line: string;
+    column: string;
+  };
+};
+
+export const isAgentErrorInvalidTOML = (
+  e: AgentError,
+): e is AgentErrorInvalidTOML => {
+  return e.code === "invalidTOML" || e.code === "unknownTOMLKey";
 };

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -43,7 +43,8 @@ export const openFileInEditor = async (
     }
   }
 
+  // we'll only indicate a location, if one was passed to us.
   await window.showTextDocument(Uri.file(path), {
-    selection: new Range(start, end),
+    selection: options && options.selection ? new Range(start, end) : undefined,
   });
 };

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -2,9 +2,10 @@
 
 import * as path from "path";
 
-import { ExtensionContext } from "vscode";
+import { ExtensionContext, Position, window, Range, Uri } from "vscode";
 
 import { HOST } from "src";
+import { EditConfigurationSelection } from "./types/messages/webviewToHostMessages";
 
 export const create = async (
   context: ExtensionContext,
@@ -18,4 +19,31 @@ export const create = async (
 
 const getExecutableBinary = (context: ExtensionContext): string => {
   return path.join(context.extensionPath, "bin", "publisher");
+};
+
+export const openFileInEditor = async (
+  path: string,
+  options?: { selection?: EditConfigurationSelection },
+) => {
+  let start = new Position(0, 0);
+  let end = new Position(0, 0);
+
+  if (options && options.selection) {
+    start = new Position(
+      options.selection.start.line,
+      options.selection.start.character,
+    );
+    if (options.selection.end) {
+      end = new Position(
+        options.selection.end.line,
+        options.selection.end.character,
+      );
+    } else {
+      end = start;
+    }
+  }
+
+  await window.showTextDocument(Uri.file(path), {
+    selection: new Range(start, end),
+  });
 };

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -106,10 +106,23 @@ export type DeployMsg = AnyWebviewToHostMessage<
 export type InitializingMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.INITIALIZING>;
 
+export type EditConfigurationSelection = {
+  // numbers below are base-zero
+  start: {
+    line: number;
+    character: number;
+  };
+  end?: {
+    line: number;
+    character: number;
+  };
+};
+
 export type EditConfigurationMsg = AnyWebviewToHostMessage<
   WebviewToHostMessageType.EDIT_CONFIGURATION,
   {
     configurationPath: string;
+    selection?: EditConfigurationSelection;
   }
 >;
 

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -75,6 +75,7 @@ import { newCredential } from "src/multiStepInputs/newCredential";
 import { PublisherState } from "src/state";
 import { throttleWithLastPending } from "src/utils/throttle";
 import { showAssociateGUID } from "src/actions/showAssociateGUID";
+import { openFileInEditor } from "src/commands";
 
 enum HomeViewInitialized {
   initialized = "initialized",
@@ -318,10 +319,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   }
 
   private async onEditConfigurationMsg(msg: EditConfigurationMsg) {
-    await commands.executeCommand(
-      "vscode.open",
-      Uri.file(msg.content.configurationPath),
-    );
+    await openFileInEditor(msg.content.configurationPath, {
+      selection: msg.content.selection,
+    });
   }
 
   private async onNavigateMsg(msg: NavigateMsg) {

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -66,7 +66,19 @@
         }}</a
         >.
       </p>
-      <p v-if="home.config.active.isError">
+      <p v-if="home.config.active.isTOMLError">
+        The selected Configuration has a schema error
+        {{ getActiveConfigTOMLErrorDetails }}.
+        <a
+          class="webview-link"
+          role="button"
+          @click="
+            onEditConfiguration(home.selectedConfiguration!.configurationPath)
+          "
+          >Edit the Configuration</a
+        >.
+      </p>
+      <p v-if="home.config.active.isUnknownError">
         The selected Configuration has an error.
         <a
           class="webview-link"
@@ -219,6 +231,7 @@ import QuickPickItem from "src/components/QuickPickItem.vue";
 import ActionToolbar from "src/components/ActionToolbar.vue";
 import DeployButton from "src/components/DeployButton.vue";
 import TextStringWithAnchor from "./TextStringWithAnchor.vue";
+import { isAgentErrorInvalidTOML } from "../../../../src/api/types/error";
 
 const home = useHomeStore();
 const hostConduit = useHostConduitService();
@@ -336,7 +349,7 @@ const entrypointSubTitle = computed(() => {
       if (contentRecord.projectDir !== ".") {
         subTitle = `${contentRecord.projectDir}${home.platformFileSeparator}`;
       }
-      if (!home.config.active.isError) {
+      if (!home.config.active.isUnknownError) {
         subTitle += config.configuration.entrypoint;
       }
       return subTitle;
@@ -396,6 +409,17 @@ const toolTipText = computed(() => {
 - Project Dir: ${home.selectedContentRecord?.projectDir || "<undefined>"}
 - Entrypoint: ${entrypoint}
 - Server URL: ${home.serverCredential?.url || "<undefined>"}`;
+});
+
+const getActiveConfigTOMLErrorDetails = computed(() => {
+  if (
+    home.selectedConfiguration &&
+    isConfigurationError(home.selectedConfiguration) &&
+    isAgentErrorInvalidTOML(home.selectedConfiguration.error)
+  ) {
+    return `on line ${home.selectedConfiguration.error.data.line}`;
+  }
+  return "";
 });
 
 const onErrorMessageAnchorClick = (splitOptionId: number) => {

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -16,6 +16,10 @@ import { WebviewToHostMessageType } from "../../../../src/types/messages/webview
 import { RPackage } from "../../../../src/api/types/packages";
 import { DeploymentSelector } from "../../../../src/types/shared";
 import { splitFilesOnInclusion } from "src/utils/files";
+import {
+  isAgentErrorInvalidTOML,
+  isAgentErrorTypeUnknown,
+} from "../../../../src/api/types/error";
 
 export const useHomeStore = defineStore("home", () => {
   const platformFileSeparator = ref<string>("/");
@@ -357,10 +361,19 @@ export const useHomeStore = defineStore("home", () => {
         );
       }),
 
-      isError: computed((): boolean => {
+      isTOMLError: computed((): boolean => {
         return Boolean(
           selectedConfiguration.value &&
-            isConfigurationError(selectedConfiguration.value),
+            isConfigurationError(selectedConfiguration.value) &&
+            isAgentErrorInvalidTOML(selectedConfiguration.value.error),
+        );
+      }),
+
+      isUnknownError: computed((): boolean => {
+        return Boolean(
+          selectedConfiguration.value &&
+            isConfigurationError(selectedConfiguration.value) &&
+            isAgentErrorTypeUnknown(selectedConfiguration.value.error),
         );
       }),
 
@@ -385,7 +398,8 @@ export const useHomeStore = defineStore("home", () => {
         return (
           config.active.isEntryMissing.value ||
           config.active.isMissing.value ||
-          config.active.isError.value ||
+          config.active.isTOMLError.value ||
+          config.active.isUnknownError.value ||
           config.active.isCredentialMissing.value
         );
       }),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

With this PR, configuration files which are unable to be parsed by the agent due to a TOML parsing error, will now indicate that the file was unable to be parsed and what line the error has been detected.

Resolves #2330 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The ConfigurationError object contains an AgentError. I have redefined an AgentError to be either an `AgentErrorTypeUnknown` or a `AgentErrorInvalidTOML`, with type guards defined for both.

When the active configuration has a TOML parsing error, the `EvenEasierDeploy` component will now display a brief statement as seen below. It includes an anchor to edit the configuration and the cursor will be positioned at the line and character location reported within the TOML parsing error.

![2024-10-04 at 12 32 PM](https://github.com/user-attachments/assets/dcb29811-048d-423d-8d15-4238d57fb189)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

1. Confirm that if there is no error, the UX displays as expected prior to these changes.
2. Edit the active configuration, making the file invalid in some way, and save the file. Verify that the new error is displayed. Close the configuration file window and click on the `edit configuration` link. Verify that the correct configuration file is opened and that the cursor is positioned on the line indicated in the error message.
3. Correct the active configuration and include overlapping variable definitions for secrets and environment variables. Confirm that the proper warning message is displayed. Close the configuration file and then click the `edit configuration` link and confirm that the correct file is opened, with the cursor located at the top of the file.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
