### PR TITLE
`renv` setup -  Provide users with an easy solution for renv errors

### DIFF
--- a/extensions/vscode/src/eventErrors.ts
+++ b/extensions/vscode/src/eventErrors.ts
@@ -36,6 +36,18 @@ type renvPackageEvtErr = baseEvtErr & {
   libraryVersion: string;
 };
 
+export type RenvAction =
+  | "renvsetup"
+  | "renvinit"
+  | "renvsnapshot"
+  | "renvstatus";
+
+export type renvSetupEvtErr = baseEvtErr & {
+  command: string;
+  action: RenvAction;
+  actionLabel: string;
+};
+
 export const isEvtErrDeploymentFailed = (
   emsg: EventStreamMessageErrorCoded,
 ): emsg is EventStreamMessageErrorCoded<baseEvtErr> => {
@@ -58,6 +70,15 @@ export const isEvtErrRenvPackageSourceMissing = (
   emsg: EventStreamMessageErrorCoded,
 ): emsg is EventStreamMessageErrorCoded<renvPackageEvtErr> => {
   return emsg.errCode === "renvPackageSourceMissing";
+};
+
+export const isEvtErrRenvEnvironmentSetup = (
+  emsg: EventStreamMessageErrorCoded,
+): emsg is EventStreamMessageErrorCoded<renvSetupEvtErr> => {
+  return (
+    emsg.errCode === "renvPackageNotInstalledError" ||
+    emsg.errCode === "renvActionRequiredError"
+  );
 };
 
 export const isEvtErrRequirementsReadingFailed = (

--- a/extensions/vscode/src/utils/errorTypes.ts
+++ b/extensions/vscode/src/utils/errorTypes.ts
@@ -13,6 +13,8 @@ export type ErrorCode =
   | "renvPackageVersionMismatch"
   | "renvPackageSourceMissing"
   | "renvlockPackagesReadingError"
+  | "renvPackageNotInstalledError"
+  | "renvActionRequiredError"
   | "requirementsFileReadingError"
   | "deployedContentNotRunning"
   | "tomlValidationError"

--- a/extensions/vscode/src/utils/window.test.ts
+++ b/extensions/vscode/src/utils/window.test.ts
@@ -1,0 +1,141 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { describe, expect, beforeEach, test, vi } from "vitest";
+import { window } from "vscode";
+import {
+  showErrorMessageWithTroubleshoot,
+  showInformationMsg,
+  taskWithProgressMsg,
+  runTerminalCommand,
+} from "./window";
+
+const terminalMock = {
+  sendText: vi.fn(),
+  show: vi.fn(),
+  exitStatus: {
+    code: 0,
+  },
+};
+
+vi.mock("vscode", () => {
+  // mock Disposable
+  const disposableMock = vi.fn();
+  disposableMock.prototype.dispose = vi.fn();
+
+  // mock window
+  const windowMock = {
+    showErrorMessage: vi.fn(),
+    showWarningMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+    withProgress: vi.fn().mockImplementation((_, progressCallback) => {
+      progressCallback();
+    }),
+    createTerminal: vi.fn().mockImplementation(() => {
+      terminalMock.sendText = vi.fn();
+      terminalMock.show = vi.fn();
+      return terminalMock;
+    }),
+    onDidCloseTerminal: vi.fn().mockImplementation((fn) => {
+      setTimeout(() => fn(terminalMock), 100);
+      return new disposableMock();
+    }),
+  };
+
+  return {
+    Disposable: disposableMock,
+    window: windowMock,
+    ProgressLocation: {
+      SourceControl: 1,
+      Window: 10,
+      Notification: 15,
+    },
+  };
+});
+
+describe("Consumers of vscode window", () => {
+  beforeEach(() => {
+    terminalMock.exitStatus.code = 0;
+  });
+
+  test("showErrorMessageWithTroubleshoot", () => {
+    showErrorMessageWithTroubleshoot("Bad things happened");
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      "Bad things happened. See [Troubleshooting docs](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md) for help.",
+    );
+
+    showErrorMessageWithTroubleshoot(
+      "Bad things happened.",
+      "one",
+      "two",
+      "three",
+    );
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      "Bad things happened. See [Troubleshooting docs](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md) for help.",
+      "one",
+      "two",
+      "three",
+    );
+  });
+
+  test("showInformationMsg", () => {
+    showInformationMsg("Good thing happened");
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      "Good thing happened",
+    );
+
+    showInformationMsg("Good thing happened", "one", "two", "three");
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      "Good thing happened",
+      "one",
+      "two",
+      "three",
+    );
+  });
+
+  test("taskWithProgressMsg", () => {
+    const taskMock = vi.fn();
+    taskWithProgressMsg(
+      "Running a task with a progress notification",
+      taskMock,
+    );
+    expect(window.withProgress).toHaveBeenCalledWith(
+      {
+        location: 15,
+        title: "Running a task with a progress notification",
+        cancellable: false,
+      },
+      expect.any(Function),
+    );
+    expect(taskMock).toHaveBeenCalled();
+  });
+
+  describe("runTerminalCommand", () => {
+    test("showing the terminal", async () => {
+      await runTerminalCommand("stat somefile.txt", true);
+      expect(terminalMock.sendText).toHaveBeenCalledWith("stat somefile.txt");
+      expect(terminalMock.show).toHaveBeenCalled();
+      // For terminals that we open, we don't track close events
+      expect(window.onDidCloseTerminal).not.toHaveBeenCalled();
+    });
+
+    test("NOT showing the terminal", async () => {
+      await runTerminalCommand("stat somefile.txt");
+      expect(terminalMock.sendText).toHaveBeenCalledWith("stat somefile.txt");
+      // For terminals that we DO NOT open, we DO track close events
+      expect(terminalMock.show).not.toHaveBeenCalled();
+      expect(window.onDidCloseTerminal).toHaveBeenCalled();
+    });
+
+    test("catch non zero exit status", async () => {
+      terminalMock.exitStatus.code = 1;
+      try {
+        await runTerminalCommand("stat somefile.txt");
+      } catch (_) {
+        expect(terminalMock.sendText).toHaveBeenCalledWith("stat somefile.txt");
+        // For terminals that we DO NOT open, we DO track close events
+        expect(terminalMock.show).not.toHaveBeenCalled();
+        expect(window.onDidCloseTerminal).toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/extensions/vscode/src/utils/window.ts
+++ b/extensions/vscode/src/utils/window.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 by Posit Software, PBC.
 
-import { window } from "vscode";
+import { window, ProgressLocation, Progress, CancellationToken } from "vscode";
 
 export function showErrorMessageWithTroubleshoot(
   message: string,
@@ -13,4 +13,68 @@ export function showErrorMessageWithTroubleshoot(
   msg +=
     " See [Troubleshooting docs](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md) for help.";
   return window.showErrorMessage(msg, ...items);
+}
+
+export function showInformationMsg(msg: string, ...items: string[]) {
+  return window.showInformationMessage(msg, ...items);
+}
+
+type taskFunc = <T>(p: Progress<T>, t: CancellationToken) => Promise<void>;
+const progressCallbackHandlerFactory =
+  (
+    task: taskFunc,
+    cancellable: boolean = false,
+    onCancel?: () => void,
+  ): taskFunc =>
+  (progress, token) => {
+    if (cancellable && onCancel) {
+      token.onCancellationRequested(() => {
+        onCancel();
+      });
+    }
+    return task(progress, token);
+  };
+
+export function taskWithProgressMsg(
+  msg: string,
+  task: taskFunc,
+  cancellable: boolean = false,
+  onCancel?: () => void,
+) {
+  return window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: msg,
+      cancellable,
+    },
+    progressCallbackHandlerFactory(task, cancellable, onCancel),
+  );
+}
+
+export function runTerminalCommand(
+  cmd: string,
+  show: boolean = false,
+): Promise<void> {
+  const term = window.createTerminal();
+  term.sendText(cmd);
+
+  // If terminal is shown, there is no need to track exit status for it
+  // everything will be visible on it.
+  if (show) {
+    term.show();
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const disposeToken = window.onDidCloseTerminal((closedTerminal) => {
+      if (closedTerminal === term) {
+        disposeToken.dispose();
+        if (term.exitStatus && term.exitStatus.code === 0) {
+          resolve();
+        } else {
+          reject();
+        }
+      }
+    });
+  });
 }

--- a/extensions/vscode/src/utils/window.ts
+++ b/extensions/vscode/src/utils/window.ts
@@ -21,13 +21,9 @@ export function showInformationMsg(msg: string, ...items: string[]) {
 
 type taskFunc = <T>(p: Progress<T>, t: CancellationToken) => Promise<void>;
 const progressCallbackHandlerFactory =
-  (
-    task: taskFunc,
-    cancellable: boolean = false,
-    onCancel?: () => void,
-  ): taskFunc =>
+  (task: taskFunc, onCancel?: () => void): taskFunc =>
   (progress, token) => {
-    if (cancellable && onCancel) {
+    if (onCancel) {
       token.onCancellationRequested(() => {
         onCancel();
       });
@@ -38,16 +34,15 @@ const progressCallbackHandlerFactory =
 export function taskWithProgressMsg(
   msg: string,
   task: taskFunc,
-  cancellable: boolean = false,
   onCancel?: () => void,
 ) {
   return window.withProgress(
     {
       location: ProgressLocation.Notification,
       title: msg,
-      cancellable,
+      cancellable: onCancel !== undefined,
     },
-    progressCallbackHandlerFactory(task, cancellable, onCancel),
+    progressCallbackHandlerFactory(task, onCancel),
   );
 }
 

--- a/extensions/vscode/src/views/deployHandlers.test.ts
+++ b/extensions/vscode/src/views/deployHandlers.test.ts
@@ -1,0 +1,209 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { EventStreamMessage } from "src/api";
+import {
+  EventStreamMessageErrorCoded,
+  RenvAction,
+  renvSetupEvtErr,
+} from "src/eventErrors";
+import { DeploymentFailureRenvHandler } from "./deployHandlers";
+
+const windowMethodsMocks = {
+  showErrorMessageWithTroubleshoot: vi.fn(),
+  showInformationMsg: vi.fn(),
+  runTerminalCommand: vi.fn(),
+  taskWithProgressMsg: vi.fn((_: string, cb: () => void) => cb()),
+};
+
+vi.mock("src/utils/window", () => {
+  return {
+    runTerminalCommand: (c: string, show: boolean = false) =>
+      windowMethodsMocks.runTerminalCommand(c, show),
+    showInformationMsg: (m: string) => windowMethodsMocks.showInformationMsg(m),
+    taskWithProgressMsg: (m: string, cb: () => void) =>
+      windowMethodsMocks.taskWithProgressMsg(m, cb),
+    showErrorMessageWithTroubleshoot: (m: string, l: string) =>
+      windowMethodsMocks.showErrorMessageWithTroubleshoot(m, l),
+  };
+});
+
+describe("Deploy Handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("DeploymentFailureRenvHandler", () => {
+    describe("shouldHandleEventMsg", () => {
+      test("not an renv setup error event", () => {
+        const handler = new DeploymentFailureRenvHandler();
+        const shouldHandle = handler.shouldHandleEventMsg({
+          type: "publish/failure",
+          time: new Date().toISOString(),
+          data: {},
+          errCode: "unknown",
+        });
+        expect(shouldHandle).toBe(false);
+      });
+
+      test("a true renv setup error event", () => {
+        const errPayload: EventStreamMessage = {
+          type: "publish/failure",
+          time: new Date().toISOString(),
+          data: {
+            message: "Renv is not setup, click the button and smile",
+            command: "renv::init()",
+            action: "renvsetup",
+            actionLabel: "Set it up",
+          },
+          errCode: "renvPackageNotInstalledError",
+        };
+
+        const handler = new DeploymentFailureRenvHandler();
+        let shouldHandle = handler.shouldHandleEventMsg(errPayload);
+        expect(shouldHandle).toBe(true);
+
+        errPayload.errCode = "renvActionRequiredError";
+        shouldHandle = handler.shouldHandleEventMsg(errPayload);
+        expect(shouldHandle).toBe(true);
+      });
+    });
+
+    describe("handle", () => {
+      test("when suggested action is renv::status, we call to open the terminal without progress indicators", async () => {
+        const errData: renvSetupEvtErr = {
+          message: "Renv is not setup, click the button and smile",
+          command: "/user/lib/R renv::status()",
+          action: "renvstatus",
+          actionLabel: "Set it up",
+          dashboardUrl: "",
+          localId: "",
+          error: "",
+        };
+        const errPayload: EventStreamMessageErrorCoded<renvSetupEvtErr> = {
+          type: "publish/failure",
+          time: new Date().toISOString(),
+          data: errData,
+          errCode: "renvActionRequiredError",
+        };
+
+        // Fake user picks option to run setup command
+        windowMethodsMocks.showErrorMessageWithTroubleshoot.mockResolvedValue(
+          errData.actionLabel,
+        );
+
+        const handler = new DeploymentFailureRenvHandler();
+        await handler.handle(errPayload);
+        expect(
+          windowMethodsMocks.showErrorMessageWithTroubleshoot,
+        ).toHaveBeenCalledWith(errData.message, errData.actionLabel);
+        expect(windowMethodsMocks.runTerminalCommand).toHaveBeenCalledWith(
+          "/user/lib/R renv::status();",
+          true,
+        );
+
+        // No progrss indicator is shown when we open the terminal
+        expect(windowMethodsMocks.taskWithProgressMsg).not.toHaveBeenCalled();
+      });
+
+      test.each([
+        ["renvsetup", `/user/lib/R install.packages("renv"); renv::init();`],
+        ["renvinit", "/user/lib/R renv::init()"],
+        ["renvsnapshot", "/user/lib/R renv::snapshot()"],
+      ])(
+        "for action %s, the provided command runs and notifies success",
+        async (action: string, command: string) => {
+          const errData: renvSetupEvtErr = {
+            message: "Renv is not setup, click the button and smile",
+            command,
+            action: action as RenvAction,
+            actionLabel: "Set it up",
+            dashboardUrl: "",
+            localId: "",
+            error: "",
+          };
+          const errPayload: EventStreamMessageErrorCoded<renvSetupEvtErr> = {
+            type: "publish/failure",
+            time: new Date().toISOString(),
+            data: errData,
+            errCode: "renvActionRequiredError",
+          };
+
+          // Fake user picks option to run setup command
+          windowMethodsMocks.showErrorMessageWithTroubleshoot.mockResolvedValueOnce(
+            errData.actionLabel,
+          );
+
+          const handler = new DeploymentFailureRenvHandler();
+          await handler.handle(errPayload);
+          expect(
+            windowMethodsMocks.showErrorMessageWithTroubleshoot,
+          ).toHaveBeenCalledWith(errData.message, errData.actionLabel);
+          expect(windowMethodsMocks.taskWithProgressMsg).toHaveBeenCalledWith(
+            "Setting up renv for this project...",
+            expect.any(Function),
+          );
+          // Terminal command executed
+          expect(windowMethodsMocks.runTerminalCommand).toHaveBeenCalledWith(
+            `${command}; exit $?`,
+            false,
+          );
+          expect(windowMethodsMocks.showInformationMsg).toHaveBeenCalledWith(
+            "Finished setting up renv.",
+          );
+        },
+      );
+
+      test.each([
+        ["renvsetup", `/user/lib/R install.packages("renv"); renv::init();`],
+        ["renvinit", "/user/lib/R renv::init()"],
+        ["renvsnapshot", "/user/lib/R renv::snapshot()"],
+      ])(
+        "terminal run failure for action %s, notifies of error",
+        async (action: string, command: string) => {
+          const errData: renvSetupEvtErr = {
+            message: "Renv is not setup, click the button and smile",
+            command,
+            action: action as RenvAction,
+            actionLabel: "Set it up",
+            dashboardUrl: "",
+            localId: "",
+            error: "",
+          };
+          const errPayload: EventStreamMessageErrorCoded<renvSetupEvtErr> = {
+            type: "publish/failure",
+            time: new Date().toISOString(),
+            data: errData,
+            errCode: "renvActionRequiredError",
+          };
+
+          // Fake user picks option to run setup command
+          windowMethodsMocks.showErrorMessageWithTroubleshoot.mockResolvedValueOnce(
+            errData.actionLabel,
+          );
+
+          // Mock a rejection from terminal run
+          windowMethodsMocks.taskWithProgressMsg.mockRejectedValueOnce(
+            new Error("oh no"),
+          );
+
+          const handler = new DeploymentFailureRenvHandler();
+          await handler.handle(errPayload);
+          expect(
+            windowMethodsMocks.showErrorMessageWithTroubleshoot,
+          ).toHaveBeenCalledWith(errData.message, errData.actionLabel);
+          expect(windowMethodsMocks.taskWithProgressMsg).toHaveBeenCalled();
+
+          // The message shown is a troubleshoot error one
+          expect(windowMethodsMocks.showInformationMsg).not.toHaveBeenCalled();
+          expect(
+            windowMethodsMocks.showErrorMessageWithTroubleshoot,
+          ).toHaveBeenCalledWith(
+            `Something went wrong while running renv command. Command used ${command}`,
+            undefined,
+          );
+        },
+      );
+    });
+  });
+});

--- a/extensions/vscode/src/views/deployHandlers.ts
+++ b/extensions/vscode/src/views/deployHandlers.ts
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { EventStreamMessage } from "src/api";
+import {
+  EventStreamMessageErrorCoded,
+  isEvtErrRenvEnvironmentSetup,
+  isCodedEventErrorMessage,
+  renvSetupEvtErr,
+} from "src/eventErrors";
+import {
+  showErrorMessageWithTroubleshoot,
+  showInformationMsg,
+  runTerminalCommand,
+  taskWithProgressMsg,
+} from "src/utils/window";
+
+export interface DeploymentFailureHandler {
+  /**
+   * Determine if the deployment failure handler should do something with an incoming event stream message.
+   *
+   * @param msg The EventStreamMessage to determine if the deployment failure handler should do something about it.
+   */
+  shouldHandleEventMsg(msg: EventStreamMessage): boolean;
+
+  /**
+   * Handle the incoming event stream message.
+   *
+   * @param msg The EventStreamMessage with the details for the given deployment failure handler to act upon it.
+   */
+  handle(msg: EventStreamMessage): Promise<void>;
+}
+
+export class DeploymentFailureRenvHandler implements DeploymentFailureHandler {
+  shouldHandleEventMsg(
+    msg: EventStreamMessage,
+  ): msg is EventStreamMessageErrorCoded<renvSetupEvtErr> {
+    return isCodedEventErrorMessage(msg) && isEvtErrRenvEnvironmentSetup(msg);
+  }
+
+  async handle(
+    msg: EventStreamMessageErrorCoded<renvSetupEvtErr>,
+  ): Promise<void> {
+    const { message, command, action, actionLabel } = msg.data;
+    const selection = await showErrorMessageWithTroubleshoot(
+      message,
+      actionLabel,
+    );
+
+    if (selection !== actionLabel) {
+      return;
+    }
+
+    // If renv status is the action, then run the command and open the terminal
+    if (action === "renvstatus") {
+      return runTerminalCommand(`${command};`, true);
+    }
+
+    try {
+      await taskWithProgressMsg("Setting up renv for this project...", () =>
+        runTerminalCommand(`${command}; exit $?`),
+      );
+      showInformationMsg("Finished setting up renv.");
+    } catch (_) {
+      showErrorMessageWithTroubleshoot(
+        `Something went wrong while running renv command. Command used ${command}`,
+      );
+    }
+  }
+}

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -34,6 +34,7 @@ import {
   findErrorMessageSplitOption,
 } from "src/utils/errorEnhancer";
 import { showErrorMessageWithTroubleshoot } from "src/utils/window";
+import { DeploymentFailureRenvHandler } from "src/views/deployHandlers";
 
 enum LogStageStatus {
   notStarted,
@@ -184,6 +185,11 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     });
 
     this.stream.register("publish/failure", async (msg: EventStreamMessage) => {
+      const deploymentFailureRenvHandler = new DeploymentFailureRenvHandler();
+      if (deploymentFailureRenvHandler.shouldHandleEventMsg(msg)) {
+        return deploymentFailureRenvHandler.handle(msg).then(this.refresh);
+      }
+
       const failedOrCanceledStatus = msg.data.canceled
         ? LogStageStatus.canceled
         : LogStageStatus.failed;

--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -195,7 +195,7 @@ func (m *defaultPackageMapper) GetManifestPackages(
 	lockfile, err := ReadLockfile(lockfilePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, m.renvEnvironmentCheck(base, log)
+			return nil, m.renvEnvironmentCheck(log)
 		}
 		return nil, err
 	}
@@ -260,7 +260,6 @@ func (m *defaultPackageMapper) GetManifestPackages(
 }
 
 func (m *defaultPackageMapper) renvEnvironmentCheck(
-	base util.AbsolutePath,
 	log logging.Logger,
 ) *types.AgentError {
 	rInterpreter, err := m.rInterpreterFactory()

--- a/internal/interpreters/r.go
+++ b/internal/interpreters/r.go
@@ -29,11 +29,27 @@ func newInvalidRError(desc string, err error) *types.AgentError {
 
 type ExistsFunc func(p util.Path) (bool, error)
 
+type RenvAction = string
+
+const (
+	RenvSetup    RenvAction = "renvsetup"
+	RenvInit     RenvAction = "renvinit"
+	RenvSnapshot RenvAction = "renvsnapshot"
+	RenvStatus   RenvAction = "renvstatus"
+)
+
+type renvCommandObj struct {
+	Action      RenvAction `json:"action"`
+	ActionLabel string     `json:"actionLabel"`
+	Command     string     `json:"command"`
+}
+
 type RInterpreter interface {
 	GetRExecutable() (util.AbsolutePath, error)
 	GetRVersion() (string, error)
 	GetLockFilePath() (util.RelativePath, bool, error)
 	CreateLockfile(util.AbsolutePath) error
+	RenvEnvironmentErrorCheck() *types.AgentError
 }
 
 type defaultRInterpreter struct {
@@ -171,6 +187,111 @@ func (i *defaultRInterpreter) GetLockFilePath() (relativePath util.RelativePath,
 
 func (i *defaultRInterpreter) IsRExecutableValid() bool {
 	return i.rExecutable.Path.String() != "" && i.version != ""
+}
+
+func (i *defaultRInterpreter) RenvEnvironmentErrorCheck() *types.AgentError {
+	rExec, err := i.GetRExecutable()
+	if err != nil {
+		i.log.Error("Could not get an R executable while determining if renv is installed", "error", err.Error())
+		return i.cannotVerifyRenvErr(err)
+	}
+
+	aerr := i.isRenvInstalled(rExec.String())
+	if aerr != nil {
+		return aerr
+	}
+
+	renvStatusOutput, aerr := i.renvStatus(rExec.String())
+	if aerr != nil {
+		return aerr
+	}
+
+	return i.prepRenvActionCommand(rExec.String(), renvStatusOutput)
+}
+
+func (i *defaultRInterpreter) isRenvInstalled(rexecPath string) *types.AgentError {
+	args := []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}
+	output, _, err := i.cmdExecutor.RunCommand(rexecPath, args, i.base, i.log)
+	if err != nil {
+		i.log.Error("Unable to determine if renv is installed", "error", err.Error())
+		return types.NewAgentError(
+			types.ErrorUnknown,
+			errors.Join(
+				errors.New("unable to determine if renv is installed"),
+				err,
+			),
+			nil)
+	}
+
+	// If renv package is not installed, prep and send the terminal command that'll help the user
+	renvLibFile := string(output)
+	if renvLibFile == "" {
+		return types.NewAgentError(
+			types.ErrorRenvPackageNotInstalled,
+			errors.New("package renv is not installed. An renv lockfile is needed for deployment"),
+			renvCommandObj{
+				Action:      RenvSetup,
+				ActionLabel: "Setup renv",
+				Command:     fmt.Sprintf(`%s -s -e "install.packages(\"renv\"); renv::init();"`, rexecPath),
+			})
+	}
+
+	return nil
+}
+
+func (i *defaultRInterpreter) renvStatus(rexecPath string) (string, *types.AgentError) {
+	args := []string{"-s", "-e", "renv::status()"}
+	output, _, err := i.cmdExecutor.RunCommand(rexecPath, args, i.base, i.log)
+	if err != nil {
+		i.log.Error("Error attempting to run renv::status()", "error", err.Error())
+		return "", types.NewAgentError(
+			types.ErrorUnknown,
+			errors.Join(
+				errors.New("error attempting to run renv::status()"),
+				err,
+			),
+			nil)
+	}
+
+	return string(output), nil
+}
+
+func (i *defaultRInterpreter) prepRenvActionCommand(rexecPath string, renvStatus string) *types.AgentError {
+	// The default command suggested is renv::status()
+	renvDescError := errors.New("the renv environment for this project is not in a healthy state. Run renv::status() for more details")
+	commandObj := renvCommandObj{
+		Action:      RenvStatus,
+		ActionLabel: "Run and show renv::status()",
+		Command:     fmt.Sprintf(`%s -s -e "renv::status()"`, rexecPath),
+	}
+
+	if strings.Contains(renvStatus, "renv::init()") {
+		// Renv suggests to init() the project
+		renvDescError = errors.New(`project requires renv initialization "renv::init()" to be deployed`)
+		commandObj.Action = RenvInit
+		commandObj.ActionLabel = "Setup renv"
+		commandObj.Command = fmt.Sprintf(`%s -s -e "renv::init()"`, rexecPath)
+	} else if strings.Contains(renvStatus, "renv::snapshot()") {
+		// Renv suggests to snapshot(), only the lockfile is missing
+		renvDescError = errors.New(`project requires renv to update the lockfile to be deployed`)
+		commandObj.Action = RenvSnapshot
+		commandObj.ActionLabel = "Setup lockfile"
+		commandObj.Command = fmt.Sprintf(`%s -s -e "renv::snapshot()"`, rexecPath)
+	}
+
+	return types.NewAgentError(
+		types.ErrorRenvActionRequired,
+		renvDescError,
+		commandObj)
+}
+
+func (i *defaultRInterpreter) cannotVerifyRenvErr(err error) *types.AgentError {
+	if aerr, isAgentErr := types.IsAgentError(err); isAgentErr {
+		return aerr
+	}
+	verifyErr := types.NewAgentError(types.ErrorUnknown, err, nil)
+	verifyErr.Message = "Unable to determine if renv is installed"
+	return verifyErr
 }
 
 // Determine which R Executable to use by:

--- a/internal/interpreters/r_mock.go
+++ b/internal/interpreters/r_mock.go
@@ -3,6 +3,7 @@ package interpreters
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import (
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 	"github.com/stretchr/testify/mock"
 )
@@ -77,4 +78,9 @@ func (m *MockRInterpreter) GetLockFilePath() (util.RelativePath, bool, error) {
 func (m *MockRInterpreter) CreateLockfile(lockfilePath util.AbsolutePath) error {
 	args := m.Called(lockfilePath)
 	return args.Error(0)
+}
+
+func (m *MockRInterpreter) RenvEnvironmentErrorCheck() *types.AgentError {
+	args := m.Called()
+	return args.Error(0).(*types.AgentError)
 }

--- a/internal/interpreters/r_test.go
+++ b/internal/interpreters/r_test.go
@@ -595,3 +595,126 @@ func (s *RSuite) TestCreateLockfileWithEmptyPath() {
 	err := i.CreateLockfile(util.AbsolutePath{})
 	s.NoError(err)
 }
+
+func (s *RSuite) TestRenvEnvironmentErrorCheck_renvNotInstalled() {
+	log := logging.New()
+
+	executor := executortest.NewMockExecutor()
+	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte(""), nil, nil)
+
+	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
+	interpreter := i.(*defaultRInterpreter)
+	interpreter.rExecutable = util.NewAbsolutePath("/usr/bin/R", s.cwd.Fs())
+	interpreter.version = "1.2.3"
+	interpreter.fs = s.cwd.Fs()
+
+	err := i.RenvEnvironmentErrorCheck()
+	s.Error(err)
+	s.Equal(err.GetCode(), types.ErrorRenvPackageNotInstalled)
+	s.Equal(err.Message, "Package renv is not installed. An renv lockfile is needed for deployment.")
+	s.Equal(err.Data, types.ErrorData{
+		"Action":      "renvsetup",
+		"ActionLabel": "Setup renv",
+		"Command":     "/usr/bin/R -s -e \"install.packages(\\\"renv\\\"); renv::init();\"",
+	})
+}
+
+func (s *RSuite) TestRenvEnvironmentErrorCheck_renvInstallCheckErr() {
+	log := logging.New()
+
+	renvCmdErr := errors.New("renv command errrz")
+	executor := executortest.NewMockExecutor()
+	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte(""), nil, renvCmdErr)
+
+	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
+	interpreter := i.(*defaultRInterpreter)
+	interpreter.rExecutable = util.NewAbsolutePath("/usr/bin/R", s.cwd.Fs())
+	interpreter.version = "1.2.3"
+	interpreter.fs = s.cwd.Fs()
+
+	err := i.RenvEnvironmentErrorCheck()
+	s.Error(err)
+	s.Equal(err.GetCode(), types.ErrorUnknown)
+	s.Equal(err.Message, "Unable to determine if renv is installed\nrenv command errrz.")
+	s.Equal(err.Data, types.ErrorData{})
+}
+
+func (s *RSuite) TestRenvEnvironmentErrorCheck_renvRequiresInit() {
+	log := logging.New()
+
+	renvStatusOutput := []byte("Use `renv::init()` to initialize the project.")
+	executor := executortest.NewMockExecutor()
+	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "renv::status()"}, mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
+
+	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
+	interpreter := i.(*defaultRInterpreter)
+	interpreter.rExecutable = util.NewAbsolutePath("/usr/bin/R", s.cwd.Fs())
+	interpreter.version = "1.2.3"
+	interpreter.fs = s.cwd.Fs()
+
+	err := i.RenvEnvironmentErrorCheck()
+	s.Error(err)
+	s.Equal(err.GetCode(), types.ErrorRenvActionRequired)
+	s.Equal(err.Message, `Project requires renv initialization "renv::init()" to be deployed.`)
+	s.Equal(err.Data, types.ErrorData{
+		"Action":      "renvinit",
+		"ActionLabel": "Setup renv",
+		"Command":     "/usr/bin/R -s -e \"renv::init()\"",
+	})
+}
+
+func (s *RSuite) TestRenvEnvironmentErrorCheck_lockfileMissing() {
+	log := logging.New()
+
+	renvStatusOutput := []byte("Use `renv::snapshot()` to create a lockfile.")
+	executor := executortest.NewMockExecutor()
+	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "renv::status()"}, mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
+
+	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
+	interpreter := i.(*defaultRInterpreter)
+	interpreter.rExecutable = util.NewAbsolutePath("/usr/bin/R", s.cwd.Fs())
+	interpreter.version = "1.2.3"
+	interpreter.fs = s.cwd.Fs()
+
+	err := i.RenvEnvironmentErrorCheck()
+	s.Error(err)
+	s.Equal(err.GetCode(), types.ErrorRenvActionRequired)
+	s.Equal(err.Message, `Project requires renv to update the lockfile to be deployed.`)
+	s.Equal(err.Data, types.ErrorData{
+		"Action":      "renvsnapshot",
+		"ActionLabel": "Setup lockfile",
+		"Command":     "/usr/bin/R -s -e \"renv::snapshot()\"",
+	})
+}
+
+func (s *RSuite) TestRenvEnvironmentErrorCheck_unknownRenvStatus() {
+	log := logging.New()
+
+	renvStatusOutput := []byte("- The project is out-of-sync -- use `renv::status()` for details.")
+	executor := executortest.NewMockExecutor()
+	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
+	executor.On("RunCommand", "/usr/bin/R", []string{"-s", "-e", "renv::status()"}, mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
+
+	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
+	interpreter := i.(*defaultRInterpreter)
+	interpreter.rExecutable = util.NewAbsolutePath("/usr/bin/R", s.cwd.Fs())
+	interpreter.version = "1.2.3"
+	interpreter.fs = s.cwd.Fs()
+
+	err := i.RenvEnvironmentErrorCheck()
+	s.Error(err)
+	s.Equal(err.GetCode(), types.ErrorRenvActionRequired)
+	s.Equal(err.Message, `The renv environment for this project is not in a healthy state. Run renv::status() for more details.`)
+	s.Equal(err.Data, types.ErrorData{
+		"Action":      "renvstatus",
+		"ActionLabel": "Run and show renv::status()",
+		"Command":     "/usr/bin/R -s -e \"renv::status()\"",
+	})
+}

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -3,9 +3,7 @@
 package publish
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/posit-dev/publisher/internal/bundles"
 	"github.com/posit-dev/publisher/internal/events"
@@ -20,8 +18,6 @@ type getRPackageDescriptionsSuccessData struct{}
 type lockfileErrDetails struct {
 	Lockfile string
 }
-
-const lockfileMissing = `Missing dependency lockfile %s. This file must be included in the deployment.`
 
 func (p *defaultPublisher) getRPackages() (bundles.PackageMap, error) {
 	op := events.PublishGetRPackageDescriptionsOp
@@ -45,9 +41,6 @@ func (p *defaultPublisher) getRPackages() (bundles.PackageMap, error) {
 		}
 		agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: lockfilePath.String()})
 		agentErr.Message = fmt.Sprintf("Could not scan R packages from lockfile: %s, %s", lockfileString, err.Error())
-		if errors.Is(err, os.ErrNotExist) {
-			agentErr.Message = fmt.Sprintf(lockfileMissing, lockfileString)
-		}
 		return nil, agentErr
 	}
 	log.Info("Done collecting R package descriptions")

--- a/internal/publish/r_package_descriptions_test.go
+++ b/internal/publish/r_package_descriptions_test.go
@@ -4,7 +4,6 @@ package publish
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/posit-dev/publisher/internal/bundles"
@@ -156,24 +155,5 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesKnownAgentError() {
 	_, err := publisher.getRPackages()
 	s.NotNil(err)
 	s.Equal(err.(*types.AgentError).Message, "Bad package version, this is a known failure.")
-	s.log.AssertExpectations(s.T())
-}
-
-func (s *RPackageDescSuite) TestGetRPackages_PackageFileNotFound() {
-	expectedLockfilePath := s.dirPath.Join("custom.lock")
-
-	// With a package file
-	s.stateStore.Config = &config.Config{
-		R: &config.R{
-			PackageFile: "custom.lock",
-		},
-	}
-
-	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(bundles.PackageMap{}, os.ErrNotExist)
-
-	publisher := s.makePublisher()
-	_, err := publisher.getRPackages()
-	s.NotNil(err)
-	s.Contains(err.(*types.AgentError).Message, "Missing dependency lockfile custom.lock")
 	s.log.AssertExpectations(s.T())
 }

--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -25,6 +25,8 @@ const (
 	ErrorRenvPackageVersionMismatch   ErrorCode = "renvPackageVersionMismatch"
 	ErrorRenvPackageSourceMissing     ErrorCode = "renvPackageSourceMissing"
 	ErrorRenvLockPackagesReading      ErrorCode = "renvlockPackagesReadingError"
+	ErrorRenvPackageNotInstalled      ErrorCode = "renvPackageNotInstalledError"
+	ErrorRenvActionRequired           ErrorCode = "renvActionRequiredError"
 	ErrorRequirementsFileReading      ErrorCode = "requirementsFileReadingError"
 	ErrorDeployedContentNotRunning    ErrorCode = "deployedContentNotRunning"
 	ErrorUnknown                      ErrorCode = "unknown"
@@ -53,7 +55,8 @@ type AgentError struct {
 // Normalize punctuation on messages derived from errors
 func normalizeAgentErrorMsg(errMsg string) string {
 	spChars := []string{"?", "!", ")", "."}
-	msg := strings.ToUpper(errMsg[:1]) + errMsg[1:]
+	msg := strings.TrimSpace(errMsg)
+	msg = strings.ToUpper(msg[:1]) + msg[1:]
 
 	msgLastChar := msg[len(msg)-1:]
 	if slices.Contains(spChars, msgLastChar) {

--- a/internal/types/error_test.go
+++ b/internal/types/error_test.go
@@ -86,8 +86,8 @@ func (s *ErrorSuite) TestIsAgentError() {
 }
 
 func (s *ErrorSuite) TestNewAgentError_MessagePunctuation() {
-	// Sentence case and period ending
-	originalError := errors.New("oh sorry, my mistake")
+	// Sentence case, period ending, space trimming
+	originalError := errors.New("  oh sorry, my mistake  ")
 	aerr := NewAgentError(ErrorResourceNotFound, originalError, nil)
 	s.Equal(aerr, &AgentError{
 		Message: "Oh sorry, my mistake.",


### PR DESCRIPTION
## Intent

PR with the goal to provide immediate help to users when `renv` errors show up while trying to deploy.

Common scenarios that it handles, providing the option within the error message to set it up easily:
1. No `renv` installed at all. Installs `renv` and runs `init`.
2. `renv` is installed but project requires `init`, we do the `init` for the user.
3. `renv` environment exists, but lockfile does not. We help with `snapshot`.

For any other case outside the common and known issues, we provide the user with guidance and set up the `renv::status` command to get more information.

https://github.com/user-attachments/assets/d66c93b9-57d8-48ae-a2af-a22a55f06518

Resolves #2543 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Rely more on the information `renv::status` provides to help users with common scenarios. 

## User Impact

Users with project using `R` and that the deployment requires a `lockfile`. When the lockfile or an `renv` environment do not exist, it'll be a matter of a click to get up to speed and continue the deployment.

## Automated Tests

Created and updated unit tests for these changes.

## Directions for Reviewers

The following checklist assumes you have a project that requires `R`:
- With no `renv` installed at all and no lockfile on the project. (It can be uninstalled with `remove.packages("renv")`)
    - [ ] Attempt to deploy the project. An error message should show up with an option to set things up.
    - [ ] Hitting the "Setup renv" button installs and initializes the project.
    - [ ] Trying to deploy one more time succeeds.
- `renv` is installed but project does not have `lockfile` nor `renv/`.
    - [ ] Attempt to deploy the project. An error message should show up with an option to set things up.
    - [ ] Hitting the "Setup renv" button initializes the project.
    - [ ] Trying to deploy one more time succeeds.
- `renv` environment exists, but lockfile is not present.
    - [ ] Attempt to deploy the project. An error message should show up with an option to set things up.
    - [ ] Hitting the "Setup renv" button initializes the project.
    - [ ] Trying to deploy one more time succeeds.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
