### PR TITLE
Remove deprecated part of husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged
+lint-staged


### PR DESCRIPTION
Simple change to our husky pre-commit hook to use the new format from [`v9.0.1`](https://github.com/typicode/husky/releases/tag/v9.0.1).

This prevents a deprecated message from appearing, and is a bit faster ⚡ 