### PR TITLE
Add credential server URL discovery

### DIFF
--- a/extensions/vscode/src/api/types/credentials.ts
+++ b/extensions/vscode/src/api/types/credentials.ts
@@ -19,5 +19,6 @@ export type CredentialUser = {
 
 export type TestResult = {
   user: CredentialUser | null;
+  url: string | null;
   error: AgentError | null;
 };

--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -8,7 +8,22 @@ type AgentErrorBase = {
   operation: string;
 };
 
+export const isAgentError = (e: any): e is AgentError => {
+  const keys = Object.keys(e);
+  if (keys.length) {
+    if (
+      keys.includes("code") &&
+      keys.includes("msg") &&
+      keys.includes("operation")
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export type AgentError =
+  | AgentErrorBase
   | AgentErrorTypeUnknown
   | AgentErrorInvalidTOML
   | AgentErrorContentNotRunning;
@@ -19,13 +34,25 @@ export type AgentErrorTypeUnknown = AgentErrorBase & {
   };
 };
 
+export const isAgentErrorBase = (e: any): e is AgentErrorBase => {
+  if (isAgentError(e)) {
+    const keys = Object.keys(e);
+    if (keys.length) {
+      if (keys.includes("data")) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
 // This represents the Agent Errors we haven't been able to
 // narrow down to a specific type.
-export const isAgentErrorTypeUnknown = (
-  e: AgentError,
-): e is AgentErrorTypeUnknown => {
+export const isAgentErrorTypeUnknown = (e: any): e is AgentErrorTypeUnknown => {
   return (
-    !isAgentErrorInvalidTOML(e) && !isAgentErrorDeployedContentNotRunning(e)
+    isAgentErrorBase(e) &&
+    !isAgentErrorInvalidTOML(e) &&
+    !isAgentErrorDeployedContentNotRunning(e)
   );
 };
 
@@ -38,16 +65,17 @@ export type AgentErrorInvalidTOML = AgentErrorBase & {
   };
 };
 
-export const isAgentErrorInvalidTOML = (
-  e: AgentError,
-): e is AgentErrorInvalidTOML => {
-  return e.code === "invalidTOML" || e.code === "unknownTOMLKey";
+export const isAgentErrorInvalidTOML = (e: any): e is AgentErrorInvalidTOML => {
+  return (
+    isAgentErrorBase(e) &&
+    (e.code === "invalidTOML" || e.code === "unknownTOMLKey")
+  );
 };
 
 export type AgentErrorContentNotRunning = AgentErrorBase;
 
 export const isAgentErrorDeployedContentNotRunning = (
-  e: AgentError,
+  e: any,
 ): e is AgentErrorContentNotRunning => {
-  return e.code === "deployedContentNotRunning";
+  return isAgentErrorBase(e) && e.code === "deployedContentNotRunning";
 };

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -112,11 +112,11 @@ export async function newCredential(
             severity: InputBoxValidationSeverity.Error,
           });
         }
-        const existingCredential = credentials.find(
-          (credential) =>
-            normalizeURL(input).toLowerCase() ===
-            normalizeURL(credential.url).toLowerCase(),
-        );
+        const existingCredential = credentials.find((credential) => {
+          const existing = normalizeURL(credential.url).toLowerCase();
+          const newURL = normalizeURL(input).toLowerCase();
+          return newURL.includes(existing);
+        });
         if (existingCredential) {
           return Promise.resolve({
             message: `Error: Invalid URL (this server URL is already assigned to your credential "${existingCredential.name}". Only one credential per unique URL is allowed).`,

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -174,6 +174,7 @@ export async function newCredential(
       typeof state.data.apiKey === "string" && state.data.apiKey.length
         ? state.data.apiKey
         : "";
+    let validatedURL = "";
 
     const apiKey = await input.showInputBox({
       title: state.title,
@@ -224,6 +225,11 @@ export async function newCredential(
               severity: InputBoxValidationSeverity.Error,
             });
           }
+          // we have success, but credentials.test may have returned a different
+          // url for us to use.
+          if (testResult.data.url) {
+            validatedURL = testResult.data.url;
+          }
         } catch (e) {
           return Promise.resolve({
             message: `Error: Invalid API Key (${getMessageFromError(e)})`,
@@ -237,6 +243,7 @@ export async function newCredential(
     });
 
     state.data.apiKey = apiKey;
+    state.data.url = validatedURL;
     state.lastStep = thisStepNumber;
     return (input: MultiStepInput) => inputCredentialName(input, state);
   }

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -84,8 +84,8 @@ export async function newCredential(
       step: thisStepNumber,
       totalSteps: state.totalSteps,
       value: currentURL,
-      prompt: "Enter the Public URL of the Posit Connect Server",
-      placeholder: "https://servername.com:3939",
+      prompt: "Please provide the Posit Connect server's URL",
+      placeholder: "Server URL",
       validate: (input: string) => {
         if (input.includes(" ")) {
           return Promise.resolve({

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -531,8 +531,8 @@ export async function newDeployment(
         step: 0,
         totalSteps: 0,
         value: currentURL,
-        prompt: "Enter the Public URL of the Posit Connect Server",
-        placeholder: "example: https://servername.com:3939",
+        prompt: "Please provide the Posit Connect server's URL",
+        placeholder: "Server URL",
         validate: (input: string) => {
           if (input.includes(" ")) {
             return Promise.resolve({

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -559,11 +559,11 @@ export async function newDeployment(
               severity: InputBoxValidationSeverity.Error,
             });
           }
-          const existingCredential = credentials.find(
-            (credential) =>
-              normalizeURL(input).toLowerCase() ===
-              normalizeURL(credential.url).toLowerCase(),
-          );
+          const existingCredential = credentials.find((credential) => {
+            const existing = normalizeURL(credential.url).toLowerCase();
+            const newURL = normalizeURL(input).toLowerCase();
+            return newURL.includes(existing);
+          });
           if (existingCredential) {
             return Promise.resolve({
               message: `Error: Invalid URL (this server URL is already assigned to your credential "${existingCredential.name}". Only one credential per unique URL is allowed).`,

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -613,6 +613,7 @@ export async function newDeployment(
       const currentAPIKey = newDeploymentData.newCredentials.apiKey
         ? newDeploymentData.newCredentials.apiKey
         : "";
+      let validatedURL = "";
 
       const apiKey = await input.showInputBox({
         title: state.title,
@@ -664,6 +665,11 @@ export async function newDeployment(
                 severity: InputBoxValidationSeverity.Error,
               });
             }
+            // we have success, but credentials.test may have returned a different
+            // url for us to use.
+            if (testResult.data.url) {
+              validatedURL = testResult.data.url;
+            }
           } catch (e) {
             return Promise.resolve({
               message: `Error: Invalid API Key (${getMessageFromError(e)})`,
@@ -677,6 +683,7 @@ export async function newDeployment(
       });
 
       newDeploymentData.newCredentials.apiKey = apiKey;
+      newDeploymentData.newCredentials.url = validatedURL;
       return (input: MultiStepInput) => inputCredentialName(input, state);
     }
     return inputCredentialName(input, state);

--- a/extensions/vscode/src/utils/errors.test.ts
+++ b/extensions/vscode/src/utils/errors.test.ts
@@ -49,11 +49,11 @@ describe("getSummaryStringFromError", () => {
     });
   });
 
-  describe("unknown or unregistered errors", () => {
-    test("returns a summary of available data", () => {
-      let summary = getSummaryStringFromError(
+  describe("Axios errors", () => {
+    test("Axios Error #1", () => {
+      const summary = getSummaryStringFromError(
         "callerMethodHere",
-        new AxiosError(undefined, undefined, undefined, undefined, {
+        new AxiosError("Bad Error", undefined, undefined, undefined, {
           status: 400,
           statusText: "Bad Request",
           headers: new AxiosHeaders(),
@@ -61,12 +61,10 @@ describe("getSummaryStringFromError", () => {
           data: undefined,
         }),
       );
-
-      expect(summary).toBe(
-        "An error has occurred at callerMethodHere, Status=400, StatusText=Bad Request",
-      );
-
-      summary = getSummaryStringFromError(
+      expect(summary).toBe("Bad Error");
+    });
+    test("Axios Error #2", () => {
+      const summary = getSummaryStringFromError(
         "callerMethodHere",
         new AxiosError(
           "Bricks are falling",
@@ -82,10 +80,38 @@ describe("getSummaryStringFromError", () => {
           },
         ),
       );
-
+      expect(summary).toBe("Bricks are falling");
+    });
+    test("Axios Error #3", () => {
+      const readOnlyError = new AxiosError(
+        "Request failed with status code 500",
+        "ERR_BAD_RESPONSE",
+        undefined,
+        undefined,
+        {
+          status: 500,
+          statusText: "Bad Request",
+          headers: new AxiosHeaders(),
+          config: { headers: new AxiosHeaders(), baseURL: "localhost:9874" },
+          data: "open /Users/billsager/dev/publishing-client/test/sample-content/shinyapp/.posit/publish/shinyapp-file-check-DUQ4.toml: operation not permitted",
+        },
+      );
+      const summary = getSummaryStringFromError(
+        "callerMethodHere",
+        readOnlyError,
+      );
       expect(summary).toBe(
-        "An error has occurred at callerMethodHere, Status=400, StatusText=Bad Request, Code=CODE_WHOOPS, Msg=Bricks are falling",
+        "open /Users/billsager/dev/publishing-client/test/sample-content/shinyapp/.posit/publish/shinyapp-file-check-DUQ4.toml: operation not permitted",
       );
     });
+  });
+});
+describe("Unknown errors", () => {
+  test("Non-error Object", () => {
+    const summary = getSummaryStringFromError("callerMethodHere", {
+      problem: "oops",
+      data: "stuff",
+    });
+    expect(summary).toBe("Unknown Error");
   });
 });

--- a/extensions/vscode/src/utils/errors.ts
+++ b/extensions/vscode/src/utils/errors.ts
@@ -34,14 +34,18 @@ export const getCodeStringFromError = (error: unknown): string | undefined => {
 };
 
 export const getMessageFromError = (error: unknown): string => {
-  if (axios.isAxiosError(error)) {
-    return error.response?.data || error.message;
-  }
-  if (isAgentError(error)) {
-    return error.msg;
-  }
-  if (error instanceof Error) {
-    return error.message;
+  try {
+    if (axios.isAxiosError(error)) {
+      return error.response?.data || error.message;
+    }
+    if (isAgentError(error)) {
+      return error.msg;
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+  } catch {
+    // errors suppressed
   }
   return String(error);
 };
@@ -57,8 +61,9 @@ export const getAPIURLFromError = (error: unknown) => {
   return undefined;
 };
 
-// When the error is a known JSON agent error it returns it's message.
-// Otherwise, a tracing message is returned to help diagnose.
+// This method builds a diagnostic message which is output to the
+// VSCode console (output/window) to help diagnose, but then returns the
+// base error string from the error.
 export const getSummaryStringFromError = (location: string, error: unknown) => {
   let msg = `An error has occurred at ${location}`;
 
@@ -97,7 +102,8 @@ export const getSummaryStringFromError = (location: string, error: unknown) => {
   } else {
     msg += `, Error=${error}`;
   }
-  return msg;
+  console.error(msg);
+  return getMessageFromError(error);
 };
 
 export const getSummaryFromError = (error: unknown) => {

--- a/extensions/vscode/src/utils/errors.ts
+++ b/extensions/vscode/src/utils/errors.ts
@@ -2,6 +2,7 @@
 
 import axios from "axios";
 import { isAxiosErrorWithJson, resolveAgentJsonErrorMsg } from "./errorTypes";
+import { isAgentError } from "src/api/types/error";
 
 export type ErrorMessage = string[];
 export type ErrorMessages = ErrorMessage[];
@@ -26,12 +27,18 @@ export const getCodeStringFromError = (error: unknown): string | undefined => {
   if (axios.isAxiosError(error)) {
     return error.code;
   }
+  if (isAgentError(error)) {
+    return error.code;
+  }
   return undefined;
 };
 
 export const getMessageFromError = (error: unknown): string => {
   if (axios.isAxiosError(error)) {
     return error.response?.data || error.message;
+  }
+  if (isAgentError(error)) {
+    return error.msg;
   }
   if (error instanceof Error) {
     return error.message;
@@ -57,6 +64,17 @@ export const getSummaryStringFromError = (location: string, error: unknown) => {
 
   if (isAxiosErrorWithJson(error)) {
     return resolveAgentJsonErrorMsg(error);
+  }
+
+  if (isAgentError(error)) {
+    msg = error.msg;
+    if (error.code) {
+      msg += `, Code=${error.code}`;
+    }
+    if (error.operation) {
+      msg += `, Operation=${error.operation}`;
+    }
+    return msg;
   }
 
   const summary = getSummaryFromError(error);

--- a/internal/services/api/post_test_credentials.go
+++ b/internal/services/api/post_test_credentials.go
@@ -47,11 +47,13 @@ func PostTestCredentialsHandlerFunc(log logging.Logger) http.HandlerFunc {
 			return
 		}
 
-		// walk the possible URL list backwards (it has the full path first)
 		var urlToBeTested string
 		var lastTestError error
 		var user *connect.User
 
+		// walk the possible URL list backwards
+		// This prioritizes the full URL with all path segments over
+		// the URL with all path segments removed.
 		for i := len(possibleURLs) - 1; i >= 0; i-- {
 			urlToBeTested = possibleURLs[i]
 

--- a/internal/util/urls.go
+++ b/internal/util/urls.go
@@ -4,6 +4,9 @@ package util
 
 import (
 	"fmt"
+	"net/url"
+	"path"
+	"strings"
 
 	"github.com/PuerkitoBio/purell"
 	"github.com/posit-dev/publisher/internal/types"
@@ -31,4 +34,37 @@ func GetDirectURL(accountURL string, contentID types.ContentID) string {
 
 func GetBundleURL(accountURL string, contentID types.ContentID, bundleID types.BundleID) string {
 	return fmt.Sprintf("%s/__api__/v1/content/%s/bundles/%s/download", accountURL, contentID, bundleID)
+}
+
+// Returns an array of URLs built from no path, to a path with a full path, one URL for each
+// path segment
+
+func GetListOfPossibleURLs(accountURL string) ([]string, error) {
+	urlStr, err := NormalizeServerURL(accountURL)
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	// clear out query and Fragment (we don't want them)
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	// break out path into segments
+	parts := strings.Split(u.Path, "/")
+
+	urls := []string{}
+	// start with no path
+	u.Path = ""
+
+	// now build a list
+	// even an URL without a path will include a ""
+	for _, p := range parts {
+		u.Path = path.Join(u.Path, p)
+		urls = append(urls, u.String())
+	}
+
+	return urls, nil
 }

--- a/internal/util/urls_test.go
+++ b/internal/util/urls_test.go
@@ -13,7 +13,7 @@ type UrlsSuite struct {
 }
 
 func TestUrlsSuite(t *testing.T) {
-	suite.Run(t, new(TOMLSuite))
+	suite.Run(t, new(UrlsSuite))
 }
 
 func (u *UrlsSuite) normalizedUrlEquals(expected string, url string) {
@@ -30,4 +30,57 @@ func (s *UrlsSuite) TestNormalizeServerURL() {
 	s.normalizedUrlEquals("https://connect.example.com", "https://CONNECT.example.com")
 	s.normalizedUrlEquals("https://connect.example.com/rsc", "https://connect.example.com:443/rsc")
 	s.normalizedUrlEquals("https://connect.example.com/rsc", "https://connect.example.com///rsc/")
+}
+
+func (u *UrlsSuite) TestGetListOfPossibleURLs() {
+
+	// invalid URL
+	_, err := GetListOfPossibleURLs(" http://example.org")
+	u.NotNil(err)
+
+	// no paths included, should have one
+	expected := "https://connect.dev.com"
+	l, err := GetListOfPossibleURLs(expected)
+	u.Nil(err)
+	u.Equal(len(l), 1)
+	u.Equal(l[0], expected)
+
+	// strip query off of URL
+	url := "https://connect.dev.com?a=b"
+	expected = "https://connect.dev.com"
+	l, err = GetListOfPossibleURLs(url)
+	u.Nil(err)
+	u.Equal(len(l), 1)
+	u.Equal(l[0], expected)
+
+	// list of paths
+	url = "https://connect.dev.com/a/b/c/d/e"
+	results := []string{
+		"https://connect.dev.com",
+		"https://connect.dev.com/a",
+		"https://connect.dev.com/a/b",
+		"https://connect.dev.com/a/b/c",
+		"https://connect.dev.com/a/b/c/d",
+		"https://connect.dev.com/a/b/c/d/e",
+	}
+	l, err = GetListOfPossibleURLs(url)
+	u.Nil(err)
+	u.Equal(len(l), 6)
+	u.Equal(l, results)
+
+	// list of paths with duplicate forward slashes
+	url = "https://connect.dev.com//a/b/c/d/e//////"
+	results = []string{
+		"https://connect.dev.com",
+		"https://connect.dev.com/a",
+		"https://connect.dev.com/a/b",
+		"https://connect.dev.com/a/b/c",
+		"https://connect.dev.com/a/b/c/d",
+		"https://connect.dev.com/a/b/c/d/e",
+	}
+	l, err = GetListOfPossibleURLs(url)
+	u.Nil(err)
+	u.Equal(len(l), 6)
+	u.Equal(l, results)
+
 }

--- a/test/vscode-ui/test/specs/error-no-config_creds.spec.ts
+++ b/test/vscode-ui/test/specs/error-no-config_creds.spec.ts
@@ -117,7 +117,7 @@ describe("Detect missing config and credentials", () => {
 
     const titleMessage = await browser.$("#quickInput_message");
     await expect(titleMessage).toHaveText(
-      "Enter the Public URL of the Posit Connect Server (Press 'Enter' to confirm or 'Escape' to cancel)",
+      "Please provide the Posit Connect server's URL (Press 'Enter' to confirm or 'Escape' to cancel)",
     );
 
     // set server url

--- a/test/vscode-ui/test/specs/nested-fastapi-configuration.spec.ts
+++ b/test/vscode-ui/test/specs/nested-fastapi-configuration.spec.ts
@@ -66,7 +66,7 @@ describe("Nested Fast API Configuration", () => {
   it("can select entrypoint", async () => {
     const titleMessage = browser.$("#quickInput_message");
     await expect(titleMessage).toHaveText(
-      "Please provide the Posit Connect server's URL (Press 'Enter' to confirm or 'Escape' to cancel)",
+      "Enter a title for your content or application. (Press 'Enter' to confirm or 'Escape' to cancel)",
     );
     // await input.waitForExist({ timeout: 30000 });
 

--- a/test/vscode-ui/test/specs/nested-fastapi-configuration.spec.ts
+++ b/test/vscode-ui/test/specs/nested-fastapi-configuration.spec.ts
@@ -66,7 +66,7 @@ describe("Nested Fast API Configuration", () => {
   it("can select entrypoint", async () => {
     const titleMessage = browser.$("#quickInput_message");
     await expect(titleMessage).toHaveText(
-      "Enter a title for your content or application. (Press 'Enter' to confirm or 'Escape' to cancel)",
+      "Please provide the Posit Connect server's URL (Press 'Enter' to confirm or 'Escape' to cancel)",
     );
     // await input.waitForExist({ timeout: 30000 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

When prompting for a server URL, discover the actual server API address needed by iteratively removing path segments and retesting API key authentication.

PR also includes word change for server URL prompts.

Resolves #2001
Resolves #2371 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Given the URL string for the server (provided by the publisher), attempt to validate the combination of server address and API key by removing path segments from the end of the server URL, until we either are able to make a successful API key validated request or we run out of possibilities.

A URL utility method was created to return the possibilities. It strips off any query params and URL fragments before producing an array of server URLs to try. 

The multi-steppers that create credentials (new credential and new deployment) have been updated to use the validated URL returned from the test credentials API, (instead of the URL provided by the user), when calling the credential creation API.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Unit tests have been added and updated to cover the functionality.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

There are two multi-steppers impacted by this change - creating a new deployment with a new credential as well as creating a new credential (from the credential view).

Validation needs to test the entry of a server URL with
- invalid or unreachable URL to a Connect server. 
- URL to another type of server, should error
- valid server URL, but the URL contains additional path segments and query params (copy/paste from the dashboard URL works nicely)
- valid server URL as previously required.

You can save yourself some time by going through the multi-steppers, entering the URL to be tested, then entering the API key, and if it moves to the naming credential step, you can then back up and you should see the updated/discovered value shown in the server URL step. This only occurs after the API key validation occurs (if you try backing up just after entering the URL at the API key entry, you will see the original entered URL).

Be sure to validate that you can deploy to the servers after creating credentials with the exact URL or one which needs to be automatically adjusted through the new discovery process.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
