### PR TITLE
Deemphasize last deployment alert descriptions

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -191,7 +191,7 @@
           <TextStringWithAnchor
             :message="home.selectedContentRecord?.deploymentError?.msg"
             :splitOptions="ErrorMessageSplitOptions"
-            class="error-message"
+            class="error-message text-description"
             @click="onErrorMessageAnchorClick"
           />
         </div>

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -30,6 +30,10 @@ body {
   color: var(--vscode-foreground);
 }
 
+.text-description {
+  color: var(--vscode-descriptionForeground);
+}
+
 .text-placeholder {
   color: var(--vscode-input-placeholderForeground);
 }


### PR DESCRIPTION
This PR uses a new VS Code `descriptionForeground` to deemphasize the last deployment alert descriptions. The links inside of those descriptions are un-affected and will use the link color as normal.

<details>
  <summary>Before</summary>
  
![image](https://github.com/user-attachments/assets/d60161f9-7fe8-41f1-97dd-40957d4627ba)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-01-13 at 12 25 52](https://github.com/user-attachments/assets/3591fc89-b85c-4b36-a92f-edd65f248e12)

</details> 

## User Impact

The design more accurately reflects the emphasis we want to put on parts of the sidebar.