### PR TITLE
Handle workspace trust states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- The Publisher extension will activate, but not initialize when the VSCode operates in Restricted Mode.
+  Initialization will commence when/if the workspace is trusted (which can be done via a button within the
+  publisher's view).
+
 ## [1.10.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The Publisher extension will activate, but not initialize when the VSCode operates in Restricted Mode.
-  Initialization will commence when/if the workspace is trusted (which can be done via a button within the
-  publisher's view).
+- Improved the extension's behavior in VS Code workspace restricted mode.
+  The extension will activate, but prompt to manage workspace trust so it can initialize.
 
 ## [1.10.0]
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -19,8 +19,8 @@
   },
   "capabilities": {
     "untrustedWorkspaces": {
-      "supported": false,
-      "description": "This extension does not support untrusted workspaces because it is not safe to deploy untrusted code."
+      "supported": "limited",
+      "description": "This extension is not functional in Restricted Mode, but will recognize the change from restricted to trusted."
     }
   },
   "categories": [
@@ -232,40 +232,40 @@
         {
           "command": "posit.publisher.deployWithEntrypoint",
           "group": "navigation",
-          "when": "posit.publish.activeFileEntrypoint == true"
+          "when": "posit.publish.activeFileEntrypoint == true && isWorkspaceTrusted"
         }
       ],
       "view/title": [
         {
           "command": "posit.publisher.files.refresh",
-          "when": "view == posit.publisher.files",
+          "when": "view == posit.publisher.files && isWorkspaceTrusted",
           "group": "navigation@2"
         },
         {
           "command": "posit.publisher.pythonPackages.edit",
-          "when": "view == posit.publisher.pythonPackages",
+          "when": "view == posit.publisher.pythonPackages && isWorkspaceTrusted",
           "group": "navigation@1"
         },
         {
           "command": "posit.publisher.pythonPackages.refresh",
-          "when": "view == posit.publisher.pythonPackages",
+          "when": "view == posit.publisher.pythonPackages && isWorkspaceTrusted",
           "group": "navigation@2"
         },
         {
           "command": "posit.publisher.pythonPackages.scan",
-          "when": "view == posit.publisher.pythonPackages",
+          "when": "view == posit.publisher.pythonPackages && isWorkspaceTrusted",
           "group": "navigation@3"
         },
         {
           "command": "posit.publisher.homeView.refresh",
-          "when": "view == posit.publisher.homeView",
+          "when": "view == posit.publisher.homeView && isWorkspaceTrusted",
           "group": "navigation@1"
         }
       ],
       "commandPalette": [
         {
           "command": "posit.publisher.init-project",
-          "when": "workbenchState == folder  && posit.publish.state == 'initialized'"
+          "when": "workbenchState == folder && posit.publish.state == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.deleteCredential",
@@ -273,7 +273,7 @@
         },
         {
           "command": "posit.publisher.homeView.refreshCredentials",
-          "when": "posit.publish.state == 'initialized'"
+          "when": "posit.publish.state == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.removeSecret",
@@ -281,7 +281,7 @@
         },
         {
           "command": "posit.publisher.files.refresh",
-          "when": "posit.publish.state == 'initialized'"
+          "when": "posit.publish.state == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.files.include",
@@ -297,43 +297,43 @@
         },
         {
           "command": "posit.publisher.pythonPackages.refresh",
-          "when": "posit.publish.state == 'initialized'"
+          "when": "posit.publish.state == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.pythonPackages.scan",
-          "when": "posit.publish.state == 'initialized'"
+          "when": "posit.publish.state == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.refresh",
-          "when": "posit.publish.state == 'initialized'"
+          "when": "posit.publish.state == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.selectDeployment",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.newDeployment",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.showOutputChannel",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.showPublishingLog",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.Server",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.Content",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.ContentLog",
-          "when": "posit.publisher.homeView.initialized == 'initialized'"
+          "when": "posit.publisher.homeView.initialized == 'initialized' && isWorkspaceTrusted"
         }
       ],
       "webview/context": [
@@ -343,49 +343,49 @@
         },
         {
           "command": "posit.publisher.homeView.associateDeployment",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-matching-configs' && posit.publish.selection.hasCredentialMatch == 'true' && posit.publish.selection.isPreContentRecord == 'false'"
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-matching-configs' && posit.publish.selection.hasCredentialMatch == 'true' && posit.publish.selection.isPreContentRecord == 'false' "
         },
         {
           "command": "posit.publisher.homeView.createConfigForDeployment",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-no-matching-configs'"
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-no-matching-configs' "
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.Server",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
           "group": "navigation@1"
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.ContentLog",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
           "group": "navigation@2"
         },
         {
           "command": "posit.publisher.showOutputChannel",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
           "group": "show@1"
         },
         {
           "command": "posit.publisher.showPublishingLog",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
           "group": "show@2"
         },
         {
           "command": "posit.publisher.showOutputChannel",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu'",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu' ",
           "group": "show@1"
         },
         {
           "command": "posit.publisher.showPublishingLog",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu'",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu' ",
           "group": "show@2"
         },
         {
           "command": "posit.publisher.homeView.deleteCredential",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'credentials-tree-item'"
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'credentials-tree-item' "
         },
         {
           "command": "posit.publisher.homeView.removeSecret",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'secrets-tree-item'"
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'secrets-tree-item' "
         }
       ]
     },
