### PR TITLE
R Version Detection: Loop over lines rather than just first line of 'R --version' output

### DIFF
--- a/internal/inspect/r.go
+++ b/internal/inspect/r.go
@@ -176,15 +176,19 @@ func (i *defaultRInspector) getRVersion(rExecutable string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	line := strings.SplitN(string(append(output, stderr...)), "\n", 2)[0]
-	m := rVersionRE.FindStringSubmatch(line)
-	if len(m) < 2 {
-		return "", fmt.Errorf("couldn't parse R version from output: %s", line)
+	lines := strings.SplitN(string(append(output, stderr...)), "\n", -1)
+	for _, l := range lines {
+		i.log.Info("Parsing line for R version", "l", l)
+		m := rVersionRE.FindStringSubmatch(l)
+		if len(m) < 2 {
+			continue
+		}
+		version := m[1]
+		i.log.Info("Detected R version", "version", version)
+		rVersionCache[rExecutable] = version
+		return version, nil
 	}
-	version := m[1]
-	i.log.Info("Detected R version", "version", version)
-	rVersionCache[rExecutable] = version
-	return version, nil
+	return "", fmt.Errorf("couldn't parse R version from command output (%s --version)", rExecutable)
 }
 
 var renvLockRE = regexp.MustCompile(`^\[1\] "(.*)"`)


### PR DESCRIPTION
…irst line.

<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Handle the case where the user has defined `R_HOME` in their environment. 

NOTE: The objective here is to determine the version of R based on the one that executes off of the path, NOT the one which may be at the `R_HOME` location.

Resolves #2343 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The existing code was only running regEx match against the first line in the output.

Fix simply loops over every line of the output and uses the first match.

Each line is logged as examined, which continues what was happening before (and helped us diagnose this so quickly).

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Unit tests updated.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

**Confirm the fix for the bug**
- You'll need to define the `R_HOME` environment variable in your base user profile (I inserted into my `~.zshenv` file.
- start a new terminal and examine the output of `R --version` to confirm that the output includes the warning that R_HOME is defined.
- Make sure no instances are running of VSCode before you start one up.
- Open an R project - I used shinyapp. 
- Delete the `renv.lock` file if you have one.
- Use the publisher's functionality to scan for R dependencies.
- Confirm the version in the `renv.lock` file is the same version as expected.
- Examine the publisher logs in the extension's output log. Search for `Parsing line for R version` to determine if the code encountered the test case where the first line examined included a warning, and if the correct version was extracted from one of the following lines. 

** Confirm regression **
- Remove the environment variable from your environment. 
- Shutdown all instances of VSCode
- Create a new terminal instance and confirm `R_HOME` is no longer present within the environment variables (`env | grep R_HOME`)
- Start up an instance of VSCode
- Repeat the steps to re-open the R project used previously, delete `renv.lock` file, and use the extension to scan for R dependencies.
- Confirm that `renv.lock` is created with the expected version of R
- Confirm within the Publisher's log (output window), that the command output did NOT include the warning previously seen when the environment variable was active.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
