### PR TITLE
Change Locked Content Error to be compatible with publisher event stream

### DIFF
--- a/internal/clients/connect/capabilities.go
+++ b/internal/clients/connect/capabilities.go
@@ -44,7 +44,13 @@ func checkRequirementsFile(base util.AbsolutePath, requirementsFilename string) 
 	return nil
 }
 
-func (c *ConnectClient) CheckCapabilities(base util.AbsolutePath, cfg *config.Config, log logging.Logger) error {
+func (c *ConnectClient) CheckCapabilities(base util.AbsolutePath, cfg *config.Config, contentID *types.ContentID, log logging.Logger) error {
+	if contentID != nil && *contentID != "" {
+		err := c.ValidateDeploymentTarget(*contentID, log)
+		if err != nil {
+			return err
+		}
+	}
 	if cfg.Python != nil {
 		err := checkRequirementsFile(base, cfg.Python.PackageFile)
 		if err != nil {

--- a/internal/clients/connect/client.go
+++ b/internal/clients/connect/client.go
@@ -30,5 +30,5 @@ type APIClient interface {
 	DeployBundle(types.ContentID, types.BundleID, logging.Logger) (types.TaskID, error)
 	WaitForTask(taskID types.TaskID, log logging.Logger) error
 	ValidateDeployment(types.ContentID, logging.Logger) error
-	CheckCapabilities(util.AbsolutePath, *config.Config, logging.Logger) error
+	CheckCapabilities(util.AbsolutePath, *config.Config, *types.ContentID, logging.Logger) error
 }

--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -486,3 +486,46 @@ func (c *ConnectClient) ValidateDeployment(contentID types.ContentID, log loggin
 	}
 	return err
 }
+
+// Handle preflight agent error details
+func (c *ConnectClient) preflightAgentError(agenterr *types.AgentError, contentID types.ContentID) *types.AgentError {
+	agenterr.Code = events.DeploymentFailedCode
+
+	if _, isNotFound := http_client.IsHTTPAgentErrorStatusOf(agenterr, http.StatusNotFound); isNotFound {
+		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - Content cannot be found", contentID)
+	} else if _, isForbidden := http_client.IsHTTPAgentErrorStatusOf(agenterr, http.StatusForbidden); isForbidden {
+		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - You may need to request collaborator permissions or verify the credentials in use", contentID)
+	} else {
+		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - Unknown error: %s", contentID, agenterr.Error())
+	}
+	return agenterr
+}
+
+func (c *ConnectClient) ValidateDeploymentTarget(contentID types.ContentID, log logging.Logger) error {
+	log.Info("Verifying existing content", "content_id", contentID)
+
+	content := &ConnectContent{}
+	err := c.ContentDetails(contentID, content, log)
+
+	// Handle possible errors from pinging to the content item
+	if aerr, isAgentErr := types.IsAgentError(err); isAgentErr {
+		return c.preflightAgentError(aerr, contentID)
+	}
+	if err != nil {
+		msg := fmt.Sprintf("Deployment target cannot be reached. Halting deployment. (Content ID = %s)", contentID)
+		return types.NewAgentError(events.DeploymentFailedCode,
+			errors.New(msg),
+			nil)
+	}
+
+	// Verify content is not locked
+	lockedErr := content.LockedError()
+	if lockedErr != nil {
+		msg := fmt.Sprintf("Content is locked, cannot deploy to it (content ID = %s)", contentID)
+		return types.NewAgentError(events.DeploymentFailedCode,
+			errors.New(msg),
+			nil)
+	}
+
+	return nil
+}

--- a/internal/clients/connect/mock_client.go
+++ b/internal/clients/connect/mock_client.go
@@ -82,7 +82,12 @@ func (m *MockClient) ValidateDeployment(id types.ContentID, log logging.Logger) 
 	return args.Error(0)
 }
 
-func (m *MockClient) CheckCapabilities(base util.AbsolutePath, cfg *config.Config, log logging.Logger) error {
-	args := m.Called(base, cfg, log)
+func (m *MockClient) CheckCapabilities(base util.AbsolutePath, cfg *config.Config, contentID *types.ContentID, log logging.Logger) error {
+	args := m.Called(base, cfg, contentID, log)
+	return args.Error(0)
+}
+
+func (m *MockClient) ValidateDeploymentTarget(contentID types.ContentID, log logging.Logger) error {
+	args := m.Called(contentID, log)
 	return args.Error(0)
 }

--- a/internal/publish/preflight_checks.go
+++ b/internal/publish/preflight_checks.go
@@ -3,8 +3,6 @@ package publish
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import (
-	"errors"
-
 	"github.com/posit-dev/publisher/internal/clients/connect"
 	"github.com/posit-dev/publisher/internal/events"
 	"github.com/posit-dev/publisher/internal/logging"
@@ -13,8 +11,6 @@ import (
 
 type checkConfigurationStartData struct{}
 type checkConfigurationSuccessData struct{}
-
-var errTypeChanged = errors.New("configuration type cannot be changed once deployed; create a new destination to use a different type")
 
 func (p *defaultPublisher) preFlightChecks(client connect.APIClient) error {
 	op := events.PublishCheckCapabilitiesOp

--- a/internal/publish/preflight_checks.go
+++ b/internal/publish/preflight_checks.go
@@ -1,12 +1,11 @@
 package publish
 
-// Copyright (C) 2023 by Posit Software, PBC.
+// Copyright (C) 2024 by Posit Software, PBC.
 
 import (
 	"errors"
 
 	"github.com/posit-dev/publisher/internal/clients/connect"
-	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/events"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/types"
@@ -17,7 +16,7 @@ type checkConfigurationSuccessData struct{}
 
 var errTypeChanged = errors.New("configuration type cannot be changed once deployed; create a new destination to use a different type")
 
-func (p *defaultPublisher) checkConfiguration(client connect.APIClient) error {
+func (p *defaultPublisher) preFlightChecks(client connect.APIClient) error {
 	op := events.PublishCheckCapabilitiesOp
 	log := p.log.WithArgs(logging.LogKeyOp, op)
 
@@ -30,17 +29,12 @@ func (p *defaultPublisher) checkConfiguration(client connect.APIClient) error {
 	}
 	log.Info("Publishing with credentials", "username", user.Username, "email", user.Email)
 
+	var existingContentID *types.ContentID
 	if p.Target != nil {
-		log.Debug("Target found while checking configuration")
-		previousType := p.Target.Type
-		currentType := p.Config.Type
-
-		if previousType != "" && previousType != config.ContentTypeUnknown && currentType != previousType {
-			log.Debug("Content type mismatch between previous and new target", "previous_type", previousType, "current_type", currentType)
-			return types.OperationError(op, errTypeChanged)
-		}
+		existingContentID = &p.Target.ID
 	}
-	err = client.CheckCapabilities(p.Dir, p.Config, log)
+
+	err = client.CheckCapabilities(p.Dir, p.Config, existingContentID, log)
 	if err != nil {
 		return types.OperationError(op, err)
 	}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -4,9 +4,7 @@ package publish
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +12,6 @@ import (
 	"github.com/posit-dev/publisher/internal/accounts"
 	"github.com/posit-dev/publisher/internal/bundles"
 	"github.com/posit-dev/publisher/internal/clients/connect"
-	"github.com/posit-dev/publisher/internal/clients/http_client"
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/deployment"
 	"github.com/posit-dev/publisher/internal/events"
@@ -198,54 +195,21 @@ func (s *PublishSuite) TestPublishWithClientRedeployErrors() {
 	target := deployment.New()
 	target.ID = "myContentID"
 
+	// Fail the preflight existing content checks. Further testing of these will
+	// occur in the connect_client package
+
 	// Forbidden
 	checksErr := types.NewAgentError(
 		events.DeploymentFailedCode,
-		http_client.NewHTTPError("", "", http.StatusForbidden),
+		errors.New("failed"),
 		nil,
 	)
-	s.publishWithClient(target, &publishErrsMock{checksErr: checksErr}, checksErr)
+	s.publishWithClient(target, &publishErrsMock{capErr: checksErr}, checksErr)
 	s.Equal(
 		checksErr.Message,
-		"Cannot deploy content: ID myContentID - You may need to request collaborator permissions or verify the credentials in use",
+		"failed",
 	)
 
-	// Not Found
-	checksErr = types.NewAgentError(
-		events.DeploymentFailedCode,
-		http_client.NewHTTPError("", "", http.StatusNotFound),
-		nil,
-	)
-	s.publishWithClient(target, &publishErrsMock{checksErr: checksErr}, checksErr)
-	s.Equal(
-		checksErr.Message,
-		"Cannot deploy content: ID myContentID - Content cannot be found",
-	)
-
-	// Unknown err
-	checksErr = types.NewAgentError(
-		events.DeploymentFailedCode,
-		http_client.NewHTTPError("", "", http.StatusBadGateway),
-		nil,
-	)
-	s.publishWithClient(target, &publishErrsMock{checksErr: checksErr}, checksErr)
-	s.Equal(
-		checksErr.Message,
-		"Cannot deploy content: ID myContentID - Unknown error: unexpected response from the server (502)",
-	)
-
-	// Content is locked
-	target.ID = "myLockedContentID"
-	checksErr = types.NewAgentError(
-		events.DeploymentFailedCode,
-		fmt.Errorf("content with ID %s is locked", target.ID),
-		nil,
-	)
-	s.publishWithClient(target, &publishErrsMock{}, checksErr)
-	s.Equal(
-		checksErr.Message,
-		"content with ID myLockedContentID is locked",
-	)
 }
 
 func (s *PublishSuite) TestPublishWithClientRedeployFailUpdate() {
@@ -309,7 +273,7 @@ func (s *PublishSuite) publishWithClient(
 		client.On("CreateDeployment", mock.Anything, mock.Anything).Return(myContentID, errsMock.createErr)
 	}
 	client.On("TestAuthentication", mock.Anything).Return(&connect.User{}, errsMock.authErr)
-	client.On("CheckCapabilities", mock.Anything, mock.Anything, mock.Anything).Return(errsMock.capErr)
+	client.On("CheckCapabilities", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errsMock.capErr)
 	client.On("ContentDetails", myContentID, mock.Anything, mock.Anything).Return(errsMock.checksErr)
 	client.On("ContentDetails", myLockedContentID, mock.Anything, mock.Anything).Return(errsMock.checksErr)
 	client.On("UpdateDeployment", myContentID, mock.Anything, mock.Anything).Return(errsMock.createErr)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2375 - Locked Content Error during deployment not represented in Publisher log view

Also, as discussed, refactors this and a few other errors to be more consistent with other preflight errors.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The preflight checks for the content on the Connect server were not returning operation errors and were not interacting with the log used for the publisher log window (and associated event stream). This has been corrected.

To increase consistency, the preflight checks have been refactored with some renaming and movement. To summarize:
- rename publish.checkConfiguration to publish.preFlightChecks
- update connectClient.CheckCapabilities to have content target checks (ValidateDeploymentTarget) - which were moved from publish
- update unit tests

After these changes, the publisher log shows an error at the "check capabilities" stage as well as showing the error at the end of the stage summary log messages.
![2024-10-09 at 10 04 PM](https://github.com/user-attachments/assets/3f45a989-da96-4692-8da8-a783ec18cb73)

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Agent unit tests have been updated as part of the refactoring. 

## Directions for Reviewers

I've tried to add useful comments to the file diffs. I understand that refactorings often make the worst diffs to follow... if you have any questions, please reach out.

<!-- Provide steps for reviewers to validate this change manually. -->
Validate that an attempt to deploy to a locked piece of content fails in the expected error and is included in the publisher log. 
Also validate a new deployment works as expected (it will bypass the existing content prechecks).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
