### PR TITLE
Address ESLint errors from recommended plugins

### DIFF
--- a/extensions/vscode/src/actions/showAssociateGUID.ts
+++ b/extensions/vscode/src/actions/showAssociateGUID.ts
@@ -8,7 +8,7 @@ import { Views } from "src/constants";
 import { useApi } from "src/api";
 
 export async function showAssociateGUID(state: PublisherState) {
-  let urlOrGuid = "";
+  const urlOrGuid = "";
   const result = await window.showInputBox({
     title: "Enter the URL of the Existing Content Item on the Server",
     prompt: "Please provide the content's URL from Connect",

--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -57,7 +57,7 @@ class PublishingClientApi {
     this.entrypoints = new EntryPoints(this.client);
   }
 
-  logDuration(response: AxiosResponse<any, any>) {
+  logDuration(response: AxiosResponse<unknown, unknown>) {
     const timestamp = response.config.ts;
     if (timestamp) {
       const request = response.request;

--- a/extensions/vscode/src/api/types/error.ts
+++ b/extensions/vscode/src/api/types/error.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import { ErrorCode } from "../../utils/errorTypes";

--- a/extensions/vscode/src/api/types/events.ts
+++ b/extensions/vscode/src/api/types/events.ts
@@ -622,10 +622,6 @@ export function isPublishCreateDeploymentStart(
 
 export interface PublishCreateDeploymentLog extends EventStreamMessage {
   type: "publish/createDeployment/log";
-  data: {
-    // structured data not guaranteed, use selective or generic queries
-    // from data map
-  };
 }
 export type OnPublishCreateDeploymentLogCallback = (
   msg: PublishCreateDeploymentLog,
@@ -683,10 +679,6 @@ export function isPublishUploadBundleStart(
 
 export interface PublishUploadBundleLog extends EventStreamMessage {
   type: "publish/uploadBundle/log";
-  data: {
-    // structured data not guaranteed, use selective or generic queries
-    // from data map
-  };
 }
 export type OnPublishUploadBundleLogCallback = (
   msg: PublishUploadBundleLog,
@@ -745,10 +737,6 @@ export function isPublishDeployBundleStart(
 
 export interface PublishDeployBundleLog extends EventStreamMessage {
   type: "publish/deployBundle/log";
-  data: {
-    // structured data not guaranteed, use selective or generic queries
-    // from data map
-  };
 }
 export type OnPublishDeployBundleLogCallback = (
   msg: PublishDeployBundleLog,

--- a/extensions/vscode/src/eventErrors.test.ts
+++ b/extensions/vscode/src/eventErrors.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import { describe, expect, test } from "vitest";

--- a/extensions/vscode/src/events.ts
+++ b/extensions/vscode/src/events.ts
@@ -287,6 +287,7 @@ export class EventStream extends Readable implements Disposable {
  * @param object - The object to convert.
  * @returns The object with camel case keys.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const convertKeysToCamelCase = (object: any): any => {
   if (typeof object !== "object" || object === null) {
     return object;
@@ -297,9 +298,10 @@ const convertKeysToCamelCase = (object: any): any => {
     return object.map((item) => convertKeysToCamelCase(item));
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const newObject: any = {};
   for (const key in object) {
-    if (object.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
       // Convert the key to camel case
       const newKey = key.charAt(0).toLowerCase() + key.slice(1);
       // Recursively convert keys for nested objects

--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -184,6 +184,7 @@ export class MultiStepInput {
             if (item === QuickInputButtons.Back) {
               reject(InputFlowAction.back);
             } else {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               resolve(<any>item);
             }
           }),
@@ -260,6 +261,7 @@ export class MultiStepInput {
             if (item === QuickInputButtons.Back) {
               reject(InputFlowAction.back);
             } else {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               resolve(<any>item);
             }
           }),

--- a/extensions/vscode/src/test/suite/extension.test.ts
+++ b/extensions/vscode/src/test/suite/extension.test.ts
@@ -7,6 +7,7 @@ import { Extension, extensions } from "vscode";
 
 suite("Extension Test Suite", () => {
   test("extension is registered", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const extension: Extension<any> =
       extensions.getExtension("posit.publisher")!;
     assert.ok(extension !== undefined);

--- a/extensions/vscode/src/types/messages/conduit.ts
+++ b/extensions/vscode/src/types/messages/conduit.ts
@@ -3,21 +3,15 @@
 import {
   HostToWebviewMessage,
   HostToWebviewMessageType,
-  isHostToWebviewMessage,
 } from "./hostToWebviewMessages";
 import {
   WebviewToHostMessage,
   WebviewToHostMessageType,
-  isWebviewToHostMessage,
 } from "./webviewToHostMessages";
 
 export type MessageType = WebviewToHostMessageType | HostToWebviewMessageType;
 
 export type ConduitMessage = HostToWebviewMessage | WebviewToHostMessage;
-
-export function isConduitMessage(msg: any): msg is ConduitMessage {
-  return isHostToWebviewMessage(msg) || isWebviewToHostMessage(msg);
-}
 
 export type WebviewToHostMessageCB = (msg: WebviewToHostMessage) => void;
 export type HostToWebviewMessageCB = (msg: HostToWebviewMessage) => void;

--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -59,6 +59,7 @@ export type HostToWebviewMessage =
   | SetPathSeparatorMsg
   | UpdateServerEnvironmentMsg;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
   return (
     msg.kind === HostToWebviewMessageType.INITIALIZING_REQUEST_COMPLETE ||

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -64,6 +64,7 @@ export type WebviewToHostMessage =
   | ViewPublishingLog
   | ShowAssociateGUIDMsg;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
   return (
     msg.kind === WebviewToHostMessageType.DEPLOY ||

--- a/extensions/vscode/src/utils/config.ts
+++ b/extensions/vscode/src/utils/config.ts
@@ -15,7 +15,9 @@ export async function getPythonInterpreterPath(): Promise<string | undefined> {
       "python.interpreterPath",
       { workspaceFolder: workspaceFolder },
     );
-  } catch {}
+  } catch {
+    // Ignore
+  }
   if (configuredPython === undefined) {
     return undefined;
   }
@@ -30,7 +32,7 @@ export async function getPythonInterpreterPath(): Promise<string | undefined> {
       "Scripts/python.exe",
       "Scripts/python3.exe",
     ];
-    for (let name of names) {
+    for (const name of names) {
       const candidate = Uri.joinPath(pythonUri, name);
       if (await fileExists(candidate)) {
         python = candidate.fsPath;

--- a/extensions/vscode/src/utils/errorEnhancer.ts
+++ b/extensions/vscode/src/utils/errorEnhancer.ts
@@ -5,6 +5,7 @@ export enum ErrorMessageActionIds {
 }
 
 export function isErrorMessageActionId(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   searchValue: any,
 ): searchValue is ErrorMessageActionIds {
   return Object.values(ErrorMessageActionIds).includes(searchValue);

--- a/extensions/vscode/src/utils/errorTypes.test.ts
+++ b/extensions/vscode/src/utils/errorTypes.test.ts
@@ -25,6 +25,7 @@ import {
   isErrPythonExecNotFoundError,
 } from "./errorTypes";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mkAxiosJsonErr = (data: Record<PropertyKey, any>) => {
   return new AxiosError(undefined, undefined, undefined, undefined, {
     status: 0,

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -53,7 +53,7 @@ export type ErrUnknown = MkErrorDataType<
   "unknown",
   {
     error: string;
-    data: Record<PropertyKey, any>;
+    data: Record<PropertyKey, unknown>;
   }
 >;
 export const isErrUnknown = mkErrorTypeGuard<ErrUnknown>("unknown");

--- a/extensions/vscode/src/utils/errors.test.ts
+++ b/extensions/vscode/src/utils/errors.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { AxiosError, AxiosHeaders } from "axios";
 import { getSummaryStringFromError } from "./errors";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mkAxiosJsonErr = (data: Record<PropertyKey, any>) => {
   return new AxiosError(undefined, undefined, undefined, undefined, {
     status: 0,

--- a/extensions/vscode/src/utils/errors.ts
+++ b/extensions/vscode/src/utils/errors.ts
@@ -142,14 +142,7 @@ export const scrubErrorData = (data: Record<string, unknown> | undefined) => {
   }
   // remove what we don't want to display
   // in this unknown list of attributes
-  const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
-    file,
-    method,
-    status,
-    url,
-    ...remainingData
-  } = data;
+  const { file, method, status, url, ...remainingData } = data;
 
   if (Object.keys(remainingData).length === 0) {
     return undefined;

--- a/extensions/vscode/src/utils/files.ts
+++ b/extensions/vscode/src/utils/files.ts
@@ -19,7 +19,7 @@ export async function fileExists(fileUri: Uri): Promise<boolean> {
   try {
     await workspace.fs.stat(fileUri);
     return true;
-  } catch (e: unknown) {
+  } catch (_e: unknown) {
     return false;
   }
 }
@@ -28,7 +28,7 @@ export async function isDir(fileUri: Uri): Promise<boolean> {
   try {
     const info = await workspace.fs.stat(fileUri);
     return (info.type & FileType.Directory) !== 0;
-  } catch (e: unknown) {
+  } catch (_e: unknown) {
     return false;
   }
 }
@@ -49,7 +49,7 @@ export function isValidFilename(filename: string): boolean {
     return false;
   }
   const forbidden = "/:*?\"<>|'\\";
-  for (let c of filename) {
+  for (const c of filename) {
     if (forbidden.includes(c)) {
       return false;
     }
@@ -175,8 +175,8 @@ export function pathSort(paths: string[], sep: string): string[] {
 }
 
 export function pathSorter(a: string[], b: string[]): number {
-  var l = Math.max(a.length, b.length);
-  for (var i = 0; i < l; i += 1) {
+  const l = Math.max(a.length, b.length);
+  for (let i = 0; i < l; i += 1) {
     if (!(i in a)) {
       return -1;
     }

--- a/extensions/vscode/src/utils/variables.ts
+++ b/extensions/vscode/src/utils/variables.ts
@@ -10,18 +10,18 @@ export function substituteVariables(s: string, recursive: boolean = false) {
   // Including it here because the NPM package is way
   // out of date and triggers npm audit messages.
 
-  let workspaces = workspace.workspaceFolders || [];
-  let workspaceFolder = workspace.workspaceFolders?.length
+  const workspaces = workspace.workspaceFolders || [];
+  const workspaceFolder = workspace.workspaceFolders?.length
     ? workspace.workspaceFolders[0]
     : null;
-  let activeFile = window.activeTextEditor?.document;
-  let absoluteFilePath = activeFile?.uri.fsPath || "";
+  const activeFile = window.activeTextEditor?.document;
+  const absoluteFilePath = activeFile?.uri.fsPath || "";
   s = s.replace(/\${workspaceFolder}/g, workspaceFolder?.uri.fsPath || "");
   s = s.replace(/\${workspaceFolderBasename}/g, workspaceFolder?.name || "");
   s = s.replace(/\${file}/g, absoluteFilePath);
   let activeWorkspace = workspaceFolder;
   let relativeFilePath = absoluteFilePath;
-  for (let workspace of workspaces) {
+  for (const workspace of workspaces) {
     if (
       absoluteFilePath.replace(workspace.uri.fsPath, "") !== absoluteFilePath
     ) {
@@ -32,7 +32,7 @@ export function substituteVariables(s: string, recursive: boolean = false) {
       break;
     }
   }
-  let parsedPath = path.parse(absoluteFilePath);
+  const parsedPath = path.parse(absoluteFilePath);
   s = s.replace(/\${fileWorkspaceFolder}/g, activeWorkspace?.uri.fsPath || "");
   s = s.replace(/\${relativeFile}/g, relativeFilePath);
   s = s.replace(

--- a/extensions/vscode/src/utils/webviewConduit.ts
+++ b/extensions/vscode/src/utils/webviewConduit.ts
@@ -16,6 +16,7 @@ export class WebviewConduit {
 
   constructor() {}
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private onRawMsgCB = (e: any) => {
     const obj = JSON.parse(e);
     // console.debug(

--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -12,7 +12,9 @@ export function deployProject(localID: string, stream: EventStream) {
       cancellable: true,
     },
     (progress, token) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let resolveCB: (reason?: any) => void;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let rejectCB: (reason?: any) => void;
       const registrations: UnregisterCallback[] = [];
       const promise = new Promise<void>((resolve, reject) => {
@@ -420,7 +422,7 @@ export function deployProject(localID: string, stream: EventStream) {
             });
             resolveCB("Success!");
 
-            let visitOption = "View";
+            const visitOption = "View";
             const selection = await window.showInformationMessage(
               "Deployment was successful",
               visitOption,

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1203,7 +1203,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           }
         }
 
-        let credential =
+        const credential =
           this.state.findCredentialForContentRecord(contentRecord);
 
         const result = calculateTitle(contentRecord, config);
@@ -1218,7 +1218,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           problem = true;
         }
 
-        let details = [];
+        const details = [];
         if (credential?.name) {
           details.push(credential.name);
         } else {
@@ -1241,7 +1241,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         }
         const detail = details.join(" • ");
 
-        let lastMatch =
+        const lastMatch =
           lastContentRecordName === contentRecord.saveName &&
           lastContentRecordProjectDir === contentRecord.projectDir &&
           lastConfigName === configName;
@@ -1262,8 +1262,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       });
       existingDeploymentQuickPickList.sort(
         (a: QuickPickItem, b: QuickPickItem) => {
-          var x = a.label.toLowerCase();
-          var y = b.label.toLowerCase();
+          const x = a.label.toLowerCase();
+          const y = b.label.toLowerCase();
           return x < y ? -1 : x > y ? 1 : 0;
         },
       );
@@ -1578,7 +1578,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
             environment: response.data,
           },
         });
-      } catch (error: unknown) {
+      } catch (_error: unknown) {
         // No matter the error we clear the environment
         this.webviewConduit.sendMsg({
           kind: HostToWebviewMessageType.UPDATE_SERVER_ENVIRONMENT,
@@ -1621,8 +1621,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     // get the configs which are filtered for the entrypoint in that projectDir
     // determine a list of deployments that use those filtered configs
 
-    let contentRecordList: (ContentRecord | PreContentRecord)[] = [];
-    const getContentRecords = new Promise<void>(async (resolve, reject) => {
+    const contentRecordList: (ContentRecord | PreContentRecord)[] = [];
+    const getContentRecords = async () => {
       try {
         const response = await api.contentRecords.getAll(entrypointDir, {
           recursive: false,
@@ -1640,19 +1640,18 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         window.showInformationMessage(
           `Unable to continue due to deployment error. ${summary}`,
         );
-        return reject();
+        throw error;
       }
-      return resolve();
-    });
+    };
 
-    let configMap = new Map<string, Configuration>();
-    const getConfigurations = new Promise<void>(async (resolve, reject) => {
+    const configMap = new Map<string, Configuration>();
+    const getConfigurations = async () => {
       try {
         const response = await api.configurations.getAll(entrypointDir, {
           entrypoint: entrypointFile,
           recursive: false,
         });
-        let rawConfigs = response.data;
+        const rawConfigs = response.data;
         rawConfigs.forEach((cfg) => {
           if (!isConfigurationError(cfg)) {
             configMap.set(cfg.configurationName, cfg);
@@ -1666,17 +1665,16 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         window.showErrorMessage(
           `Unable to continue with API Error: ${summary}`,
         );
-        return reject();
+        throw error;
       }
-      resolve();
-    });
+    };
 
     try {
       await showProgress(
         "Initializing::handleFileInitiatedDeployment",
         Views.HomeView,
         async () => {
-          return await Promise.all([getContentRecords, getConfigurations]);
+          return await Promise.all([getContentRecords(), getConfigurations()]);
         },
       );
     } catch {

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -193,9 +193,9 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
         }
       });
 
-      let showLogsOption = "View Log";
-      let options = [showLogsOption];
-      let enhancedError = findErrorMessageSplitOption(msg.data.message);
+      const showLogsOption = "View Log";
+      const options = [showLogsOption];
+      const enhancedError = findErrorMessageSplitOption(msg.data.message);
       if (enhancedError && enhancedError.buttonStr) {
         options.push(enhancedError.buttonStr);
       }

--- a/extensions/vscode/src/watchers.ts
+++ b/extensions/vscode/src/watchers.ts
@@ -104,7 +104,7 @@ export class ContentRecordWatcherManager implements Disposable {
   }
 
   dispose() {
-    this.contentRecord?.dispose;
+    this.contentRecord?.dispose();
   }
 }
 


### PR DESCRIPTION
This PR is a follow-up to #2440 that addresses all of the new rules that are failing.

## Intent

Resolves #1293

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Rather than change every `any` I figured we could make a follow-up issue to remove the `// eslint-disable-next-line @typescript-eslint/no-explicit-any` added here since those are a bit complex.

The work I did do here that wasn't auto-fixed was removed the async promise executors. To see why this is recommended I suggest reading the `no-async-promise-executor` rule docs: https://eslint.org/docs/latest/rules/no-async-promise-executor

## Directions for Reviewers

Test the changed code in the following flows:
- New Deployment flows
- Selecting a New or Existing Config
- The home view's `handleFileInitiatedDeploymentSelection` which fires when the entrypoint button is pressed

Most everything else is disabling `any` rules and changing to `const` where applicable.