### PR TITLE
Remove Kevin from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @dotNomad @kgartland-rstudio @sagerb @marcosnav
+*   @dotNomad @sagerb @marcosnav


### PR DESCRIPTION
Simple change that removes @kgartland-rstudio from `CODEOWNERS`