### PR TITLE
Remove R Package Scan action

### DIFF
--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -46,12 +46,8 @@ project needs.
 
 For R projects, you need an `renv.lock` file that captures the R package dependencies
 for your project. You also need an active `renv` library with those packages installed
-so the extension can gather details about them.
-
-If you don't have an `renv.lock` file, you can open the R Packages view and click the
-`Scan` button to generate one using `renv::snapshot()`.
-
-![](https://cdn.posit.co/publisher/assets/img/r-packages-scan.png)
+so the extension can gather details about them. See the
+[renv documentation](https://rstudio.github.io/renv/articles/renv.html) for more details.
 
 ### Ready to Deploy
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -125,12 +125,6 @@
         "category": "Posit Publisher"
       },
       {
-        "command": "posit.publisher.rPackages.scan",
-        "title": "Scan for R Packages",
-        "icon": "$(eye)",
-        "category": "Posit Publisher"
-      },
-      {
         "command": "posit.publisher.homeView.refresh",
         "title": "Refresh Home View",
         "icon": "$(refresh)",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -60,7 +60,6 @@ const pythonPackagesCommands = {
 const rPackagesCommands = {
   Edit: "posit.publisher.rPackages.edit",
   Refresh: "posit.publisher.rPackages.refresh",
-  Scan: "posit.publisher.rPackages.scan",
 } as const;
 
 const homeViewCommands = {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1884,11 +1884,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         this.refreshRPackages,
         this,
       ),
-      commands.registerCommand(
-        Commands.RPackages.Scan,
-        this.onScanForRPackageRequirements,
-        this,
-      ),
     );
 
     this.context.subscriptions.push(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2403 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Removed ability to scan from HomeView. This eliminates the original error shown, which was exposed from invalid `renv` environment.

Consolidated some errors to show consistently, and then replaced scan button with anchor link to `renv` documentation.

Updated documentation.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
Verify:
- verify that the scan button is gone from the R Package view
- verify normal publish functionality with a `renv.lock` file in place (and active `renv` environment)
- verify R Package view shows welcome view with new anchor w/ reference to `renv` doc, when package file is not present (missing or empty). Name of package file should match what is in config. Anchor should open `renv` documentation.
- verify publishing fails w/ proper error when missing, empty or invalid package file

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
