### PR TITLE
Update `@eslint/js` to latest

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -23,7 +23,7 @@
         "vscode-uri": "^3.0.8"
       },
       "devDependencies": {
-        "@eslint/js": "9.14.0",
+        "@eslint/js": "^9.15.0",
         "@twbs/fantasticon": "^3.0.0",
         "@types/eventsource": "^1.1.15",
         "@types/mocha": "^10.0.2",
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+      "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2430,15 +2430,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
-      "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/espree": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -518,7 +518,7 @@
     "test-unit": "vitest run"
   },
   "devDependencies": {
-    "@eslint/js": "9.14.0",
+    "@eslint/js": "^9.15.0",
     "@twbs/fantasticon": "^3.0.0",
     "@types/eventsource": "^1.1.15",
     "@types/mocha": "^10.0.2",


### PR DESCRIPTION
Quick follow-up to #2443, updating `@eslint/js` to the latest version to match the `eslint` version.