### PR TITLE
Change edit secret value icon from edit pencil

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -75,7 +75,7 @@ const actions = computed<ActionButton[]>(() => {
   const result = [
     {
       label: "Edit Value",
-      codicon: "codicon-pencil",
+      codicon: "codicon-symbol-string",
       fn: inputSecret,
     },
   ];


### PR DESCRIPTION
This changes the "Edit Value" codicon from `codicon-edit` to `codicon-symbol-string` to improve clarity that the action will add or edit a value, not edit the name of the secret.

https://github.com/user-attachments/assets/568ee04f-c557-43de-9a30-4ff11137ef32


