### PR TITLE
Improve Secrets view by reflecting server Environment Variable states

### DIFF
--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -28,6 +28,7 @@ export enum HostToWebviewMessageType {
   SHOW_DISABLE_OVERLAY = "showDisableOverlay",
   HIDE_DISABLE_OVERLAY = "hideDisableOverlay",
   SET_PATH_SEPARATOR = "setPathSeparator",
+  UPDATE_SERVER_ENVIRONMENT = "updateServerEnvironment",
 }
 
 export type AnyHostToWebviewMessage<
@@ -55,7 +56,8 @@ export type HostToWebviewMessage =
   | UpdateRPackages
   | ShowDisableOverlayMsg
   | HideDisableOverlayMsg
-  | SetPathSeparatorMsg;
+  | SetPathSeparatorMsg
+  | UpdateServerEnvironmentMsg;
 
 export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
   return (
@@ -73,7 +75,8 @@ export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
     msg.kind === HostToWebviewMessageType.UPDATE_R_PACKAGES ||
     msg.kind === HostToWebviewMessageType.SHOW_DISABLE_OVERLAY ||
     msg.kind === HostToWebviewMessageType.HIDE_DISABLE_OVERLAY ||
-    msg.kind === HostToWebviewMessageType.SET_PATH_SEPARATOR
+    msg.kind === HostToWebviewMessageType.SET_PATH_SEPARATOR ||
+    msg.kind === HostToWebviewMessageType.UPDATE_SERVER_ENVIRONMENT
   );
 }
 
@@ -160,5 +163,12 @@ export type SetPathSeparatorMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.SET_PATH_SEPARATOR,
   {
     separator: string;
+  }
+>;
+
+export type UpdateServerEnvironmentMsg = AnyHostToWebviewMessage<
+  HostToWebviewMessageType.UPDATE_SERVER_ENVIRONMENT,
+  {
+    environment: string[];
   }
 >;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1579,10 +1579,13 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           },
         });
       } catch (error: unknown) {
-        window.showErrorMessage(
-          `Failed to get deployment environment. ${getSummaryStringFromError("getContentRecordEnvironment", error)}`,
-        );
-        return;
+        // No matter the error we clear the environment
+        this.webviewConduit.sendMsg({
+          kind: HostToWebviewMessageType.UPDATE_SERVER_ENVIRONMENT,
+          content: {
+            environment: [],
+          },
+        });
       }
     }
   };

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -159,6 +159,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       "activeConfigChanged",
       (cfg: Configuration | ConfigurationError | undefined) => {
         this.sendRefreshedFilesLists();
+        this.getContentRecordEnvironment();
         this.refreshPythonPackages();
         this.refreshRPackages();
 
@@ -168,10 +169,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         }
         this.configWatchers = new ConfigWatcherManager(cfg);
 
-        this.configWatchers.configFile?.onDidChange(
-          this.debounceSendRefreshedFilesLists,
-          this,
-        );
+        this.configWatchers.configFile?.onDidChange(() => {
+          this.debounceSendRefreshedFilesLists();
+          this.getContentRecordEnvironment();
+        }, this);
 
         this.configWatchers.pythonPackageFile?.onDidCreate(
           this.debounceRefreshPythonPackages,

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -150,7 +150,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       );
 
       this.contentRecordWatchers.contentRecord?.onDidChange(
-        this.getContentRecordEnvironment,
+        this.updateServerEnvironment,
         this,
       );
     });
