### PR TITLE
Fix loading last selected deployment

### DIFF
--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -335,8 +335,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     return this.updateWebViewViewCredentials();
   }
 
-  private async refreshActiveConfig() {
-    const cfg = await this.state.getSelectedConfiguration();
+  private async refreshActiveConfig(cfg?: Configuration | ConfigurationError) {
+    if (!cfg) {
+      cfg = await this.state.getSelectedConfiguration();
+    }
 
     this.sendRefreshedFilesLists();
     this.updateServerEnvironment();
@@ -381,8 +383,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     );
   }
 
-  private async refreshActiveContentRecord() {
-    const contentRecord = await this.state.getSelectedContentRecord();
+  private async refreshActiveContentRecord(
+    contentRecord?: ContentRecord | PreContentRecord,
+  ) {
+    if (!contentRecord) {
+      contentRecord = await this.state.getSelectedContentRecord();
+    }
     this.contentRecordWatchers?.dispose();
 
     this.contentRecordWatchers = new ContentRecordWatcherManager(contentRecord);
@@ -1399,6 +1405,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       return;
     }
 
+    const selectedContentRecord = await this.state.getSelectedContentRecord();
+    const selectedConfig = await this.state.getSelectedConfiguration();
     const selectionState = includeSavedState
       ? this.state.getSelection()
       : undefined;
@@ -1406,8 +1414,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     this.updateWebViewViewConfigurations();
     this.updateWebViewViewContentRecords(selectionState || null);
     if (includeSavedState && selectionState) {
-      this.refreshActiveContentRecord();
-      this.refreshActiveConfig();
+      this.refreshActiveContentRecord(selectedContentRecord);
+      this.refreshActiveConfig(selectedConfig);
     }
   };
 


### PR DESCRIPTION
## Intent

This PR fixes an issue where the last selected deployment does not populate properly on the extension UI when initializing.

The cause of this issue was introduced at commit [d8eb18a](https://github.com/posit-dev/publisher/commit/d8eb18ab02c5ec3baa4138416c85fe3bbab1de45), such commit introduced two main changes:
1. Removal of an event bus
2. Moving logic from the `homeView` to `PublisherState`

Being the second change the cause of this problem, ignoring that a couple state method calls were still required to build up cached data that was used to display the last selected deployment.

Fixes #2459 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Went through the changes that caused this issue, looking for the area where the data was expected but missing.

## User Impact

Users should be able to see the last selected deployment when the publisher extension is opened and initializes.

## Automated Tests

We should have tests, we don't have any in this area of the product yet but I'll keep promoting efforts to make that happen. Specially since this issue would have been caught earlier with a test in place.

## Directions for Reviewers

- Create a deployment
- close (or reload) VS Code
- navigating to the Publisher extension home should show up the latest deployment data within the deployments dropdown

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
