### PR TITLE
Publish Release 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1]
+
+### Changed
+
+- Publishing a patch release of 1.12, without changes. Having problems
+  with publishing to OpenVSX.
+
 ## [1.12.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.12.1]
 
+### Fixed
+
+- Fix missing platform build in OpenVSX due to outage.
+
 ### Changed
 
-- Publishing a patch release of 1.12, without changes. Having problems
-  with publishing to OpenVSX.
+- Updated `record.toml` to correspond with updated schema change in v1.12
 
 ## [1.12.0]
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,11 +11,11 @@ Install.
 
 Download and install the VS Code extension.
 
-- For Arm MacOS: [publisher-1.12.0-darwin-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.0-darwin-arm64.vsix)
-- For Intel MacOS: [publisher-1.12.0-darwin-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.0-darwin-amd64.vsix)
-- For Windows: [publisher-1.12.0-windows-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.0-windows-amd64.vsix)
-- For Arm Linux: [publisher-1.12.0-linux-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.0-linux-arm64.vsix)
-- For Intel Linux: [publisher-1.12.0-linux-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.0-linux-amd64.vsix)
+- For Arm MacOS: [publisher-1.12.1-darwin-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.1-darwin-arm64.vsix)
+- For Intel MacOS: [publisher-1.12.1-darwin-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.1-darwin-amd64.vsix)
+- For Windows: [publisher-1.12.1-windows-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.1-windows-amd64.vsix)
+- For Arm Linux: [publisher-1.12.1-linux-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.1-linux-arm64.vsix)
+- For Intel Linux: [publisher-1.12.1-linux-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.10.0/publisher-1.12.1-linux-amd64.vsix)
 
 To learn how to install a `.vsix` file, see the [Install from a
 VSIX](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix)

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,13 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1]
+
+### Changed
+
+- Publishing a patch release of 1.12, without changes. Having problems
+  with publishing to OpenVSX.
+
 ## [1.12.0]
 
 ### Added

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.12.1]
 
-### Changed
+### Fixed
 
-- Publishing a patch release of 1.12, without changes. Having problems
-  with publishing to OpenVSX.
+- Fix missing platform build in OpenVSX due to outage.
 
 ## [1.12.0]
 

--- a/install-publisher.bash
+++ b/install-publisher.bash
@@ -148,7 +148,7 @@ esac
 
 # version override, swap out latest with the latest and greatest
 if [[ $VERSION_TYPE == "release" && $VERSION == "latest" ]]; then
-  VERSION="1.12.0"
+  VERSION="1.12.1"
 fi
 
 # Variables

--- a/internal/schema/schemas/record.toml
+++ b/internal/schema/schemas/record.toml
@@ -30,6 +30,7 @@ description = "This is the quarterly sales report, broken down by region."
 version = "3.11.3"
 package_file = "requirements.txt"
 package_manager = "pip"
+requires_python = "<3.12"
 
 [configuration.r]
 version = "4.3.1"


### PR DESCRIPTION
## Intent

ARM version of Mac extension is not showing up on OpenVSX. 

Unable to remove version 1.12.0, so we've decided to update to a patch version to attempt to fix it.

## Type of Change

No significant changes, other than those related to the release.
