### PR TITLE
Handle potential errors during new deployment flow

### DIFF
--- a/extensions/vscode/.eslintrc.json
+++ b/extensions/vscode/.eslintrc.json
@@ -27,13 +27,7 @@
     "eqeqeq": "warn",
     "no-throw-literal": "error",
     "semi": "off",
-    "require-await": "error",
-    "no-restricted-syntax": [
-      "error",
-      {
-        "selector": "ThrowStatement"
-      }
-    ]
+    "require-await": "error"
   },
   "ignorePatterns": ["out", "dist", "**/*.d.ts", "api"]
 }

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -875,7 +875,10 @@ export async function newDeployment(
       newDeploymentData.entrypoint.inspectionResult.projectDir,
     );
   } catch (error: unknown) {
-    // continue on, as this is not a critical failure
+    // continue on as it is not necessary to include .posit files for deployment
+    console.debug(
+      `Failed to add the configuration file '${configName}' to \`files\`.`,
+    );
   }
 
   // Create the PreContentRecord File
@@ -921,7 +924,10 @@ export async function newDeployment(
       newDeploymentData.entrypoint.inspectionResult.projectDir,
     );
   } catch (error: unknown) {
-    // continue on, as this is not a critical failure
+    // continue on as it is not necessary to include .posit files for deployment
+    console.debug(
+      `Failed to add the content record file '${newContentRecord.deploymentName}' to \`files\`.`,
+    );
   }
 
   if (!newOrSelectedCredential) {

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -125,6 +125,17 @@ func normalizeConfig(
 	entrypoint util.RelativePath,
 	log logging.Logger,
 ) error {
+	// Usually an entrypoint will be inferred.
+	// If not, use the specified entrypoint, or
+	// fall back to unknown.
+	if cfg.Entrypoint == "" {
+		cfg.Entrypoint = entrypoint.String()
+
+		if cfg.Entrypoint == "" {
+			cfg.Entrypoint = "unknown"
+		}
+	}
+
 	log.Info("Possible deployment type", "Entrypoint", cfg.Entrypoint, "Type", cfg.Type)
 	if cfg.Title == "" {
 		// Default title is the name of the project directory.
@@ -172,16 +183,6 @@ func normalizeConfig(
 	}
 	cfg.Comments = strings.Split(initialComment, "\n")
 
-	// Usually an entrypoint will be inferred.
-	// If not, use the specified entrypoint, or
-	// fall back to unknown.
-	if cfg.Entrypoint == "" {
-		cfg.Entrypoint = entrypoint.String()
-
-		if cfg.Entrypoint == "" {
-			cfg.Entrypoint = "unknown"
-		}
-	}
 	return nil
 }
 

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -205,3 +205,17 @@ func (s *InitializeSuite) TestGetPossibleConfigsWithMissingEntrypoint() {
 	s.Equal("nonexistent.py", configs[0].Entrypoint)
 	s.Nil(configs[0].Python)
 }
+
+func (s *InitializeSuite) TestNormalizeConfigHandlesUnknownConfigs() {
+	log := logging.New()
+
+	cfg := config.New()
+	cfg.Type = config.ContentTypeUnknown
+
+	ep := util.NewRelativePath("notreal.py", s.cwd.Fs())
+	normalizeConfig(cfg, s.cwd, util.Path{}, util.Path{}, ep, log)
+
+	// Entrypoint is set from the relative path passed to normalizeConfig
+	s.Equal("notreal.py", cfg.Entrypoint)
+	s.Contains(cfg.Files, "/notreal.py")
+}


### PR DESCRIPTION
This PR fixes two things:
1. When an `type="unknown"` deployment is created the entrypoint could be blank when we reach `normalizeConfig`, which would cause the entrypoint field to be missing from the Configuration and the `files` array to only contain a `/`
2. When we create a new deployment / configuration combo, if the Configuration we create is invalid (read `type="unknown"`) the API calls to update the file lists with the Posit deployment record / configuration file were failing

#### Why were the APIs failing?

The API calls were failing because when we get a `Config` from a file we validate said file before decoding it:
https://github.com/posit-dev/publisher/blob/fa07fcf2c8ce07083676118228a02597dbcecd01/internal/config/config.go#L63

This makes sense, we have to have a valid file to get a valid `Config`, but the strict nature of not allowing `type: "unknown"` means our config creation here https://github.com/posit-dev/publisher/blob/66fdddbfdf991354e01e4a0d35aa28e9d98ba98e/internal/inspect/detectors/all.go#L79 causes the following API call to fail.

We have some ways we get around this in others parts of the code: https://github.com/posit-dev/publisher/blob/8b382dec983fd0bfbc3f0d9c7cae2902b1f28421/internal/services/api/put_configuration.go#L80

It would be ideal, when we don't care about the type, to be able to ignore that part of our validation. Or even better allow the unknown type completely until it matters.

## Intent

Resolves #2419

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was two fold.

The backend now produces a more correct configuration in cases where `type = 'unknown'`.

The frontend also handles the API calls when creating a new deployment separately, only bailing out when absolutely necessary - like when a file fails to be created.

The tradeoff here is that `type = 'unknown'` configurations will not have the `.posit` files listed in their `files` field - at least with the way it is currently implemented.

## Automated Tests

A test for the backend has been added.
