### PR TITLE
Use chevron-right for deployment select

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -23,7 +23,7 @@
           :data-automation="`entrypoint-label`"
         />
         <div
-          class="select-indicator codicon codicon-chevron-down"
+          class="select-indicator codicon codicon-chevron-right"
           aria-hidden="true"
         />
       </div>


### PR DESCRIPTION
Changes the chevron icon used in the sidebar for deployment selection to `codicon-chevron-right` from `codicon-chevron-down`

<details>
  <summary>Before</summary>
  
![CleanShot 2024-12-11 at 16 42 31@2x](https://github.com/user-attachments/assets/2e8f5ea3-87a8-4292-b1da-ce16466fce80)
  
</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2024-12-11 at 16 42 54@2x](https://github.com/user-attachments/assets/885ff6ea-1684-422d-a2af-0a0e317c32e7)

</details> 