### PR TITLE
Add warning if selected config has `type = 'unknown'`

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -82,7 +82,8 @@
       </p>
 
       <p v-if="home.config.active.isUnknownType">
-        The selected Configuration has an unknown type.
+        Please set the framework you are using, for example
+        <code>type = 'python-shiny'</code>.
         <a
           class="webview-link"
           role="button"

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -80,6 +80,19 @@
           >Edit the Configuration</a
         >.
       </p>
+
+      <p v-if="home.config.active.isUnknownType">
+        The selected Configuration has an unknown type.
+        <a
+          class="webview-link"
+          role="button"
+          @click="
+            onEditConfiguration(home.selectedConfiguration!.configurationPath)
+          "
+          >Edit the Configuration</a
+        >.
+      </p>
+
       <p v-if="home.config.active.isUnknownError">
         The selected Configuration has an error.
         <a

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -349,6 +349,14 @@ export const useHomeStore = defineStore("home", () => {
         );
       }),
 
+      isUnknownType: computed((): boolean => {
+        return Boolean(
+          selectedConfiguration.value &&
+            !isConfigurationError(selectedConfiguration.value) &&
+            selectedConfiguration.value.configuration.type === "unknown",
+        );
+      }),
+
       isUnknownError: computed((): boolean => {
         return Boolean(
           selectedConfiguration.value &&


### PR DESCRIPTION
This PR adds a new warning if the selected configuration has `type = 'unknown'` now that it is a valid type in the schema due to the work in #2423.

<details>
  <summary>Preview</summary>

![CleanShot 2025-01-17 at 11 07 58@2x](https://github.com/user-attachments/assets/496961f6-a8d1-4f58-afba-07558a1b30a4)
</details> 

I'm very open to suggestions regarding the text for the warning.

## Intent

Resolves #2515 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact

When a selected configuration has `type = 'unknown'` the user will now see a helpful warning (similar to our others like duplicate environment variable names warning).

This can occur either through a manual change, but also if inspection isn't able to reason about the `type` and the initial configuration defaults to `type = 'unknown'`.
