### PR TITLE
Add Go launch.json and CONTRIB docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 # Visual Studio Code
 .vscode/*
 !.vscode/recommended.settings.json
+!.vscode/launch.json
 !.vscode/tasks.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch API",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/publisher/main.go",
+      "args": ["ui", "--listen=localhost:9001", "-vv"],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@
     - [Build Tools](#build-tools)
     - [Environment Variables](#environment-variables)
       - [Behavior in GitHub Actions](#behavior-in-github-actions)
+    - [Debugging in VS Code](#debugging-in-vs-code)
     - [Extension Development](#extension-development)
   - [Release](#release)
     - [Instructions](#instructions)
@@ -110,6 +111,20 @@ This mode can be reproduced on your local machine by setting `CI=true`.
 | Variable | Default |
 | -------- | ------- |
 | MODE     | prod    |
+
+### Debugging in VS Code
+
+A `launch.json` can be found at the root in the `.vscode` directory for
+debugging the Go API code.
+
+The "Launch API" configuration will start the API at port 9001.
+To change the directory that the API is started in, update the `cwd` property
+to the directory you want the API to be launched at.
+
+When debugging alongside the
+[VS Code Extension](./extensions/vscode/CONTRIBUTING.md#debugging) the `cwd`
+will frequently be the workspace folder of the extension host development
+window.
 
 ### Extension Development
 

--- a/extensions/vscode/CONTRIBUTING.md
+++ b/extensions/vscode/CONTRIBUTING.md
@@ -56,6 +56,12 @@ Either invocation will launch a new window named `Extension Host Development` wi
 
 When testing, utilize the sample projects in `../../test/sample-content`. Open these projects as a workspace within the `Extension Host Development` window.
 
+#### Connecting to API Debug Session
+
+To connect to the API debug session change the `Service` class in
+`extensions/vscode/src/services.ts` to a hardcoded `port = 9001;` and remove
+the code inside of the `start` and `stop` methods.
+
 ### Re-building the Webview(s)
 
 The built-in debugger watches for extension changes, but not changes for our


### PR DESCRIPTION
Adds a `.vscode/launch.json` config for launching the Go API. In addition adds some documentation how to debug both the Go code, and the extension alongside it.

It is all a little manual at the moment, but it is at least a start.

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->