### PR TITLE
Stop hidding details for renv lockfile reading errors

### DIFF
--- a/extensions/vscode/src/eventErrors.test.ts
+++ b/extensions/vscode/src/eventErrors.test.ts
@@ -7,6 +7,8 @@ import {
   isCodedEventErrorMessage,
   isEvtErrDeploymentFailed,
   isEvtErrRenvLockPackagesReadingFailed,
+  isEvtErrRenvPackageVersionMismatch,
+  isEvtErrRenvPackageSourceMissing,
   isEvtErrRequirementsReadingFailed,
   isEvtErrDeployedContentNotRunning,
   handleEventCodedError,
@@ -92,6 +94,30 @@ describe("Event errors", () => {
     expect(result).toBe(true);
   });
 
+  test("isEvtErrRenvPackageVersionMismatch", () => {
+    // Message with another error code
+    let streamMsg = mkEventStreamMsg({}, "unknown");
+    let result = isEvtErrRenvPackageVersionMismatch(streamMsg);
+    expect(result).toBe(false);
+
+    // Message with error code
+    streamMsg = mkEventStreamMsg({}, "renvPackageVersionMismatch");
+    result = isEvtErrRenvPackageVersionMismatch(streamMsg);
+    expect(result).toBe(true);
+  });
+
+  test("isEvtErrRenvPackageSourceMissing", () => {
+    // Message with another error code
+    let streamMsg = mkEventStreamMsg({}, "unknown");
+    let result = isEvtErrRenvPackageSourceMissing(streamMsg);
+    expect(result).toBe(false);
+
+    // Message with error code
+    streamMsg = mkEventStreamMsg({}, "renvPackageSourceMissing");
+    result = isEvtErrRenvPackageSourceMissing(streamMsg);
+    expect(result).toBe(true);
+  });
+
   test("handleEventCodedError", () => {
     const msgData = {
       dashboardUrl: "https://here.it.is/content/abcdefg",
@@ -112,6 +138,16 @@ describe("Event errors", () => {
     streamMsg = mkEventStreamMsg(msgData, "renvlockPackagesReadingError");
     resultMsg = handleEventCodedError(streamMsg);
     expect(resultMsg).toBe("Could not scan R packages from renv lockfile");
+
+    msgData.message = "Package version is bad";
+    streamMsg = mkEventStreamMsg(msgData, "renvPackageVersionMismatch");
+    resultMsg = handleEventCodedError(streamMsg);
+    expect(resultMsg).toBe("Package version is bad");
+
+    msgData.message = "Package is not reproducible";
+    streamMsg = mkEventStreamMsg(msgData, "renvPackageSourceMissing");
+    resultMsg = handleEventCodedError(streamMsg);
+    expect(resultMsg).toBe("Package is not reproducible");
 
     msgData.message = "requirements.txt is missing";
     streamMsg = mkEventStreamMsg(msgData, "requirementsFileReadingError");

--- a/extensions/vscode/src/eventErrors.ts
+++ b/extensions/vscode/src/eventErrors.ts
@@ -29,6 +29,13 @@ type requirementsReadingEvtErr = baseEvtErr & {
   requirementsFile: string;
 };
 
+type renvPackageEvtErr = baseEvtErr & {
+  lockfile: string;
+  package: string;
+  lockfileVersion: string;
+  libraryVersion: string;
+};
+
 export const isEvtErrDeploymentFailed = (
   emsg: EventStreamMessageErrorCoded,
 ): emsg is EventStreamMessageErrorCoded<baseEvtErr> => {
@@ -39,6 +46,18 @@ export const isEvtErrRenvLockPackagesReadingFailed = (
   emsg: EventStreamMessageErrorCoded,
 ): emsg is EventStreamMessageErrorCoded<lockfileReadingEvtErr> => {
   return emsg.errCode === "renvlockPackagesReadingError";
+};
+
+export const isEvtErrRenvPackageVersionMismatch = (
+  emsg: EventStreamMessageErrorCoded,
+): emsg is EventStreamMessageErrorCoded<renvPackageEvtErr> => {
+  return emsg.errCode === "renvPackageVersionMismatch";
+};
+
+export const isEvtErrRenvPackageSourceMissing = (
+  emsg: EventStreamMessageErrorCoded,
+): emsg is EventStreamMessageErrorCoded<renvPackageEvtErr> => {
+  return emsg.errCode === "renvPackageSourceMissing";
 };
 
 export const isEvtErrRequirementsReadingFailed = (
@@ -59,6 +78,8 @@ export const useEvtErrKnownMessage = (
   return (
     isEvtErrDeploymentFailed(emsg) ||
     isEvtErrRenvLockPackagesReadingFailed(emsg) ||
+    isEvtErrRenvPackageVersionMismatch(emsg) ||
+    isEvtErrRenvPackageSourceMissing(emsg) ||
     isEvtErrRequirementsReadingFailed(emsg) ||
     isEvtErrDeployedContentNotRunning(emsg)
   );

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -10,6 +10,8 @@ export type ErrorCode =
   | "invalidConfigFile"
   | "errorCertificateVerification"
   | "deployFailed"
+  | "renvPackageVersionMismatch"
+  | "renvPackageSourceMissing"
   | "renvlockPackagesReadingError"
   | "requirementsFileReadingError"
   | "deployedContentNotRunning"

--- a/internal/inspect/dependencies/renv/manifest_packages_test.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/posit-dev/publisher/internal/bundles"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/spf13/afero"
@@ -185,8 +186,12 @@ func (s *ManifestPackagesSuite) TestVersionMismatch() {
 
 	manifestPackages, err := mapper.GetManifestPackages(base, lockfilePath, logging.New())
 	s.NotNil(err)
-	s.ErrorIs(err, errLockfileLibraryMismatch)
 	s.Nil(manifestPackages)
+
+	aerr, isAgentErr := types.IsAgentError(err)
+	s.Equal(isAgentErr, true)
+	s.Equal(aerr.Code, types.ErrorRenvPackageVersionMismatch)
+	s.Equal(aerr.Message, "Package mypkg: versions in lockfile '1.2.3' and library '4.5.6' are out of sync. Use renv::restore() or renv::snapshot() to synchronize.")
 }
 
 func (s *ManifestPackagesSuite) TestDevVersion() {
@@ -209,8 +214,12 @@ func (s *ManifestPackagesSuite) TestDevVersion() {
 
 	manifestPackages, err := mapper.GetManifestPackages(base, lockfilePath, logging.New())
 	s.NotNil(err)
-	s.ErrorIs(err, errMissingPackageSource)
 	s.Nil(manifestPackages)
+
+	aerr, isAgentErr := types.IsAgentError(err)
+	s.Equal(isAgentErr, true)
+	s.Equal(aerr.Code, types.ErrorRenvPackageSourceMissing)
+	s.Equal(aerr.Message, "Cannot re-install packages installed from source; all packages must be installed from a reproducible location such as a repository. Package mypkg, Version 1.2.3.")
 }
 
 func (s *ManifestPackagesSuite) TestMissingDescriptionFile() {

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -20,6 +20,8 @@ const (
 	ErrorInvalidConfigFiles           ErrorCode = "invalidConfigFiles"
 	ErrorCredentialServiceUnavailable ErrorCode = "credentialsServiceUnavailable"
 	ErrorCertificateVerification      ErrorCode = "errorCertificateVerification"
+	ErrorRenvPackageVersionMismatch   ErrorCode = "renvPackageVersionMismatch"
+	ErrorRenvPackageSourceMissing     ErrorCode = "renvPackageSourceMissing"
 	ErrorRenvLockPackagesReading      ErrorCode = "renvlockPackagesReadingError"
 	ErrorRequirementsFileReading      ErrorCode = "requirementsFileReadingError"
 	ErrorDeployedContentNotRunning    ErrorCode = "deployedContentNotRunning"


### PR DESCRIPTION
## Intent

PR introducing some changes to stop hiding valuable error details when reading renv lockfile.

Instead of always displaying the message, `"Could not scan R packages from lockfile: renv.lock"`, we now allow some more details to be shown to the user related to the error in question.

**Screenshot of mismatching package version when reading renv.lock**
<img width="1790" alt="Screen Shot 2024-10-31 at 22 04 13" src="https://github.com/user-attachments/assets/3324b0a2-bd0b-4c16-830c-ee8aa8cc3f00">

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Created a couple known agent errors to share more details with the user. Also, we are now providing some more error specifics for unrecognized renv.lock reading errors.

## Automated Tests

Created and updated unit tests as needed.

## Directions for Reviewers

More details about reading the renv.lock file can be seen when:
- [ ] The version on the renv.lock file and the library doesn't match (can be tested manually changing the version of a package in the lockfile)
- [ ] The version installed locally for a package is a dev version, newer than what is present in the lockfile

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
