### PR TITLE
Add `*.lic` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 # Possible e2e tests deployment assets
 test/e2e/content-workspace/**/.posit
+
+# license files should not be commited to this repository
+*.lic


### PR DESCRIPTION
Adding `*.lic` to `.gitignore` so that accidentally committing license files requires additional steps.