### PR TITLE
De-emphasize deployments select label

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -3,7 +3,7 @@
 <template>
   <div v-if="home.initializingRequestComplete">
     <div class="label">
-      <span>Deployment:</span>
+      <span class="text-sm text-sidebar-section-header">DEPLOYMENT</span>
 
       <ActionToolbar
         title="Deployment"

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -22,6 +22,10 @@ body {
   width: 100%;
 }
 
+.text-sm {
+  font-size: 11px;
+}
+
 .text-foreground {
   color: var(--vscode-foreground);
 }
@@ -40,6 +44,10 @@ body {
 
 .text-list-deemphasized {
   color: var(--vscode-list-deemphasizedForeground);
+}
+
+.text-sidebar-section-header {
+  color: var(--vscode-sideBarSectionHeader-foreground);
 }
 
 .text-error {


### PR DESCRIPTION
Nice and simple PR that de-emphasizes the "Deployment" label for our deployment select. This is done by:
- lowering the font size to `11px` from `13px` to match the VS Code sidebar header
- uses `--vscode-sideBarSectionHeader-foreground` color rather than the default


<details>
  <summary>Before</summary>
  
![CleanShot 2024-12-11 at 16 22 12](https://github.com/user-attachments/assets/b70862bc-4600-4db2-b75e-ee7ba8dcbddc)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2024-12-11 at 16 21 33](https://github.com/user-attachments/assets/d4cc9a5b-47df-4dcc-8c66-fdb65165a15a)

</details> 