### PR TITLE
Update `get-port` dependency

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -17,7 +17,7 @@
         "entities": "^5.0.0",
         "eventsource": "^2.0.2",
         "filenamify": "^6.0.0",
-        "get-port": "5.1.1",
+        "get-port": "^7.1.0",
         "mutexify": "^1.4.0",
         "retry": "^0.13.1",
         "vscode-uri": "^3.0.8"
@@ -2860,11 +2860,11 @@
       }
     },
     "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -546,7 +546,7 @@
     "entities": "^5.0.0",
     "eventsource": "^2.0.2",
     "filenamify": "^6.0.0",
-    "get-port": "5.1.1",
+    "get-port": "^7.1.0",
     "mutexify": "^1.4.0",
     "retry": "^0.13.1",
     "vscode-uri": "^3.0.8"

--- a/extensions/vscode/src/ports.ts
+++ b/extensions/vscode/src/ports.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import getPort = require("get-port");
+import getPort from "get-port";
 
 export const acquire = (): Promise<number> => {
   return getPort();

--- a/extensions/vscode/webviews/homeView/package-lock.json
+++ b/extensions/vscode/webviews/homeView/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "axios": "1.7.4",
         "eventsource": "^2.0.2",
-        "get-port": "5.1.1",
         "pinia": "^2.1.7",
         "vue": "^3.4.21"
       },
@@ -1396,17 +1395,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/has-flag": {

--- a/extensions/vscode/webviews/homeView/package.json
+++ b/extensions/vscode/webviews/homeView/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "axios": "1.7.4",
     "eventsource": "^2.0.2",
-    "get-port": "5.1.1",
     "pinia": "^2.1.7",
     "vue": "^3.4.21"
   },


### PR DESCRIPTION
This updates our `get-port` dependency for our extension to the latest, and removes it from the home view since it is not used there.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->