### PR TITLE
Add more specificity to git ignore files pattern documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,9 @@ Description for this content. It may span multiple lines and be up to 4000 chara
 
 #### files
 
-Project-relative paths of the files to be included in the deployment. Wildcards are accepted, using [`.gitignore` syntax](https://git-scm.com/docs/gitignore).
+Project-relative paths of the files to be included in the deployment.
+Uses [`.gitignore` syntax](https://git-scm.com/docs/gitignore) for file include
+patterns, like wildcards.
 
 #### has_parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,23 @@ Project-relative paths of the files to be included in the deployment.
 Uses [`.gitignore` syntax](https://git-scm.com/docs/gitignore) for file include
 patterns, like wildcards.
 
+Here are some examples given an example project structure:
+
+```
+project-root/
+|
+├── dir/
+│   ├── util.py
+│   └─  helper.py
+│
+└── app.py
+```
+
+- To include all Python files in your project, you can use a wildcard pattern.
+  `*.py` would include all `.py` files in any directory.
+- `/dir/util.py` would include the specific `util.py` file in the `dir`
+  directory under the root of the project to be published.
+
 #### has_parameters
 
 `true` if this is a report that accepts parameters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,8 @@ project-root/
   `*.py` would include all `.py` files in any directory.
 - `/dir/util.py` would include the specific `util.py` file in the `dir`
   directory under the root of the project to be published.
+- To include the file `app.py` at the root of the project, you can use
+  `/app.py`.
 
 #### has_parameters
 


### PR DESCRIPTION
Improved documentation for the `files` attribute in our Configuration files, being a little bit more specific about it using the gitignore syntax.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->