### PR TITLE
Quote paths to support windows

### DIFF
--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -13,6 +13,28 @@ jobs:
         with:
           fetch-depth: 0
       - uses: extractions/setup-just@v2
+
+      # Install R with rig to ensure we are compatible
+      - name: Install rig with apt
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg
+          sudo sh -c 'echo "deb http://rig.r-pkg.org/deb rig main" > /etc/apt/sources.list.d/rig.list'
+          sudo apt update
+          sudo apt install -y r-rig
+      - name: Install rig with brew
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew tap r-lib/rig
+          brew install --cask rig
+      - name: Install rig with Choco
+        if: ${{ runner.os == 'Windows' }}
+        run: choco install rig
+
+      - name: Install R with rig
+        run: rig add release
+      - name: Install renv package
+        run: Rscript -e "install.packages('renv')"
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -14,7 +14,9 @@ jobs:
           fetch-depth: 0
       - uses: extractions/setup-just@v2
 
-      # Install R with rig to ensure we are compatible
+      # Install R with rig for our funcitonal tests to ensure we are compatible with it.
+      # We aren't used r-lib/actions here becuase rig, especially on windows, installs in
+      # slightly different ways (e.g. using a batch file on windows)
       - name: Install rig with apt
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -38,4 +40,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: just test
+      # Run tests without `-short` to run functional tests
+      # TODO: https://github.com/posit-dev/publisher/issues/2649
+      - run: just test ./...

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -72,8 +72,7 @@ func createTempRScript(content string) (string, func(), error) {
 }
 
 func (e *defaultExecutor) RunScript(executable string, args []string, script string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error) {
-	log.Debug("Running command", "cmd", executable, "args", strings.Join(args, " "), "script", script)
-
+	log.Debug("Running script", "cmd", executable, "args", strings.Join(args, " "), "script", script)
 	// Write script contents to a file, clean it up, and append to args
 	tempScriptPath, cleanup, scriptErr := createTempRScript(script)
 	if scriptErr != nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -43,55 +43,27 @@ func (e *defaultExecutor) RunCommand(executable string, args []string, cwd util.
 	return stdout.Bytes(), stderrBuf.Bytes(), err
 }
 
-// createTempRScript creates a temporary file with R code and returns the file path.
-// The caller is responsible for removing the temporary file.
-func createTempRScript(content string) (string, func(), error) {
+// RunScript is helpful when running R scripts, they avoid needing to ensure that the contents of the script
+// is fully escaped and quoted.
+func (e *defaultExecutor) RunScript(executable string, args []string, script string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error) {
+	log.Debug("Running script", "cmd", executable, "args", strings.Join(args, " "), "script", script)
+	// Write script contents to a file, clean it up, and append to args
 	tempFile, err := os.CreateTemp("", "*")
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to create temporary R script: %w", err)
-	}
 
-	// Write the R code to the temporary file
-	if _, err := tempFile.WriteString(content); err != nil {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
-		return "", nil, fmt.Errorf("failed to write to temporary R script: %w", err)
-	}
-	if err := tempFile.Sync(); err != nil {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
-		return "", nil, fmt.Errorf("failed to flush temporary R script to disk: %w", err)
-	}
-
-	// Return the file path and a cleanup function
+	// defer cleaning up
 	cleanup := func() {
 		tempFile.Close()
 		os.Remove(tempFile.Name())
 	}
-	return tempFile.Name(), cleanup, nil
-}
-
-func (e *defaultExecutor) RunScript(executable string, args []string, script string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error) {
-	log.Debug("Running script", "cmd", executable, "args", strings.Join(args, " "), "script", script)
-	// Write script contents to a file, clean it up, and append to args
-	tempScriptPath, cleanup, scriptErr := createTempRScript(script)
-	if scriptErr != nil {
-		return nil, nil, scriptErr
-	}
 	defer cleanup()
-	args = append(args, "-f", tempScriptPath)
-
-	cmd := exec.Command(executable, args...)
-	cmd.Dir = cwd.String()
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	stderrBuf := new(bytes.Buffer)
-	cmd.Stderr = stderrBuf
-	err := cmd.Run()
 
 	if err != nil {
-		log.Error("Error running command", "command", executable, "error", err.Error())
-		os.Stderr.Write(stderrBuf.Bytes())
+		return nil, nil, fmt.Errorf("failed to create temporary R script: %w", err)
 	}
-	return stdout.Bytes(), stderrBuf.Bytes(), err
+
+	tempFile.WriteString(script)
+	tempFile.Sync()
+
+	args = append(args, "-f", tempFile.Name())
+	return e.RunCommand(executable, args, cwd, log)
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4,6 +4,7 @@ package executor
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 type Executor interface {
 	RunCommand(executable string, args []string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error)
+	RunScript(executable string, args []string, script string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error)
 }
 
 type defaultExecutor struct{}
@@ -26,6 +28,60 @@ func NewExecutor() *defaultExecutor {
 
 func (e *defaultExecutor) RunCommand(executable string, args []string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error) {
 	log.Debug("Running command", "cmd", executable, "args", strings.Join(args, " "))
+	cmd := exec.Command(executable, args...)
+	cmd.Dir = cwd.String()
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	stderrBuf := new(bytes.Buffer)
+	cmd.Stderr = stderrBuf
+	err := cmd.Run()
+
+	if err != nil {
+		log.Error("Error running command", "command", executable, "error", err.Error())
+		os.Stderr.Write(stderrBuf.Bytes())
+	}
+	return stdout.Bytes(), stderrBuf.Bytes(), err
+}
+
+// createTempRScript creates a temporary file with R code and returns the file path.
+// The caller is responsible for removing the temporary file.
+func createTempRScript(content string) (string, func(), error) {
+	tempFile, err := os.CreateTemp("", "*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary R script: %w", err)
+	}
+
+	// Write the R code to the temporary file
+	if _, err := tempFile.WriteString(content); err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return "", nil, fmt.Errorf("failed to write to temporary R script: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return "", nil, fmt.Errorf("failed to flush temporary R script to disk: %w", err)
+	}
+
+	// Return the file path and a cleanup function
+	cleanup := func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}
+	return tempFile.Name(), cleanup, nil
+}
+
+func (e *defaultExecutor) RunScript(executable string, args []string, script string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error) {
+	log.Debug("Running command", "cmd", executable, "args", strings.Join(args, " "), "script", script)
+
+	// Write script contents to a file, clean it up, and append to args
+	tempScriptPath, cleanup, scriptErr := createTempRScript(script)
+	if scriptErr != nil {
+		return nil, nil, scriptErr
+	}
+	defer cleanup()
+	args = append(args, "-f", tempScriptPath)
+
 	cmd := exec.Command(executable, args...)
 	cmd.Dir = cwd.String()
 	var stdout bytes.Buffer

--- a/internal/executor/executortest/executortest.go
+++ b/internal/executor/executortest/executortest.go
@@ -31,3 +31,19 @@ func (m *MockExecutor) RunCommand(executable string, argv []string, cwd util.Abs
 	}
 	return outSlice, errSlice, args.Error(2)
 }
+
+func (m *MockExecutor) RunScript(executable string, args []string, script string, cwd util.AbsolutePath, log logging.Logger) ([]byte, []byte, error) {
+	mockArgs := m.Called(executable, args, script, cwd, log)
+
+	var outSlice []byte
+	out := mockArgs.Get(0)
+	if out != nil {
+		outSlice = out.([]byte)
+	}
+	var errSlice []byte
+	stderr := mockArgs.Get(1)
+	if stderr != nil {
+		errSlice = stderr.([]byte)
+	}
+	return outSlice, errSlice, mockArgs.Error(2)
+}

--- a/internal/inspect/dependencies/renv/available_packages.go
+++ b/internal/inspect/dependencies/renv/available_packages.go
@@ -187,7 +187,8 @@ func (l *defaultAvailablePackagesLister) GetLibPaths(log logging.Logger) ([]util
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if line == "" {
+		if line == "" || line[0] == '-' {
+			// e.g. "- The project is out-of-sync -- use `renv::status()` for details."
 			continue
 		}
 		paths = append(paths, util.NewAbsolutePath(line, nil))

--- a/internal/inspect/dependencies/renv/available_packages_test.go
+++ b/internal/inspect/dependencies/renv/available_packages_test.go
@@ -57,7 +57,7 @@ func (s *AvailablePackagesSuite) TestListAvailablePackages() {
 	rExecutablePath := util.NewAbsolutePath("R", nil)
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", rExecutablePath.String(), mock.Anything, s.base, mock.Anything).Return([]byte(
+	executor.On("RunScript", rExecutablePath.String(), mock.Anything, mock.Anything, s.base, mock.Anything).Return([]byte(
 		"pkg1 1.0 https://cran.rstudio.com/src/contrib \npkg2 2.0 https://cran.rstudio.com/src/contrib \n"), []byte{}, nil)
 	lister.rExecutor = executor
 
@@ -97,7 +97,7 @@ func (s *AvailablePackagesSuite) TestGetBioconductorRepos() {
 	rExecutablePath := util.NewAbsolutePath("R", nil)
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", rExecutablePath.String(), mock.Anything, s.base, mock.Anything).Return([]byte(biocReposOutput), []byte{}, nil)
+	executor.On("RunScript", rExecutablePath.String(), mock.Anything, mock.Anything, s.base, mock.Anything).Return([]byte(biocReposOutput), []byte{}, nil)
 	lister.rExecutor = executor
 
 	repos, err := lister.GetBioconductorRepos(s.base, logging.New())
@@ -139,7 +139,7 @@ func (s *AvailablePackagesSuite) TestGetLibPaths() {
 	s.NoError(err)
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", rExecutablePath.String(), mock.Anything, s.base, mock.Anything).Return([]byte(libPathsOutput), []byte{}, nil)
+	executor.On("RunScript", rExecutablePath.String(), mock.Anything, mock.Anything, s.base, mock.Anything).Return([]byte(libPathsOutput), []byte{}, nil)
 	lister.rExecutor = executor
 
 	repos, err := lister.GetLibPaths(logging.New())
@@ -177,7 +177,7 @@ func (s *AvailablePackagesSuite) TestGetLibPathsWindows() {
 	s.NoError(err)
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", rExecutablePath.String(), []string{"-s", "-e", "cat(.libPaths(), sep=\"\\n\")"}, s.base, mock.Anything).Return([]byte(windowsLibPathsOutput), []byte{}, nil)
+	executor.On("RunScript", rExecutablePath.String(), []string{"-s"}, "cat(.libPaths(), sep=\"\\n\")", s.base, mock.Anything).Return([]byte(windowsLibPathsOutput), []byte{}, nil)
 	lister.rExecutor = executor
 
 	repos, err := lister.GetLibPaths(logging.New())

--- a/internal/interpreters/r_interpreter_functional_test.go
+++ b/internal/interpreters/r_interpreter_functional_test.go
@@ -28,6 +28,10 @@ type RInterpreterFunctionalSuite struct {
 }
 
 func TestRInterpreterFunctionalSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(RInterpreterFunctionalSuite))
 }
 
@@ -64,35 +68,13 @@ func (s *RInterpreterFunctionalSuite) SetupTest() {
 	}
 }
 
-// skipIfNoR skips the current test if R executable is not available
-// unless we're running in CI where we should enforce that R tests run
-func (s *RInterpreterFunctionalSuite) skipIfNoR() bool {
-	if os.Getenv("GITHUB_ACTIONS") != "true" && s.rExecutable.String() == "" {
-		s.T().Skip("Skipping test: R executable not found")
-		return true
-	}
-	return false
-}
-
-// skipIfNoRenv skips the current test if either R executable is not available or renv is not installed
-// unless we're running in CI where we should enforce that R tests run
-func (s *RInterpreterFunctionalSuite) skipIfNoRenv() bool {
-	if s.skipIfNoR() {
-		return true
-	}
-	if os.Getenv("GITHUB_ACTIONS") != "true" && !s.renvInstalled {
-		s.T().Skip("Skipping test because renv is not installed")
-		return true
-	}
-	return false
-}
-
 func (s *RInterpreterFunctionalSuite) TearDownTest() {
 	os.RemoveAll(s.testProjectDir.String())
 }
 
 func (s *RInterpreterFunctionalSuite) createTestRenvLock() {
 	// Create a simple but valid renv.lock file
+	// this file does not need to be valid, but must exist
 	lockContent := `{
       "R": {
         "Version": "4.2.3",
@@ -121,10 +103,6 @@ func (s *RInterpreterFunctionalSuite) createTestRenvLock() {
 
 // TestIsRenvInstalled tests the isRenvInstalled function with a real R executable
 func (s *RInterpreterFunctionalSuite) TestIsRenvInstalled() {
-	if s.skipIfNoR() {
-		return
-	}
-
 	// Attempt to detect if renv is installed
 	aerr := s.defaultInterpreter.isRenvInstalled(s.rExecutable.String())
 
@@ -141,10 +119,6 @@ func (s *RInterpreterFunctionalSuite) TestIsRenvInstalled() {
 
 // TestRenvStatus tests the renvStatus function with a real R executable
 func (s *RInterpreterFunctionalSuite) TestRenvStatus() {
-	if s.skipIfNoRenv() {
-		return
-	}
-
 	// Create test project with renv.lock
 	s.createTestRenvLock()
 
@@ -157,10 +131,6 @@ func (s *RInterpreterFunctionalSuite) TestRenvStatus() {
 
 // TestGetRenvLockfilePathFromRExecutable tests the getRenvLockfilePathFromRExecutable function
 func (s *RInterpreterFunctionalSuite) TestGetRenvLockfilePathFromRExecutable() {
-	if s.skipIfNoRenv() {
-		return
-	}
-
 	// Create test project with renv.lock
 	s.createTestRenvLock()
 
@@ -182,10 +152,6 @@ func (s *RInterpreterFunctionalSuite) TestGetRenvLockfilePathFromRExecutable() {
 
 // TestCreateLockfile tests the CreateLockfile function
 func (s *RInterpreterFunctionalSuite) TestCreateLockfile() {
-	if s.skipIfNoRenv() {
-		return
-	}
-
 	// Create a temporary directory for the lockfile
 	lockfileDir := s.testProjectDir.Join("lockfile_test")
 	err := lockfileDir.MkdirAll(0755)

--- a/internal/interpreters/r_interpreter_functional_test.go
+++ b/internal/interpreters/r_interpreter_functional_test.go
@@ -1,0 +1,213 @@
+package interpreters
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+)
+
+// RInterpreterFunctionalSuite contains functional tests that actually
+// interact with real R installations
+type RInterpreterFunctionalSuite struct {
+	suite.Suite
+	testProjectDir     util.AbsolutePath
+	log                logging.Logger
+	fs                 afero.Fs
+	interpreter        RInterpreter
+	rExecutable        util.AbsolutePath
+	defaultInterpreter *defaultRInterpreter
+	renvInstalled      bool
+}
+
+func TestRInterpreterFunctionalSuite(t *testing.T) {
+	suite.Run(t, new(RInterpreterFunctionalSuite))
+}
+
+func (s *RInterpreterFunctionalSuite) SetupTest() {
+	// Set up the test directory
+	parentDir, err := os.MkdirTemp("", "r-interpreter-test-*")
+	s.Require().NoError(err)
+
+	s.fs = afero.NewOsFs()
+	s.testProjectDir = util.NewAbsolutePath(parentDir, s.fs)
+	s.log = logging.New()
+
+	// Initialize R interpreter once for all tests
+	s.interpreter, err = NewRInterpreter(s.testProjectDir, util.Path{}, s.log, nil, nil, nil)
+	s.Require().NoError(err)
+
+	// Try to get R executable
+	s.rExecutable, err = s.interpreter.GetRExecutable()
+	if err != nil {
+		s.T().Logf("R executable not found: %v", err)
+		// Not failing here, individual tests will skip if needed
+	} else {
+		s.T().Logf("Using R executable: %s", s.rExecutable)
+		s.defaultInterpreter = s.interpreter.(*defaultRInterpreter)
+
+		// Check if renv is installed
+		aerr := s.defaultInterpreter.isRenvInstalled(s.rExecutable.String())
+		s.renvInstalled = (aerr == nil)
+		if !s.renvInstalled {
+			s.T().Logf("renv is not installed: %s", aerr.Error())
+		} else {
+			s.T().Logf("renv is installed and available")
+		}
+	}
+}
+
+// skipIfNoR skips the current test if R executable is not available
+// unless we're running in CI where we should enforce that R tests run
+func (s *RInterpreterFunctionalSuite) skipIfNoR() bool {
+	if os.Getenv("GITHUB_ACTIONS") != "true" && s.rExecutable.String() == "" {
+		s.T().Skip("Skipping test: R executable not found")
+		return true
+	}
+	return false
+}
+
+// skipIfNoRenv skips the current test if either R executable is not available or renv is not installed
+// unless we're running in CI where we should enforce that R tests run
+func (s *RInterpreterFunctionalSuite) skipIfNoRenv() bool {
+	if s.skipIfNoR() {
+		return true
+	}
+	if os.Getenv("GITHUB_ACTIONS") != "true" && !s.renvInstalled {
+		s.T().Skip("Skipping test because renv is not installed")
+		return true
+	}
+	return false
+}
+
+func (s *RInterpreterFunctionalSuite) TearDownTest() {
+	os.RemoveAll(s.testProjectDir.String())
+}
+
+func (s *RInterpreterFunctionalSuite) createTestRenvLock() {
+	// Create a simple but valid renv.lock file
+	lockContent := `{
+      "R": {
+        "Version": "4.2.3",
+        "Repositories": [
+          {
+            "Name": "CRAN",
+            "URL": "https://cloud.r-project.org"
+          }
+        ]
+      },
+      "Packages": {
+        "renv": {
+          "Package": "renv",
+          "Version": "1.1.4",
+          "Source": "Repository",
+          "Repository": "CRAN",
+          "Hash": "fa15e"
+        }
+      }
+    }`
+
+	lockPath := s.testProjectDir.Join("renv.lock")
+	err := lockPath.WriteFile([]byte(lockContent), 0644)
+	s.Require().NoError(err)
+}
+
+// TestIsRenvInstalled tests the isRenvInstalled function with a real R executable
+func (s *RInterpreterFunctionalSuite) TestIsRenvInstalled() {
+	if s.skipIfNoR() {
+		return
+	}
+
+	// Attempt to detect if renv is installed
+	aerr := s.defaultInterpreter.isRenvInstalled(s.rExecutable.String())
+
+	// If renv is not installed, we expect an error with ErrorRenvPackageNotInstalled code
+	if aerr != nil {
+		// Check we got the expected error
+		s.Equal(types.ErrorRenvPackageNotInstalled, aerr.GetCode())
+		s.T().Logf("renv is not installed: %s", aerr.Error())
+		s.Contains(aerr.Data["Command"], "install.packages(\"renv\")")
+	} else {
+		s.T().Logf("renv is already installed on the system")
+	}
+}
+
+// TestRenvStatus tests the renvStatus function with a real R executable
+func (s *RInterpreterFunctionalSuite) TestRenvStatus() {
+	if s.skipIfNoRenv() {
+		return
+	}
+
+	// Create test project with renv.lock
+	s.createTestRenvLock()
+
+	// Check renv status
+	statusOutput, aerr := s.defaultInterpreter.renvStatus(s.rExecutable.String())
+	s.Require().Nil(aerr)
+	s.T().Logf("renv status output: %s", statusOutput)
+	s.NotEmpty(statusOutput)
+}
+
+// TestGetRenvLockfilePathFromRExecutable tests the getRenvLockfilePathFromRExecutable function
+func (s *RInterpreterFunctionalSuite) TestGetRenvLockfilePathFromRExecutable() {
+	if s.skipIfNoRenv() {
+		return
+	}
+
+	// Create test project with renv.lock
+	s.createTestRenvLock()
+
+	// Get lockfile path
+	lockfilePath, err := s.defaultInterpreter.getRenvLockfilePathFromRExecutable(s.rExecutable.String())
+	if err != nil {
+		s.T().Logf("Error getting lockfile path: %v", err)
+		// This is not necessarily a failure - renv might not be in a project context
+		return
+	}
+
+	s.T().Logf("Detected lockfile path: %s", lockfilePath)
+	s.NotEmpty(lockfilePath.String())
+
+	// If we got a path, verify it's a valid path that could exist
+	_, err = os.Stat(filepath.Dir(lockfilePath.String()))
+	s.NoError(err, "The directory containing the lockfile should exist")
+}
+
+// TestCreateLockfile tests the CreateLockfile function
+func (s *RInterpreterFunctionalSuite) TestCreateLockfile() {
+	if s.skipIfNoRenv() {
+		return
+	}
+
+	// Create a temporary directory for the lockfile
+	lockfileDir := s.testProjectDir.Join("lockfile_test")
+	err := lockfileDir.MkdirAll(0755)
+	s.Require().NoError(err)
+
+	lockfilePath := lockfileDir.Join("custom_renv.lock")
+
+	// Create the lockfile - this might fail in non-project contexts,
+	// but we should still attempt it for real-world testing
+	err = s.interpreter.CreateLockfile(lockfilePath)
+	if err != nil {
+		s.T().Logf("Error creating lockfile (may be expected in non-project context): %v", err)
+		return
+	}
+
+	// If lockfile was created, verify it exists and has content
+	exists, err := lockfilePath.Exists()
+	s.NoError(err)
+	s.True(exists, "Lockfile should have been created")
+
+	content, err := lockfilePath.ReadFile()
+	s.NoError(err)
+	s.NotEmpty(content, "Lockfile should not be empty")
+	s.T().Logf("Successfully created lockfile at %s", lockfilePath)
+}

--- a/internal/interpreters/r_test.go
+++ b/internal/interpreters/r_test.go
@@ -68,7 +68,7 @@ func (s *RSuite) TestInit() {
 
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::paths$lockfile()"}, mock.Anything, mock.Anything).Return([]byte(`[1] "/test/sample-content/shinyapp/renv.lock"`), nil, nil).Once()
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::paths$lockfile()", mock.Anything, mock.Anything).Return([]byte(`[1] "/test/sample-content/shinyapp/renv.lock"`), nil, nil).Once()
 
 	i, err := NewRInterpreter(s.cwd, rPath.Path, log, executor, nil, nil)
 	s.NoError(err)
@@ -212,7 +212,7 @@ func (s *RSuite) TestGetRVersionFromExecutable() {
 
 		executor := executortest.NewMockExecutor()
 		executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(tc.versionOutput), nil, nil)
-		executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::paths$lockfile()"}, mock.Anything, mock.Anything).Return([]byte(tc.pathsLockfileOutput), nil, nil)
+		executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::paths$lockfile()", mock.Anything, mock.Anything).Return([]byte(tc.pathsLockfileOutput), nil, nil)
 
 		rInterpreter, err := NewRInterpreter(s.cwd, rPath.Path, log, executor, nil, nil)
 		s.NoError(err)
@@ -253,7 +253,7 @@ func (s *RSuite) TestGetRVersionFromExecutableWindows() {
 
 		executor := executortest.NewMockExecutor()
 		executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return(nil, []byte(tc.versionOutput), nil)
-		executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::paths$lockfile()"}, mock.Anything, mock.Anything).Return(nil, []byte(tc.pathsLockfileOutput), nil)
+		executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::paths$lockfile()", mock.Anything, mock.Anything).Return(nil, []byte(tc.pathsLockfileOutput), nil)
 
 		rInterpreter, err := NewRInterpreter(s.cwd, rPath.Path, log, executor, nil, nil)
 		s.NoError(err)
@@ -486,7 +486,7 @@ func (s *RSuite) TestResolveRenvLockFileWithRSpecifyingDefaultNameAndExists() {
 
 	executor := executortest.NewMockExecutor()
 	outputLine := fmt.Sprintf(`[1] "%s"`, rPath.String())
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::paths$lockfile()"}, mock.Anything, mock.Anything).Return([]byte(outputLine), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::paths$lockfile()", mock.Anything, mock.Anything).Return([]byte(outputLine), nil, nil)
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(""), nil, errors.New("problem"))
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
@@ -509,7 +509,7 @@ func (s *RSuite) TestResolveRenvLockFileWithRSpecifyingDefaultNameAndDoesNotExis
 	}
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::paths$lockfile()"}, mock.Anything, mock.Anything).Return([]byte(`[1] "internal/interpreters/renv.lock"`), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::paths$lockfile()", mock.Anything, mock.Anything).Return([]byte(`[1] "internal/interpreters/renv.lock"`), nil, nil)
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(""), nil, errors.New("problem"))
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
@@ -536,7 +536,7 @@ func (s *RSuite) TestResolveRenvLockFileWithRSpecialNameAndExists() {
 
 	executor := executortest.NewMockExecutor()
 	outputLine := fmt.Sprintf(`[1] "%s"`, rPath.String())
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::paths$lockfile()"}, mock.Anything, mock.Anything).Return([]byte(outputLine), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::paths$lockfile()", mock.Anything, mock.Anything).Return([]byte(outputLine), nil, nil)
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(""), nil, errors.New("problem"))
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
@@ -569,7 +569,7 @@ func (s *RSuite) TestCreateLockfileWithNonEmptyPath() {
 	log := logging.New()
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte("success"), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, mock.Anything, mock.Anything, mock.Anything).Return([]byte("success"), nil, nil)
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(""), nil, errors.New("problem"))
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
@@ -586,7 +586,7 @@ func (s *RSuite) TestCreateLockfileWithEmptyPath() {
 	log := logging.New()
 
 	executor := executortest.NewMockExecutor()
-	executor.On("RunCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte("success"), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::snapshot()", mock.Anything, mock.Anything).Return([]byte("success"), nil, nil)
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte(""), nil, errors.New("problem"))
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
@@ -604,7 +604,7 @@ func (s *RSuite) TestRenvEnvironmentErrorCheck_renvNotInstalled() {
 
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte(""), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "cat(system.file(package = \"renv\"))", mock.Anything, mock.Anything).Return([]byte(""), nil, nil)
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
 	interpreter := i.(*defaultRInterpreter)
@@ -628,7 +628,7 @@ func (s *RSuite) TestRenvEnvironmentErrorCheck_renvInstallCheckErr() {
 	renvCmdErr := errors.New("renv command errrz")
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte(""), nil, renvCmdErr)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "cat(system.file(package = \"renv\"))", mock.Anything, mock.Anything).Return([]byte(""), nil, renvCmdErr)
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
 	interpreter := i.(*defaultRInterpreter)
@@ -649,8 +649,8 @@ func (s *RSuite) TestRenvEnvironmentErrorCheck_renvRequiresInit() {
 	renvStatusOutput := []byte("Use `renv::init()` to initialize the project.")
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::status()"}, mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "cat(system.file(package = \"renv\"))", mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::status()", mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
 	interpreter := i.(*defaultRInterpreter)
@@ -673,8 +673,8 @@ func (s *RSuite) TestRenvEnvironmentErrorCheck_lockfileMissing() {
 	renvStatusOutput := []byte("Use `renv::snapshot()` to create a lockfile.")
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::status()"}, mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "cat(system.file(package = \"renv\"))", mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::status()", mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
 	interpreter := i.(*defaultRInterpreter)
@@ -697,8 +697,8 @@ func (s *RSuite) TestRenvEnvironmentErrorCheck_unknownRenvStatus() {
 	renvStatusOutput := []byte("- The project is out-of-sync -- use `renv::status()` for details.")
 	executor := executortest.NewMockExecutor()
 	executor.On("RunCommand", mock.Anything, []string{"--version"}, mock.Anything, mock.Anything).Return([]byte("R version 4.3.0 (2023-04-21)"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "cat(system.file(package = \"renv\"))"}, mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
-	executor.On("RunCommand", mock.Anything, []string{"-s", "-e", "renv::status()"}, mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "cat(system.file(package = \"renv\"))", mock.Anything, mock.Anything).Return([]byte("/usr/dir/lib/R/x86_64/4.4/library/renv"), nil, nil)
+	executor.On("RunScript", mock.Anything, []string{"-s"}, "renv::status()", mock.Anything, mock.Anything).Return(renvStatusOutput, nil, nil)
 
 	i, _ := NewRInterpreter(s.cwd, util.Path{}, log, executor, nil, nil)
 	interpreter := i.(*defaultRInterpreter)

--- a/internal/publish/r_functional_test.go
+++ b/internal/publish/r_functional_test.go
@@ -1,0 +1,319 @@
+package publish
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/accounts"
+	"github.com/posit-dev/publisher/internal/clients/connect"
+	"github.com/posit-dev/publisher/internal/config"
+	"github.com/posit-dev/publisher/internal/deployment"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+	"github.com/posit-dev/publisher/internal/interpreters"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/schema"
+	"github.com/posit-dev/publisher/internal/state"
+	"github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type RPublishFunctionalSuite struct {
+	suite.Suite
+	testProjectDir util.AbsolutePath
+	log            logging.Logger
+	stateStore     *state.State
+	emitter        events.Emitter
+	rExecutable    util.AbsolutePath
+	renvInstalled  bool
+}
+
+func TestRPublishFunctionalSuite(t *testing.T) {
+	suite.Run(t, new(RPublishFunctionalSuite))
+}
+
+// skipIfNoR skips the current test if R executable is not available,
+// unless we're running in CI where we should enforce that R tests run
+func (s *RPublishFunctionalSuite) skipIfNoR() bool {
+	if os.Getenv("GITHUB_ACTIONS") != "true" && s.rExecutable.String() == "" {
+		s.T().Skip("Skipping test: R executable not found")
+		return true
+	}
+	return false
+}
+
+func (s *RPublishFunctionalSuite) SetupTest() {
+	// Set up the test directory
+	parentDir, err := os.MkdirTemp("", "r-packages-test-*")
+	s.Require().NoError(err)
+
+	// Create a subdirectory with spaces in the name
+	dirWithSpaces := filepath.Join(parentDir, "With Spaces")
+	err = os.MkdirAll(dirWithSpaces, 0755)
+	s.Require().NoError(err)
+
+	s.testProjectDir = util.NewAbsolutePath(dirWithSpaces, afero.NewOsFs())
+
+	// Set up our test state
+	s.stateStore = state.Empty()
+	s.stateStore.Dir = s.testProjectDir
+	s.emitter = events.NewCapturingEmitter()
+	s.log = logging.New()
+
+	// Create minimal renv.lock file in the temp directory
+	s.createTestRenvLock()
+
+	// Initialize R interpreter and check for R executable and renv availability
+	rInterpreter, err := interpreters.NewRInterpreter(s.testProjectDir, util.Path{}, s.log, nil, nil, nil)
+	s.Require().NoError(err)
+
+	// Try to get R executable
+	s.rExecutable, err = rInterpreter.GetRExecutable()
+	if err != nil {
+		s.T().Logf("R executable not found: %v", err)
+		// Not failing here, individual tests will skip if needed
+	} else {
+		s.T().Logf("Using R executable: %s", s.rExecutable)
+
+		// Check if renv is installed using RenvEnvironmentErrorCheck
+		// If no error or error is not about renv installation, then renv is available
+		err := rInterpreter.RenvEnvironmentErrorCheck()
+		if err == nil {
+			s.renvInstalled = true
+			s.T().Logf("renv is installed and available")
+		} else if _, isRenvNotInstalled := types.IsAgentErrorOf(err, types.ErrorRenvPackageNotInstalled); isRenvNotInstalled {
+			s.renvInstalled = false
+			s.T().Logf("renv is not installed: %v", err)
+		} else {
+			// Other errors with renv status, but renv itself is installed
+			s.renvInstalled = true
+			s.T().Logf("renv is installed but has issues: %v", err)
+		}
+	}
+}
+
+func (s *RPublishFunctionalSuite) TearDownTest() {
+	parentDir := filepath.Dir(s.testProjectDir.String())
+	os.RemoveAll(parentDir)
+}
+
+func (s *RPublishFunctionalSuite) createTestRenvLock() {
+	// Create a simple but valid renv.lock file
+	lockContent := `{
+      "R": {
+        "Version": "4.2.3",
+        "Repositories": [
+          {
+            "Name": "CRAN",
+            "URL": "https://cloud.r-project.org"
+          }
+        ]
+      },
+      "Packages": {
+        "renv": {
+          "Package": "renv",
+          "Version": "1.1.4",
+          "Source": "Repository",
+          "Repository": "CRAN",
+          "Hash": "fa15e"
+        }
+      }
+    }`
+
+	lockPath := s.testProjectDir.Join("renv.lock")
+	err := lockPath.WriteFile([]byte(lockContent), 0644)
+	s.Require().NoError(err)
+}
+
+func (s *RPublishFunctionalSuite) TestGetRPackagesFunctional() {
+	if s.skipIfNoR() {
+		return
+	}
+
+	// Configure the state
+	s.stateStore.Config = &config.Config{
+		R: &config.R{
+			PackageFile: "renv.lock",
+		},
+	}
+
+	rInterpreter, err := interpreters.NewRInterpreter(s.testProjectDir, util.Path{}, s.log, nil, nil, nil)
+	s.Require().NoError(err)
+
+	rExecutable, err := rInterpreter.GetRExecutable()
+	s.T().Logf("R executable path: %s", rExecutable)
+	// Don't require this to succeed as it might not be available in all test environments
+	if err != nil {
+		s.T().Logf("Could not get R executable: %v", err)
+	}
+
+	mapper, err := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log)
+	s.Require().NoError(err)
+
+	publisher := &defaultPublisher{
+		State:          s.stateStore,
+		log:            s.log,
+		emitter:        s.emitter,
+		rPackageMapper: mapper,
+	}
+
+	// Actually call getRPackages
+	packageMap, err := publisher.getRPackages()
+
+	// we should have a valid package map
+	s.Require().Nil(err)
+	s.Require().Contains(packageMap, "renv")
+
+	// And it includes renv
+	renvPackage := packageMap["renv"]
+	s.Require().Equal("CRAN", renvPackage.Source)
+}
+
+func (s *RPublishFunctionalSuite) TestPublishWithClientFunctional() {
+	if s.skipIfNoR() {
+		return
+	}
+
+	// 1. Set up test account
+	account := &accounts.Account{
+		ServerType: accounts.ServerTypeConnect,
+		Name:       "test-account",
+		URL:        "https://connect.example.com",
+	}
+
+	// 2. Set up a mock client
+	client := connect.NewMockClient()
+
+	// 3. Configure mock responses for each API call made by publishWithClient
+	// Content creation
+	contentID := types.ContentID("test-content-id")
+	client.On("CreateDeployment", mock.Anything, mock.Anything).Return(contentID, nil)
+
+	// Authentication
+	client.On("TestAuthentication", mock.Anything).Return(&connect.User{
+		Username: "test-user",
+		Email:    "test@example.com",
+	}, nil)
+
+	// Capability checks
+	client.On("CheckCapabilities", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	// Content updates
+	client.On("UpdateDeployment", contentID, mock.Anything, mock.Anything).Return(nil)
+
+	// Environment variables
+	client.On("SetEnvVars", contentID, mock.Anything, mock.Anything).Return(nil)
+
+	// Bundle upload
+	bundleID := types.BundleID("test-bundle-id")
+	client.On("UploadBundle", contentID, mock.Anything, mock.Anything).Return(bundleID, nil)
+
+	// Deployment
+	taskID := types.TaskID("test-task-id")
+	client.On("DeployBundle", contentID, bundleID, mock.Anything).Return(taskID, nil)
+
+	// Wait for task
+	client.On("WaitForTask", taskID, mock.Anything, mock.Anything).Return(nil)
+
+	// Validation
+	client.On("ValidateDeployment", contentID, mock.Anything).Return(nil)
+
+	// 4. Set up config for R Shiny app (instead of Python Dash)
+	cfg := config.New()
+	cfg.Schema = schema.ConfigSchemaURL
+	cfg.Type = config.ContentTypeRShiny // Change to R Shiny type
+	cfg.Entrypoint = "app.R"            // Use R entrypoint
+	cfg.Title = "Test R Application"
+	cfg.Environment = map[string]string{"TEST_VAR": "test-value"}
+	cfg.Validate = true
+
+	// Add required configuration items for R applications
+	cfg.R = &config.R{
+		Version:        "4.2", // Specify R version
+		PackageManager: "renv",
+		PackageFile:    "renv.lock",
+	}
+
+	// Include files required for R applications
+	cfg.Files = []string{
+		"app.R",
+		"renv.lock",
+	}
+
+	// 5. Create state store
+	stateStore := &state.State{
+		Dir:        s.testProjectDir,
+		Account:    account,
+		Config:     cfg,
+		ConfigName: "test-config",
+		SaveName:   "test-deployment",
+		TargetName: "test-deployment",
+	}
+
+	// 6. Create a real package mapper instance instead of a mock
+	rPackageMapper, err := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log)
+	s.Require().NoError(err)
+
+	// // ADD TEST FOR RENV STATUS: Get the R interpreter and test renv functionality
+	// rInterpreter, err := interpreters.NewRInterpreter(s.testProjectDir, util.Path{}, s.log, nil, nil, nil)
+	// s.Require().NoError(err)
+
+	// // Get R executable
+	// rExecutable, err := rInterpreter.GetRExecutable()
+	// if err == nil && rExecutable.String() != "" {
+	// 	// If we can get a valid R executable, check renv environment
+	// 	// This will indirectly call renvStatus() internally
+	// 	envErr := rInterpreter.RenvEnvironmentErrorCheck()
+	// 	s.T().Logf("RenvEnvironmentErrorCheck result: %v", envErr)
+	// }
+
+	// 7. Create publisher instance with the real package mapper
+	publisher := &defaultPublisher{
+		State:          stateStore,
+		log:            s.log,
+		emitter:        events.NewCapturingEmitter(),
+		rPackageMapper: rPackageMapper,
+	}
+
+	// 8. Create test files in the temp directory - R files instead of Python
+	appRPath := s.testProjectDir.Join("app.R")
+	err = appRPath.WriteFile([]byte(`
+library(shiny)
+
+ui <- fluidPage(
+  titlePanel("Hello Shiny!")
+)
+
+server <- function(input, output) {
+}
+
+shinyApp(ui = ui, server = server)
+`), 0644)
+	s.Require().NoError(err)
+
+	// Our renv.lock file was already created in SetupTest
+
+	// 9. Call publishWithClient
+	err = publisher.publishWithClient(account, client)
+	s.Require().NoError(err)
+
+	// 10. Verify the mock calls were made as expected
+	client.AssertExpectations(s.T())
+
+	// 11. Verify deployment record was created with correct information
+	recordPath := deployment.GetDeploymentPath(stateStore.Dir, stateStore.TargetName)
+	record, err := deployment.FromFile(recordPath)
+	s.Require().NoError(err)
+
+	s.Equal(contentID, record.ID)
+	s.Equal(bundleID, record.BundleID)
+	s.Equal("https://connect.example.com/connect/#/apps/test-content-id", record.DashboardURL)
+	s.Equal("https://connect.example.com/content/test-content-id/", record.DirectURL)
+	s.NotEmpty(record.DeployedAt)
+}

--- a/justfile
+++ b/justfile
@@ -233,8 +233,9 @@ run *args:
     pathname=`just executable-path`
     ${pathname} {{ args }}
 
-# Execute unit tests.
-test *args=("./..."):
+# Execute unit tests. -short disables our functional tests
+# To run all of the tests, use `just test ./...`
+test *args=("-short ./..."):
     #!/usr/bin/env bash
     set -eou pipefail
     {{ _with_debug }}


### PR DESCRIPTION
## Intent

Added functional tests for calling into R from Windows (and particularly when R is installed by rig). Those confirmed the failure. Due to the [way quotes work in windows](https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way), when the R executable was a `.bat`, we needed to do more + different quoting than we already were for the scripts we shelled out to. This PR changes those to write the script portions out to files and then use `R... -f ...` to run them. This is more robust since we don't have to worry about quoting within the contents of the script.

Resolves #2598

## Type of Change

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

_last sentence of intent_

## User Impact

Windows users who have installed rig are able to use the publisher.

## Automated Tests

Added functional tests that confirm the bug and assert that it is resolved.

## Directions for Reviewers

The first commit shows the test failures, and the second shows the code the resolves the issue. If you want to review the tests separately from the fix, that is the way.

## Checklist

Not yet, but will:
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
