### PR TITLE
Consolidate CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 *   @dotNomad @kgartland-rstudio @sagerb @marcosnav
-/internal/ @tdstein


### PR DESCRIPTION
This just removed @tdstein from the CODEOWNERS.

This fixes the issue where changes in `/internal` were only auto-requesting reviews from Taylor.