### PR TITLE
Allow `type: 'unknown'` in our Configuration schema

### DIFF
--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -542,7 +542,7 @@ func (c *ConnectClient) ValidateDeploymentTarget(contentID types.ContentID, cfg 
 	log.Info("Verifying content type is the same")
 	existingType := ContentTypeFromAppMode(content.AppMode)
 	configType := cfg.Type
-	if existingType != configType {
+	if existingType != configType && existingType != config.ContentTypeUnknown {
 		msg := fmt.Sprintf("Content was previously deployed as '%s' but your configuration is set to '%s'.", existingType, configType)
 		return types.NewAgentError(events.AppModeNotModifiableCode, errors.New(msg), nil)
 	}

--- a/internal/clients/connect/client_connect_test.go
+++ b/internal/clients/connect/client_connect_test.go
@@ -788,6 +788,37 @@ func (s *ConnectClientSuite) TestValidateDeploymentTargetAppModeNotModifiableCod
 	)
 }
 
+func (s *ConnectClientSuite) TestValidateDeploymentTargetAllowsAppModeToChangeFromUnknown() {
+	lgr := logging.New()
+	content := &ConnectContent{}
+	queryResult := &ConnectContent{
+		AppMode:            "",
+		Name:               "",
+		Title:              "",
+		GUID:               "",
+		Description:        "",
+		AccessType:         "",
+		ServiceAccountName: "",
+		DefaultImageName:   "",
+		Locked:             false,
+	}
+	httpClient := &http_client.MockHTTPClient{}
+
+	httpClient.On("Get", "/__api__/v1/content/e8922765-4880-43cd-abc0-d59fe59b8b4b", content, lgr).Return(nil, queryResult).Run(func(args mock.Arguments) {
+		// this will update the ConnectContent structure
+		// with the value that we passed in as the second
+		// return argument
+		arg := args.Get(1).(*ConnectContent)
+		*arg = *queryResult
+	})
+
+	client := &ConnectClient{
+		client: httpClient,
+	}
+	err := client.ValidateDeploymentTarget("e8922765-4880-43cd-abc0-d59fe59b8b4b", s.cfg, lgr)
+	s.NoError(err)
+}
+
 func (s *ConnectClientSuite) TestCheckCapabilities() {
 	lgr := logging.New()
 	httpClient := &http_client.MockHTTPClient{}

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -42,7 +42,8 @@
         "r-plumber",
         "r-shiny",
         "rmd-shiny",
-        "rmd"
+        "rmd",
+        "unknown"
       ],
       "examples": ["quarto"]
     },


### PR DESCRIPTION
This PR does two things:
- Adds `type = 'unknown'` to our schema making it a valid option in our Configuration files
- Allows changing the type from `unknown` to something else and re-deploying
  - Changing types if the previous type is not unknown is still invalid

### Consequences of this PR

With `type = 'unknown'` now passing schema validation for our Configuration files, when Config has that type:
- We lose the sidebar warning showing the user that the config is in error
- We lose TOML validation warnings if the user is using an extension like [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)
- Actions like including or excluding files can now be done
  - This addresses the trade off introduced in #2422 where `.posit` files couldn't be added automatically to the generated config with `type = 'unknown'`
- When deploying the content, it now gets created on Connect, as opposed to failing a pre-check in Publisher. Connect communicates that failure with "“Cannot process manifest: Unrecognized app mode”"
  - This can be addressed by the user by changing the type to something that produces a valid App Mode (anything but `unknown`) and re-deploying due to the 2nd change mentioned above

## Intent

Further addresses #2419 and allows more actions on the Configuration file from sidebar when the Configuration `type = 'unknown'`

## Type of Change

- [x] Refactor

## Automated Tests

I did add an automated test to check that moving from App Mode `""` (or `type = 'unknown'`) to a valid App Mode was acceptable in our deployment pre-checks.