### PR TITLE
Messaging details for deployed content that runs with error

### DIFF
--- a/extensions/vscode/src/api/types/error.test.ts
+++ b/extensions/vscode/src/api/types/error.test.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+import { describe, expect, test } from "vitest";
+import {
+  isAgentErrorTypeUnknown,
+  isAgentErrorInvalidTOML,
+  isAgentErrorDeployedContentNotRunning,
+} from "./error";
+
+describe("Agent Errors", () => {
+  test("isAgentErrorTypeUnknown", () => {
+    let result = isAgentErrorTypeUnknown({
+      code: "unknown",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(true);
+
+    result = isAgentErrorTypeUnknown({
+      code: "resourceNotFound",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(true);
+
+    result = isAgentErrorTypeUnknown({
+      code: "unknownTOMLKey",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(false);
+
+    result = isAgentErrorTypeUnknown({
+      code: "invalidTOML",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(false);
+
+    result = isAgentErrorTypeUnknown({
+      code: "deployedContentNotRunning",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(false);
+  });
+
+  test("isAgentErrorInvalidTOML", () => {
+    let result = isAgentErrorInvalidTOML({
+      code: "unknown",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(false);
+
+    result = isAgentErrorInvalidTOML({
+      code: "unknownTOMLKey",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(true);
+
+    result = isAgentErrorInvalidTOML({
+      code: "invalidTOML",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(true);
+  });
+
+  test("isAgentErrorDeployedContentNotRunning", () => {
+    let result = isAgentErrorDeployedContentNotRunning({
+      code: "unknown",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(false);
+
+    result = isAgentErrorDeployedContentNotRunning({
+      code: "deployedContentNotRunning",
+      msg: "",
+      operation: "",
+      data: {},
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -1,12 +1,17 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
+import { ErrorCode } from "../../utils/errorTypes";
+
 type AgentErrorBase = {
-  code: string;
+  code: ErrorCode;
   msg: string;
   operation: string;
 };
 
-export type AgentError = AgentErrorTypeUnknown | AgentErrorInvalidTOML;
+export type AgentError =
+  | AgentErrorTypeUnknown
+  | AgentErrorInvalidTOML
+  | AgentErrorContentNotRunning;
 
 export type AgentErrorTypeUnknown = AgentErrorBase & {
   data: {
@@ -19,7 +24,9 @@ export type AgentErrorTypeUnknown = AgentErrorBase & {
 export const isAgentErrorTypeUnknown = (
   e: AgentError,
 ): e is AgentErrorTypeUnknown => {
-  return !isAgentErrorInvalidTOML(e);
+  return (
+    !isAgentErrorInvalidTOML(e) && !isAgentErrorDeployedContentNotRunning(e)
+  );
 };
 
 export type AgentErrorInvalidTOML = AgentErrorBase & {
@@ -35,4 +42,12 @@ export const isAgentErrorInvalidTOML = (
   e: AgentError,
 ): e is AgentErrorInvalidTOML => {
   return e.code === "invalidTOML" || e.code === "unknownTOMLKey";
+};
+
+export type AgentErrorContentNotRunning = AgentErrorBase;
+
+export const isAgentErrorDeployedContentNotRunning = (
+  e: AgentError,
+): e is AgentErrorContentNotRunning => {
+  return e.code === "deployedContentNotRunning";
 };

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -174,7 +174,7 @@
           v-if="home.selectedContentRecord.deploymentError"
           class="last-deployment-details last-deployment-error"
         >
-          <span class="codicon codicon-error error-icon"></span>
+          <span class="codicon codicon-alert"></span>
           <TextStringWithAnchor
             :message="home.selectedContentRecord?.deploymentError?.msg"
             :splitOptions="ErrorMessageSplitOptions"
@@ -191,7 +191,7 @@
             @click="viewContent"
             class="w-full"
           >
-            View Content
+            {{ deployedContentButtonLabel }}
           </vscode-button>
         </div>
       </div>
@@ -235,6 +235,7 @@ import TextStringWithAnchor from "./TextStringWithAnchor.vue";
 import {
   AgentError,
   isAgentErrorInvalidTOML,
+  isAgentErrorDeployedContentNotRunning,
 } from "../../../../src/api/types/error";
 
 const home = useHomeStore();
@@ -438,6 +439,20 @@ const getActiveConfigTOMLErrorDetails = computed(() => {
   return "";
 });
 
+const isDeployedContentOnError = computed((): boolean => {
+  const deploymentError = home.selectedContentRecord?.deploymentError;
+  return Boolean(
+    deploymentError && isAgentErrorDeployedContentNotRunning(deploymentError),
+  );
+});
+
+const deployedContentButtonLabel = computed((): string => {
+  if (isDeployedContentOnError.value) {
+    return "View Deployment Logs";
+  }
+  return "View Content";
+});
+
 const onEditConfigurationWithTOMLError = () => {
   const agentError = getActiveConfigError.value;
   if (agentError && isAgentErrorInvalidTOML(agentError)) {
@@ -492,8 +507,14 @@ const onAssociateDeployment = () => {
 };
 
 const viewContent = () => {
-  if (home.selectedContentRecord?.dashboardUrl) {
-    navigateToUrl(home.selectedContentRecord.dashboardUrl);
+  const record = home.selectedContentRecord;
+  if (!record) {
+    return;
+  }
+  if (isDeployedContentOnError.value && !isPreContentRecord(record)) {
+    navigateToUrl(record.logsUrl);
+  } else if (record.dashboardUrl) {
+    navigateToUrl(record.dashboardUrl);
   }
 };
 </script>

--- a/internal/clients/connect/capabilities.go
+++ b/internal/clients/connect/capabilities.go
@@ -25,7 +25,7 @@ type allSettings struct {
 	quarto      server_settings.QuartoInfo
 }
 
-const requirementsFileMissing = `Missing dependency file %s. This file must be included in the deployment.`
+const requirementsFileMissing = `missing dependency file %s. This file must be included in the deployment`
 
 type requirementsErrDetails struct {
 	RequirementsFile string `json:"requirements_file"`
@@ -51,9 +51,8 @@ func checkRequirementsFile(base util.AbsolutePath, cfg *config.Config) error {
 	}
 
 	if !exists || !requirementsIsIncluded {
-		missingErr := fmt.Errorf("missing dependency file %s", cfg.Python.PackageFile)
+		missingErr := fmt.Errorf(requirementsFileMissing, cfg.Python.PackageFile)
 		aerr := types.NewAgentError(types.ErrorRequirementsFileReading, missingErr, requirementsErrDetails{RequirementsFile: packageFile.String()})
-		aerr.Message = fmt.Sprintf(requirementsFileMissing, cfg.Python.PackageFile)
 		return aerr
 	}
 	return nil

--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -492,9 +492,9 @@ func (c *ConnectClient) preflightAgentError(agenterr *types.AgentError, contentI
 	agenterr.Code = events.DeploymentFailedCode
 
 	if _, isNotFound := http_client.IsHTTPAgentErrorStatusOf(agenterr, http.StatusNotFound); isNotFound {
-		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - Content cannot be found", contentID)
+		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - Content cannot be found.", contentID)
 	} else if _, isForbidden := http_client.IsHTTPAgentErrorStatusOf(agenterr, http.StatusForbidden); isForbidden {
-		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - You may need to request collaborator permissions or verify the credentials in use", contentID)
+		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - You may need to request collaborator permissions or verify the credentials in use.", contentID)
 	} else {
 		agenterr.Message = fmt.Sprintf("Cannot deploy content: ID %s - Unknown error: %s", contentID, agenterr.Error())
 	}

--- a/internal/clients/connect/client_connect_test.go
+++ b/internal/clients/connect/client_connect_test.go
@@ -668,7 +668,7 @@ func (s *ConnectClientSuite) TestValidateDeploymentTargetNotFoundFailure() {
 	}
 	expectedErr := types.NewAgentError(
 		events.DeploymentFailedCode,
-		errors.New("Cannot deploy content: ID e8922765-4880-43cd-abc0-d59fe59b8b4b - Content cannot be found"),
+		errors.New("cannot deploy content: ID e8922765-4880-43cd-abc0-d59fe59b8b4b - Content cannot be found"),
 		nil)
 	err := client.ValidateDeploymentTarget("e8922765-4880-43cd-abc0-d59fe59b8b4b", s.cfg, lgr)
 	aerr, ok := types.IsAgentError(err)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -207,7 +207,7 @@ func (s *PublishSuite) TestPublishWithClientRedeployErrors() {
 	s.publishWithClient(target, &publishErrsMock{capErr: checksErr}, checksErr)
 	s.Equal(
 		checksErr.Message,
-		"failed",
+		"Failed.",
 	)
 
 }
@@ -418,7 +418,7 @@ func (s *PublishSuite) TestEmitErrorEventsNoTarget() {
 	s.Len(emitter.Events, 2)
 	for _, event := range emitter.Events {
 		s.True(strings.HasSuffix(event.Type, "/failure"))
-		s.Equal(expectedErr.Error(), event.Data["message"])
+		s.Equal("Test error.", event.Data["message"])
 	}
 	s.Equal("publish/failure", emitter.Events[1].Type)
 }
@@ -454,7 +454,7 @@ func (s *PublishSuite) TestEmitErrorEventsWithTarget() {
 	s.Len(emitter.Events, 2)
 	for _, event := range emitter.Events {
 		s.True(strings.HasSuffix(event.Type, "/failure"))
-		s.Equal(expectedErr.Error(), event.Data["message"])
+		s.Equal("Test error.", event.Data["message"])
 		s.Equal(util.GetDashboardURL("connect.example.com", targetID), event.Data["dashboardUrl"])
 		s.Equal(util.GetDirectURL("connect.example.com", targetID), event.Data["url"])
 		s.Equal(util.GetLogsURL("connect.example.com", targetID), event.Data["logsUrl"])

--- a/internal/services/api/get_deployment_test.go
+++ b/internal/services/api/get_deployment_test.go
@@ -138,7 +138,7 @@ func (s *GetDeploymentSuite) TestGetPreDeployment() {
 	dec.DisallowUnknownFields()
 	s.NoError(dec.Decode(&res))
 	s.NotNil(res.Error)
-	s.Equal("test error", res.Error.Message)
+	s.Equal("Test error.", res.Error.Message)
 	s.Equal(deploymentStateNew, res.State)
 	s.Equal("myTargetName", res.Name)
 	s.Equal(".", res.ProjectDir)

--- a/internal/services/api/post_test_credentials_test.go
+++ b/internal/services/api/post_test_credentials_test.go
@@ -124,5 +124,5 @@ func (s *PostTestCredentialsHandlerSuite) TestPostTestCredentialsHandlerFuncBadA
 	s.NoError(err)
 	s.Nil(response.User)
 	s.NotNil(response.Error)
-	s.Equal("test error from TestAuthentication", response.Error.Message)
+	s.Equal("Test error from TestAuthentication.", response.Error.Message)
 }

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -3,6 +3,9 @@ package types
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -39,6 +42,19 @@ type AgentError struct {
 	Data    ErrorData `json:"data" toml:"data,omitempty"`
 }
 
+// Normalize punctuation on messages derived from errors
+func normalizeAgentErrorMsg(errMsg string) string {
+	spChars := []string{"?", "!", ")", "."}
+	msg := strings.ToUpper(errMsg[:1]) + errMsg[1:]
+
+	msgLastChar := msg[len(msg)-1:]
+	if slices.Contains(spChars, msgLastChar) {
+		return msg
+	}
+
+	return msg + "."
+}
+
 func AsAgentError(e error) *AgentError {
 	if e == nil {
 		return nil
@@ -55,7 +71,7 @@ func NewAgentError(code ErrorCode, err error, details any) *AgentError {
 	msg := ""
 
 	if err != nil {
-		msg = err.Error()
+		msg = normalizeAgentErrorMsg(err.Error())
 	}
 	if details != nil {
 		detailMap := make(ErrorData)

--- a/internal/types/error_test.go
+++ b/internal/types/error_test.go
@@ -61,7 +61,7 @@ func (s *ErrorSuite) TestNewAgentError() {
 	originalError := errors.New("shattered glass!")
 	aerr := NewAgentError(ErrorInvalidTOML, originalError, nil)
 	s.Equal(aerr, &AgentError{
-		Message: "shattered glass!",
+		Message: "Shattered glass!",
 		Code:    ErrorInvalidTOML,
 		Err:     originalError,
 		Data:    make(ErrorData),
@@ -78,8 +78,50 @@ func (s *ErrorSuite) TestIsAgentError() {
 	aerr, isIt = IsAgentError(aTrueAgentError)
 	s.Equal(isIt, true)
 	s.Equal(aerr, &AgentError{
-		Message: "shattered glass!",
+		Message: "Shattered glass!",
 		Code:    ErrorInvalidTOML,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+}
+
+func (s *ErrorSuite) TestNewAgentError_MessagePunctuation() {
+	// Sentence case and period ending
+	originalError := errors.New("oh sorry, my mistake")
+	aerr := NewAgentError(ErrorResourceNotFound, originalError, nil)
+	s.Equal(aerr, &AgentError{
+		Message: "Oh sorry, my mistake.",
+		Code:    ErrorResourceNotFound,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+
+	// No need for period ending when shouting "!"
+	originalError = errors.New("i can't believe is October already!")
+	aerr = NewAgentError(ErrorResourceNotFound, originalError, nil)
+	s.Equal(aerr, &AgentError{
+		Message: "I can't believe is October already!",
+		Code:    ErrorResourceNotFound,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+
+	// No need for period ending when asking "?"
+	originalError = errors.New("can you believe 2024 is almos over?")
+	aerr = NewAgentError(ErrorResourceNotFound, originalError, nil)
+	s.Equal(aerr, &AgentError{
+		Message: "Can you believe 2024 is almos over?",
+		Code:    ErrorResourceNotFound,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+
+	// No need for period ending when ending parentheses ")"
+	originalError = errors.New("wrong credentials (is this one of those bad typing days?)")
+	aerr = NewAgentError(ErrorResourceNotFound, originalError, nil)
+	s.Equal(aerr, &AgentError{
+		Message: "Wrong credentials (is this one of those bad typing days?)",
+		Code:    ErrorResourceNotFound,
 		Err:     originalError,
 		Data:    make(ErrorData),
 	})


### PR DESCRIPTION
## Intent

This PR applies some presentational details for content that for some reason fails to start, this is only for content that has runtime.

- Showing a warning sign now, instead of an "x" icon that mistakenly suggested to be clickable
- The button reads as "View Content Logs" and directs to Connect content logs page.

<img width="2539" alt="Screen Shot 2024-10-11 at 14 34 30" src="https://github.com/user-attachments/assets/41392f96-8502-4fe4-8c94-d84e64b0ac56">

Fixes #2206 

## Approach

Just some presentational changes and checks for errored deployments.

## Automated Tests

Added some unit tests around the Agent Errors type guards

## Directions for Reviewers

- [ ] Deploy an R or Python content item that has some code with errors in it - forcing it to fail at runtime. The message should be better now.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
