### PR TITLE
Rewording "canceled" to "dismissed" and show notification as an informational message

### DIFF
--- a/extensions/vscode/src/events.ts
+++ b/extensions/vscode/src/events.ts
@@ -77,7 +77,7 @@ export function displayEventStreamMessage(msg: EventStreamMessage): string {
       return `Deployment failed, click to view Connect logs: ${msg.data.dashboardUrl}`;
     }
     if (msg.data.canceled === "true") {
-      return "Deployment canceled";
+      return "Deployment dismissed";
     }
     return "Deployment failed";
   }

--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -71,7 +71,7 @@ export function deployProject(
               localId: localID,
               canceled: "true",
               message:
-                "Deployment has been dismissed (but will continue to be processed on the Connect Server).",
+                "Deployment has been dismissed, but will continue to be processed on the Connect Server.",
             },
             error: "Deployment has been dismissed.",
           });
@@ -81,7 +81,7 @@ export function deployProject(
             "deployProject, token.onCancellationRequested",
             error,
           );
-          window.showErrorMessage(`Unable to abort deployment: ${summary}`);
+          window.showErrorMessage(`Unable to dismiss deployment: ${summary}`);
         }
         resolveCB();
       });

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -209,10 +209,18 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       } else {
         errorMessage =
           msg.data.canceled === "true"
-            ? `Deployment canceled: ${msg.data.message}`
+            ? msg.data.message
             : `Deployment failed: ${msg.data.message}`;
       }
-      const selection = await window.showErrorMessage(errorMessage, ...options);
+      let selection: string | undefined;
+      if (msg.data.canceled === "true") {
+        selection = await window.showInformationMessage(
+          errorMessage,
+          ...options,
+        );
+      } else {
+        selection = await window.showErrorMessage(errorMessage, ...options);
+      }
       if (selection === showLogsOption) {
         await commands.executeCommand(Commands.Logs.Focus);
       } else if (selection === enhancedError?.buttonStr) {

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -406,7 +406,7 @@ const lastStatusDescription = computed(() => {
       : "Not Yet Deployed";
   }
   if (isAbortedContentRecord.value) {
-    return "Last Deployment Canceled";
+    return "Last Deployment Dismissed";
   }
   return "Last Deployment Successful";
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Change term from "Canceled" to "Dismissed" for the display status when the user has dismissed a deployment in progress. The notification which indicates that the deployment has been dismissed now shows as an informational message rather than an error message (the icon has changed).

With these changes, the UX displays the following when the user has clicked cancel on the deployment progress indicator:
![2025-01-14 at 5 11 PM](https://github.com/user-attachments/assets/36e62d74-5461-4958-aa89-b1c17030b1f7)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