@@ -422,7 +422,7 @@
           "contextualTitle": "Publisher",
           "visibility": "visible",
           "initialSize": 0,
-          "when": "workbenchState == empty || workbenchState == workspace || (workbenchState == folder && posit.publish.state == 'uninitialized')"
+          "when": "(workbenchState == empty || workbenchState == workspace || (workbenchState == folder && posit.publish.state == 'uninitialized')) && isWorkspaceTrusted"
         },
         {
           "id": "posit.publisher.homeView",
@@ -432,7 +432,15 @@
           "icon": "$(symbol-file)",
           "visibility": "visible",
           "initialSize": 1,
-          "when": "workbenchState == folder && posit.publish.state == 'initialized'"
+          "when": "workbenchState == folder && posit.publish.state == 'initialized' && isWorkspaceTrusted"
+        },
+        {
+          "id": "posit.publisher.untrusted",
+          "name": "",
+          "contextualTitle": "Publisher",
+          "visibility": "visible",
+          "initialSize": 0,
+          "when": "!isWorkspaceTrusted"
         }
       ],
       "posit-publisher-logs": [
@@ -441,7 +449,7 @@
           "name": "Log",
           "contextualTitle": "Log",
           "icon": "$(output)",
-          "when": "workbenchState == folder && posit.publish.state == 'initialized'"
+          "when": "!isWorkspaceTrusted"
         }
       ]
     },
@@ -449,17 +457,22 @@
       {
         "view": "posit.publisher.project",
         "contents": "In order to deploy using Posit Publisher, you must open a folder.\n[Open Folder](command:vscode.openFolder)",
-        "when": "workbenchState == empty"
+        "when": "workbenchState == empty && isWorkspaceTrusted"
       },
       {
         "view": "posit.publisher.project",
         "contents": "Posit Publisher currently only supports single folder workspaces, open a folder.\n[Open Folder](command:vscode.openFolder)",
-        "when": "workbenchState == workspace"
+        "when": "workbenchState == workspace && isWorkspaceTrusted"
       },
       {
         "view": "posit.publisher.project",
         "contents": "Scanning folder for a Posit project...",
-        "when": "workbenchState == folder && posit.publish.state == 'uninitialized'"
+        "when": "workbenchState == folder && posit.publish.state == 'uninitialized' && isWorkspaceTrusted"
+      },
+      {
+        "view": "posit.publisher.untrusted",
+        "contents": "The Posit Publisher extension is disabled when operating in Restricted Mode.\n\n[Manage Workspaces Trust](command:workbench.trust.manage)",
+        "when": "!isWorkspaceTrusted"
       }
     ],
     "walkthroughs": [

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -343,49 +343,49 @@
         },
         {
           "command": "posit.publisher.homeView.associateDeployment",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-matching-configs' && posit.publish.selection.hasCredentialMatch == 'true' && posit.publish.selection.isPreContentRecord == 'false' "
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-matching-configs' && posit.publish.selection.hasCredentialMatch == 'true' && posit.publish.selection.isPreContentRecord == 'false'"
         },
         {
           "command": "posit.publisher.homeView.createConfigForDeployment",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-no-matching-configs' "
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'even-easier-deploy-more-menu-no-matching-configs'"
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.Server",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
           "group": "navigation@1"
         },
         {
           "command": "posit.publisher.homeView.navigateToDeployment.ContentLog",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
           "group": "navigation@2"
         },
         {
           "command": "posit.publisher.showOutputChannel",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
           "group": "show@1"
         },
         {
           "command": "posit.publisher.showPublishingLog",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu' ",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-last-contentRecord-more-menu'",
           "group": "show@2"
         },
         {
           "command": "posit.publisher.showOutputChannel",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu' ",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu'",
           "group": "show@1"
         },
         {
           "command": "posit.publisher.showPublishingLog",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu' ",
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'homeview-active-contentRecord-more-menu'",
           "group": "show@2"
         },
         {
           "command": "posit.publisher.homeView.deleteCredential",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'credentials-tree-item' "
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'credentials-tree-item'"
         },
         {
           "command": "posit.publisher.homeView.removeSecret",
-          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'secrets-tree-item' "
+          "when": "webviewId == 'posit.publisher.homeView' && webviewSection == 'secrets-tree-item'"
         }
       ]
     },
