### PR TITLE
Add endpoint to fetch Connect Cloud accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved support for Posit Connect deployments hosted in Snowpark Container
   Services. (#2687, #2691)
 - Added endpoints for performing OAuth Device Authorization Grant with Posit Cloud login. (#2692)
+- Added endpoint to list Connect Cloud accounts. (#2695)
 
 ## [1.16.1]
 

--- a/internal/api_client/auth/plain.go
+++ b/internal/api_client/auth/plain.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"net/http"
+)
+
+type plainAuthenticator struct {
+	authValue string
+}
+
+func NewPlainAuthenticator(authValue string) AuthMethod {
+	return &plainAuthenticator{
+		authValue: authValue,
+	}
+}
+
+func (a *plainAuthenticator) AddAuthHeaders(req *http.Request) error {
+	req.Header.Set("Authorization", a.authValue)
+	return nil
+}

--- a/internal/api_client/auth/plain.go
+++ b/internal/api_client/auth/plain.go
@@ -1,5 +1,7 @@
 package auth
 
+// Copyright (C) 2025 by Posit Software, PBC.
+
 import (
 	"net/http"
 )

--- a/internal/clients/connect_cloud/client.go
+++ b/internal/clients/connect_cloud/client.go
@@ -1,0 +1,7 @@
+package connect_cloud
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+type APIClient interface {
+	GetCurrentUser() (*UserResponse, error)
+}

--- a/internal/clients/connect_cloud/client_connect_cloud.go
+++ b/internal/clients/connect_cloud/client_connect_cloud.go
@@ -1,0 +1,36 @@
+package connect_cloud
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"time"
+
+	"github.com/posit-dev/publisher/internal/clients/http_client"
+	"github.com/posit-dev/publisher/internal/logging"
+)
+
+type ConnectCloudClient struct {
+	log    logging.Logger
+	client http_client.HTTPClient
+}
+
+func NewConnectCloudClientWithAuth(
+	baseURL string,
+	log logging.Logger,
+	timeout time.Duration,
+	authValue string) APIClient {
+	httpClient := http_client.NewBasicHTTPClientWithAuth(baseURL, timeout, authValue)
+	return &ConnectCloudClient{
+		log:    log,
+		client: httpClient,
+	}
+}
+
+func (c ConnectCloudClient) GetCurrentUser() (*UserResponse, error) {
+	into := UserResponse{}
+	err := c.client.Get("/v1/users/me", &into, c.log)
+	if err != nil {
+		return nil, err
+	}
+	return &into, nil
+}

--- a/internal/clients/connect_cloud/client_connect_cloud_test.go
+++ b/internal/clients/connect_cloud/client_connect_cloud_test.go
@@ -1,0 +1,65 @@
+package connect_cloud
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/posit-dev/publisher/internal/clients/http_client"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConnectCloudClientSuite struct {
+	utiltest.Suite
+}
+
+func TestConnectCloudClientSuite(t *testing.T) {
+	s := new(ConnectCloudClientSuite)
+	suite.Run(t, s)
+}
+
+func (s *ConnectCloudClientSuite) TestNewConnectCloudClient() {
+	timeout := 10 * time.Second
+	log := logging.New()
+
+	apiClient := NewConnectCloudClientWithAuth("https://api.staging.login.posit.cloud", log, timeout, "Bearer the_token")
+	client := apiClient.(*ConnectCloudClient)
+	s.NotNil(client.client)
+}
+
+func (s *ConnectCloudClientSuite) TestGetCurrentUser() {
+	httpClient := &http_client.MockHTTPClient{}
+	expectedResult := &UserResponse{
+		AccountRoles: map[string]UserAccountRole{
+			"account1": {
+				Role: "admin",
+				Account: UserAccountRoleAccount{
+					Name: "Account 1",
+				},
+			},
+			"account2": {
+				Role: "admin",
+				Account: UserAccountRoleAccount{
+					Name: "Account 2",
+				},
+			},
+		},
+	}
+
+	httpClient.On("Get", "/v1/users/me", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).RunFn = func(args mock.Arguments) {
+		result := args.Get(1).(*UserResponse)
+		result.AccountRoles = expectedResult.AccountRoles
+	}
+	client := &ConnectCloudClient{
+		client: httpClient,
+		log:    logging.New(),
+	}
+	result, err := client.GetCurrentUser()
+	s.NoError(err)
+	s.Equal(expectedResult, result)
+}

