### PR TITLE
Warning message for missing Python executable

### DIFF
--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -2,6 +2,10 @@
 
 import { ConfigurationInspectionResult } from "src/api";
 import {
+  isAxiosErrorWithJson,
+  resolveAgentJsonErrorMsg,
+} from "src/utils/errorTypes";
+import {
   QuickPickItem,
   window,
   Disposable,
@@ -125,9 +129,11 @@ export class MultiStepInput {
         } else if (err === InputFlowAction.cancel) {
           step = undefined;
         } else {
-          window.showErrorMessage(
-            `Internal Error: MultiStepInput::stepThrough, err = ${JSON.stringify(err)}.`,
-          );
+          let errMsg = `Internal Error: MultiStepInput::stepThrough, err = ${JSON.stringify(err)}.`;
+          if (isAxiosErrorWithJson(err)) {
+            errMsg = resolveAgentJsonErrorMsg(err);
+          }
+          window.showErrorMessage(errMsg);
           step = undefined;
         }
       }

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -37,6 +37,7 @@ import {
   getMessageFromError,
   getSummaryStringFromError,
 } from "src/utils/errors";
+import { isAxiosErrorWithJson } from "src/utils/errorTypes";
 import { newDeploymentName, newConfigFileNameFromTitle } from "src/utils/names";
 import { formatURL, normalizeURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
@@ -146,6 +147,9 @@ export async function newDeployment(
             }
           });
         } catch (error: unknown) {
+          if (isAxiosErrorWithJson(error)) {
+            return reject(error);
+          }
           const summary = getSummaryStringFromError(
             "newDeployment, configurations.inspect",
             error,

--- a/extensions/vscode/src/utils/errorTypes.test.ts
+++ b/extensions/vscode/src/utils/errorTypes.test.ts
@@ -365,8 +365,6 @@ describe("resolveAgentJsonErrorMsg", () => {
       }) as axiosErrorWithJson,
     );
 
-    expect(msg).toBe(
-      "Could not find a Python executable in the system to inspect deployment requirements.",
-    );
+    expect(msg).toBe("Could not find a Python executable.");
   });
 });

--- a/extensions/vscode/src/utils/errorTypes.test.ts
+++ b/extensions/vscode/src/utils/errorTypes.test.ts
@@ -22,6 +22,7 @@ import {
   ErrTOMLValidationError,
   isErrTOMLValidationError,
   errTOMLValidationErrorMessage,
+  isErrPythonExecNotFoundError,
 } from "./errorTypes";
 
 const mkAxiosJsonErr = (data: Record<PropertyKey, any>) => {
@@ -293,6 +294,26 @@ describe("ErrInvalidConfigFiles", () => {
   });
 });
 
