### PR TITLE
Set R and Python Config defaults

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -680,11 +680,14 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return;
     }
 
-    const relPathPackageFile =
-      activeConfiguration.configuration.python?.packageFile;
-    if (relPathPackageFile === undefined) {
+    // Project is not configured for Python so cannot scan
+    // Scan button is not visible when this is the case
+    if (!activeConfiguration.configuration.python) {
       return;
     }
+
+    const relPathPackageFile =
+      activeConfiguration.configuration.python.packageFile;
 
     const fileUri = Uri.joinPath(
       this.root.uri,
@@ -747,11 +750,13 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return;
     }
 
-    const relPathPackageFile =
-      activeConfiguration?.configuration.r?.packageFile;
-    if (relPathPackageFile === undefined) {
+    // Project is not configured for R so cannot scan
+    // Scan button is not visible when this is the case
+    if (!activeConfiguration.configuration.r) {
       return;
     }
+
+    const relPathPackageFile = activeConfiguration.configuration.r.packageFile;
 
     const fileUri = Uri.joinPath(
       this.root.uri,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ func FromFile(path util.AbsolutePath) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	cfg.FillDefaults()
 	cfg.Comments, err = readLeadingComments(path)
 	if err != nil {
 		return nil, err
@@ -106,6 +107,28 @@ func (cfg *Config) WriteFile(path util.AbsolutePath) error {
 	}
 	defer f.Close()
 	return cfg.Write(f)
+}
+
+func (cfg *Config) FillDefaults() error {
+	if cfg.R != nil {
+		if cfg.R.PackageFile == "" {
+			cfg.R.PackageFile = "renv.lock"
+		}
+		if cfg.R.PackageManager == "" {
+			cfg.R.PackageManager = "renv"
+		}
+	}
+
+	if cfg.Python != nil {
+		if cfg.Python.PackageFile == "" {
+			cfg.Python.PackageFile = "requirements.txt"
+		}
+		if cfg.Python.PackageManager == "" {
+			cfg.Python.PackageManager = "pip"
+		}
+	}
+
+	return nil
 }
 
 func (cfg *Config) AddSecret(secret string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,7 +109,7 @@ func (cfg *Config) WriteFile(path util.AbsolutePath) error {
 	return cfg.Write(f)
 }
 
-func (cfg *Config) FillDefaults() error {
+func (cfg *Config) FillDefaults() {
 	if cfg.R != nil {
 		if cfg.R.PackageFile == "" {
 			cfg.R.PackageFile = "renv.lock"
@@ -127,8 +127,6 @@ func (cfg *Config) FillDefaults() error {
 			cfg.Python.PackageManager = "pip"
 		}
 	}
-
-	return nil
 }
 
 func (cfg *Config) AddSecret(secret string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,6 +85,42 @@ func (s *ConfigSuite) TestFromExampleFile() {
 	s.Equal(true, *valuePtr)
 }
 
+func (s *ConfigSuite) TestFromFileFillsDefaultsForPython() {
+	configFile := GetConfigPath(s.cwd, "defaults")
+	cfg := New()
+	cfg.Type = "python-streamlit"
+	cfg.Entrypoint = "app.py"
+	cfg.Python = &Python{
+		Version: "3.4.5",
+	}
+	err := cfg.WriteFile(configFile)
+	s.NoError(err)
+
+	cfgFromFile, err := FromFile(configFile)
+	s.NoError(err)
+	s.NotNil(cfgFromFile)
+	s.Equal(cfgFromFile.Python.PackageFile, "requirements.txt")
+	s.Equal(cfgFromFile.Python.PackageManager, "pip")
+}
+
+func (s *ConfigSuite) TestFromFileFillsDefaultsForR() {
+	configFile := GetConfigPath(s.cwd, "defaults")
+	cfg := New()
+	cfg.Type = "r-shiny"
+	cfg.Entrypoint = "app.R"
+	cfg.R = &R{
+		Version: "4.4.1",
+	}
+	err := cfg.WriteFile(configFile)
+	s.NoError(err)
+
+	cfgFromFile, err := FromFile(configFile)
+	s.NoError(err)
+	s.NotNil(cfgFromFile)
+	s.Equal(cfgFromFile.R.PackageFile, "renv.lock")
+	s.Equal(cfgFromFile.R.PackageManager, "renv")
+}
+
 func (s *ConfigSuite) TestFromFileErr() {
 	cfg, err := FromFile(s.cwd.Join("nonexistent.toml"))
 	s.ErrorIs(err, fs.ErrNotExist)
@@ -155,6 +191,49 @@ func (s *ConfigSuite) TestReadComments() {
 	s.NoError(err)
 
 	s.Equal([]string{" These are comments.", " They will be preserved."}, cfg.Comments)
+}
+
+func (s *ConfigSuite) TestFillDefaultsDoesNotAddROrPythonSection() {
+	cfg := New()
+	cfg.FillDefaults()
+	s.Nil(cfg.R)
+	s.Nil(cfg.Python)
+}
+
+func (s *ConfigSuite) TestFillDefaultsAddsPackageFileAndPackageManager() {
+	cfg := New()
+	cfg.R = &R{Version: "4.4.1"}
+	cfg.Python = &Python{Version: "3.12.7"}
+	cfg.FillDefaults()
+
+	s.NotNil(cfg.R)
+	s.NotNil(cfg.Python)
+
+	s.Equal(cfg.R.Version, "4.4.1")
+	s.Equal(cfg.R.PackageFile, "renv.lock")
+	s.Equal(cfg.R.PackageManager, "renv")
+
+	s.Equal(cfg.Python.Version, "3.12.7")
+	s.Equal(cfg.Python.PackageFile, "requirements.txt")
+	s.Equal(cfg.Python.PackageManager, "pip")
+}
+
+func (s *ConfigSuite) TestFillDefaultsDoesNotOverwrite() {
+	cfg := New()
+	cfg.R = &R{Version: "4.4.1", PackageFile: "custom.lock", PackageManager: "custom"}
+	cfg.Python = &Python{Version: "3.12.7", PackageFile: "custom.txt", PackageManager: "custom"}
+	cfg.FillDefaults()
+
+	s.NotNil(cfg.R)
+	s.NotNil(cfg.Python)
+
+	s.Equal(cfg.R.Version, "4.4.1")
+	s.Equal(cfg.R.PackageFile, "custom.lock")
+	s.Equal(cfg.R.PackageManager, "custom")
+
+	s.Equal(cfg.Python.Version, "3.12.7")
+	s.Equal(cfg.Python.PackageFile, "custom.txt")
+	s.Equal(cfg.Python.PackageManager, "custom")
 }
 
 func (s *ConfigSuite) TestApplySecretActionAdd() {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -117,14 +117,14 @@ type Environment = map[string]string
 
 type Python struct {
 	Version        string `toml:"version" json:"version"`
-	PackageFile    string `toml:"package_file" json:"packageFile"`
-	PackageManager string `toml:"package_manager" json:"packageManager"`
+	PackageFile    string `toml:"package_file,omitempty" json:"packageFile"`
+	PackageManager string `toml:"package_manager,omitempty" json:"packageManager"`
 }
 
 type R struct {
 	Version        string `toml:"version" json:"version"`
-	PackageFile    string `toml:"package_file" json:"packageFile"`
-	PackageManager string `toml:"package_manager" json:"packageManager"`
+	PackageFile    string `toml:"package_file,omitempty" json:"packageFile"`
+	PackageManager string `toml:"package_manager,omitempty" json:"packageManager"`
 }
 
 type Quarto struct {

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -145,6 +145,7 @@ func (s *InitializeSuite) TestInitIfNeededWhenNotNeeded() {
 		PackageManager: "pip",
 	}
 	cfg.WriteFile(configPath)
+	cfg.FillDefaults()
 
 	PythonInspectorFactory = func(util.AbsolutePath, util.Path, logging.Logger) inspect.PythonInspector {
 		return &inspect.MockPythonInspector{}

--- a/internal/services/api/get_configuration_test.go
+++ b/internal/services/api/get_configuration_test.go
@@ -52,7 +52,9 @@ func (s *GetConfigurationuite) makeConfiguration(name string) *config.Config {
 	}
 	err := cfg.WriteFile(path)
 	s.NoError(err)
-	return cfg
+	r, err := config.FromFile(path)
+	s.NoError(err)
+	return r
 }
 
 func (s *GetConfigurationuite) TestGetConfiguration() {

--- a/internal/services/api/get_configurations_test.go
+++ b/internal/services/api/get_configurations_test.go
@@ -51,7 +51,9 @@ func (s *GetConfigurationsSuite) makeConfiguration(name string) *config.Config {
 	}
 	err := cfg.WriteFile(path)
 	s.NoError(err)
-	return cfg
+	r, err := config.FromFile(path)
+	s.NoError(err)
+	return r
 }
 
 func (s *GetConfigurationsSuite) TestGetConfigurations() {
@@ -214,7 +216,9 @@ func (s *GetConfigurationsSuite) makeSubdirConfiguration(name string, subdir str
 	}
 	err = cfg.WriteFile(path)
 	s.NoError(err)
-	return cfg
+	r, err := config.FromFile(path)
+	s.NoError(err)
+	return r
 }
 
 func (s *GetConfigurationsSuite) TestGetConfigurationsRecursive() {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -277,7 +277,9 @@ func (s *StateSuite) makeConfiguration(name string) *config.Config {
 	}
 	err := cfg.WriteFile(path)
 	s.NoError(err)
-	return cfg
+	r, err := config.FromFile(path)
+	s.NoError(err)
+	return r
 }
 
 func (s *StateSuite) makeConfigurationWithSecrets(name string, secrets []string) *config.Config {
@@ -424,6 +426,7 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	s.Equal("savedConfigName", state.ConfigName)
 	s.Equal("myTargetName", state.TargetName)
 	s.Equal(&acct2, state.Account)
+
 	s.Equal(cfg, state.Config)
 	s.Equal(d, state.Target)
 }


### PR DESCRIPTION
This PR sets the the defaults for the `R` and `Python` structs for the Config after we fetch the details from the file.

Our schema defaults `package_manager` and `package_file` for both sections, but when doing a `GET /api/configurations/$name` we would get back empty strings for those values with a configuration file that looked like:

```
...
[r]
version = '4.3.1'

[python]
version = '3.8.5'
```

This PR avoids us from defaulting in the frontend and moving the onus to the backend to tell us how it interprets the Configuration

## Intent

Resolves #2328

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The error from #2328 was caused by:

https://github.com/posit-dev/publisher/blob/67706f071bff37b69e5e94bbb6ab4e521d25b31b/extensions/vscode/src/views/homeView.ts#L685

Assuming that if `package_file` was unset it was `undefined` when in fact it is `""` causing it to continue in the flow and hit an overwrite prompt for the wrong file URI, then opening the wrong file URI. 

The backend handles this well since it is using the default value of `renv.lock` but the frontend isn't being communicated that is the case via the Configuration.

The idea here was to correct that by inserting the defaults.

We investigated if there was a way to default in the struct tags, but there is not.
