### PR TITLE
Expose Publisher credentials via an AuthenticationProvider

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,13 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Credentials are now exposed via a `posit-connect` authentication provider,
+  which surfaces them in the native Accounts UI. (#2608)
+
 ## [1.10.0]
 
 ### Added

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -33,6 +33,12 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "authentication": [
+      {
+        "id": "posit-connect",
+        "label": "Posit Connect"
+      }
+    ],
     "configuration": [
       {
         "title": "Posit Publisher",

--- a/extensions/vscode/src/authProvider.ts
+++ b/extensions/vscode/src/authProvider.ts
@@ -1,0 +1,175 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import {
+  authentication,
+  AuthenticationProvider,
+  AuthenticationProviderAuthenticationSessionsChangeEvent,
+  AuthenticationProviderSessionOptions,
+  AuthenticationSession,
+  AuthenticationSessionAccountInformation,
+  Disposable,
+  Event,
+  EventEmitter,
+  window,
+} from "vscode";
+import { Credential, useApi } from "./api";
+import { PublisherState } from "./state";
+import { getSummaryStringFromError } from "./utils/errors";
+
+// AuthenticationProvider identifiers. The main identifier is exposed to other
+// extensions for lookup purposes, while the "label" controls what is shown in
+// the Accounts UI next to each entry.
+//
+// Note: must be kept in sync with contributes.authentication in package.json.
+const CONNECT_AUTH_PROVIDER_ID = "posit-connect";
+const CONNECT_AUTH_PROVIDER_LABEL = "Posit Connect";
+
+// A dedicated output channel for debugging auth-related state changes.
+const authLogger = window.createOutputChannel(
+  "Posit Publisher Authentication",
+  { log: true },
+);
+
+class ConnectAuthSession implements AuthenticationSession {
+  readonly id: string;
+  readonly account: AuthenticationSessionAccountInformation;
+  readonly accessToken: string;
+
+  // Note: Connect doesn't really have a notion of "scopes", but we can
+  // equivocate to the role here, instead.
+  readonly scopes = ["Publisher"];
+
+  constructor(credential: Credential) {
+    this.id = credential.guid;
+    this.account = { id: credential.url, label: credential.name };
+    this.accessToken = credential.apiKey;
+  }
+}
+
+export class PublisherAuthProvider
+  implements AuthenticationProvider, Disposable
+{
+  private disposable: Disposable;
+  private emitter =
+    new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+
+  constructor(private readonly state: PublisherState) {
+    this.disposable = Disposable.from(
+      authentication.registerAuthenticationProvider(
+        CONNECT_AUTH_PROVIDER_ID,
+        CONNECT_AUTH_PROVIDER_LABEL,
+        this,
+        { supportsMultipleAccounts: true },
+      ),
+      state.onDidRefreshCredentials((e) => this.onRefresh(e.oldCredentials)),
+    );
+    authLogger.info(
+      `Declared authentication provider "${CONNECT_AUTH_PROVIDER_ID}"`,
+    );
+  }
+
+  dispose(): void {
+    this.disposable.dispose();
+  }
+
+  get onDidChangeSessions(): Event<AuthenticationProviderAuthenticationSessionsChangeEvent> {
+    return this.emitter.event;
+  }
+
+  // Called by other extensions via authentication.getSession(), and by the
+  // editor itself to populate the Accounts UI. Also called several times during
+  // editor startup, when credentials have not yet been refreshed. It seems
+  // harmless to delay until we show the Publisher home view (which loads
+  // credentials for the first time), though.
+  getSessions(
+    _scopes?: string[],
+    options?: AuthenticationProviderSessionOptions,
+  ): Promise<AuthenticationSession[]> {
+    let creds = this.state.credentials;
+    if (options?.account) {
+      creds = creds.filter((x) => x.url === options?.account?.id);
+    }
+    authLogger.debug(
+      `Got a request for Connect auth sessions, count=${creds.length} url=${options?.account?.id ?? "<any>"}`,
+    );
+    return Promise.resolve(creds.map((x) => new ConnectAuthSession(x)));
+  }
+
+  // Called by other extensions via authentication.getSessions() with
+  // createIfNone or forceNewSession set to true.
+  //
+  // It's unclear whether we should support creating Publisher credentials this
+  // way.
+  createSession(
+    _scopes: string[],
+    _options: AuthenticationProviderSessionOptions,
+  ): Promise<AuthenticationSession> {
+    throw new Error("Not supported");
+  }
+
+  // Called when the user selects "Sign Out" in the Accounts UI.
+  async removeSession(sessionId: string): Promise<void> {
+    const cred = this.state.credentials.find((x) => x.guid === sessionId);
+    if (!cred) {
+      authLogger.warn(
+        `Aborted removing non-existent Connect auth session, id=${sessionId}`,
+      );
+      throw new Error("No session to remove");
+    }
+    // This largely follows HomeViewProvider.deleteCredential(), except the
+    // Accounts UI already has a confirmation dialog and a success notification,
+    // so we skip those bits.
+    try {
+      const api = await useApi();
+      await api.credentials.delete(cred.guid);
+    } catch (error: unknown) {
+      window.showInformationMessage(
+        getSummaryStringFromError("credential::delete", error),
+      );
+      authLogger.error(
+        `Failed to remove Connect auth session, name=${cred.name} url=${cred.url} error="${error}"`,
+      );
+      throw error;
+    }
+    await this.state.refreshCredentials();
+  }
+
+  private onRefresh(oldCredentials: Credential[]) {
+    const added: AuthenticationSession[] = [];
+    const removed: AuthenticationSession[] = [];
+    const changed: AuthenticationSession[] = [];
+
+    // Find credentials that have been removed.
+    for (const prev of oldCredentials) {
+      if (!this.state.credentials.find((x) => x.guid === prev.guid)) {
+        removed.push(new ConnectAuthSession(prev));
+        authLogger.info(
+          `Removed Connect auth session, name=${prev.name} url=${prev.url}`,
+        );
+      }
+    }
+
+    // Find credentials that have been added or modified.
+    for (const cred of this.state.credentials) {
+      const prev = oldCredentials.find((x) => x.guid === cred.guid);
+      if (!prev) {
+        added.push(new ConnectAuthSession(cred));
+        authLogger.info(
+          `Added Connect auth session, name=${cred.name} url=${cred.url}`,
+        );
+      } else if (
+        // Check all mutable fields manually.
+        prev.name !== cred.name ||
+        prev.url !== cred.url ||
+        prev.apiKey !== cred.apiKey
+      ) {
+        changed.push(new ConnectAuthSession(cred));
+        authLogger.info(
+          `Updated Connect auth session, name=${cred.name} url=${cred.url}`,
+        );
+      }
+    }
+
+    this.emitter.fire({ added: added, removed: removed, changed: changed });
+  }
+}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -17,6 +17,8 @@ import { HomeViewProvider } from "src/views/homeView";
 import { WatcherManager } from "src/watchers";
 import { Commands } from "src/constants";
 import { DocumentTracker } from "./entrypointTracker";
+import { PublisherState } from "./state";
+import { PublisherAuthProvider } from "./authProvider";
 
 const STATE_CONTEXT = "posit.publish.state";
 
@@ -108,12 +110,14 @@ export async function activate(context: ExtensionContext) {
   const watchers = new WatcherManager();
   context.subscriptions.push(watchers);
 
+  const state = new PublisherState(context);
+
   // First the construction of the data providers
   const projectTreeDataProvider = new ProjectTreeDataProvider(context);
 
   const logsTreeDataProvider = new LogsTreeDataProvider(context, stream);
 
-  const homeViewProvider = new HomeViewProvider(context, stream);
+  const homeViewProvider = new HomeViewProvider(context, stream, state);
   context.subscriptions.push(homeViewProvider);
 
   // Then the registration of the data providers with the VSCode framework
@@ -143,6 +147,8 @@ export async function activate(context: ExtensionContext) {
       homeViewProvider.handleFileInitiatedDeploymentSelection(uri);
     }),
   );
+
+  context.subscriptions.push(new PublisherAuthProvider(state));
 }
 
 // This method is called when your extension is deactivated

--- a/extensions/vscode/src/servers.ts
+++ b/extensions/vscode/src/servers.ts
@@ -19,7 +19,9 @@ export class Server implements Disposable {
 
   constructor(port: number, useKeyChain: boolean) {
     this.port = port;
-    this.outputChannel = window.createOutputChannel(`Posit Publisher`);
+    this.outputChannel = window.createOutputChannel(
+      `Posit Publisher Deployment`,
+    );
     this.useKeyChain = useKeyChain;
   }
 

--- a/extensions/vscode/src/state.test.ts
+++ b/extensions/vscode/src/state.test.ts
@@ -81,6 +81,7 @@ vi.mock("vscode", () => {
     Disposable: disposableMock,
     window: windowMock,
     workspace: workspaceStateMock,
+    EventEmitter: vi.fn(),
   };
 });
 

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -97,8 +97,6 @@ enum HomeViewInitialized {
 export class HomeViewProvider implements WebviewViewProvider, Disposable {
   private disposables: Disposable[] = [];
 
-  private state: PublisherState;
-
   private root: WorkspaceFolder | undefined;
   private webviewView?: WebviewView;
   private extensionUri: Uri;
@@ -118,13 +116,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   constructor(
     private readonly context: ExtensionContext,
     private readonly stream: EventStream,
+    private state: PublisherState,
   ) {
     const workspaceFolders = workspace.workspaceFolders;
     if (workspaceFolders !== undefined) {
       this.root = workspaceFolders[0];
     }
-
-    this.state = new PublisherState(this.context);
 
     this.extensionUri = this.context.extensionUri;
     this.webviewConduit = new WebviewConduit();
@@ -279,6 +276,13 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     // so we have the state, and can notify dependent views.
     this.requestWebviewSaveSelection();
 
+    // Listen for credential updates.
+    this.disposables.push(
+      this.state.onDidRefreshCredentials((_e) => {
+        this.updateWebViewViewCredentials();
+      }),
+    );
+
     // Signal the webapp that we believe the initialization refreshes
     // are finished.
     this.webviewConduit.sendMsg({
@@ -383,7 +387,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   private async refreshCredentials() {
     await this.state.refreshCredentials();
-    return this.updateWebViewViewCredentials();
   }
 
   private async refreshActiveConfig(cfg?: Configuration | ConfigurationError) {


### PR DESCRIPTION
## Intent

This commit adds an [`AuthenticationProvider`][0] implementation for existing Publisher credentials. This has a few advantages:

1. It makes the Publisher's credentials feel more "native" to VS Code and Positron, in that they appear in the Accounts UI and can leverage the editors' native Sign Out flow.

2. It introduces a well-established way for other extensions to access Publisher credentials: via the helpers in the `authentication` namespace (provided that the user specifically designates a given extension as "trusted", which I think is quite a nice feature).

Demo:

[Screencast from 2025-03-24 08:37:14 AM.webm](https://github.com/user-attachments/assets/fbe87e8a-5850-48ef-98e4-9bfcb432a81d)

[0]: https://code.visualstudio.com/api/references/vscode-api#AuthenticationProvider

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

In order to make this work dynamically, I had to introduce an event listener mechanism for credential refreshes. And to aid in debugging, I've also added a bespoke Output channel for Publisher-related authentication messages.

## User Impact

This change will make Publisher credentials appear in the Accounts UI.

## Automated Tests

No new tests; it seems fairly hard to write unit tests for this functionality.

## Directions for Reviewers

Please advise.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
