### PR TITLE
Disable vitest thresholds `autoUpdate`

### DIFF
--- a/.github/workflows/home-view-unit-test.yaml
+++ b/.github/workflows/home-view-unit-test.yaml
@@ -15,5 +15,3 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
       - run: npm install
       - run: npm test
-      - name: Check Vitest thresholds
-        run: git diff --name-only --exit-code vite.config.ts

--- a/extensions/vscode/webviews/homeView/vite.config.ts
+++ b/extensions/vscode/webviews/homeView/vite.config.ts
@@ -40,11 +40,12 @@ export default defineConfig({
     coverage: {
       enabled: true,
       thresholds: {
-        functions: 30.13,
-        lines: 17.46,
-        branches: 44.82,
-        statements: 17.46,
-        autoUpdate: true,
+        functions: 30,
+        lines: 17,
+        branches: 44,
+        statements: 17,
+        // avoid auto-updating thresholds to avoid off by 0.01 differences
+        autoUpdate: false,
       },
     },
   },


### PR DESCRIPTION
This PR sets the `coverage.thresholds.autoUpdate` feature of `vitest` to `false` to avoid off by `0.01` coverage reporting errors.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->