### PR TITLE
Emphasize select deployment title

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/QuickPickItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/QuickPickItem.vue
@@ -38,6 +38,15 @@ defineProps<{
     display: flex;
     align-items: center;
 
+    &:not(:only-child) {
+      .quick-pick-label-container {
+        .quick-pick-label {
+          font-weight: 600;
+          padding-bottom: 4px;
+        }
+      }
+    }
+
     .quick-pick-icon {
       vertical-align: text-bottom;
       padding-right: 6px;


### PR DESCRIPTION
This PR emphasizes the selected deployment content title in the sidebar by bolding the text (with `font-weight: 600`) and adding a small amount of `padding-bottom` to separate it from the server and entrypoint details below it.

<details>
  <summary>Before</summary>

![CleanShot 2024-12-11 at 16 40 22@2x](https://github.com/user-attachments/assets/d33840ca-8216-46c1-9018-fa9a985a951d)
  
</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2024-12-11 at 16 39 53@2x](https://github.com/user-attachments/assets/02719ce5-a214-4b94-95a1-1ce45c22a4f5)

</details> 