### PR TITLE
Be silent on renv.lock file errors until trying to deploy

### DIFF
--- a/extensions/vscode/src/eventErrors.test.ts
+++ b/extensions/vscode/src/eventErrors.test.ts
@@ -6,6 +6,7 @@ import {
   EventStreamMessageErrorCoded,
   isCodedEventErrorMessage,
   isEvtErrDeploymentFailed,
+  isEvtErrRenvLockPackagesReadingFailed,
   handleEventCodedError,
 } from "./eventErrors";
 import { ErrorCode } from "./utils/errorTypes";
@@ -53,6 +54,18 @@ describe("Event errors", () => {
     expect(result).toBe(true);
   });
 
+  test("isEvtErrRenvLockPackagesReadingFailed", () => {
+    // Message with another error code
+    let streamMsg = mkEventStreamMsg({}, "unknown");
+    let result = isEvtErrRenvLockPackagesReadingFailed(streamMsg);
+    expect(result).toBe(false);
+
+    // Message with error code
+    streamMsg = mkEventStreamMsg({}, "renvlockPackagesReadingError");
+    result = isEvtErrRenvLockPackagesReadingFailed(streamMsg);
+    expect(result).toBe(true);
+  });
+
   test("handleEventCodedError", () => {
     const msgData = {
       dashboardUrl: "https://here.it.is/content/abcdefg",
@@ -68,5 +81,10 @@ describe("Event errors", () => {
     expect(resultMsg).toBe(
       "Deployment failed - structured message from the agent",
     );
+
+    msgData.message = "Could not scan R packages from renv lockfile";
+    streamMsg = mkEventStreamMsg(msgData, "renvlockPackagesReadingError");
+    resultMsg = handleEventCodedError(streamMsg);
+    expect(resultMsg).toBe("Could not scan R packages from renv lockfile");
   });
 });

--- a/extensions/vscode/src/eventErrors.ts
+++ b/extensions/vscode/src/eventErrors.ts
@@ -14,23 +14,37 @@ export function isCodedEventErrorMessage(
   return msg.errCode !== undefined;
 }
 
-type deploymentEvtErr = {
+type baseEvtErr = {
   dashboardUrl: string;
   localId: string;
   message: string;
   error: string;
 };
 
+type lockfileReadingEvtErr = baseEvtErr & {
+  lockfile: string;
+};
+
 export const isEvtErrDeploymentFailed = (
   emsg: EventStreamMessageErrorCoded,
-): emsg is EventStreamMessageErrorCoded<deploymentEvtErr> => {
+): emsg is EventStreamMessageErrorCoded<baseEvtErr> => {
   return emsg.errCode === "deployFailed";
+};
+
+export const isEvtErrRenvLockPackagesReadingFailed = (
+  emsg: EventStreamMessageErrorCoded,
+): emsg is EventStreamMessageErrorCoded<lockfileReadingEvtErr> => {
+  return emsg.errCode === "renvlockPackagesReadingError";
 };
 
 export const handleEventCodedError = (
   emsg: EventStreamMessageErrorCoded,
 ): string => {
   if (isEvtErrDeploymentFailed(emsg)) {
+    return emsg.data.message;
+  }
+
+  if (isEvtErrRenvLockPackagesReadingFailed(emsg)) {
     return emsg.data.message;
   }
 

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -9,7 +9,8 @@ export type ErrorCode =
   | "unknownTOMLKey"
   | "invalidConfigFile"
   | "errorCertificateVerification"
-  | "deployFailed";
+  | "deployFailed"
+  | "renvlockPackagesReadingError";
 
 export type axiosErrorWithJson<T = { code: ErrorCode; details: unknown }> =
   AxiosError & {

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -133,16 +133,23 @@ func normalizeConfig(
 	// The inspector may populate the file list.
 	// If it doesn't, default to just the entrypoint file.
 	if len(cfg.Files) == 0 {
+		log.Debug("Inspector did not populate files list, defaulting to single file entrypoint", "entrypoint", cfg.Entrypoint)
 		cfg.Files = []string{fmt.Sprint("/", cfg.Entrypoint)}
+	} else {
+		log.Debug("Inspector populate files list", "total_files", len(cfg.Files))
 	}
+
 	needPython, err := requiresPython(cfg, base)
 	if err != nil {
+		log.Debug("Error while determining Python as a requirement", "error", err.Error())
 		return err
 	}
 	if needPython {
+		log.Debug("Determined that Python is required")
 		inspector := PythonInspectorFactory(base, python, log)
 		pyConfig, err := inspector.InspectPython()
 		if err != nil {
+			log.Debug("Error while inspecting to generate a Python based configuration", "error", err.Error())
 			return err
 		}
 		cfg.Python = pyConfig
@@ -150,12 +157,14 @@ func normalizeConfig(
 	}
 	needR, err := requiresR(cfg, base, rExecutable)
 	if err != nil {
+		log.Debug("Error while determining R as a requirement", "error", err.Error())
 		return err
 	}
 	if needR {
 		inspector := RInspectorFactory(base, rExecutable, log)
 		rConfig, err := inspector.InspectR()
 		if err != nil {
+			log.Debug("Error while inspecting to generate an R based configuration", "error", err.Error())
 			return err
 		}
 		cfg.R = rConfig

--- a/internal/inspect/r.go
+++ b/internal/inspect/r.go
@@ -57,6 +57,7 @@ func (i *defaultRInspector) InspectR() (*config.R, error) {
 	lockfilePath := i.base.Join(DefaultRenvLockfile)
 	exists, err := lockfilePath.Exists()
 	if err != nil {
+		i.log.Debug("Error while looking up renv lock file", "renv_lock", lockfilePath)
 		return nil, err
 	}
 
@@ -65,15 +66,21 @@ func (i *defaultRInspector) InspectR() (*config.R, error) {
 
 	if !exists {
 		// Maybe R can give us the lockfile path (e.g. from an renv profile)
+		i.log.Debug("Attempting to get renv lock file via R executable")
 		rExecutable, getRExecutableErr = i.getRExecutable()
 		if getRExecutableErr == nil {
 			lockfilePath, err = i.getRenvLockfile(rExecutable)
 			if err != nil {
+				i.log.Debug("Error attempting to get renv lockfile path via R executable", "r_executable", rExecutable, "error", err.Error())
 				return nil, err
 			}
 			exists, err = lockfilePath.Exists()
 			if err != nil {
+				i.log.Debug("Error asserting renv lockfile exists", "renv_lock", lockfilePath, "error", err.Error())
 				return nil, err
+			}
+			if exists {
+				i.log.Debug("renv lockfile found via R executable", "r_executable", rExecutable, "renv_lock", lockfilePath)
 			}
 		} // else stay with the default lockfile path
 	}
@@ -84,20 +91,29 @@ func (i *defaultRInspector) InspectR() (*config.R, error) {
 		// Get R version from the lockfile
 		rVersion, err = i.getRVersionFromLockfile(lockfilePath)
 		if err != nil {
-			return nil, err
+			i.log.Debug("Error getting R version from existing renv lockfile. Attempting to get R version from executable", "renv_lock", lockfilePath, "error", err.Error())
+			rExecutable, getRExecutableErr = i.getRExecutable()
 		}
-	} else {
+	}
+
+	// renv.lock exists but could not be read
+	// thus, R version is still empty
+	renvFallback := exists && rVersion == ""
+	if !exists || renvFallback {
 		// Now R is required, err if it couldn't be found.
 		if getRExecutableErr != nil {
+			i.log.Debug("R is required and could not be found", "error", getRExecutableErr)
 			return nil, getRExecutableErr
 		}
 		rVersion, err = i.getRVersion(rExecutable)
 		if err != nil {
+			i.log.Debug("Error while looking up for R version from executable", "r_executable", rExecutable, "error", err.Error())
 			return nil, err
 		}
 	}
 	lockfileRelPath, err := lockfilePath.Rel(i.base)
 	if err != nil {
+		i.log.Debug("Error getting relative path for renv lockfile", "basepath", i.base.String(), "error", err.Error())
 		return nil, err
 	}
 	return &config.R{

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -3,14 +3,21 @@
 package publish
 
 import (
+	"fmt"
+
 	"github.com/posit-dev/publisher/internal/bundles"
 	"github.com/posit-dev/publisher/internal/events"
 	"github.com/posit-dev/publisher/internal/inspect"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 )
 
 type getRPackageDescriptionsStartData struct{}
 type getRPackageDescriptionsSuccessData struct{}
+
+type lockfileErrDetails struct {
+	Lockfile string
+}
 
 func (p *defaultPublisher) getRPackages() (bundles.PackageMap, error) {
 	op := events.PublishGetRPackageDescriptionsOp
@@ -28,7 +35,9 @@ func (p *defaultPublisher) getRPackages() (bundles.PackageMap, error) {
 	log.Debug("Collecting manifest R packages", "lockfile", lockfilePath)
 	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
 	if err != nil {
-		return nil, err
+		agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: lockfilePath.String()})
+		agentErr.Message = fmt.Sprintf("Could not scan R packages from renv lockfile: %s", lockfilePath.String())
+		return nil, agentErr
 	}
 	log.Info("Done collecting R package descriptions")
 	p.emitter.Emit(events.New(op, events.SuccessPhase, events.NoError, getRPackageDescriptionsSuccessData{}))

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -36,7 +36,7 @@ func (p *defaultPublisher) getRPackages() (bundles.PackageMap, error) {
 	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
 	if err != nil {
 		agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: lockfilePath.String()})
-		agentErr.Message = fmt.Sprintf("Could not scan R packages from renv lockfile: %s", lockfilePath.String())
+		agentErr.Message = fmt.Sprintf("Could not scan R packages from lockfile: %s", lockfileString)
 		return nil, agentErr
 	}
 	log.Info("Done collecting R package descriptions")

--- a/internal/publish/r_package_descriptions_test.go
+++ b/internal/publish/r_package_descriptions_test.go
@@ -131,7 +131,7 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesError() {
 	publisher := s.makePublisher()
 	_, err := publisher.getRPackages()
 	s.NotNil(err)
-	s.Contains(err.(*types.AgentError).Message, "Could not scan R packages from renv lockfile:")
+	s.Contains(err.(*types.AgentError).Message, "Could not scan R packages from lockfile:")
 	s.Contains(err.(*types.AgentError).Message, "custom.lock")
 	s.log.AssertExpectations(s.T())
 }

--- a/internal/publish/r_package_descriptions_test.go
+++ b/internal/publish/r_package_descriptions_test.go
@@ -1,0 +1,137 @@
+package publish
+
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/bundles"
+	"github.com/posit-dev/publisher/internal/config"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/logging/loggingtest"
+	"github.com/posit-dev/publisher/internal/state"
+	"github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/util/dcf"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type RPackageDescSuite struct {
+	utiltest.Suite
+	log               *loggingtest.MockLogger
+	stateStore        *state.State
+	emitter           events.Emitter
+	packageMapper     *mockPackageMapper
+	successPackageMap bundles.PackageMap
+	dirPath           util.AbsolutePath
+}
+
+func TestRPackageDescSuite(t *testing.T) {
+	suite.Run(t, new(RPackageDescSuite))
+}
+
+func (s *RPackageDescSuite) makePublisher() *defaultPublisher {
+	return &defaultPublisher{
+		State:          s.stateStore,
+		log:            s.log,
+		emitter:        s.emitter,
+		rPackageMapper: s.packageMapper,
+	}
+}
+
+func (s *RPackageDescSuite) SetupTest() {
+	s.stateStore = state.Empty()
+	s.emitter = events.NewCapturingEmitter()
+	s.packageMapper = &mockPackageMapper{}
+	s.log = loggingtest.NewMockLogger()
+
+	s.log.On("WithArgs", logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp).Return(s.log)
+	s.log.On("Info", "Collecting R package descriptions").Return()
+	s.log.On("Debug", "Collecting manifest R packages", "lockfile", mock.Anything).Return()
+
+	s.dirPath = util.NewAbsolutePath("bundles-rpackages-test-path", afero.NewMemMapFs())
+	s.stateStore.Dir = s.dirPath
+
+	s.successPackageMap = bundles.PackageMap{
+		"R6": bundles.Package{
+			Source:      "r6-source",
+			Repository:  "r6-repo",
+			Description: dcf.Record{},
+		},
+		"bslib": bundles.Package{
+			Source:      "bslib-source",
+			Repository:  "bslib-repo",
+			Description: dcf.Record{},
+		},
+	}
+}
+
+func (s *RPackageDescSuite) TestGetRPackages() {
+	// Log only called on success
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+
+	expectedLockfilePath := s.dirPath.Join("renv.lock")
+
+	// With EMPTY package file
+	s.stateStore.Config = &config.Config{
+		R: &config.R{
+			PackageFile: "",
+		},
+	}
+
+	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(s.successPackageMap, nil)
+
+	publisher := s.makePublisher()
+	packageMap, err := publisher.getRPackages()
+	s.NoError(err)
+	s.Equal(packageMap, s.successPackageMap)
+	s.log.AssertExpectations(s.T())
+}
+
+func (s *RPackageDescSuite) TestGetRPackages_PackageFilePresent() {
+	// Log only called on success
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+
+	expectedLockfilePath := s.dirPath.Join("custom.lock")
+
+	// With a package file
+	s.stateStore.Config = &config.Config{
+		R: &config.R{
+			PackageFile: "custom.lock",
+		},
+	}
+
+	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(s.successPackageMap, nil)
+
+	publisher := s.makePublisher()
+	packageMap, err := publisher.getRPackages()
+	s.NoError(err)
+	s.Equal(packageMap, s.successPackageMap)
+	s.log.AssertExpectations(s.T())
+}
+
+func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesError() {
+	expectedLockfilePath := s.dirPath.Join("custom.lock")
+	expectedPkgsErr := errors.New("chair is required to reach the top shelf")
+
+	// With a package file
+	s.stateStore.Config = &config.Config{
+		R: &config.R{
+			PackageFile: "custom.lock",
+		},
+	}
+
+	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(bundles.PackageMap{}, expectedPkgsErr)
+
+	publisher := s.makePublisher()
+	_, err := publisher.getRPackages()
+	s.NotNil(err)
+	s.Contains(err.(*types.AgentError).Message, "Could not scan R packages from renv lockfile:")
+	s.Contains(err.(*types.AgentError).Message, "custom.lock")
+	s.log.AssertExpectations(s.T())
+}

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -17,6 +17,7 @@ const (
 	ErrorInvalidConfigFiles           ErrorCode = "invalidConfigFiles"
 	ErrorCredentialServiceUnavailable ErrorCode = "credentialsServiceUnavailable"
 	ErrorCertificateVerification      ErrorCode = "errorCertificateVerification"
+	ErrorRenvLockPackagesReading      ErrorCode = "renvlockPackagesReadingError"
 	ErrorUnknown                      ErrorCode = "unknown"
 )
 


### PR DESCRIPTION
## Intent

This PR aims to stop showing or blocking the user on `renv.lock` file errors. Only showing the error when proceeding to deploy.

Fixes #2327 

**Screenshot of the new friendlier message**
<img width="2556" alt="Screen Shot 2024-10-07 at 14 08 37" src="https://github.com/user-attachments/assets/b351100a-8256-44a6-8836-ce1b639ede55">

## Type of Change

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Having a more structured and identifiable error to handle better the messaging when R packages cannot be scanned from the existing `renv.lock` file. Now logging out the errors as needed but not blocking the user until the `renv.lock` file scanning is absolutely required.

## Automated Tests

Updated and added unit tests as needed.

## Directions for Reviewers

Having an empty `renv.lock`, you shouldn't see an `renv.lock` related error message until trying to deploy.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