@@ -159,7 +159,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       "activeConfigChanged",
       (cfg: Configuration | ConfigurationError | undefined) => {
         this.sendRefreshedFilesLists();
-        this.getContentRecordEnvironment();
+        this.updateServerEnvironment();
         this.refreshPythonPackages();
         this.refreshRPackages();
 
@@ -171,7 +171,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
         this.configWatchers.configFile?.onDidChange(() => {
           this.debounceSendRefreshedFilesLists();
-          this.getContentRecordEnvironment();
+          this.updateServerEnvironment();
         }, this);
 
         this.configWatchers.pythonPackageFile?.onDidCreate(
@@ -1555,7 +1555,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
   };
 
-  public getContentRecordEnvironment = async () => {
+  public updateServerEnvironment = async () => {
     const deployment = await this.state.getSelectedContentRecord();
     if (deployment && !isContentRecordError(deployment)) {
       // We have a valid deployment to call

--- a/extensions/vscode/src/watchers.ts
+++ b/extensions/vscode/src/watchers.ts
@@ -8,7 +8,7 @@ import {
   Uri,
 } from "vscode";
 
-import { Configuration } from "src/api";
+import { Configuration, ContentRecordLocation } from "src/api";
 import {
   PUBLISH_DEPLOYMENTS_FOLDER,
   POSIT_FOLDER,
@@ -18,6 +18,7 @@ import {
   DEFAULT_PYTHON_PACKAGE_FILE,
   DEFAULT_R_PACKAGE_FILE,
 } from "src/constants";
+import { relativePath } from "./utils/files";
 
 /**
  * Manages persistent file system watchers for the extension.
@@ -79,6 +80,31 @@ export class WatcherManager implements Disposable {
     this.contentRecordsDir?.dispose();
     this.contentRecords?.dispose();
     this.allFiles?.dispose();
+  }
+}
+
+/**
+ *  Manages file watchers for a specific Content Record
+ */
+export class ContentRecordWatcherManager implements Disposable {
+  contentRecord: FileSystemWatcher | undefined;
+
+  constructor(location?: ContentRecordLocation) {
+    const root = workspace.workspaceFolders?.[0];
+    if (root === undefined || location === undefined) {
+      return;
+    }
+
+    const relPath = relativePath(Uri.file(location.deploymentPath));
+    if (relPath) {
+      this.contentRecord = workspace.createFileSystemWatcher(
+        new RelativePattern(root, relPath),
+      );
+    }
+  }
+
+  dispose() {
+    this.contentRecord?.dispose;
   }
 }
 

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -14,6 +14,7 @@ import {
   UpdateRPackages,
   RefreshFilesMsg,
   SetPathSeparatorMsg,
+  UpdateServerEnvironmentMsg,
 } from "../../../src/types/messages/hostToWebviewMessages";
 import {
   WebviewToHostMessage,
@@ -86,6 +87,8 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
       return onHideDisableOverlayMsg();
     case HostToWebviewMessageType.SET_PATH_SEPARATOR:
       return onSetPathSeparatorMsg(msg);
+    case HostToWebviewMessageType.UPDATE_SERVER_ENVIRONMENT:
+      return onUpdateServerEnvironmentMsg(msg);
     default:
       console.warn(`unexpected command: ${JSON.stringify(msg)}`);
   }
@@ -216,4 +219,9 @@ const onUpdateRPackages = (msg: UpdateRPackages) => {
     msg.content.manager,
     msg.content.rVersion,
   );
+};
+
+const onUpdateServerEnvironmentMsg = (msg: UpdateServerEnvironmentMsg) => {
+  const home = useHomeStore();
+  home.serverSecrets = new Set(msg.content.environment);
 };

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -71,11 +71,19 @@ const updateSecret = () => {
 };
 
 const tooltip = computed(() => {
-  if (secretValue.value) {
-    return "On the next deploy the new value will be set for the deployment.";
+  if (onServer.value) {
+    if (secretValue.value) {
+      return "On the next deploy the secret will be overwritten with the new value.";
+    } else {
+      return "The value is set on the server. Set a new value to overwrite it on the next deploy.";
+    }
+  } else {
+    if (secretValue.value) {
+      return "On the next deploy the secret will be set.";
+    } else {
+      return "The secret will not be created on the next deploy without a value. Set a value to set it.";
+    }
   }
-
-  return "No value has been set. The value will not change on the next deploy.";
 });
 
 const actions = computed<ActionButton[]>(() => {

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -2,8 +2,16 @@
   <TreeItem
     :title="name"
     :actions="actions"
-    codicon="codicon-lock-small"
-    :list-style="secretValue || isEditing ? 'default' : 'deemphasized'"
+    :codicon="
+      needsValue
+        ? 'codicon-warning'
+        : secretValue
+          ? 'codicon-cloud-upload'
+          : 'codicon-check'
+    "
+    :list-style="
+      needsValue || secretValue || isEditing ? 'default' : 'deemphasized'
+    "
     :tooltip="tooltip"
     align-icon-with-twisty
     :data-vscode-context="vscodeContext"
@@ -18,7 +26,7 @@
         @submit="updateSecret"
         @cancel="isEditing = false"
       />
-      <template v-else-if="secretValue">••••••</template>
+      <template v-else-if="!needsValue">••••••</template>
     </template>
   </TreeItem>
 </template>
@@ -44,6 +52,10 @@ const inputValue = ref<string>();
 const home = useHomeStore();
 
 const secretValue = computed(() => home.secrets.get(props.name));
+
+const needsValue = computed(
+  () => !secretValue.value && !home.serverSecrets.includes(props.name),
+);
 
 const inputSecret = () => {
   // Update inputValue in case the secret value has changed or been cleared

--- a/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/secrets/Secret.vue
@@ -53,9 +53,9 @@ const home = useHomeStore();
 
 const secretValue = computed(() => home.secrets.get(props.name));
 
-const needsValue = computed(
-  () => !secretValue.value && !home.serverSecrets.includes(props.name),
-);
+const onServer = computed(() => home.serverSecrets.has(props.name));
+
+const needsValue = computed(() => !secretValue.value && !onServer.value);
 
 const inputSecret = () => {
   // Update inputValue in case the secret value has changed or been cleared

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -33,6 +33,7 @@ export const useHomeStore = defineStore("home", () => {
     return credentials.value.sort((a, b) => a.name.localeCompare(b.name));
   });
 
+  const serverSecrets = ref(["ON_SERVER"]);
   const secrets = ref(new Map<string, string | undefined>());
 
   const environment = computed((): Map<string, string> => {
@@ -415,6 +416,7 @@ export const useHomeStore = defineStore("home", () => {
     configurationsInError,
     credentials,
     sortedCredentials,
+    serverSecrets,
     secrets,
     environment,
     duplicatedEnvironmentVariables,

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -33,7 +33,7 @@ export const useHomeStore = defineStore("home", () => {
     return credentials.value.sort((a, b) => a.name.localeCompare(b.name));
   });
 
-  const serverSecrets = ref(["ON_SERVER"]);
+  const serverSecrets = ref<Set<string>>(new Set());
   const secrets = ref(new Map<string, string | undefined>());
 
   const environment = computed((): Map<string, string> => {


### PR DESCRIPTION
This PR introduces a new feature for the Secrets view showing more detail based on the state of the content on Connect using [the Get environment variables API endpoint](https://docs.posit.co/connect/api/#get-/v1/content/-guid-/environment).

![image](https://github.com/user-attachments/assets/cf9d5dee-2257-4f89-8125-3683b84890ad)

Now the Secret will be de-emphasized if it already has a value is on the server, and emphasized when an action needs to be taken or is currently being taken (for example setting a value) by the user.

Additional the codicons are improved showing:
- a warning when the Configuration has a Secret declared that is not on the server yet
- showing a cloud upload icon when a value is ready to be sent up
- showing a check mark when the server already the Environment Variable set

The tooltips are also improved for the 4 different states the Secrets can have.

## Intent

Resolves #2365

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach is similar to our other features, this one being a bit more unique since it potentially calls the Connect API.

When the Configuration changes or the Deployment changes we make a request to the binaries API at `GET api/deployments/$NAME/environment` which handles whether it should error or if it has all of the details to call Connect.

If Connect is called we either silently error if the API errors (for example from a missing piece of Content from deletion or auth errors) or we send the web view the array of Environment Variable names.

From there the names are put into the webview Pinia store to compare with the secrets the user has locally set or unset.

One thing to note about the approach is that the `updateServerEnvironment` method in the `homeView` fails silently. The idea here is that the environment updating flow may not be the best place to surface more general errors like the content missing or auth errors. Instead the errors from our API or the Connect API are captured and the web view is told there are no Environment Variables.

Most cases where our binaries API can fail this doesn't impact anything. Those cases are:
- the content record file doesn't exist
- the content record file is in error
- the deployment has not been deployed
- the credential is missing

Once a failure happens on Connect that is more note-able, but it felt out of the scope of this ticket to surface those errors.

#### Why request the server environment on Configuration changes?

The content record could have a new secret added.

#### Why request the server environment on Content Record changes?

The content record changes when a deployment is made, so we update the server environment afterwords to ensure that what is displayed is correct.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->
