### PR TITLE
Update design for last deployment alerts

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -618,7 +618,7 @@ const viewContent = () => {
     border-right-width: 1px;
     border-right-style: solid;
     padding-right: 5px;
-    margin-right: 5px;
+    margin-right: 7px;
   }
 }
 

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -185,7 +185,9 @@
           v-if="home.selectedContentRecord.deploymentError"
           class="last-deployment-details last-deployment-error"
         >
-          <span class="codicon codicon-alert"></span>
+          <div class="alert-border border-warning text-warning">
+            <span class="codicon codicon-alert" />
+          </div>
           <TextStringWithAnchor
             :message="home.selectedContentRecord?.deploymentError?.msg"
             :splitOptions="ErrorMessageSplitOptions"
@@ -607,11 +609,17 @@ const viewContent = () => {
 }
 
 .last-deployment-error {
-  border: solid 2px;
-  border-color: gray;
-  padding: 5px;
   display: flex;
-  align-items: center;
+  align-items: stretch;
+
+  .alert-border {
+    display: flex;
+    align-items: center;
+    border-right-width: 1px;
+    border-right-style: solid;
+    padding-right: 5px;
+    margin-right: 5px;
+  }
 }
 
 .error-icon {
@@ -621,7 +629,6 @@ const viewContent = () => {
 .error-message {
   min-width: 0;
   word-wrap: break-word;
-  margin-left: 5px;
 }
 
 .progress-container {

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -50,8 +50,20 @@ body {
   color: var(--vscode-sideBarSectionHeader-foreground);
 }
 
+.text-warning {
+  color: var(--vscode-list-warningForeground);
+}
+
+.border-warning {
+  border-color: var(--vscode-list-warningForeground);
+}
+
 .text-error {
   color: var(--vscode-list-errorForeground);
+}
+
+.border-error {
+  border-color: var(--vscode-list-errorForeground);
 }
 
 .text-git-added {

--- a/extensions/vscode/webviews/homeView/vite.config.ts
+++ b/extensions/vscode/webviews/homeView/vite.config.ts
@@ -41,9 +41,9 @@ export default defineConfig({
       enabled: true,
       thresholds: {
         functions: 30.13,
-        lines: 17.48,
+        lines: 17.46,
         branches: 44.82,
-        statements: 17.48,
+        statements: 17.46,
         autoUpdate: true,
       },
     },


### PR DESCRIPTION
This PR updates the design of the last deployment alerts in the sidebar.

<details>
  <summary>Before</summary>
  
![CleanShot 2025-01-13 at 12 09 04](https://github.com/user-attachments/assets/f897315d-8b95-4158-8060-16aa812a656d)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-01-13 at 17 04 51@2x](https://github.com/user-attachments/assets/abdafa3b-32c8-4b92-86c9-a1ec877901bd)

</details> 

It uses a simpler border on the left giving us slightly more room in the horizontal space. It also colorizes the icon and border using the `--vscode-list-warningForeground` variable from the user's selected theme.

## User Impact

Users will see a colorized warning matching other aspects of the VS Code UI. They will be able to fit slightly more text on the horizontal reducing a little of the vertical push that they experience with deployment alerts.
