### PR TITLE
fix(runtime): Fix inconsistent runtime discovery and selection when deploying from Positron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the naming of "Shiny for Python" and "Shiny for R" content types.
   (#2664)
 
+- Fixed inconsistent runtime discovery and selection at deploy time. (#2648)
+
 - Fixed the inability for e2e tests to run on some Mac systems due to the
   docker files not being built for the correct platform.
 

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -8,10 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the naming of "Shiny for Python" and "Shiny for R" content types.
+  (#2664)
+
+- Fixed inconsistent runtime discovery and selection at deploy time. (#2648)
+
 ### Added
 
 - Improved support for Posit Connect deployments hosted in Snowpark Container
   Services. (#2687, #2691)
+
+### Changed
+
+- Bumped the credential version to 2 to support Posit Connect Cloud credentials. (#2684)
 
 ## [1.16.1]
 

--- a/internal/inspect/dependencies/renv/available_packages_test.go
+++ b/internal/inspect/dependencies/renv/available_packages_test.go
@@ -159,6 +159,8 @@ func (s *AvailablePackagesSuite) TestGetLibPathsWindows() {
 		s.T().Skip()
 	}
 
+	rExecutablePath := util.NewAbsolutePath("R", nil)
+
 	setupMockRInterpreter := func(
 		base util.AbsolutePath,
 		rExecutableParam util.Path,
@@ -169,10 +171,9 @@ func (s *AvailablePackagesSuite) TestGetLibPathsWindows() {
 	) (interpreters.RInterpreter, error) {
 		i := interpreters.NewMockRInterpreter()
 		i.On("Init").Return(nil)
-		i.On("GetRExecutable").Return("R", nil)
+		i.On("GetRExecutable").Return(rExecutablePath, nil)
 		return i, nil
 	}
-	rExecutablePath := util.NewAbsolutePath("R", nil)
 
 	lister, err := NewAvailablePackageLister(s.base, util.NewPath("R", nil), s.log, setupMockRInterpreter, nil)
 	s.NoError(err)

--- a/internal/inspect/dependencies/renv/available_packages_test.go
+++ b/internal/inspect/dependencies/renv/available_packages_test.go
@@ -37,6 +37,8 @@ func (s *AvailablePackagesSuite) SetupTest() {
 }
 
 func (s *AvailablePackagesSuite) TestListAvailablePackages() {
+	rExecutablePath := util.NewAbsolutePath("R", nil)
+
 	setupMockRInterpreter := func(
 		base util.AbsolutePath,
 		rExecutableParam util.Path,
@@ -47,14 +49,12 @@ func (s *AvailablePackagesSuite) TestListAvailablePackages() {
 	) (interpreters.RInterpreter, error) {
 		i := interpreters.NewMockRInterpreter()
 		i.On("Init").Return(nil)
-		i.On("GetRExecutable").Return("R", nil)
+		i.On("GetRExecutable").Return(rExecutablePath, nil)
 		return i, nil
 	}
 
 	lister, err := NewAvailablePackageLister(s.base, util.Path{}, s.log, setupMockRInterpreter, nil)
 	s.NoError(err)
-
-	rExecutablePath := util.NewAbsolutePath("R", nil)
 
 	executor := executortest.NewMockExecutor()
 	executor.On("RunScript", rExecutablePath.String(), mock.Anything, mock.Anything, s.base, mock.Anything).Return([]byte(
@@ -79,6 +79,8 @@ BioCbooks https://bioconductor.org/packages/3.18/books
 `
 
 func (s *AvailablePackagesSuite) TestGetBioconductorRepos() {
+	rExecutablePath := util.NewAbsolutePath("R", nil)
+
 	setupMockRInterpreter := func(
 		base util.AbsolutePath,
 		rExecutableParam util.Path,
@@ -89,12 +91,10 @@ func (s *AvailablePackagesSuite) TestGetBioconductorRepos() {
 	) (interpreters.RInterpreter, error) {
 		i := interpreters.NewMockRInterpreter()
 		i.On("Init").Return(nil)
-		i.On("GetRExecutable").Return("R", nil)
+		i.On("GetRExecutable").Return(rExecutablePath, nil)
 		return i, nil
 	}
-
 	lister, _ := NewAvailablePackageLister(s.base, util.Path{}, s.log, setupMockRInterpreter, nil)
-	rExecutablePath := util.NewAbsolutePath("R", nil)
 
 	executor := executortest.NewMockExecutor()
 	executor.On("RunScript", rExecutablePath.String(), mock.Anything, mock.Anything, s.base, mock.Anything).Return([]byte(biocReposOutput), []byte{}, nil)
@@ -120,6 +120,8 @@ func (s *AvailablePackagesSuite) TestGetLibPaths() {
 		s.T().Skip()
 	}
 
+	rExecutablePath := util.NewAbsolutePath("R", nil)
+
 	setupMockRInterpreter := func(
 		base util.AbsolutePath,
 		rExecutableParam util.Path,
@@ -130,10 +132,9 @@ func (s *AvailablePackagesSuite) TestGetLibPaths() {
 	) (interpreters.RInterpreter, error) {
 		i := interpreters.NewMockRInterpreter()
 		i.On("Init").Return(nil)
-		i.On("GetRExecutable").Return("R", nil)
+		i.On("GetRExecutable").Return(rExecutablePath, nil)
 		return i, nil
 	}
-	rExecutablePath := util.NewAbsolutePath("R", nil)
 
 	lister, err := NewAvailablePackageLister(s.base, util.NewPath("R", nil), s.log, setupMockRInterpreter, nil)
 	s.NoError(err)

--- a/internal/interpreters/python.go
+++ b/internal/interpreters/python.go
@@ -263,7 +263,7 @@ func (i *defaultPythonInterpreter) GetPythonRequires() string {
 	pyProjectRequires := NewPyProjectPythonRequires(i.base)
 	python_requires, err := pyProjectRequires.GetPythonVersionRequirement()
 	if err != nil {
-		i.log.Warn("Error retrieving Python requires", err)
+		i.log.Warn("Error retrieving Python requires", "error", err.Error())
 		python_requires = ""
 	}
 	return python_requires

--- a/internal/interpreters/r.go
+++ b/internal/interpreters/r.go
@@ -478,7 +478,7 @@ func (i *defaultRInterpreter) getRenvLockfilePathFromRExecutable(rExecutable str
 	}
 	lines := strings.SplitN(string(append(output, stderr...)), "\n", -1)
 	for _, l := range lines {
-		i.log.Info("Parsing line for renv::path output", "l", l)
+		i.log.Info("Parsing line for renv::path output", "output", l)
 		m := renvLockRE.FindStringSubmatch(l)
 		if len(m) < 2 {
 			continue
@@ -529,7 +529,7 @@ func (i *defaultRInterpreter) GetRRequires() string {
 	rProjectRequires := NewRProjectRRequires(i.base)
 	rRequires, err := rProjectRequires.GetRVersionRequirement()
 	if err != nil {
-		i.log.Warn("Error retrieving required R version", err)
+		i.log.Warn("Error retrieving required R version", "error", err.Error())
 		rRequires = ""
 	}
 	return rRequires

--- a/internal/interpreters/r_mock.go
+++ b/internal/interpreters/r_mock.go
@@ -46,8 +46,8 @@ func (m *MockRInterpreter) GetRExecutable() (util.AbsolutePath, error) {
 		return util.AbsolutePath{}, args.Error(1)
 	} else {
 		var i interface{} = arg0
-		if path, ok := i.(string); ok {
-			return util.NewAbsolutePath(path, nil), args.Error(1)
+		if path, ok := i.(util.AbsolutePath); ok {
+			return path, args.Error(1)
 		} else {
 			return util.AbsolutePath{}, args.Error(1)
 		}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -79,15 +79,9 @@ func NewFromState(s *state.State, rInterpreter interpreters.RInterpreter, python
 		emitter = events.NewDataEmitter(dataMap, emitter)
 	}
 
-	rexec, err := rInterpreter.GetRExecutable()
-	if err != nil {
-		return nil, err
-	}
-
-	pyexec, err := pythonInterpreter.GetPythonExecutable()
-	if err != nil {
-		return nil, err
-	}
+	// It is ok if the system does not have R or Python interpreters.
+	rexec, _ := rInterpreter.GetRExecutable()
+	pyexec, _ := pythonInterpreter.GetPythonExecutable()
 
 	packageManager, err := renv.NewPackageMapper(s.Dir, rexec.Path, log)
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -4,7 +4,6 @@ package publish
 import (
 	"bytes"
 	"errors"
-	"github.com/posit-dev/publisher/internal/server_type"
 	"log/slog"
 	"strings"
 	"testing"
@@ -17,9 +16,11 @@ import (
 	"github.com/posit-dev/publisher/internal/deployment"
 	"github.com/posit-dev/publisher/internal/events"
 	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+	"github.com/posit-dev/publisher/internal/interpreters"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/logging/loggingtest"
 	"github.com/posit-dev/publisher/internal/project"
+	"github.com/posit-dev/publisher/internal/server_type"
 	"github.com/posit-dev/publisher/internal/state"
 	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
@@ -120,7 +121,11 @@ func (s *PublishSuite) TearDownTest() {
 func (s *PublishSuite) TestNewFromState() {
 	stateStore := state.Empty()
 	stateStore.Dir = s.cwd
-	publisher, err := NewFromState(stateStore, util.Path{}, util.Path{}, events.NewNullEmitter(), logging.New())
+	mockRIntr := interpreters.NewMockRInterpreter()
+	mockPyIntr := interpreters.NewMockPythonInterpreter()
+	mockRIntr.On("GetRExecutable").Return(util.NewAbsolutePath("/path/to/r", nil), nil)
+	mockPyIntr.On("GetPythonExecutable").Return(util.NewAbsolutePath("/path/to/python", nil), nil)
+	publisher, err := NewFromState(stateStore, mockRIntr, mockPyIntr, events.NewNullEmitter(), logging.New())
 	s.NoError(err)
 	s.Equal(stateStore, publisher.(*defaultPublisher).State)
 }

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -124,9 +124,7 @@ func PostDeploymentHandlerFunc(
 		log := log.WithArgs("local_id", localID)
 		newState.LocalID = localID
 
-		rExecutable := util.NewPath(b.R, nil)
-		pythonExecutable := util.NewPath(b.Python, nil)
-		publisher, err := publisherFactory(newState, rExecutable, pythonExecutable, emitter, log)
+		publisher, err := publisherFactory(newState, rInterpreter, pythonInterpreter, emitter, log)
 		log.Debug("New publisher derived from state", "account", b.AccountName, "config", b.ConfigName)
 		if err != nil {
 			InternalError(w, req, log, err)

--- a/internal/services/api/post_deployment_test.go
+++ b/internal/services/api/post_deployment_test.go
@@ -75,8 +75,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 	// Create a url.Values to hold query parameters
 	queryParams := url.Values{}
 	queryParams.Add("dir", ".")
-	queryParams.Add("r", "bin/my_r")
-	queryParams.Add("python", "bin/my_python")
+	queryParams.Add("r", "/bin/my_r")
+	queryParams.Add("python", "/bin/my_python")
 
 	// Encode query parameters and set them to the URL
 	parsedURL.RawQuery = queryParams.Encode()
@@ -97,10 +97,13 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 	publisher.On("PublishDirectory", mock.Anything).Return(nil)
 	publisherFactory = func(
 		state *state.State,
-		rExecutable util.Path,
-		pythonExecutable util.Path,
+		rInterpreter interpreters.RInterpreter,
+		pythonInterpreter interpreters.PythonInterpreter,
 		emitter events.Emitter,
 		log logging.Logger) (publish.Publisher, error) {
+		// confirm that the interpreter paths made it to the publisher factory.
+		s.Equal("/bin/my_r", rInterpreter.GetPreferredPath())
+		s.Equal("/bin/my_python", pythonInterpreter.GetPreferredPath())
 		return publisher, nil
 	}
 	stateFactory = func(
@@ -121,8 +124,8 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 		s.Equal("", saveName)
 
 		// confirm that the interpreter paths made it through the request.
-		s.Equal("bin/my_r", rInterpreter.GetPreferredPath())
-		s.Equal("bin/my_python", pythonInterpreter.GetPreferredPath())
+		s.Equal("/bin/my_r", rInterpreter.GetPreferredPath())
+		s.Equal("/bin/my_python", pythonInterpreter.GetPreferredPath())
 
 		st := state.Empty()
 		st.Account = &accounts.Account{}
@@ -248,7 +251,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncPublishErr
 	testErr := errors.New("test error from PublishDirectory")
 	publisher := &mockPublisher{}
 	publisher.On("PublishDirectory", mock.Anything).Return(testErr)
-	publisherFactory = func(*state.State, util.Path, util.Path, events.Emitter, logging.Logger) (publish.Publisher, error) {
+	publisherFactory = func(*state.State, interpreters.RInterpreter, interpreters.PythonInterpreter, events.Emitter, logging.Logger) (publish.Publisher, error) {
 		return publisher, nil
 	}
 
@@ -284,7 +287,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentSubdir() {
 
 	publisher := &mockPublisher{}
 	publisher.On("PublishDirectory", mock.Anything).Return(nil)
-	publisherFactory = func(*state.State, util.Path, util.Path, events.Emitter, logging.Logger) (publish.Publisher, error) {
+	publisherFactory = func(*state.State, interpreters.RInterpreter, interpreters.PythonInterpreter, events.Emitter, logging.Logger) (publish.Publisher, error) {
 		return publisher, nil
 	}
 	stateFactory = func(
@@ -337,7 +340,7 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWithSecret
 
 	publisher := &mockPublisher{}
 	publisher.On("PublishDirectory", mock.Anything).Return(nil)
-	publisherFactory = func(*state.State, util.Path, util.Path, events.Emitter, logging.Logger) (publish.Publisher, error) {
+	publisherFactory = func(*state.State, interpreters.RInterpreter, interpreters.PythonInterpreter, events.Emitter, logging.Logger) (publish.Publisher, error) {
 		return publisher, nil
 	}
 

--- a/internal/services/api/post_inspect_test.go
+++ b/internal/services/api/post_inspect_test.go
@@ -1,0 +1,182 @@
+package api
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/config"
+	"github.com/posit-dev/publisher/internal/interpreters"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type PostInspectHandlerFuncSuite struct {
+	utiltest.Suite
+	cwd                util.AbsolutePath
+	log                logging.Logger
+	mockConfigGetter   *mockConfigGetter
+	mockMatchingWalker *mockMatchingWalker
+}
+
+func TestPostInspectHandlerFuncSuite(t *testing.T) {
+	suite.Run(t, new(PostInspectHandlerFuncSuite))
+}
+
+func (s *PostInspectHandlerFuncSuite) SetupTest() {
+	afs := afero.NewMemMapFs()
+	cwd, err := util.Getwd(afs)
+	s.Nil(err)
+	s.cwd = cwd
+	s.cwd.MkdirAll(0700)
+	s.log = logging.New()
+
+	s.mockConfigGetter = &mockConfigGetter{}
+	s.mockMatchingWalker = &mockMatchingWalker{}
+
+	// Create a test file that can be used as an entrypoint
+	entrypointPath, _ := s.cwd.SafeJoin("index.rmd")
+	entrypointPath.WriteFile([]byte("# Header"), 0644)
+}
+
+// Helper to create a simple configuration for testing
+func createTestConfig() *config.Config {
+	cfg := config.New()
+	cfg.Type = config.ContentTypeRMarkdown
+	cfg.Entrypoint = "index.rmd"
+	return cfg
+}
+
+// Mock for initialize.Initialize interface
+type mockConfigGetter struct {
+	mock.Mock
+}
+
+func (m *mockConfigGetter) GetPossibleConfigs(
+	path util.AbsolutePath,
+	pythonPath util.Path,
+	rPath util.Path,
+	entrypoint util.RelativePath,
+	log logging.Logger,
+) ([]*config.Config, error) {
+	args := m.Called(path, pythonPath, rPath, entrypoint, log)
+	if configs, ok := args.Get(0).([]*config.Config); ok {
+		return configs, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// Mock for the MatchingWalker
+type mockMatchingWalker struct {
+	mock.Mock
+}
+
+func (m *mockMatchingWalker) Walk(root util.AbsolutePath, walkFn util.AbsoluteWalkFunc) error {
+	args := m.Called(root, walkFn)
+	return args.Error(0)
+}
+
+// Mock for NewMatchingWalker factory function
+func (s *PostInspectHandlerFuncSuite) mockNewMatchingWalker(patterns []string, base util.AbsolutePath, log logging.Logger) (util.Walker, error) {
+	return s.mockMatchingWalker, nil
+}
+
+// Helper to create a basic request for testing
+func (s *PostInspectHandlerFuncSuite) createRequest(queryParams map[string]string) *http.Request {
+	// Base URL
+	baseURL := "/api/inspect"
+
+	// Create a url.URL struct
+	parsedURL, err := url.Parse(baseURL)
+	s.NoError(err)
+
+	// Create a url.Values to hold query parameters
+	params := url.Values{}
+	params.Add("dir", ".")
+	for k, v := range queryParams {
+		params.Add(k, v)
+	}
+
+	// Encode query parameters and set them to the URL
+	parsedURL.RawQuery = params.Encode()
+
+	req, err := http.NewRequest("POST", parsedURL.String(), nil)
+	s.NoError(err)
+
+	return req
+}
+
+func (s *PostInspectHandlerFuncSuite) TestPostInspectHandlerFunc() {
+	// Create test configurations
+	configs := []*config.Config{createTestConfig()}
+
+	// Create request with Python and R interpreter paths
+	req := s.createRequest(map[string]string{
+		"dir":        ".",
+		"entrypoint": "index.rmd",
+		"python":     "/custom/bin/python3",
+		"r":          "/custom/bin/R",
+	})
+
+	// Create Python and R interpreters
+	pythonInterpreter := interpreters.NewMockPythonInterpreter()
+	pythonPath := util.NewAbsolutePath("/custom/bin/python3", nil)
+	pythonInterpreter.On("GetPythonExecutable").Return(pythonPath, nil)
+
+	rInterpreter := interpreters.NewMockRInterpreter()
+	rPath := util.NewAbsolutePath("/custom/bin/R", nil)
+	rInterpreter.On("GetRExecutable").Return(rPath, nil)
+
+	// Setup mock to return test configs and assert interpreter paths are used
+	s.mockConfigGetter.On("GetPossibleConfigs",
+		s.cwd,
+		pythonPath.Path,
+		rPath.Path,
+		mock.Anything,
+		s.log,
+	).Return(configs, nil)
+
+	// Create HTTP recorder
+	rec := httptest.NewRecorder()
+
+	// Create and call the handler
+	handler := &postInspectHandler{
+		base:           s.cwd,
+		log:            s.log,
+		initializer:    s.mockConfigGetter,
+		matchingWalker: s.mockNewMatchingWalker,
+		interpretersResolve: func(projectDir util.AbsolutePath, w http.ResponseWriter, req *http.Request, log logging.Logger) (interpreters.RInterpreter, interpreters.PythonInterpreter, error) {
+			return rInterpreter, pythonInterpreter, nil
+		},
+	}
+
+	// Call the handler
+	handler.Handle(rec, req)
+
+	// Verify response
+	s.Equal(http.StatusOK, rec.Result().StatusCode)
+	s.Equal("application/json", rec.Header().Get("content-type"))
+
+	// Decode response body
+	var response []postInspectResponseBody
+	err := json.NewDecoder(rec.Body).Decode(&response)
+	s.NoError(err)
+
+	// Validate response content
+	s.Len(response, 1)
+	s.Equal(configs[0], response[0].Configuration)
+	s.Equal(".", response[0].ProjectDir)
+
+	// Verify mock calls
+	s.mockConfigGetter.AssertExpectations(s.T())
+	pythonInterpreter.AssertExpectations(s.T())
+	rInterpreter.AssertExpectations(s.T())
+}


### PR DESCRIPTION
## Intent

Fix inconsistent runtime discovery and selection when deploying from Positron.

Fixes #2648 #2663

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The API deployment handler was taking into account the preferred runtime at the beginning but it was ignoring it after some initial validations.

Updated the necessary methods to make use of the preferred runtime across the complete deployment request.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

Users should be able to deploy with the selected runtime in Positron.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Updated the related unit tests

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Try deploying content from Positron, while selecting a different R or Python version and seeing the deployment go through with success.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