--- a/internal/clients/connect_cloud/mock_client.go
+++ b/internal/clients/connect_cloud/mock_client.go
@@ -1,0 +1,22 @@
+package connect_cloud
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockClient struct {
+	mock.Mock
+}
+
+func NewMockClient() *MockClient {
+	return new(MockClient)
+}
+
+var _ APIClient = &MockClient{}
+
+func (m *MockClient) GetCurrentUser() (*UserResponse, error) {
+	args := m.Called()
+	return args.Get(0).(*UserResponse), args.Error(1)
+}

--- a/internal/clients/connect_cloud/user.go
+++ b/internal/clients/connect_cloud/user.go
@@ -1,0 +1,21 @@
+package connect_cloud
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+type DeviceAuthRequest struct {
+	ClientID string `json:"client_id"`
+	Scope    string `json:"scope"`
+}
+
+type UserAccountRoleAccount struct {
+	Name string `json:"name"`
+}
+
+type UserAccountRole struct {
+	Role    string                 `json:"role"`
+	Account UserAccountRoleAccount `json:"account"`
+}
+
+type UserResponse struct {
+	AccountRoles map[string]UserAccountRole `json:"account_roles"`
+}

--- a/internal/services/api/api_service.go
+++ b/internal/services/api/api_service.go
@@ -197,6 +197,10 @@ func RouterHandlerFunc(base util.AbsolutePath, lister accounts.AccountList, log 
 	r.Handle(ToPath("connect-cloud", "oauth", "token"), PostConnectCloudOAuthTokenHandlerFunc(log)).
 		Methods(http.MethodPost)
 
+	// GET /api/connect-cloud/accounts
+	r.Handle(ToPath("connect-cloud", "accounts"), GetConnectCloudAccountsFunc(log)).
+		Methods(http.MethodGet)
+
 	c := cors.AllowAll().Handler(r)
 	return c.ServeHTTP
 }

