### PR TITLE
Include connectivity to server check in invalid server or credentials error

### DIFF
--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -86,7 +86,7 @@ func (u *UserDTO) CanPublish() bool {
 	return u.UserRole == AuthRoleAdmin || u.UserRole == AuthRolePublisher
 }
 
-var errInvalidServerOrCredentials = errors.New("could not validate credentials; check server URL and API key or token")
+var errInvalidServerOrCredentials = errors.New("could not validate credentials; check connectivity to the server, the URL, and API key")
 var errInvalidApiKey = errors.New("could not log in with the provided credentials")
 var errInvalidServer = errors.New("could not access the server; check the server URL and try again")
 


### PR DESCRIPTION
This PR changes the `errInvalidServerOrCredentials` to be more board to include the case where the Connect server is down or cannot be connected to. Now rather than only suggesting to check the provided server URL and API key it now also suggested checking "connectivity to the server".

## Intent

Resolves #2450