### PR TITLE
Allow empty string for `dismissed_at` in schema

### DIFF
--- a/internal/schema/schemas/draft/posit-publishing-record-schema-v3.json
+++ b/internal/schema/schemas/draft/posit-publishing-record-schema-v3.json
@@ -70,10 +70,18 @@
       "examples": ["2024-01-19T09:33:33.131481-05:00"]
     },
     "dismissed_at": {
-      "type": "string",
-      "format": "date-time",
       "description": "Date and time that the deployment process was dismissed. Will be empty if the deployment process was not dismissed.",
-      "examples": ["2024-01-19T09:33:33.131481-05:00"]
+      "examples": ["2024-01-19T09:33:33.131481-05:00"],
+      "anyOf": [
+        {
+          "type": "string",
+          "maxLength": 0
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
     },
     "deployed_at": {
       "type": "string",

--- a/internal/schema/schemas/posit-publishing-record-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-record-schema-v3.json
@@ -71,10 +71,18 @@
       "examples": ["2024-01-19T09:33:33.131481-05:00"]
     },
     "dismissed_at": {
-      "type": "string",
-      "format": "date-time",
       "description": "Date and time that the deployment process was dismissed. Will be empty if the deployment process was not dismissed.",
-      "examples": ["2024-01-19T09:33:33.131481-05:00"]
+      "examples": ["2024-01-19T09:33:33.131481-05:00"],
+      "anyOf": [
+        {
+          "type": "string",
+          "maxLength": 0
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
     },
     "deployed_at": {
       "type": "string",


### PR DESCRIPTION
I noticed that with the changes in #2522 that deployment files were showing schema errors through Even Better TOML. I didn't get errors when using Publisher, but the JSON schema was saying that `""` wasn't a `date-time`.

This allows the `dismissed_at` attribute be either an empty string or a `date-time`.

![CleanShot 2025-01-22 at 16 32 57](https://github.com/user-attachments/assets/803290c2-519a-4fb4-9eca-460ed8bb96a8)

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->