### PR TITLE
Add emphasis to entrypoint TreeItem in Files

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItem.vue
@@ -4,6 +4,7 @@
     :class="{
       'align-icon-with-twisty': alignIconWithTwisty,
       collapsible: $slots.default,
+      'text-list-emphasized': listStyle === 'emphasized',
       'text-foreground': listStyle === 'default',
       'text-list-deemphasized': listStyle === 'deemphasized',
     }"
@@ -60,7 +61,7 @@
 <script setup lang="ts">
 import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
 
-export type TreeItemStyle = "default" | "deemphasized";
+export type TreeItemStyle = "emphasized" | "default" | "deemphasized";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
@@ -4,6 +4,7 @@
     :class="{
       'align-icon-with-twisty': alignIconWithTwisty,
       collapsible: $slots.default,
+      'text-list-emphasized': listStyle === 'emphasized',
       'text-foreground': listStyle === 'default',
       'text-list-deemphasized': listStyle === 'deemphasized',
     }"
@@ -54,7 +55,7 @@
 <script setup lang="ts">
 import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
 
-export type TreeItemStyle = "default" | "deemphasized";
+export type TreeItemStyle = "emphasized" | "default" | "deemphasized";
 
 const expanded = defineModel("expanded", { required: false, default: false });
 

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/TreeProjectFiles.vue
@@ -8,7 +8,13 @@
       file.reason?.source === 'built-in' ||
       file.reason?.source === 'permissions'
     "
-    :list-style="isFileIncluded(file) ? 'default' : 'deemphasized'"
+    :list-style="
+      isEntrypoint(file)
+        ? 'emphasized'
+        : isFileIncluded(file)
+          ? 'default'
+          : 'deemphasized'
+    "
     :tooltip="
       isFileIncluded(file)
         ? includedFileTooltip(file)
@@ -61,7 +67,10 @@ import { useHostConduitService } from "src/HostConduitService";
 import PostDecor from "src/components/tree/PostDecor.vue";
 import { ActionButton } from "src/components/ActionToolbar.vue";
 
-import { ContentRecordFile, FileMatchSource } from "../../../../../../src/api";
+import {
+  ContentRecordFile,
+  isConfigurationError,
+} from "../../../../../../src/api";
 import { WebviewToHostMessageType } from "../../../../../../src/types/messages/webviewToHostMessages";
 
 interface Props {
@@ -75,6 +84,14 @@ const props = withDefaults(defineProps<Props>(), {
 
 const home = useHomeStore();
 const { sendMsg } = useHostConduitService();
+
+const isEntrypoint = (file: ContentRecordFile): boolean => {
+  const config = home.selectedConfiguration;
+  if (config != undefined && !isConfigurationError(config)) {
+    return file.id === config.configuration.entrypoint;
+  }
+  return false;
+};
 
 const isFileIncluded = (file: ContentRecordFile) => {
   return Boolean(file.reason?.exclude === false);

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -34,6 +34,10 @@ body {
   color: var(--vscode-icon-foreground);
 }
 
+.text-list-emphasized {
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
 .text-list-deemphasized {
   color: var(--vscode-list-deemphasizedForeground);
 }


### PR DESCRIPTION
Adds the ability to emphasize our Tree Item components with a new `listStyle` prop option, then uses that to emphasize the entrypoint.

## Intent

Resolves #2239

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach was to use a CSS variable provided by VS Code, in this case `--vscode-list-activeSelectionForeground`. This is the same color as the active file when looking at the Explorer.

## User Impact

This provides the user a bit of glanceability to the understand what the "main"/entrypoint file is when looking at the Project Files view. It reinforces the most important file being deployed.

This is particularly helpful if the folder has multiple deployments with multiple entrypoints.

This option of using the same color as the active file in the Explorer view may be a bit confusing since our Project Files looks a bit like the Explorer pane, and has the "open file" icon button. This is opened as a draft to discuss this.