### PR TITLE
Show error message if backing up credential file fails

### DIFF
--- a/extensions/vscode/src/api/resources/Credentials.ts
+++ b/extensions/vscode/src/api/resources/Credentials.ts
@@ -48,6 +48,7 @@ export class Credentials {
 
   // Returns:
   // 204 - success (no response)
+  // 500 - internal server error cannot backup file
   // 503 - credentials service unavailable
   reset() {
     return this.client.delete<{ backupFile: string }>(`credentials`);

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -22,6 +22,8 @@ import {
 import {
   isErrCredentialsCorrupted,
   errCredentialsCorruptedMessage,
+  isErrCannotBackupCredentialsFile,
+  errCannotBackupCredentialsFileMessage,
 } from "src/utils/errorTypes";
 import { DeploymentSelector, SelectionState } from "src/types/shared";
 import { LocalState, Views } from "./constants";
@@ -308,6 +310,10 @@ export class PublisherState implements Disposable {
       const listResponse = await api.credentials.list();
       this.credentials = listResponse.data;
     } catch (err: unknown) {
+      if (isErrCannotBackupCredentialsFile(err)) {
+        window.showErrorMessage(errCannotBackupCredentialsFileMessage(err));
+        return;
+      }
       const summary = getSummaryStringFromError("resetCredentials", err);
       window.showErrorMessage(summary);
     }

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -18,6 +18,7 @@ export type ErrorCode =
   | "tomlValidationError"
   | "tomlUnknownError"
   | "pythonExecNotFound"
+  | "credentialsCannotBackupFile"
   | "credentialsCorrupted";
 
 export type axiosErrorWithJson<T = { code: ErrorCode; details: unknown }> =
@@ -174,6 +175,21 @@ export const errCredentialsCorruptedMessage = (backupFile: string) => {
     msg += ` Previous credentials data backed up at ${backupFile}`;
   }
   return msg;
+};
+
+// Unable to backup credentials file
+export type ErrCannotBackupCredentialsFile = MkErrorDataType<
+  "credentialsCannotBackupFile",
+  { filename: string; message: string }
+>;
+export const isErrCannotBackupCredentialsFile =
+  mkErrorTypeGuard<ErrCannotBackupCredentialsFile>(
+    "credentialsCannotBackupFile",
+  );
+export const errCannotBackupCredentialsFileMessage = (
+  err: axiosErrorWithJson<ErrCannotBackupCredentialsFile>,
+) => {
+  return err.response.data.details.message;
 };
 
 // Tries to match an Axios error that comes with an identifiable Json structured data

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -189,7 +189,7 @@ export const isErrCannotBackupCredentialsFile =
 export const errCannotBackupCredentialsFileMessage = (
   err: axiosErrorWithJson<ErrCannotBackupCredentialsFile>,
 ) => {
-  return err.response.data.details.message;
+  return `Unrecognizable credentials for Posit Publisher were found. ${err.response.data.details.message}`;
 };
 
 // Tries to match an Axios error that comes with an identifiable Json structured data

--- a/internal/credentials/errors.go
+++ b/internal/credentials/errors.go
@@ -107,7 +107,7 @@ func (e *IncompleteCredentialError) Error() string {
 func NewBackupFileAgentError(filename string, err error) *types.AgentError {
 	details := types.ErrorCredentialsCannotBackupFileDetails{
 		Filename: filename,
-		Message:  fmt.Sprintf("failed to backup credentials to %s: %v", filename, err.Error()),
+		Message:  fmt.Sprintf("Failed to backup credentials to %s: %v", filename, err.Error()),
 	}
 	return types.NewAgentError(types.ErrorCredentialsCannotBackupFile, err, details)
 }

--- a/internal/credentials/errors.go
+++ b/internal/credentials/errors.go
@@ -2,7 +2,11 @@
 
 package credentials
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/posit-dev/publisher/internal/types"
+)
 
 type CorruptedError struct {
 	GUID string
@@ -98,4 +102,12 @@ func NewIncompleteCredentialError() *IncompleteCredentialError {
 
 func (e *IncompleteCredentialError) Error() string {
 	return "New credentials require non-empty Name, URL and Api Key fields"
+}
+
+func NewBackupFileAgentError(filename string, err error) *types.AgentError {
+	details := types.ErrorCredentialsCannotBackupFileDetails{
+		Filename: filename,
+		Message:  fmt.Sprintf("failed to backup credentials to %s: %v", filename, err.Error()),
+	}
+	return types.NewAgentError(types.ErrorCredentialsCannotBackupFile, err, details)
 }

--- a/internal/credentials/file.go
+++ b/internal/credentials/file.go
@@ -231,20 +231,20 @@ func (c *fileCredentialsService) backupFile() (string, error) {
 	if os.IsNotExist(err) {
 		file, err := credsCopyPath.Create()
 		if err != nil {
-			return "", err
+			return "", NewBackupFileAgentError(credsCopyPath.String(), err)
 		}
 		file.Close()
 	}
 
 	credsCopyFile, err := credsCopyPath.OpenFile(os.O_TRUNC|os.O_RDWR, 0644)
 	if err != nil {
-		return "", err
+		return "", NewBackupFileAgentError(credsCopyPath.String(), err)
 	}
 	defer credsCopyFile.Close()
 
 	credsFile, err := c.credsFilepath.Open()
 	if err != nil {
-		return "", err
+		return "", NewBackupFileAgentError(credsCopyPath.String(), err)
 	}
 	defer credsFile.Close()
 

--- a/internal/services/api/reset_credentials_test.go
+++ b/internal/services/api/reset_credentials_test.go
@@ -101,8 +101,8 @@ func (s *ResetCredsSuite) TestReset_BackupFileError() {
 	h(rec, req)
 
 	bodyRes := rec.Body.String()
-	s.Equal(http.StatusInternalServerError, rec.Result().StatusCode)
-	s.Contains(bodyRes, `{"code":"credentialsCannotBackupFile","details":{"filename":"~/.connect-creds","message":"failed to backup credentials to ~/.connect-creds: do not have write permissions"}}`)
+	s.Equal(http.StatusBadRequest, rec.Result().StatusCode)
+	s.Contains(bodyRes, `{"code":"credentialsCannotBackupFile","details":{"filename":"~/.connect-creds","message":"Failed to backup credentials to ~/.connect-creds: do not have write permissions"}}`)
 }
 
 func (s *ResetCredsSuite) TestReset_UnknownError() {

--- a/internal/types/api_errors.go
+++ b/internal/types/api_errors.go
@@ -187,7 +187,7 @@ type APIErrorCredentialsBackupFileError struct {
 }
 
 func (apierr *APIErrorCredentialsBackupFileError) JSONResponse(w http.ResponseWriter) {
-	jsonResult(w, http.StatusInternalServerError, apierr)
+	jsonResult(w, http.StatusBadRequest, apierr)
 }
 
 func APIErrorCredentialsBackupFileFromAgentError(aerr AgentError) APIErrorCredentialsBackupFileError {

--- a/internal/types/api_errors.go
+++ b/internal/types/api_errors.go
@@ -176,6 +176,30 @@ func APIErrorCredentialsCorruptedFromAgentError(aerr AgentError) APIErrorCredent
 	}
 }
 
+type ErrorCredentialsCannotBackupFileDetails struct {
+	Filename string `json:"filename"`
+	Message  string `json:"message"`
+}
+
+type APIErrorCredentialsBackupFileError struct {
+	Code    ErrorCode                               `json:"code"`
+	Details ErrorCredentialsCannotBackupFileDetails `json:"details"`
+}
+
+func (apierr *APIErrorCredentialsBackupFileError) JSONResponse(w http.ResponseWriter) {
+	jsonResult(w, http.StatusInternalServerError, apierr)
+}
+
+func APIErrorCredentialsBackupFileFromAgentError(aerr AgentError) APIErrorCredentialsBackupFileError {
+	return APIErrorCredentialsBackupFileError{
+		Code: ErrorCredentialsCannotBackupFile,
+		Details: ErrorCredentialsCannotBackupFileDetails{
+			Filename: aerr.Data["Filename"].(string),
+			Message:  aerr.Data["Message"].(string),
+		},
+	}
+}
+
 type APIErrorPythonExecNotFound struct {
 	Code ErrorCode `json:"code"`
 }

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -20,6 +20,7 @@ const (
 	ErrorInvalidConfigFiles           ErrorCode = "invalidConfigFiles"
 	ErrorCredentialServiceUnavailable ErrorCode = "credentialsServiceUnavailable"
 	ErrorCredentialsCorrupted         ErrorCode = "credentialsCorrupted"
+	ErrorCredentialsCannotBackupFile  ErrorCode = "credentialsCannotBackupFile"
 	ErrorCertificateVerification      ErrorCode = "errorCertificateVerification"
 	ErrorRenvPackageVersionMismatch   ErrorCode = "renvPackageVersionMismatch"
 	ErrorRenvPackageSourceMissing     ErrorCode = "renvPackageSourceMissing"


### PR DESCRIPTION
This PR adds a new `AgentError` that bubbles up if operations in the backing-up of the credential file fail, showing the user the message so they may take action on it.

## Intent

Resolves #2513

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact

Now a notification will be shown with the specific error that occurred when backing up a credential file, with an error code that we can do more with in the future.

## Automated Tests

Automated tests were added to ensure that the correct data is sent back when the reset API errors.

## Directions for Reviewers

Ensure that the error bubbles up via the API, is shown as a notification, and works in Workbench.
