### PR TITLE
Fix python scan creating renv.lock file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version when there is `.python-version` file declaring a specific version number
   without any version requirement operator (#2628)
 
+- Fixed an issue where scanning for Python dependencies created an `renv.lock` file.
+  Now the dependencies file is properly named `requirements.txt`. (#2639)
+
 ## [1.12.1]
 
 ### Fixed

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,23 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Introduced detection of required R interpreter version based on
+  `DESCRIPTION` file and `renv.lock` file. The detected version
+  will fill the `requires_r` field in configuration (#2636)
+
+### Fixed
+
+- Detection of required python interpreter version now will request a compatible
+  version when there is `.python-version` file declaring a specific version number
+  without any version requirement operator (#2628)
+
+- Fixed an issue where scanning for Python dependencies created an `renv.lock` file.
+  Now the dependencies file is properly named `requirements.txt`. (#2639)
+
 ## [1.12.1]
 
 ### Fixed

--- a/extensions/vscode/src/api/types/configurations.test.ts
+++ b/extensions/vscode/src/api/types/configurations.test.ts
@@ -1,0 +1,131 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { describe, expect, test } from "vitest";
+import {
+  RConfig,
+  PythonConfig,
+  Configuration,
+  UpdateConfigWithDefaults,
+  UpdateAllConfigsWithDefaults,
+} from "./configurations";
+import { InterpreterDefaults } from "./interpreters";
+import {
+  configurationFactory,
+  interpreterDefaultsFactory,
+} from "src/test/unit-test-utils/factories";
+
+const interpreterDefaults: InterpreterDefaults =
+  interpreterDefaultsFactory.build();
+const blankIntprConf = {
+  version: "",
+  packageFile: "",
+  packageManager: "",
+};
+
+describe("Configurations Types", () => {
+  describe("UpdateConfigWithDefaults", () => {
+    test("No R and no Python sections in config, no need to fill in anything", () => {
+      const config: Configuration = configurationFactory.build();
+      expect(config.configuration.r).toEqual(undefined);
+      expect(config.configuration.python).toEqual(undefined);
+
+      UpdateConfigWithDefaults(config, interpreterDefaults);
+      expect(config.configuration.r).toEqual(undefined);
+      expect(config.configuration.python).toEqual(undefined);
+    });
+
+    test("Existing R and Python sections in config are filled up with defaults", () => {
+      const config: Configuration = configurationFactory.build();
+
+      config.configuration.r = { ...blankIntprConf };
+      config.configuration.python = { ...blankIntprConf };
+
+      UpdateConfigWithDefaults(config, interpreterDefaults);
+      expect(config.configuration.r).toEqual({
+        version: "4.4.0",
+        packageFile: "renv.lock",
+        packageManager: "renv",
+      });
+      expect(config.configuration.python).toEqual({
+        version: "3.11.0",
+        packageFile: "requirements.txt",
+        packageManager: "pip",
+      });
+    });
+
+    test.each([
+      // version, packageFile, packageManager
+      ["", "custom_pack_file", "custom_pack_man"],
+      ["3.6.0", "", "custom_pack_man"],
+      ["3.6.0", "custom_pack_file", ""],
+    ])(
+      `When version is "%s", packageFile "%s" and packageManager is "%s", existing interpreter values are respected, only empty values are filled up`,
+      (version: string, packFile: string, packMan: string) => {
+        const config: Configuration = configurationFactory.build();
+
+        const incomingIntprConfig = {
+          version: version,
+          packageFile: packFile,
+          packageManager: packMan,
+        };
+
+        config.configuration.r = { ...incomingIntprConfig };
+        config.configuration.python = { ...incomingIntprConfig };
+
+        UpdateConfigWithDefaults(config, interpreterDefaults);
+
+        const expectedRConf: RConfig = { ...incomingIntprConfig };
+        const expectedPythonConf: PythonConfig = { ...incomingIntprConfig };
+
+        if (version === "") {
+          expectedRConf.version = "4.4.0";
+          expectedPythonConf.version = "3.11.0";
+        }
+
+        if (packFile === "") {
+          expectedRConf.packageFile = "renv.lock";
+          expectedPythonConf.packageFile = "requirements.txt";
+        }
+
+        if (packMan === "") {
+          expectedRConf.packageManager = "renv";
+          expectedPythonConf.packageManager = "pip";
+        }
+
+        expect(config.configuration.r).toEqual(expectedRConf);
+        expect(config.configuration.python).toEqual(expectedPythonConf);
+      },
+    );
+  });
+
+  describe("UpdateAllConfigsWithDefaults", () => {
+    test("updates all configs passed to it", () => {
+      const multiConfigs: Configuration[] = [];
+
+      for (let index = 0; index < 5; index++) {
+        const cf = configurationFactory.build();
+        cf.configuration.r = { ...blankIntprConf };
+        cf.configuration.python = { ...blankIntprConf };
+        multiConfigs.push(cf);
+      }
+      multiConfigs.forEach((cf) => {
+        expect(cf.configuration.r).toEqual(blankIntprConf);
+        expect(cf.configuration.python).toEqual(blankIntprConf);
+      });
+
+      UpdateAllConfigsWithDefaults(multiConfigs, interpreterDefaults);
+      multiConfigs.forEach((cf) => {
+        expect(cf.configuration.r).toEqual({
+          version: "4.4.0",
+          packageFile: "renv.lock",
+          packageManager: "renv",
+        });
+        expect(cf.configuration.python).toEqual({
+          version: "3.11.0",
+          packageFile: "requirements.txt",
+          packageManager: "pip",
+        });
+      });
+    });
+  });
+});

--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -211,13 +211,14 @@ export function UpdateConfigWithDefaults(
   }
   if (config.configuration.python !== undefined) {
     if (config.configuration.python.version === "") {
-      config.configuration.python.version = defaults.r.version;
+      config.configuration.python.version = defaults.python.version;
     }
     if (config.configuration.python.packageFile === "") {
-      config.configuration.python.packageFile = defaults.r.packageFile;
+      config.configuration.python.packageFile = defaults.python.packageFile;
     }
     if (config.configuration.python.packageManager === "") {
-      config.configuration.python.packageManager = defaults.r.packageManager;
+      config.configuration.python.packageManager =
+        defaults.python.packageManager;
     }
   }
   return config;

--- a/extensions/vscode/src/test/unit-test-utils/factories.ts
+++ b/extensions/vscode/src/test/unit-test-utils/factories.ts
@@ -9,6 +9,7 @@ import {
 } from "src/api/types/contentRecords";
 import { ContentType, Configuration } from "src/api/types/configurations";
 import { Credential } from "src/api/types/credentials";
+import { InterpreterDefaults } from "src/api/types/interpreters";
 import { DeploymentSelectorState } from "src/types/shared";
 
 export const selectionStateFactory = Factory.define<DeploymentSelectorState>(
@@ -33,6 +34,23 @@ export const configurationFactory = Factory.define<Configuration>(
     configurationName: `configuration-GUD${sequence}`,
     configurationPath: `report/path/configuration-${sequence}`,
     configurationRelPath: `report/path/configuration-${sequence}`,
+  }),
+);
+
+export const interpreterDefaultsFactory = Factory.define<InterpreterDefaults>(
+  () => ({
+    preferredPythonPath: "usr/bin/python3",
+    python: {
+      packageFile: "requirements.txt",
+      packageManager: "pip",
+      version: "3.11.0",
+    },
+    preferredRPath: "usr/bin/R",
+    r: {
+      packageFile: "renv.lock",
+      packageManager: "renv",
+      version: "4.4.0",
+    },
   }),
 );
 


### PR DESCRIPTION
## Intent

Fix for default interpreter data creating `renv.lock` file when scanning Python dependencies, instead of `requirements.txt`

Fixes #2639 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Add the proper default interpreter values for Python configurations.

## User Impact

Users hitting the `Scan` button in Python should get a proper `requirements.txt` file now

## Automated Tests

Added new unit-tests to cover the methods handling the interpreter defaults.

## Directions for Reviewers

1. Open a workspace within Visual Code which has a python file present, can be done with the sample project: `test/sample-content/fastapi-simple` from the publisher repo.
2. Switch to Publisher
3. Create new deployment and select `app.py` as the entrypoint.
4. Expand the python section
5. Click `scan`

A new `requirements.txt` file should be created, without this change you'll see the file as `renv.lock`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
