### PR TITLE
Use icons with deployment selection details

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -18,7 +18,7 @@
       <div class="deployment-control" v-on="{ click: onSelectDeployment }">
         <QuickPickItem
           :label="deploymentTitle"
-          :details="deploymentSubTitles"
+          :details="deploymentDetails"
           :title="toolTipText"
           :data-automation="`entrypoint-label`"
         />
@@ -241,7 +241,7 @@ import { filterConfigurationsToValidAndType } from "../../../../src/utils/filter
 import { useHostConduitService } from "src/HostConduitService";
 import { useHomeStore } from "src/stores/home";
 
-import QuickPickItem from "src/components/QuickPickItem.vue";
+import QuickPickItem, { IconDetail } from "src/components/QuickPickItem.vue";
 import ActionToolbar from "src/components/ActionToolbar.vue";
 import DeployButton from "src/components/DeployButton.vue";
 import TextStringWithAnchor from "./TextStringWithAnchor.vue";
@@ -343,13 +343,13 @@ const deploymentTitle = computed(() => {
   return result.title;
 });
 
-const deploymentSubTitles = computed(() => {
-  const subTitles: string[] = [];
-  subTitles.push(credentialSubTitle.value);
+const deploymentDetails = computed(() => {
+  const details: IconDetail[] = [];
+  details.push({ icon: "codicon-server", text: credentialSubTitle.value });
   if (entrypointSubTitle.value) {
-    subTitles.push(entrypointSubTitle.value);
+    details.push({ icon: "codicon-file", text: entrypointSubTitle.value });
   }
-  return subTitles;
+  return details;
 });
 
 const credentialSubTitle = computed(() => {

--- a/extensions/vscode/webviews/homeView/src/components/QuickPickItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/QuickPickItem.vue
@@ -12,16 +12,25 @@
       </div>
     </div>
     <div v-for="detail in details" class="quick-pick-row">
-      <span class="quick-pick-detail">{{ detail }}</span>
+      <div v-if="isIconDetail(detail)" class="quick-pick-detail">
+        <div class="quick-pick-icon codicon" :class="detail.icon" />
+        <span>{{ detail.text }}</span>
+      </div>
+      <span v-else class="quick-pick-detail">{{ detail }}</span>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+export type IconDetail = { icon: string; text: string };
+
+const isIconDetail = (detail: string | IconDetail): detail is IconDetail =>
+  typeof detail === "object" && "icon" in detail && "text" in detail;
+
 defineProps<{
   label: string;
   description?: string;
-  details: string[];
+  details: Array<string | IconDetail>;
   codicon?: string;
 }>();
 </script>
@@ -42,7 +51,7 @@ defineProps<{
       .quick-pick-label-container {
         .quick-pick-label {
           font-weight: 600;
-          padding-bottom: 4px;
+          margin-bottom: 4px;
         }
       }
     }
@@ -85,6 +94,14 @@ defineProps<{
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: pre;
+
+      &:not(:last-child) {
+        margin-bottom: 2px;
+      }
+
+      .quick-pick-icon {
+        font-size: var(--vscode-font-size);
+      }
     }
   }
 }

--- a/extensions/vscode/webviews/homeView/src/components/QuickPickItem.vue
+++ b/extensions/vscode/webviews/homeView/src/components/QuickPickItem.vue
@@ -56,6 +56,12 @@ defineProps<{
       }
     }
 
+    &:not(:last-child) {
+      .quick-pick-detail {
+        margin-bottom: 2px;
+      }
+    }
+
     .quick-pick-icon {
       vertical-align: text-bottom;
       padding-right: 6px;
@@ -94,10 +100,6 @@ defineProps<{
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: pre;
-
-      &:not(:last-child) {
-        margin-bottom: 2px;
-      }
 
       .quick-pick-icon {
         font-size: var(--vscode-font-size);


### PR DESCRIPTION
This PR adds icons next to the details in the deployment selection `QuickPickItem` component.

Specifically:
- the `server` codicon next to the Credential indicating the Connect Server the deployment will be going to 
- the `file` codicon next to the entrypoint file name

If you have an alternative suggest the list of codicons can be found here: https://microsoft.github.io/vscode-codicons/dist/codicon.html

<details>
  <summary>Before</summary>
  
![CleanShot 2025-01-14 at 14 49 59@2x](https://github.com/user-attachments/assets/347d796a-73d5-4461-8830-8894498bdebc)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-01-14 at 16 58 09@2x](https://github.com/user-attachments/assets/3837cecc-f04c-48c9-82d0-522f9e7fde56)

</details> 

## Intent

Resolves #2483

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to support both strings (as we did before) and the new `IconDetail` object in the `QuickPickItem` `details` prop. Now that it supports both we can easily send the new `IconDetail` array to the component.

Additional margin (`margin-bottom: 2px`) was added to the detail rows to provide a bit more spacing between the details with the new icons.