### PR TITLE
Follow-on #2 for dismissed deployment support PR

### DIFF
--- a/extensions/vscode/src/events.ts
+++ b/extensions/vscode/src/events.ts
@@ -177,15 +177,24 @@ export class EventStream extends Readable implements Disposable {
   }
 
   private processMessage(msg: EventStreamMessage) {
-    const localId = msg.data.localId;
-    if (localId && this.canceledLocalIDs.includes(localId)) {
+    // Some log messages passed on from Connect include
+    // the localId using snake_case, rather than pascalCase.
+    // To filter correctly, we need to check for both.
+
+    const localIdForm1 = msg.data.localId;
+    if (localIdForm1 && this.canceledLocalIDs.includes(localIdForm1)) {
       // suppress and ignore
       return;
     }
-    // Trace message
-    // console.debug(
-    //   `eventSource trace: ${event.type}: ${JSON.stringify(event)}`,
-    // );
+    const localIdForm2 = msg.data.local_id;
+    if (localIdForm2 && this.canceledLocalIDs.includes(localIdForm2)) {
+      // suppress and ignore
+      return;
+    }
+
+    // // Trace message
+    // console.debug(`eventSource trace: ${msg.type}: ${JSON.stringify(msg)}`);
+
     // Add the message to the messages array
     this.messages.push(msg);
     // Emit a 'message' event with the message as the payload

--- a/extensions/vscode/src/events.ts
+++ b/extensions/vscode/src/events.ts
@@ -190,7 +190,7 @@ export class EventStream extends Readable implements Disposable {
     // Trace message
     // Uncomment the following code if you want to dump every message to the
     // console as it is received.
-    console.debug(`eventSource trace: ${msg.type}: ${JSON.stringify(msg)}`);
+    // console.debug(`eventSource trace: ${msg.type}: ${JSON.stringify(msg)}`);
 
     // Add the message to the messages array
     this.messages.push(msg);

--- a/extensions/vscode/src/events.ts
+++ b/extensions/vscode/src/events.ts
@@ -181,19 +181,16 @@ export class EventStream extends Readable implements Disposable {
     // the localId using snake_case, rather than pascalCase.
     // To filter correctly, we need to check for both.
 
-    const localIdForm1 = msg.data.localId;
-    if (localIdForm1 && this.canceledLocalIDs.includes(localIdForm1)) {
-      // suppress and ignore
-      return;
-    }
-    const localIdForm2 = msg.data.local_id;
-    if (localIdForm2 && this.canceledLocalIDs.includes(localIdForm2)) {
+    const localId = msg.data.localId || msg.data.local_id;
+    if (localId && this.canceledLocalIDs.includes(localId)) {
       // suppress and ignore
       return;
     }
 
-    // // Trace message
-    // console.debug(`eventSource trace: ${msg.type}: ${JSON.stringify(msg)}`);
+    // Trace message
+    // Uncomment the following code if you want to dump every message to the
+    // console as it is received.
+    console.debug(`eventSource trace: ${msg.type}: ${JSON.stringify(msg)}`);
 
     // Add the message to the messages array
     this.messages.push(msg);

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -167,6 +167,25 @@ export class PublisherState implements Disposable {
     }
   }
 
+  updateContentRecord(
+    newValue: ContentRecord | PreContentRecord | PreContentRecordWithConfig,
+  ) {
+    const existingContentRecord = this.findContentRecord(
+      newValue.saveName,
+      newValue.projectDir,
+    );
+    if (existingContentRecord) {
+      const crIndex = this.contentRecords.findIndex(
+        (contentRecord) => contentRecord.id === existingContentRecord?.id,
+      );
+      if (crIndex !== -1) {
+        this.contentRecords[crIndex] = newValue;
+      } else {
+        this.contentRecords.push(newValue);
+      }
+    }
+  }
+
   async getSelectedConfiguration() {
     const contentRecord = await this.getSelectedContentRecord();
     if (!contentRecord) {

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -177,8 +177,7 @@ export class PublisherState implements Disposable {
     if (existingContentRecord) {
       const crIndex = this.contentRecords.findIndex(
         (contentRecord) =>
-          contentRecord.deploymentPath ===
-          existingContentRecord?.deploymentPath,
+          contentRecord.deploymentPath === existingContentRecord.deploymentPath,
       );
       if (crIndex !== -1) {
         this.contentRecords[crIndex] = newValue;

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -176,7 +176,9 @@ export class PublisherState implements Disposable {
     );
     if (existingContentRecord) {
       const crIndex = this.contentRecords.findIndex(
-        (contentRecord) => contentRecord.id === existingContentRecord?.id,
+        (contentRecord) =>
+          contentRecord.deploymentPath ===
+          existingContentRecord?.deploymentPath,
       );
       if (crIndex !== -1) {
         this.contentRecords[crIndex] = newValue;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -36,6 +36,7 @@ import {
   useApi,
   AllContentRecordTypes,
   EnvironmentConfig,
+  PreContentRecordWithConfig,
 } from "src/api";
 import { EventStream } from "src/events";
 import { getPythonInterpreterPath, getRInterpreterPath } from "../utils/vscode";
@@ -213,6 +214,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         projectDir,
         response.data.localId,
         this.stream,
+        this.updateActiveContentRecordLocally.bind(this),
       );
     } catch (error: unknown) {
       // Most failures will occur on the event stream. These are the ones which
@@ -313,6 +315,19 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       window.showErrorMessage(`Failed to update config file. ${summary}`);
       return;
     }
+  }
+
+  private updateActiveContentRecordLocally(
+    activeContentRecord:
+      | ContentRecord
+      | PreContentRecord
+      | PreContentRecordWithConfig,
+  ) {
+    // update our local state, so we don't wait on file refreshes
+    this.state.updateContentRecord(activeContentRecord);
+
+    // refresh the webview
+    this.updateWebViewViewContentRecords();
   }
 
   private onPublishStart() {

--- a/extensions/vscode/webviews/homeView/vite.config.ts
+++ b/extensions/vscode/webviews/homeView/vite.config.ts
@@ -41,9 +41,9 @@ export default defineConfig({
       enabled: true,
       thresholds: {
         functions: 30.13,
-        lines: 17.48,
+        lines: 17.38,
         branches: 44.82,
-        statements: 17.48,
+        statements: 17.38,
         autoUpdate: true,
       },
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves: https://github.com/posit-dev/publisher/issues/2179

This PR contains follow-on changes to https://github.com/posit-dev/publisher/pull/2522. These changes have been separated by request to facilitate reviews in progress.

This PR addresses:
- removing the  flash of success status when canceling a deployment.
- Also fixed filtering to include some log messages from connect which had the local ID value in snake_case rather than camelCase. This suppresses a message from the Connect server which occurred when a second redeployment was progressing while the original, cancelled deployment was still processing.

![image](https://github.com/user-attachments/assets/57248495-53cf-42bf-8db6-5912f6035395)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->