### PR TITLE
Add frontend types for environment API endpoint

### DIFF
--- a/extensions/vscode/src/api/resources/ContentRecords.ts
+++ b/extensions/vscode/src/api/resources/ContentRecords.ts
@@ -6,6 +6,7 @@ import {
   PreContentRecord,
   AllContentRecordTypes,
   ContentRecord,
+  Environment,
 } from "../types/contentRecords";
 
 export class ContentRecords {
@@ -123,6 +124,18 @@ export class ContentRecords {
         configurationName: data.configName,
         id: data.guid,
       },
+      {
+        params: {
+          dir,
+        },
+      },
+    );
+  }
+
+  getEnv(deploymentName: string, dir: string) {
+    const encodedName = encodeURIComponent(deploymentName);
+    return this.client.get<Environment>(
+      `deployments/${encodedName}/environment`,
       {
         params: {
           dir,

--- a/extensions/vscode/src/api/types/contentRecords.ts
+++ b/extensions/vscode/src/api/types/contentRecords.ts
@@ -76,6 +76,8 @@ export type AllContentRecordTypes =
   | PreContentRecordWithConfig
   | ContentRecordError;
 
+export type Environment = Array<string>;
+
 export function isSuccessful(
   d: AllContentRecordTypes | undefined,
 ): boolean | undefined {


### PR DESCRIPTION
Super simple PR that adds a type and a method for the new `GET /api/deployments/$NAME/environment` introduced in #2412.

## Intent

Part of #2365

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->