@@ -449,7 +449,7 @@
           "name": "Log",
           "contextualTitle": "Log",
           "icon": "$(output)",
-          "when": "!isWorkspaceTrusted"
+          "when": "workbenchState == folder && posit.publish.state == 'initialized' && isWorkspaceTrusted"
         }
       ]
     },

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -151,7 +151,8 @@ async function initializeExtension(context: ExtensionContext) {
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: ExtensionContext) {
-  console.log("Posit Publisher extension activated");
+  const now = new Date();
+  console.log("Posit Publisher extension activated at %s", now.toString());
   // Is our workspace trusted?
   if (workspace.isTrusted) {
     console.log("initializing extension within a trusted workspace");

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -78,10 +78,7 @@ export function setSelectionIsPreContentRecord(
   );
 }
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
-export async function activate(context: ExtensionContext) {
-  console.log("Activating Posit Publisher extension");
+async function initializeExtension(context: ExtensionContext) {
   setStateContext(PositPublishState.uninitialized);
   setInitializationInProgressContext(InitializationInProgress.false);
 
@@ -149,6 +146,32 @@ export async function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(new PublisherAuthProvider(state));
+}
+
+// This method is called when your extension is activated
+// Your extension is activated the very first time the command is executed
+export function activate(context: ExtensionContext) {
+  console.log("Posit Publisher extension activated");
+  // Is our workspace trusted?
+  if (workspace.isTrusted) {
+    console.log("initializing extension within a trusted workspace");
+    initializeExtension(context);
+    return;
+  }
+  console.log(
+    "activated within a restricted workspace. Initialization is paused until trust is granted.",
+  );
+
+  // We are not trusted yet... so if and when we are, then start the initialization
+  context.subscriptions.push(
+    workspace.onDidGrantWorkspaceTrust(() => {
+      console.log("Trust mode granted by user.");
+      console.log(
+        "Proceeding forward with initializion for extension within a trusted workspace",
+      );
+      initializeExtension(context);
+    }),
+  );
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This PR provides the publisher extension with the functionality to support running within Restricted Mode. When in restricted mode, all publishing functionality is hidden, with only a button made available to manage the trust of the workspace (which is common with other extensions).

If and when the workspace is trusted by the user, the extension will commence its initialization. If the workspace is untrusted once again, the publisher returns to its restricted view.

Resolves #2611 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

At activation, the code will check if it is being activated in trusted mode or not. If it is, it proceeds with initialization. If restricted mode is active instead, it registers an event handler for when trust is granted to proceed with initialization.

The views and commands configured within `package.json` have been updated to use the context that VSCode API provides (`isWorkspaceTrusted`)

When in restricted mode, clicking on the publisher icon will show this view:

<img width="1367" alt="Screenshot 2025-04-08 at 4 04 31 PM" src="https://github.com/user-attachments/assets/ead8021b-1f7e-4093-8565-c541b81db522" />


## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

User should see no difference in functionality for trusted folders. In restricted mode, they will now see an experience much more common to what other extensions do.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Launch VSCode with the extension and open a folder which you have not trusted. If you need to force one to be untrusted, you can use the pallete command of "Workspaces: Manage Workspace Trust" and untrust the open workspace.

Then confirm that you only see the view described above. Confirm that the button will bring up the trust management page, and click trust. Confirm that the publisher extension initializes and is functional. You can then untrust the workspace and confirm that the extension switches back to the restricted mode.

Confirm that you see no difference from before if you open a trusted workspace/folder.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
