### PR TITLE
Use the same structure and spacing for deployment summaries

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -549,7 +549,6 @@ const viewContent = () => {
 
 .deployment-summary-container {
   display: flex;
-  align-items: center;
   justify-content: space-between;
   align-items: baseline;
 }

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -124,29 +124,34 @@
     >
       <vscode-divider class="home-view-divider" />
 
-      <div v-if="home.publishInProgress">
-        <div class="deployment-in-progress-container">
-          <div class="progress-container">
-            <vscode-progress-ring class="progress-ring" />
-            <div class="progress-desc">
-              <div data-automation="deployment-progress">
-                Deployment in Progress...
-              </div>
-              <p class="progress-log-anchor">
-                <a
-                  class="webview-link"
-                  role="button"
-                  @click="onViewPublishingLog"
-                  >View Log</a
+      <div
+        v-if="home.publishInProgress"
+        class="deployment-in-progress-container"
+      >
+        <vscode-progress-ring class="progress-ring" />
+        <div class="flex-grow">
+          <div class="deployment-summary-container">
+            <div class="progress-container">
+              <div class="progress-desc">
+                <h4
+                  data-automation="deployment-progress"
+                  class="deployment-summary-title"
                 >
-              </p>
+                  Deployment in Progress...
+                </h4>
+              </div>
             </div>
+            <ActionToolbar
+              title="Logs"
+              :actions="[]"
+              :context-menu="contextMenuVSCodeContext"
+            />
           </div>
-          <ActionToolbar
-            title="Logs"
-            :actions="[]"
-            :context-menu="contextMenuVSCodeContext"
-          />
+          <p class="progress-log-anchor">
+            <a class="webview-link" role="button" @click="onViewPublishingLog">
+              View Log
+            </a>
+          </p>
         </div>
       </div>
       <div v-else>
@@ -154,7 +159,7 @@
           class="deployment-summary-container"
           data-automation="deploy-status"
         >
-          <h4 class="deployment-summary">
+          <h4 class="deployment-summary-title">
             {{ lastStatusDescription }}
           </h4>
           <ActionToolbar
@@ -543,8 +548,6 @@ const viewContent = () => {
 
 .deployment-in-progress-container {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .deployment-summary-container {
@@ -595,7 +598,8 @@ const viewContent = () => {
   margin-top: 1.33em;
 }
 
-.deployment-summary {
+.deployment-summary-title {
+  margin-block-start: 1.33em;
   margin-bottom: 5px;
 }
 
@@ -634,10 +638,11 @@ const viewContent = () => {
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-top: 10px;
 }
 
 .progress-ring {
+  flex-grow: 0;
+  margin-top: 1.33em;
   margin-right: 10px;
 }
 
@@ -648,7 +653,7 @@ const viewContent = () => {
 }
 
 .progress-log-anchor {
-  margin-top: 5px;
-  margin-bottom: 0px;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 </style>

--- a/extensions/vscode/webviews/homeView/src/style.css
+++ b/extensions/vscode/webviews/homeView/src/style.css
@@ -22,6 +22,14 @@ body {
   width: 100%;
 }
 
+.flex-grow-0 {
+  flex-grow: 0;
+}
+
+.flex-grow {
+  flex-grow: 1;
+}
+
 .text-sm {
   font-size: 11px;
 }


### PR DESCRIPTION
This PR changes the structure and CSS of the in progress summary to be more similar to our other states - cancelled, successful, failed.

It unifies some of the CSS and markup to accomplish this so the vertical spacing and font-weight do not change across those summaries.

<details>
  <summary>Preview Video</summary>

https://github.com/user-attachments/assets/2c2e569e-27c6-4908-b1ad-dfdfcc114448

</details> 

Notice how the vertical space between the title (progress ring) and the line above no longer change.

## Intent

Resolves #2531 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->