### PR TITLE
Disable `ProjectFile` checkbox when it is a package file

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/ProjectFile.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/ProjectFile.vue
@@ -4,7 +4,7 @@
     :checked="isIncluded"
     :disabled="isDisabled"
     :list-style="listStyle"
-    :disable-opacity="isEntrypoint"
+    :disable-opacity="isEntrypoint || isPackageFile"
     :indent-level="file.indent + 1"
     :expandable="file.isDir"
     :tooltip="tooltip"
@@ -60,6 +60,7 @@ const isDisabled = computed((): boolean => {
   const source = props.file.reason?.source;
   return (
     (isEntrypoint.value && isIncluded.value) ||
+    (isPackageFile.value && isIncluded.value) ||
     source === "built-in" ||
     source === "permissions"
   );
@@ -89,6 +90,26 @@ const isEntrypoint = computed((): boolean => {
   return false;
 });
 
+const isPackageFile = computed((): boolean => {
+  return isPythonPackageFile.value || isRPackageFile.value;
+});
+
+const isPythonPackageFile = computed((): boolean => {
+  const config = home.selectedConfiguration;
+  if (config != undefined && !isConfigurationError(config)) {
+    return props.file.id === config.configuration.python?.packageFile;
+  }
+  return false;
+});
+
+const isRPackageFile = computed((): boolean => {
+  const config = home.selectedConfiguration;
+  if (config != undefined && !isConfigurationError(config)) {
+    return props.file.id === config.configuration.r?.packageFile;
+  }
+  return false;
+});
+
 const listStyle = computed((): "emphasized" | "default" | "deemphasized" => {
   return isEntrypoint.value
     ? "emphasized"
@@ -99,7 +120,10 @@ const listStyle = computed((): "emphasized" | "default" | "deemphasized" => {
 
 const tooltip = computed((): string => {
   return isIncluded.value
-    ? includedFileTooltip(props.file, isEntrypoint.value)
+    ? includedFileTooltip(props.file, {
+        isEntrypoint: isEntrypoint.value,
+        isPackageFile: isPackageFile.value,
+      })
     : excludedFileTooltip(props.file);
 });
 

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.test.ts
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.test.ts
@@ -30,9 +30,17 @@ describe("includedFileTooltip", () => {
 
   it("should return correct tooltip for entrypoint file", () => {
     const file = { rel: "src/index.ts", reason: null };
-    const tooltip = includedFileTooltip(file, true);
+    const tooltip = includedFileTooltip(file, { isEntrypoint: true });
     expect(tooltip).toBe(
       `src/index.ts will be included in the next deployment.\nsrc/index.ts is the entrypoint. Entrypoints must be included in the configuration 'files' list.`,
+    );
+  });
+
+  it("should return correct tooltip for package file", () => {
+    const file = { rel: "src/requirements.txt", reason: null };
+    const tooltip = includedFileTooltip(file, { isPackageFile: true });
+    expect(tooltip).toBe(
+      `src/requirements.txt will be included in the next deployment.\nsrc/requirements.txt is a package file. Package files must be included in the configuration 'files' list.`,
     );
   });
 });

--- a/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
+++ b/extensions/vscode/webviews/homeView/src/components/views/projectFiles/tooltips.ts
@@ -5,7 +5,10 @@ import {
 
 export function includedFileTooltip(
   file: Pick<ContentRecordFile, "rel" | "reason">,
-  isEntrypoint: boolean = false,
+  {
+    isEntrypoint = false,
+    isPackageFile = false,
+  }: { isEntrypoint?: boolean; isPackageFile?: boolean } = {},
 ) {
   let tooltip = `${file.rel} will be included in the next deployment.`;
   if (file.reason) {
@@ -13,6 +16,9 @@ export function includedFileTooltip(
   }
   if (isEntrypoint) {
     tooltip += `\n${file.rel} is the entrypoint. Entrypoints must be included in the configuration 'files' list.`;
+  }
+  if (isPackageFile) {
+    tooltip += `\n${file.rel} is a package file. Package files must be included in the configuration 'files' list.`;
   }
   return tooltip;
 }


### PR DESCRIPTION
This PR disables the checkbox for R and Python package files in the Project Files view, as well as includes a new tooltip when this is the case. It works very similar to #2487 

## Intent

Part of #1503

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact

Users can no longer un-check package files' checkboxes in the Project Files view - they can still check them to include the file if they are not included.

## Automated Tests

New automated tests are included for the new tooltip.

## Directions for Reviewers

Ensure that the R and Python package files, no matter the details in the configuration, can be unchecked.

Checking the checkbox for the file should still be available if the configuration is manually edited and the package file needs to be added.
