### PR TITLE
Disable entrypoint checkbox in Project Files view

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
@@ -35,6 +35,7 @@
         :checked="checked"
         :disabled="disabled"
         class="tree-item-checkbox"
+        :class="{ 'opacity-100': disableOpacity }"
         @click="checked ? $emit('uncheck') : $emit('check')"
       >
         <span class="tree-item-title">{{ title }}</span>
@@ -77,6 +78,7 @@ interface Props {
   indentLevel?: number;
   expandable?: boolean;
   virtualized?: boolean;
+  disableOpacity?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -84,6 +86,7 @@ const props = withDefaults(defineProps<Props>(), {
   indentLevel: 1,
   expandable: false,
   virtualized: false,
+  disableOpacity: false,
 });
 
 const slots = defineSlots<{

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/ProjectFile.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/ProjectFile.vue
@@ -4,6 +4,7 @@
     :checked="isIncluded"
     :disabled="isDisabled"
     :list-style="listStyle"
+    :disable-opacity="isEntrypoint"
     :indent-level="file.indent + 1"
     :expandable="file.isDir"
     :tooltip="tooltip"
@@ -57,7 +58,11 @@ const fileStore = useFileStore();
 
 const isDisabled = computed((): boolean => {
   const source = props.file.reason?.source;
-  return source === "built-in" || source === "permissions";
+  return (
+    (isEntrypoint.value && isIncluded.value) ||
+    source === "built-in" ||
+    source === "permissions"
+  );
 });
 
 const isIncluded = computed((): boolean => {

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/ProjectFile.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/ProjectFile.vue
@@ -99,7 +99,7 @@ const listStyle = computed((): "emphasized" | "default" | "deemphasized" => {
 
 const tooltip = computed((): string => {
   return isIncluded.value
-    ? includedFileTooltip(props.file)
+    ? includedFileTooltip(props.file, isEntrypoint.value)
     : excludedFileTooltip(props.file);
 });
 

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.test.ts
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { includedFileTooltip, excludedFileTooltip } from "./tooltips";
+import { FileMatchSource } from "../../../../../../src/api/types/files";
+
+describe("includedFileTooltip", () => {
+  it("should return correct tooltip for included file without reason", () => {
+    const file = { rel: "src/index.ts", reason: null };
+    const tooltip = includedFileTooltip(file);
+    expect(tooltip).toBe(
+      "src/index.ts will be included in the next deployment.",
+    );
+  });
+
+  it("should return correct tooltip for included file with reason", () => {
+    const file = {
+      rel: "src/config.json",
+      reason: {
+        fileName: "config.json",
+        pattern: "*.json",
+        source: FileMatchSource.FILE,
+        filePath: "src/config.json",
+        exclude: false,
+      },
+    };
+    const tooltip = includedFileTooltip(file);
+    expect(tooltip).toBe(
+      `src/config.json will be included in the next deployment.\nThe configuration file config.json is including it with the pattern '*.json'`,
+    );
+  });
+
+  it("should return correct tooltip for entrypoint file", () => {
+    const file = { rel: "src/index.ts", reason: null };
+    const tooltip = includedFileTooltip(file, true);
+    expect(tooltip).toBe(
+      `src/index.ts will be included in the next deployment.\nsrc/index.ts is the entrypoint. Entrypoints must be included in the configuration 'files' list.`,
+    );
+  });
+});
+
+describe("excludedFileTooltip", () => {
+  it("should return correct tooltip for excluded file without reason", () => {
+    const file = { rel: "src/index.ts", reason: null };
+    const tooltip = excludedFileTooltip(file);
+    expect(tooltip).toBe(
+      `src/index.ts will be excluded in the next deployment.\nIt did not match any pattern in the configuration 'files' list.`,
+    );
+  });
+
+  it("should return correct tooltip for excluded file with built-in reason", () => {
+    const file = {
+      rel: "src/index.ts",
+      reason: {
+        source: FileMatchSource.BUILT_IN,
+        pattern: "*.ts",
+        fileName: "config.json",
+        filePath: "src/index.ts",
+        exclude: true,
+      },
+    };
+    const tooltip = excludedFileTooltip(file);
+    expect(tooltip).toBe(
+      `src/index.ts will be excluded in the next deployment.\nThis is a built-in exclusion for the pattern: '*.ts' and cannot be overridden.`,
+    );
+  });
+
+  it("should return correct tooltip for excluded file with permissions error", () => {
+    const file = {
+      rel: "src/index.ts",
+      reason: {
+        source: FileMatchSource.PERMISSIONS_ERROR,
+        pattern: "",
+        fileName: "",
+        filePath: "",
+        exclude: true,
+      },
+    };
+    const tooltip = excludedFileTooltip(file);
+    expect(tooltip).toBe(
+      `src/index.ts will be excluded in the next deployment.\nYou don't have permission to access this directory.`,
+    );
+  });
+
+  it("should return correct tooltip for excluded file with custom reason", () => {
+    const file = {
+      rel: "src/index.ts",
+      reason: {
+        fileName: "config.json",
+        pattern: "*.ts",
+        source: FileMatchSource.FILE,
+        filePath: "src/index.ts",
+        exclude: true,
+      },
+    };
+    const tooltip = excludedFileTooltip(file);
+    expect(tooltip).toBe(
+      `src/index.ts will be excluded in the next deployment.\nThe configuration file config.json is excluding it with the pattern '*.ts'`,
+    );
+  });
+});

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
@@ -2,10 +2,14 @@ import { ContentRecordFile, FileMatchSource } from "../../../../../../src/api";
 
 export function includedFileTooltip(
   file: Pick<ContentRecordFile, "rel" | "reason">,
+  isEntrypoint: boolean = false,
 ) {
   let tooltip = `${file.rel} will be included in the next deployment.`;
   if (file.reason) {
     tooltip += `\nThe configuration file ${file.reason?.fileName} is including it with the pattern '${file.reason?.pattern}'`;
+  }
+  if (isEntrypoint) {
+    tooltip += `\n${file.rel} is the entrypoint. Entrypoints must be included in the configuration 'files' list.`;
   }
   return tooltip;
 }

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
@@ -1,4 +1,7 @@
-import { ContentRecordFile, FileMatchSource } from "../../../../../../src/api";
+import {
+  ContentRecordFile,
+  FileMatchSource,
+} from "../../../../../../src/api/types/files";
 
 export function includedFileTooltip(
   file: Pick<ContentRecordFile, "rel" | "reason">,

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -85,3 +85,7 @@ body {
 .text-git-conflicting {
   color: var(--vscode-gitDecoration-conflictingResourceForeground);
 }
+
+.opacity-100 {
+  opacity: 1;
+}

--- a/extensions/vscode/webviews/homeView/vite.config.ts
+++ b/extensions/vscode/webviews/homeView/vite.config.ts
@@ -40,10 +40,10 @@ export default defineConfig({
     coverage: {
       enabled: true,
       thresholds: {
-        functions: 27.77,
-        lines: 16.06,
-        branches: 37.97,
-        statements: 16.06,
+        functions: 30.13,
+        lines: 17.48,
+        branches: 44.82,
+        statements: 17.48,
         autoUpdate: true,
       },
     },


### PR DESCRIPTION
This prevents the user from unchecking the entrypoint checkbox (and therefor removing the entrypoint from the `files` attribute in their configuration).

The configuration can still be edited by hand, but the sidebar no longer allows getting into this bad state.

## Intent

Part of #1493 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact

The user will no longer be able to uncheck the entrypoint's checkbox.

## Directions for Reviewers

Ensure that the entrypoint, no matter the details in the configuration, can be unchecked.

Checking the entrypoint checkbox should still be available if the configuration is manually edited and the entrypoint needs to be added.