+describe("ErrPythonExecNotFoundError", () => {
+  test("isErrPythonExecNotFoundError", () => {
+    let result = isErrPythonExecNotFoundError(
+      mkAxiosJsonErr({
+        code: "pythonExecNotFound",
+      }),
+    );
+
+    expect(result).toBe(true);
+
+    result = isErrPythonExecNotFoundError(
+      mkAxiosJsonErr({
+        code: "bricks_raining",
+      }),
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
 describe("resolveAgentJsonErrorMsg", () => {
   test("returns proper message based on the provided error", () => {
     let msg = resolveAgentJsonErrorMsg(
@@ -337,5 +358,15 @@ describe("resolveAgentJsonErrorMsg", () => {
     );
 
     expect(msg).toBe(`The Configuration has a schema error on line 7`);
+
+    msg = resolveAgentJsonErrorMsg(
+      mkAxiosJsonErr({
+        code: "pythonExecNotFound",
+      }) as axiosErrorWithJson,
+    );
+
+    expect(msg).toBe(
+      "Could not find a Python executable in the system to inspect deployment requirements.",
+    );
   });
 });

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -14,7 +14,8 @@ export type ErrorCode =
   | "requirementsFileReadingError"
   | "deployedContentNotRunning"
   | "tomlValidationError"
-  | "tomlUnknownError";
+  | "tomlUnknownError"
+  | "pythonExecNotFound";
 
 export type axiosErrorWithJson<T = { code: ErrorCode; details: unknown }> =
   AxiosError & {
@@ -141,6 +142,16 @@ export const errTomlUnknownErrorMessage = (
   return `The Configuration has a schema error`;
 };
 
+// Python executable not found
+export type ErrPythonExecNotFoundError = MkErrorDataType<"pythonExecNotFound">;
+export const isErrPythonExecNotFoundError =
+  mkErrorTypeGuard<ErrPythonExecNotFoundError>("pythonExecNotFound");
+export const errPythonExecNotFoundErrorMessage = (
+  _: axiosErrorWithJson<ErrPythonExecNotFoundError>,
+) => {
+  return "Could not find a Python executable in the system to inspect deployment requirements.";
+};
+
 // Invalid configuration file(s)
 export type ErrInvalidConfigFiles = MkErrorDataType<
   "invalidConfigFile",
@@ -167,5 +178,10 @@ export function resolveAgentJsonErrorMsg(err: axiosErrorWithJson) {
   if (isErrTomlUnknownError(err)) {
     return errTomlUnknownErrorMessage(err);
   }
+
+  if (isErrPythonExecNotFoundError(err)) {
+    return errPythonExecNotFoundErrorMessage(err);
+  }
+
   return errUnknownMessage(err as axiosErrorWithJson<ErrUnknown>);
 }

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -149,7 +149,7 @@ export const isErrPythonExecNotFoundError =
 export const errPythonExecNotFoundErrorMessage = (
   _: axiosErrorWithJson<ErrPythonExecNotFoundError>,
 ) => {
-  return "Could not find a Python executable in the system to inspect deployment requirements.";
+  return "Could not find a Python executable.";
 };
 
 // Invalid configuration file(s)

--- a/internal/inspect/python_test.go
+++ b/internal/inspect/python_test.go
@@ -5,11 +5,13 @@ package inspect
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/posit-dev/publisher/internal/executor/executortest"
 	"github.com/posit-dev/publisher/internal/inspect/dependencies/pydeps"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/spf13/afero"
@@ -189,4 +191,41 @@ func (s *PythonSuite) TestReadRequirementsFile() {
 		"numpy==1.26.1",
 		"pandas",
 	}, reqs)
+}
+
+func (s *PythonSuite) TestInspectPython_SpecifiedPathNotFound() {
+	log := logging.New()
+	pathLooker := util.NewMockPathLooker()
+	pythonPath := util.NewPath("/usr/bin/python", nil)
+	i := NewPythonInspector(s.cwd, pythonPath, log)
+	inspector := i.(*defaultPythonInspector)
+	inspector.pathLooker = pathLooker
+
+	_, err := inspector.InspectPython()
+	s.NotNil(err)
+
+	aerr, isAerr := types.IsAgentErrorOf(err, types.ErrorPythonExecNotFound)
+	s.Equal(isAerr, true)
+	s.Equal(aerr.Message, "Cannot find the specified Python executable /usr/bin/python: file does not exist.")
+}
+
+func (s *PythonSuite) TestInspectPython_NotFoundInPATH() {
+	log := logging.New()
+	pathLooker := util.NewMockPathLooker()
+	pythonPath := util.NewPath("/usr/bin/python", nil)
+	i := NewPythonInspector(s.cwd, pythonPath, log)
+	inspector := i.(*defaultPythonInspector)
+	inspector.pathLooker = pathLooker
+	inspector.pythonPath = util.NewPath("", afero.NewMemMapFs())
+
+	// Won't find any exec names
+	pathLooker.On("LookPath", "python3").Return("", exec.ErrNotFound)
+	pathLooker.On("LookPath", "python").Return("", exec.ErrNotFound)
+	_, err := inspector.InspectPython()
+	s.NotNil(err)
+
+	aerr, isAerr := types.IsAgentErrorOf(err, types.ErrorPythonExecNotFound)
+	s.Equal(isAerr, true)
+	s.Equal(aerr.Message, "Executable file not found in $PATH.")
+	pathLooker.AssertExpectations(s.T())
 }

--- a/internal/inspect/python_test.go
+++ b/internal/inspect/python_test.go
@@ -196,7 +196,10 @@ func (s *PythonSuite) TestReadRequirementsFile() {
 func (s *PythonSuite) TestInspectPython_SpecifiedPathNotFound() {
 	log := logging.New()
 	pathLooker := util.NewMockPathLooker()
-	pythonPath := util.NewPath("/usr/bin/python", nil)
+
+	// Using .Join() to create the path for cross-platform compatibility tests
+	pythonPath := util.NewPath("", nil)
+	pythonPath = pythonPath.Join("usr", "bin", "pythontonotbefound")
 	i := NewPythonInspector(s.cwd, pythonPath, log)
 	inspector := i.(*defaultPythonInspector)
 	inspector.pathLooker = pathLooker
@@ -206,13 +209,13 @@ func (s *PythonSuite) TestInspectPython_SpecifiedPathNotFound() {
 
 	aerr, isAerr := types.IsAgentErrorOf(err, types.ErrorPythonExecNotFound)
 	s.Equal(isAerr, true)
-	s.Equal(aerr.Message, "Cannot find the specified Python executable /usr/bin/python: file does not exist.")
+	s.Contains(aerr.Message, "Cannot find the specified Python executable")
 }
 
 func (s *PythonSuite) TestInspectPython_NotFoundInPATH() {
 	log := logging.New()
 	pathLooker := util.NewMockPathLooker()
-	pythonPath := util.NewPath("/usr/bin/python", nil)
+	pythonPath := util.NewPath("", nil)
 	i := NewPythonInspector(s.cwd, pythonPath, log)
 	inspector := i.(*defaultPythonInspector)
 	inspector.pathLooker = pathLooker
@@ -226,6 +229,6 @@ func (s *PythonSuite) TestInspectPython_NotFoundInPATH() {
 
 	aerr, isAerr := types.IsAgentErrorOf(err, types.ErrorPythonExecNotFound)
 	s.Equal(isAerr, true)
-	s.Equal(aerr.Message, "Executable file not found in $PATH.")
+	s.Contains(aerr.Message, "Executable file not found")
 	pathLooker.AssertExpectations(s.T())
 }

--- a/internal/services/api/post_inspect.go
+++ b/internal/services/api/post_inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/initialize"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 )
 
@@ -130,6 +131,12 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 				return nil
 			})
 			if err != nil {
+				if aerr, ok := types.IsAgentErrorOf(err, types.ErrorPythonExecNotFound); ok {
+					apiErr := types.APIErrorPythonExecNotFoundFromAgentError(*aerr)
+					log.Error("Python executable not found", "error", err.Error())
+					apiErr.JSONResponse(w)
+					return
+				}
 				InternalError(w, req, log, err)
 				return
 			}
@@ -141,6 +148,12 @@ func PostInspectHandlerFunc(base util.AbsolutePath, log logging.Logger) http.Han
 			}
 			configs, err := initialize.GetPossibleConfigs(projectDir, pythonPath, util.Path{}, entrypointPath, log)
 			if err != nil {
+				if aerr, ok := types.IsAgentErrorOf(err, types.ErrorPythonExecNotFound); ok {
+					apiErr := types.APIErrorPythonExecNotFoundFromAgentError(*aerr)
+					log.Error("Python executable not found", "error", err.Error())
+					apiErr.JSONResponse(w)
+					return
+				}
 				InternalError(w, req, log, err)
 				return
 			}

--- a/internal/types/api_errors.go
+++ b/internal/types/api_errors.go
@@ -161,3 +161,17 @@ func APIErrorCredentialsUnavailableFromAgentError(aerr AgentError) APIErrorCrede
 		Code: ErrorCredentialServiceUnavailable,
 	}
 }
+
+type APIErrorPythonExecNotFound struct {
+	Code ErrorCode `json:"code"`
+}
+
+func APIErrorPythonExecNotFoundFromAgentError(aerr AgentError) APIErrorPythonExecNotFound {
+	return APIErrorPythonExecNotFound{
+		Code: ErrorPythonExecNotFound,
+	}
+}
+
+func (apierr *APIErrorPythonExecNotFound) JSONResponse(w http.ResponseWriter) {
+	jsonResult(w, http.StatusUnprocessableEntity, apierr)
+}

--- a/internal/types/api_errors_test.go
+++ b/internal/types/api_errors_test.go
@@ -68,3 +68,23 @@ func (s *ApiErrorsSuite) TestAPIErrorInvalidTOMLFileFromAgentError() {
 	s.Equal(http.StatusBadRequest, rec.Result().StatusCode)
 	s.Contains(bodyRes, `{"code":"invalidTOML","details":{"filename":"/project-a/configuration-avcd.toml","line":3,"column":1}}`)
 }
+
+func (s *ApiErrorsSuite) TestAPIErrorPythonExecNotFoundFromAgentError() {
+	agentErr := AgentError{
+		Message: "Bad syntax",
+		Code:    ErrorPythonExecNotFound,
+		Err:     errors.New("unknown field error"),
+		Data:    ErrorData{},
+	}
+
+	rec := httptest.NewRecorder()
+
+	apiError := APIErrorPythonExecNotFoundFromAgentError(agentErr)
+	s.Equal(apiError.Code, ErrorPythonExecNotFound)
+
+	apiError.JSONResponse(rec)
+
+	bodyRes := rec.Body.String()
+	s.Equal(http.StatusUnprocessableEntity, rec.Result().StatusCode)
+	s.Contains(bodyRes, `{"code":"pythonExecNotFound"}`)
+}

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -26,6 +26,7 @@ const (
 	ErrorUnknown                      ErrorCode = "unknown"
 	ErrorTomlValidationError          ErrorCode = "tomlValidationError"
 	ErrorTomlUnknownError             ErrorCode = "tomlUnknownError"
+	ErrorPythonExecNotFound           ErrorCode = "pythonExecNotFound"
 )
 
 type EventableError interface {
@@ -128,6 +129,16 @@ func OperationError(op Operation, err error) EventableError {
 func IsAgentError(err error) (*AgentError, bool) {
 	if aerr, ok := err.(*AgentError); ok {
 		return aerr, ok
+	}
+	return nil, false
+}
+
+// Evaluate if a given error is an AgentError of a specific code
+// returning the error as AgentError type when it is
+// and a bool flag of the comparison result.
+func IsAgentErrorOf(err error, code ErrorCode) (*AgentError, bool) {
+	if err, isAgentErr := err.(*AgentError); isAgentErr {
+		return err, err.Code == code
 	}
 	return nil, false
 }

--- a/internal/types/error_test.go
+++ b/internal/types/error_test.go
@@ -126,3 +126,30 @@ func (s *ErrorSuite) TestNewAgentError_MessagePunctuation() {
 		Data:    make(ErrorData),
 	})
 }
+
+func (s *ErrorSuite) TestIsAgentErrorOf() {
+	originalError := errors.New("shattered glass!")
+	aerr, isIt := IsAgentErrorOf(originalError, ErrorInvalidConfigFiles)
+	s.Equal(isIt, false)
+	s.Nil(aerr)
+
+	aTrueAgentError := NewAgentError(ErrorInvalidTOML, originalError, nil)
+	aerr, isIt = IsAgentErrorOf(aTrueAgentError, ErrorInvalidConfigFiles)
+	s.Equal(isIt, false)
+	s.Equal(aerr, &AgentError{
+		Message: "Shattered glass!",
+		Code:    ErrorInvalidTOML,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+
+	aTrueAgentError = NewAgentError(ErrorInvalidConfigFiles, originalError, nil)
+	aerr, isIt = IsAgentErrorOf(aTrueAgentError, ErrorInvalidConfigFiles)
+	s.Equal(isIt, true)
+	s.Equal(aerr, &AgentError{
+		Message: "Shattered glass!",
+		Code:    ErrorInvalidConfigFiles,
+		Err:     originalError,
+		Data:    make(ErrorData),
+	})
+}


### PR DESCRIPTION
## Intent

PR with the work to show a message warning the user about Python not available in the system as the reason to not be able to scan requirements or generate a deployment configuration.

Such message is shown, when not having a Python executable available, and when:
- Opening a directory in the IDE that can be easily identified as a Python project
- Trying to create a new deployment
- Trying to scan and generate a requirements.txt on a existing deployment (this is an edge case since the user cannot create a new deployment without Python, getting to this state should be fairly uncommon)

**Screenshot**
<img width="790" alt="Screen Shot 2024-11-06 at 1 52 47" src="https://github.com/user-attachments/assets/2d2b122f-f31a-40ea-b8d7-5cc9729b87fd">

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Identify and return a well known error when trying to get a Python executable for project inspection and it does not exist.

## Automated Tests

Updated and created new tests as needed.

## Directions for Reviewers

In order to test this PR and replicate the behavior, the system in use must not have a Python executable.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