--- a/internal/services/api/get_connect_cloud_accounts.go
+++ b/internal/services/api/get_connect_cloud_accounts.go
@@ -1,0 +1,67 @@
+package api
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/posit-dev/publisher/internal/clients/connect_cloud"
+	"net/http"
+	"time"
+
+	"github.com/posit-dev/publisher/internal/logging"
+)
+
+type connectCloudAccountsBodyAccount struct {
+	Name                string `json:"name"`
+	ID                  string `json:"id"`
+	PermissionToPublish bool   `json:"permissionToPublish"`
+}
+
+const connectCloudBaseURLHeader = "Cloud-Auth-Base-Url"
+
+type connectCloudAccountsBody struct {
+	Accounts []connectCloudAccountsBodyAccount `json:"accounts"`
+}
+
+func GetConnectCloudAccountsFunc(log logging.Logger) http.HandlerFunc {
+	fmt.Println("asdf asdf asdf")
+	return func(w http.ResponseWriter, req *http.Request) {
+		fmt.Println("start!")
+		baseURL := req.Header.Get(connectCloudBaseURLHeader)
+		if baseURL == "" {
+			BadRequest(w, req, log, errors.New("Cloud-Auth-Base-Url header is required"))
+			return
+		}
+		authorization := req.Header.Get("Authorization")
+
+		client := connect_cloud.NewConnectCloudClientWithAuth(baseURL, log, 10*time.Second, authorization)
+		fmt.Println("calling vivid-api")
+
+		currentUser, err := client.GetCurrentUser()
+		if err != nil {
+			fmt.Println("whee")
+			InternalError(w, req, log, err)
+			return
+		}
+		fmt.Println("Called vivid-api")
+
+		accounts := make([]connectCloudAccountsBodyAccount, 0, len(currentUser.AccountRoles))
+		for accountID, accountRole := range currentUser.AccountRoles {
+			role := accountRole.Role
+			accounts = append(accounts, connectCloudAccountsBodyAccount{
+				ID:                  accountID,
+				Name:                accountRole.Account.Name,
+				PermissionToPublish: role == "owner" || role == "admin" || accountRole.Role == "publisher",
+			})
+		}
+
+		apiResponse := connectCloudAccountsBody{
+			Accounts: accounts,
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(apiResponse)
+		fmt.Println("done!")
+	}
+}

--- a/internal/services/api/get_connect_cloud_accounts.go
+++ b/internal/services/api/get_connect_cloud_accounts.go
@@ -4,7 +4,7 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"github.com/posit-dev/publisher/internal/clients/connect_cloud"
 	"net/http"
 	"time"
@@ -20,7 +20,7 @@ type connectCloudAccountsBodyAccount struct {
 
 var connectCloudClientFactory = connect_cloud.NewConnectCloudClientWithAuth
 
-const connectCloudBaseURLHeader = "Cloud-Auth-Base-Url"
+const connectCloudBaseURLHeader = "Connect-Cloud-Base-Url"
 
 type connectCloudAccountsBody struct {
 	Accounts []connectCloudAccountsBodyAccount `json:"accounts"`
@@ -30,7 +30,7 @@ func GetConnectCloudAccountsFunc(log logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		baseURL := req.Header.Get(connectCloudBaseURLHeader)
 		if baseURL == "" {
-			BadRequest(w, req, log, errors.New("Cloud-Auth-Base-Url header is required"))
+			BadRequest(w, req, log, fmt.Errorf("%s header is required", connectCloudBaseURLHeader))
 			return
 		}
 		authorization := req.Header.Get("Authorization")

--- a/internal/services/api/get_connect_cloud_accounts_test.go
+++ b/internal/services/api/get_connect_cloud_accounts_test.go
@@ -1,0 +1,148 @@
+package api
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"github.com/posit-dev/publisher/internal/clients/connect_cloud"
+	"github.com/posit-dev/publisher/internal/clients/http_client"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/types"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/stretchr/testify/suite"
+)
+
+type GetConnectCloudAccountsSuite struct {
+	utiltest.Suite
+	log logging.Logger
+	h   http.HandlerFunc
+}
+
+func TestGetConnectCloudAccountsSuite(t *testing.T) {
+	suite.Run(t, new(GetConnectCloudAccountsSuite))
+}
+
+func (s *GetConnectCloudAccountsSuite) SetupSuite() {
+	s.log = logging.New()
+}
+
+func (s *GetConnectCloudAccountsSuite) SetupTest() {
+	s.h = GetConnectCloudAccountsFunc(s.log)
+}
+
+func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts() {
+	client := connect_cloud.NewMockClient()
+	accountRoles := map[string]connect_cloud.UserAccountRole{
+		"account1": {
+			Role: "owner",
+			Account: connect_cloud.UserAccountRoleAccount{
+				Name: "Account 1",
+			},
+		},
+		"account2": {
+			Role: "publisher",
+			Account: connect_cloud.UserAccountRoleAccount{
+				Name: "Account 2",
+			},
+		},
+		"account3": {
+			Role: "user",
+			Account: connect_cloud.UserAccountRoleAccount{
+				Name: "Account 3",
+			},
+		},
+	}
+	userResponse := &connect_cloud.UserResponse{
+		AccountRoles: accountRoles,
+	}
+	client.On("GetCurrentUser").Return(userResponse, nil)
+
+	connectCloudClientFactory = func(baseURL string, log logging.Logger, timeout time.Duration, authValue string) connect_cloud.APIClient {
+		return client
+	}
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(
+		"GET",
+		"/connect-cloud/accounts",
+		nil,
+	)
+	s.NoError(err)
+	req.Header.Set(connectCloudBaseURLHeader, "https://api.login.staging.posit.cloud")
+	req.Header.Set("Authorization", "Bearer token123")
+
+	s.h(rec, req)
+
+	result := rec.Result()
+	s.Equal(http.StatusOK, result.StatusCode)
+	respBody, _ := io.ReadAll(rec.Body)
+	// The expected response should include all accounts, with PermissionToPublish
+	// set to true for owner and publisher roles, false otherwise
+	s.JSONEq(`{
+		"accounts": [
+			{
+				"id": "account1",
+				"name": "Account 1",
+				"permissionToPublish": true
+			},
+			{
+				"id": "account2",
+				"name": "Account 2",
+				"permissionToPublish": true
+			},
+			{
+				"id": "account3",
+				"name": "Account 3",
+				"permissionToPublish": false
+			}
+		]
+	}`, string(respBody))
+}
+
+func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts_MissingBaseURL() {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(
+		"GET",
+		"/connect-cloud/accounts",
+		nil,
+	)
+	s.NoError(err)
+	// Not setting Cloud-Auth-Base-Url header
+
+	s.h(rec, req)
+
+	result := rec.Result()
+	s.Equal(http.StatusBadRequest, result.StatusCode)
+}
+
+func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts_GetCurrentUserError() {
+	client := connect_cloud.NewMockClient()
+	client.On("GetCurrentUser").Return((*connect_cloud.UserResponse)(nil), types.NewAgentError(
+		events.ServerErrorCode,
+		http_client.NewHTTPError("https://foo.bar", "GET", http.StatusBadRequest), nil))
+
+	connectCloudClientFactory = func(baseURL string, log logging.Logger, timeout time.Duration, authValue string) connect_cloud.APIClient {
+		return client
+	}
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(
+		"GET",
+		"/connect-cloud/accounts",
+		nil,
+	)
+	s.NoError(err)
+	req.Header.Set(connectCloudBaseURLHeader, "https://api.login.staging.posit.cloud")
+	req.Header.Set("Authorization", "Bearer token123")
+
+	s.h(rec, req)
+
+	result := rec.Result()
+	s.Equal(http.StatusInternalServerError, result.StatusCode)
+}

--- a/internal/services/api/get_connect_cloud_accounts_test.go
+++ b/internal/services/api/get_connect_cloud_accounts_test.go
@@ -84,15 +84,14 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts() {
 
 	result := rec.Result()
 	s.Equal(http.StatusOK, result.StatusCode)
-	
+
 	respBody, _ := io.ReadAll(rec.Body)
 	respMap := map[string]interface{}{}
 	err = json.Unmarshal(respBody, &respMap)
 	s.NoError(err)
 
 	// sort accounts by ID to ensure consistent order for testing
-	accounts := respMap["accounts"].(interface{})
-	slices.SortFunc(accounts.([]interface{}), func(a, b interface{}) int {
+	slices.SortFunc(respMap["accounts"].([]interface{}), func(a, b interface{}) int {
 		return strings.Compare(
 			a.(map[string]interface{})["name"].(string),
 			b.(map[string]interface{})["name"].(string))

--- a/internal/services/api/get_connect_cloud_accounts_test.go
+++ b/internal/services/api/get_connect_cloud_accounts_test.go
@@ -77,7 +77,7 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts() {
 		nil,
 	)
 	s.NoError(err)
-	req.Header.Set(connectCloudBaseURLHeader, "https://api.login.staging.posit.cloud")
+	req.Header.Set("Connect-Cloud-Base-Url", "https://api.login.staging.posit.cloud")
 	req.Header.Set("Authorization", "Bearer token123")
 
 	s.h(rec, req)
@@ -127,7 +127,7 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts_MissingBaseUR
 		nil,
 	)
 	s.NoError(err)
-	// Not setting Cloud-Auth-Base-Url header
+	// Not setting Connect-Cloud-Base-Url header
 
 	s.h(rec, req)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves https://github.com/posit-dev/publisher/issues/2694.

The API is called as follows:

```
GET /api/connect-cloud/accounts
Cloud-Auth-Base-Url: https://api.staging.connect.posit.cloud
Authorization: Bearer {token}

//response body:
{
    "accounts": [
      {
        "id": "account1",
        "name": "Account 1",
        "permissionToPublish": true
      },
      {
        "id": "account2",
        "name": "Account 2",
        "permissionToPublish": true
      },
      {
        "id": "account3",
        "name": "Account 3",
        "permissionToPublish": false
      }
    ]
  }
```

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The endpoint calls Connect Cloud's `GET /users/me` endpoint, which returns the accounts the user is a member of and what roles they have. The user's role on the account is used to determine whether they have permission to publish.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

None until we implement the add credential flow for Connect Cloud.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Added tests for the new API handler and the new connect cloud API client.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

1. Log into Connect Cloud
2. Open dev tools and copy an `Authorization` header from an API call
3. Run `just build && just run ui`
4. Call the endpoint: `curl -vv 'http://localhost:${your_port}/api/connect-cloud/accounts' -H 'Cloud-Auth-Base-Url: https://api.staging.connect.posit.cloud' -H 'Authorization: Bearer ${token_from_step_2}'`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
