### PR TITLE
Support Jupyter hide options in Connect manifest

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,24 @@ package_file = "renv.lock"
 package_manager = "renv"
 ```
 
+## Jupyter settings
+
+### hide_all_input
+
+Hide all input cells when rendering output.
+
+### hide_tagged_input
+
+Hide input code cells with the 'hide_input' tag when rendering output.
+
+Example:
+
+```toml
+[jupyter]
+hide_all_input = false
+hide_tagged_input = false
+```
+
 ## Quarto settings
 
 #### engines

--- a/internal/bundles/manifest.go
+++ b/internal/bundles/manifest.go
@@ -159,7 +159,6 @@ func NewManifestFromConfig(cfg *config.Config) *Manifest {
 			AppMode:    contentType,
 			Entrypoint: cfg.Entrypoint,
 		},
-		Jupyter:     nil,
 		Environment: nil,
 		Packages:    make(PackageMap),
 		Files:       make(ManifestFileMap),
@@ -174,6 +173,12 @@ func NewManifestFromConfig(cfg *config.Config) *Manifest {
 				Name:        cfg.Python.PackageManager,
 				PackageFile: cfg.Python.PackageFile,
 			},
+		}
+	}
+	if cfg.Jupyter != nil {
+		m.Jupyter = &Jupyter{
+			HideAllInput:    cfg.Jupyter.HideAllInput,
+			HideTaggedInput: cfg.Jupyter.HideTaggedInput,
 		}
 	}
 	if cfg.Quarto != nil {

--- a/internal/bundles/manifest_test.go
+++ b/internal/bundles/manifest_test.go
@@ -161,3 +161,43 @@ func (s *ManifestSuite) TestNewManifestFromConfig() {
 		Files:    map[string]ManifestFile{},
 	}, m)
 }
+
+func (s *ManifestSuite) TestNewManifestFromConfigWithJupyterOptions() {
+	cfg := &config.Config{
+		Schema:        schema.ConfigSchemaURL,
+		Type:          "jupyter-notebook",
+		Entrypoint:    "notebook.ipynb",
+		Title:         "Some Notebook",
+		HasParameters: true,
+		Python: &config.Python{
+			Version:        "3.4.5",
+			PackageFile:    "requirements.in",
+			PackageManager: "pip",
+		},
+		Jupyter: &config.Jupyter{
+			HideAllInput: true,
+		},
+	}
+	m := NewManifestFromConfig(cfg)
+	s.Equal(&Manifest{
+		Version: 1,
+		Metadata: Metadata{
+			AppMode:       "jupyter-static",
+			Entrypoint:    "notebook.ipynb",
+			HasParameters: true,
+		},
+		Python: &Python{
+			Version: "3.4.5",
+			PackageManager: PythonPackageManager{
+				Name:        "pip",
+				PackageFile: "requirements.in",
+			},
+		},
+		Jupyter: &Jupyter{
+			HideAllInput:    true,
+			HideTaggedInput: false,
+		},
+		Packages: map[string]Package{},
+		Files:    map[string]ManifestFile{},
+	}, m)
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -96,6 +96,7 @@ type Config struct {
 	Tags          []string    `toml:"tags,omitempty" json:"tags,omitempty"`
 	Python        *Python     `toml:"python,omitempty" json:"python,omitempty"`
 	R             *R          `toml:"r,omitempty" json:"r,omitempty"`
+	Jupyter       *Jupyter    `toml:"jupyter,omitempty" json:"jupyter,omitempty"`
 	Quarto        *Quarto     `toml:"quarto,omitempty" json:"quarto,omitempty"`
 	Environment   Environment `toml:"environment,omitempty" json:"environment,omitempty"`
 	Secrets       []string    `toml:"secrets,omitempty" json:"secrets,omitempty"`
@@ -125,6 +126,11 @@ type R struct {
 	Version        string `toml:"version" json:"version"`
 	PackageFile    string `toml:"package_file,omitempty" json:"packageFile"`
 	PackageManager string `toml:"package_manager,omitempty" json:"packageManager"`
+}
+
+type Jupyter struct {
+	HideAllInput    bool `toml:"hide_all_input,omitempty" json:"hideAllInput"`
+	HideTaggedInput bool `toml:"hide_tagged_input,omitempty" json:"hideTaggedInput"`
 }
 
 type Quarto struct {

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -133,6 +133,21 @@
         }
       }
     },
+    "jupyter": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Additional rendering options for Jupyter Notebooks.",
+      "properties": {
+        "hide_all_input": {
+          "type": "boolean",
+          "description": "Hide all input cells when rendering output."
+        },
+        "hide_tagged_input": {
+          "type": "boolean",
+          "description": "Hide input code cells with the 'hide_input' tag when rendering output."
+        }
+      }
+    },
     "quarto": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
This PR adds the two rendering options for Jupyter available in the Connect manifest:
- `hide_all_input` which hides all of the input cells on render
- `hide_tagged_input` hides the input cells marked `hide_input` 

See the documentation for `rsconnect-jupyter` for more information: https://docs.posit.co/rsconnect-jupyter/usage/#hide-input

**After merging we will need to update the schema on the CDN.**

## Intent

Resolves #2399

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

We already had the types for the Manifest, and were aware of these issues, but our Configuration didn't have a way to set / pass through those options.

Here I'm using the same technique for R, Python, and Quarto configuration settings to create the manifest.

## Automated Tests

Added automated tests around the new manifest creation code.

## Directions for Reviewers

Deploy a Jupyter Notebook:
- without using the new render options
- using `hide_all_input`
- using `hide_tagged_input`
