### PR TITLE
Update `softprops/action-gh-release` to version 2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           path: dist
       - id: get-prerelease
         run: echo "prerelease=$(just pre-release)" >> "$GITHUB_OUTPUT"
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: ${{ steps.get-prerelease.outputs.prerelease == 'true' }}


### PR DESCRIPTION
Our release GitHub action uses version 1 of [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release) we can update it to version 2 to avoid the deprecated Node.js version warning:

> [release](https://github.com/posit-dev/publisher/actions/runs/11826395875/job/32952545635)
The following actions use a deprecated Node.js version and will be forced to run on node20: softprops/action-gh-release@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

See this run for an example of the warning: https://github.com/posit-dev/publisher/actions/runs/11826395875

Reading [the release notes for `softprops/action-gh-release`](https://github.com/softprops/action-gh-release/releases) it doesn't look like we will need to make any changes.