### PR TITLE
Add troubleshooting link to documentation when `publish/failure` occurs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,10 @@ See the [VS Code Extension](vscode.md) page.
 
 See the [Configuration Reference](configuration.md) page.
 
+## Troubleshooting
+
+See the [Troubleshooting](troubleshooting.md) page.
+
 ## Acknowledgements
 
 See the [Licenses](licenses.md) page.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 This document contains some common issues and solutions for Posit Publisher.
 
-### The Configuration has a schema error
+## The Configuration has a schema error
 
 If deploying results in the following error:
 
@@ -19,7 +19,7 @@ Carefully check your Configuration file for any errors, and refer to the
 [Configuration File reference documentation](https://github.com/posit-dev/publisher/blob/main/docs/configuration.md)
 for more details on the fields and values that are expected.
 
-### Unrecognized app mode
+## Unrecognized app mode
 
 If when deploying you see the following error:
 
@@ -27,7 +27,7 @@ If when deploying you see the following error:
 
 there are few things to check.
 
-#### Using `type = 'unknown'`
+### Using `type = 'unknown'`
 
 If your Configuration file contains `type = 'unknown'`, either from the
 generated Configuration being unable to identify the type of your content, or
@@ -40,7 +40,7 @@ Configuration.
 To fix this you will need to find and set the `type` in your Configuration file.
 Supported types can be found in the [Configuration File Reference documentation](https://github.com/posit-dev/publisher/blob/main/docs/configuration.md#type).
 
-#### Using a `type` that is not supported by your server
+### Using a `type` that is not supported by your server
 
 Another possibility is Posit Connect, on the server you are deploying to, is
 older than the version that introduced support for the `type` set in your

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,20 +2,53 @@
 
 This document contains some common issues and solutions for Posit Publisher.
 
-### Unrecongized app mode
+### The Configuration has a schema error
+
+If deploying results in the following error:
+
+> Failed to deploy. The Configuration has a schema error
+
+This occurs when there is a problem with the Deployment's Configuration file.
+This can occur due to a missing field, an incorrect value, or even a typo.
+
+Using an extension like [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)
+can help catch problems in the Configuration by providing syntax highlighting,
+completion, and hover text using the schema provided by Posit Publisher.
+
+Carefully check your Configuration file for any errors, and refer to the
+[Configuration File reference documentation](https://github.com/posit-dev/publisher/blob/main/docs/configuration.md)
+for more details on the fields and values that are expected.
+
+### Unrecognized app mode
 
 If when deploying you see the following error:
 
 > Cannot process manifest: Unrecognized app mode
 
-It is likely due to Posit Connect, on the server you are deploying to, being
+there are few things to check.
+
+#### Using `type = 'unknown'`
+
+If your Configuration file contains `type = 'unknown'`, either from the
+generated Configuration being unable to identify the type of your content, or
+if it was set to the `unknown` type manually, you will see this error.
+
+The Posit Publisher extension view will show an alert when this occurs, asking
+for the framework you are using to be set using the `type` field in your
+Configuration.
+
+To fix this you will need to find and set the `type` in your Configuration file.
+Supported types can be found in the [Configuration File Reference documentation](https://github.com/posit-dev/publisher/blob/main/docs/configuration.md#type).
+
+#### Using a `type` that is not supported by your server
+
+Another possibility is Posit Connect, on the server you are deploying to, is
 older than the version that introduced support for the `type` set in your
 configuration file.
 
 For example, in [Posit Connect 2024.12.0](https://docs.posit.co/connect/news/#posit-connect-2024.12.0-new)
 Gradio app support was introduced. When deploying a Gradio app to a server
-running an older version of Posit Connect than 2024.12.0, the error
-above is seen.
+running an older version of Posit Connect than 2024.12.0, it will error.
 
 ## Still having trouble?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting Posit Publisher
+
+This document contains some common issues and solutions for Posit Publisher.
+
+### Unrecongized app mode
+
+If when deploying you see the following error:
+
+> Cannot process manifest: Unrecognized app mode
+
+It is likely due to Posit Connect, on the server you are deploying to, being
+older than the version that introduced support for the `type` set in your
+configuration file.
+
+For example, in [Posit Connect 2024.12.0](https://docs.posit.co/connect/news/#posit-connect-2024.12.0-new)
+Gradio app support was introduced. When deploying a Gradio app to a server
+running an older version of Posit Connect than 2024.12.0, the error
+above is seen.
+
+## Still having trouble?
+
+If you're still having trouble with Posit Publisher or have any questions,
+please reach out to us using a new
+[GitHub discussion](https://github.com/posit-dev/publisher/discussions).
+
+If you think you've found a bug or have a feature request,
+please open a
+[GitHub Issue](https://github.com/posit-dev/publisher/issues).

--- a/extensions/vscode/src/utils/window.ts
+++ b/extensions/vscode/src/utils/window.ts
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
 import { window } from "vscode";
 
 export function showErrorMessageWithTroubleshoot(

--- a/extensions/vscode/src/utils/window.ts
+++ b/extensions/vscode/src/utils/window.ts
@@ -6,6 +6,11 @@ export function showErrorMessageWithTroubleshoot(
   message: string,
   ...items: string[]
 ) {
-  const msg = `${message} See [Troubleshooting docs](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md) for help.`;
+  let msg = message;
+  if (!message.endsWith(".")) {
+    msg += ".";
+  }
+  msg +=
+    " See [Troubleshooting docs](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md) for help.";
   return window.showErrorMessage(msg, ...items);
 }

--- a/extensions/vscode/src/utils/window.ts
+++ b/extensions/vscode/src/utils/window.ts
@@ -1,0 +1,9 @@
+import { window } from "vscode";
+
+export function showErrorMessageWithTroubleshoot(
+  message: string,
+  ...items: string[]
+) {
+  const msg = `${message} See [Troubleshooting docs](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md) for help.`;
+  return window.showErrorMessage(msg, ...items);
+}

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -33,6 +33,7 @@ import {
   ErrorMessageActionIds,
   findErrorMessageSplitOption,
 } from "src/utils/errorEnhancer";
+import { showErrorMessageWithTroubleshoot } from "src/utils/window";
 
 enum LogStageStatus {
   notStarted,
@@ -219,7 +220,10 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
           ...options,
         );
       } else {
-        selection = await window.showErrorMessage(errorMessage, ...options);
+        selection = await showErrorMessageWithTroubleshoot(
+          errorMessage,
+          ...options,
+        );
       }
       if (selection === showLogsOption) {
         await commands.executeCommand(Commands.Logs.Focus);


### PR DESCRIPTION
This PR adds:
- a new Troubleshooting document linked from our `docs/index.md`
  - The start of this document includes information for how to address the "Unrecognized app mode" error during deployment.
- a change to the `window.showErrorMessage` call on `publish/failure` to include a new "See **Troubleshooting docs** for help."
  - The **Troubleshooting docs** text will link to the new troubleshooting document.

<details>
  <summary>Preview</summary>
  
![CleanShot 2025-01-21 at 18 42 50](https://github.com/user-attachments/assets/e791641e-ae84-42e4-bcdd-e2d6daafd06b)

</details> 

## Intent

Resolves #2476

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

I only included the troubleshooting link at our `window.showErrorMessage` call from `publish/failure` as opposed to always showing the Troubleshooting link because the only content in our troubleshooting doc has to do with publish failure.

As we add more to the document we can easily replace `window.showErrorMessage` usage with usage of the new `showErrorMessageWithTroubleshoot` helper I created here.

I can change this based on feedback on this PR.

## User Impact

Users will now see a handy **Troubleshoot docs** link when deploying to a Connect server without Gradio support - and really for any `publish/failure` error message they receive.

## Directions for Reviewers

The easiest way I found to test this is to change our two schemas to support a type that is not supported like `"nonsense"`.

Then use that in a configuration file and attempt to deploy - leading to the error notification above. Note that the app mode isn't listed. That is due to https://github.com/posit-dev/publisher/issues/2542