### PR TITLE
use 1.93.0 in vscode tests

### DIFF
--- a/test/vscode-ui/wdio.conf.ts
+++ b/test/vscode-ui/wdio.conf.ts
@@ -76,7 +76,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: "vscode",
-      browserVersion: "stable", // also possible: "insiders" or a specific version e.g. "1.80.0"
+      browserVersion: "1.93.0", // also possible: "insiders" or a specific version e.g. "1.80.0"
       "wdio:vscodeOptions": {
         // points to directory where extension package.json is located
         extensionPath:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
Pin vscode to 1.93.0 for tests for now. It seems webdriver.io has broken with the 1.94.1 release today.  This will be needed to unblock CI.

I'll keep reaching out to webdriver to see what we can do.

