### PR TITLE
Only enable publishing log view after user has initiated their first …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+- The Publisher Log Panel now stays hidden until the user initiates a deployment operation
+  from within the extension. It remains visible until the VSCode window is restarted. (##2596)
+
 ## [1.10.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The Publisher Log Panel now stays hidden until the user initiates a deployment operation
-  from within the extension. It remains visible until the VSCode window is restarted. (##2596)
+- The Publisher Log Panel has now been renamed to "PUBLISHER" and now will stay hidden until the
+  user initiates a deployment operation from within the extension. It remains visible until the
+  VSCode window is restarted. (#2596)
 
 ## [1.10.0]
 

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,17 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+- The Publisher Log Panel now stays hidden until the user initiates a deployment operation
+  from within the extension. It remains visible until the VSCode window is restarted. (##2596)
+
 ## [1.10.0]
 
 ### Added

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -435,7 +435,7 @@
           "name": "Log",
           "contextualTitle": "Log",
           "icon": "$(output)",
-          "when": "workbenchState == folder && posit.publish.state == 'initialized'"
+          "when": "workbenchState == folder && posit.publish.state == 'initialized' && posit.publisher.homeView.userHasInitiatedDeploymentOperation == 'true'"
         }
       ]
     },

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -409,7 +409,7 @@
       "panel": [
         {
           "id": "posit-publisher-logs",
-          "title": "Posit Publisher Log",
+          "title": "Publisher",
           "icon": "$(output)"
         }
       ]

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -22,6 +22,11 @@ export const ENTRYPOINT_FILE_EXTENSIONS = [
   ".rmd",
 ];
 
+export enum BooleanContextValues {
+  True = "true",
+  False = "false",
+}
+
 const baseCommands = {
   InitProject: "posit.publisher.init-project",
   ShowOutputChannel: "posit.publisher.showOutputChannel",
@@ -89,6 +94,8 @@ const homeViewCommands = {
 
 const homeViewContexts = {
   Initialized: "posit.publisher.homeView.initialized",
+  UserHasInitiatedDeployment:
+    "posit.publisher.homeView.userHasInitiatedDeploymentOperation",
 };
 
 export const LocalState = {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -73,7 +73,13 @@ import {
   ContentRecordWatcherManager,
   WatcherManager,
 } from "src/watchers";
-import { Commands, Contexts, DebounceDelaysMS, Views } from "src/constants";
+import {
+  BooleanContextValues,
+  Commands,
+  Contexts,
+  DebounceDelaysMS,
+  Views,
+} from "src/constants";
 import { showProgress } from "src/utils/progress";
 import { newCredential } from "src/multiStepInputs/newCredential";
 import { PublisherState } from "src/state";
@@ -275,6 +281,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     await this.refreshAll(false, true);
     this.setInitializationContext(HomeViewInitialized.initialized);
 
+    // initialize our context to false - user hasn't hit publish yet!
+    this.setUserHasInitiatedDeploymentContext(BooleanContextValues.False);
+
     // On first run, we have no saved state. Trigger a save
     // so we have the state, and can notify dependent views.
     this.requestWebviewSaveSelection();
@@ -296,6 +305,14 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       "setContext",
       Contexts.HomeView.Initialized,
       context,
+    );
+  }
+
+  private setUserHasInitiatedDeploymentContext(value: BooleanContextValues) {
+    commands.executeCommand(
+      "setContext",
+      Contexts.HomeView.UserHasInitiatedDeployment,
+      value,
     );
   }
 
@@ -362,6 +379,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     this.webviewConduit.sendMsg({
       kind: HostToWebviewMessageType.PUBLISH_START,
     });
+    // Set this context and now the Posit Publishing Log view will be visible.
+    this.setUserHasInitiatedDeploymentContext(BooleanContextValues.True);
   }
 
   private onPublishSuccess() {


### PR DESCRIPTION
…deployment operation

<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This PR suppresses the Posit Publisher Log panel view until the user has clicked the deployment button from within the publishing extension. Until they do so, it remains hidden as it has no value until a deployment is initiated.

Resolves #2596 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

I added an additional context within the view's `when` definition, initialized it to "false" at extension startup, and set it to "true"  when the user initiates the deployment.

On load, first view:

![image](https://github.com/user-attachments/assets/22b97623-e260-40f6-b74a-cf9a9ed413f9)

After clicking the deploy button:

![image](https://github.com/user-attachments/assets/df020b6c-260b-443a-a180-cdedc0c68b73)

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

There shouldn't be any impact since we do not keep logs from previous runs (since the agent is killed and restarted each time the VSCode window is restarted).

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

This is not something we could test in unit tests as it is implemented within VSCode's infrastructure. It would be possible to test within e2e testing, but that infrastructure is still under development.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Should be able to reproduce the user scenario easily enough. Open VSCode, activate the publisher extension, verify the output panel does not list the Posit Publisher Log. Deploy something and verify that the log window is available once you clicked the deploy your project button.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
