### PR TITLE
Compare AppMode in pre-check not ContentType

### DIFF
--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -539,11 +539,10 @@ func (c *ConnectClient) ValidateDeploymentTarget(contentID types.ContentID, cfg 
 	}
 
 	// Verify content type has not changed
-	log.Info("Verifying content type is the same")
-	existingType := ContentTypeFromAppMode(content.AppMode)
-	configType := cfg.Type
-	if existingType != configType {
-		msg := fmt.Sprintf("Content was previously deployed as '%s' but your configuration is set to '%s'.", existingType, configType)
+	log.Info("Verifying app mode is the same")
+	configAppType := AppModeFromType(cfg.Type)
+	if content.AppMode != configAppType && content.AppMode != UnknownMode {
+		msg := fmt.Sprintf("Content was previously deployed as '%s' but your configuration is set to '%s'.", ContentTypeFromAppMode(content.AppMode), cfg.Type)
 		return types.NewAgentError(events.AppModeNotModifiableCode, errors.New(msg), nil)
 	}
 


### PR DESCRIPTION
This PR changes our behavior in our pre-check comparing the App Mode on Connect and the Content Type we are trying to deploy.

Previously we compared the Content Type from our Config with the AppMode converted to a Content Type. With the introduction of the `quarto` and `quarto-static` types both leading to the same AppMode this comparison didn't quite work.

This changes the check to compare AppModes specifically since that is what truly can or cannot change, and handles our deprecated `quarto` type much better.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
