### PR TITLE
Only show the view content button with a valid link

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -221,10 +221,7 @@
             />
           </div>
         </template>
-        <div
-          v-if="!isPreContentRecord(home.selectedContentRecord)"
-          class="last-deployment-details"
-        >
+        <div v-if="showContentButton" class="last-deployment-details">
           <vscode-button
             appearance="secondary"
             @click="viewContent"
@@ -551,6 +548,16 @@ const onAssociateDeployment = () => {
     kind: WebviewToHostMessageType.SHOW_ASSOCIATE_GUID,
   });
 };
+
+const showContentButton = computed(() => {
+  const record = home.selectedContentRecord;
+  if (!record) {
+    return;
+  }
+  return (
+    record?.dashboardUrl || (!isPreContentRecord(record) && record.logsUrl)
+  );
+});
 
 const viewContent = () => {
   const record = home.selectedContentRecord;


### PR DESCRIPTION
This PR changes the behavior around the "View Content" button to only show it if we have a URL to go to. Previously we checked if the deployment wasn't a pre-deployment, but a failed deployment will not have a valid ID or links.

## Intent

Resolves #2373

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact

If an error occurs during the deployment that causes the deployment to no longer be a pre-deployment, but still doesn't have an ID the "View Content" button no longer is shown.
