### PR TITLE
emit client factory errors so publish flow will halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Detect and report auth client errors at deploy time. (#2654)
+
 ## [1.16.0]
 
 ### Added

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,12 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Detect and report auth client errors at deploy time. (#2654)
+
 ## [1.16.0]
 
 ### Added

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -184,6 +184,8 @@ func (p *defaultPublisher) emitErrorEvents(err error) {
 		data))
 }
 
+var clientFactory = connect.NewConnectClient
+
 func (p *defaultPublisher) PublishDirectory() error {
 	p.log.Info("Publishing from directory", logging.LogKeyOp, events.AgentOp, "path", p.Dir, "localID", p.State.LocalID)
 	p.emitter.Emit(events.New(events.PublishOp, events.StartPhase, events.NoError, publishStartData{
@@ -194,8 +196,9 @@ func (p *defaultPublisher) PublishDirectory() error {
 
 	// TODO: factory method to create client based on server type
 	// TODO: timeout option
-	client, err := connect.NewConnectClient(p.Account, 2*time.Minute, p.emitter, p.log)
+	client, err := clientFactory(p.Account, 2*time.Minute, p.emitter, p.log)
 	if err != nil {
+		p.emitErrorEvents(err)
 		return err
 	}
 	err = p.publishWithClient(p.Account, client)


### PR DESCRIPTION
## Intent

An error from constructing a new Connect client will now emit an event so the UI can react.

fixes #2654

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Noticed via debugging that this specific error gets logged but is not surfaced to the UI. Added a call to emit the error event.

This was sufficient to get the actual error message to surface in the UI and to halt the publishing flow, so I stopped there. Possibly it would be better to create a specific Agent Error code? I'm not sure what that gets us.

## User Impact

Users who break their snowflake configuration will now get a useful error message instead of a hung process.

## Automated Tests

Added a unit test.

## Directions for Reviewers

Assume a valid snowflake connections.toml:

```toml
[default]
account = "the-account"
user = "user@posit.co"
authenticator = "SNOWFLAKE_JWT"
private_key_file = "/Users/me/.snowflake/rsa_key.p8"
```

Add a new credential for Connect running in snowflake, using this connection.

Edit the connection to break it:

```toml
...
private_key_file = "/Users/me/.snowflake/rsa_key.NOW_INVALID"
```

Attempt to deploy content. Observe that the deployment now halts and reports the error.

<img width="462" alt="Screenshot 2025-05-23 at 2 39 14 PM" src="https://github.com/user-attachments/assets/4fc8aa39-fa93-4000-8eb3-e31aa66a205a" />

<img width="298" alt="Screenshot 2025-05-23 at 2 39 19 PM" src="https://github.com/user-attachments/assets/7fc0f843-3729-4bae-a7cd-80d95c63fceb" />

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
