### PR TITLE
Chris release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.18.0]
 
 ### Fixed
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,11 +11,11 @@ Install.
 
 Download and install the VS Code extension.
 
-- For Arm MacOS: [publisher-1.16.1-darwin-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.16.1/publisher-1.16.1-darwin-arm64.vsix)
-- For Intel MacOS: [publisher-1.16.1-darwin-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.16.1/publisher-1.16.1-darwin-amd64.vsix)
-- For Windows: [publisher-1.16.1-windows-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.16.1/publisher-1.16.1-windows-amd64.vsix)
-- For Arm Linux: [publisher-1.16.1-linux-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.16.1/publisher-1.16.1-linux-arm64.vsix)
-- For Intel Linux: [publisher-1.16.1-linux-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.16.1/publisher-1.16.1-linux-amd64.vsix)
+- For Arm MacOS: [publisher-1.18.0-darwin-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-darwin-arm64.vsix)
+- For Intel MacOS: [publisher-1.18.0-darwin-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-darwin-amd64.vsix)
+- For Windows: [publisher-1.18.0-windows-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-windows-amd64.vsix)
+- For Arm Linux: [publisher-1.18.0-linux-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-linux-arm64.vsix)
+- For Intel Linux: [publisher-1.18.0-linux-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-linux-amd64.vsix)
 
 To learn how to install a `.vsix` file, see the [Install from a
 VSIX](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix)

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.18.0]
 
 ### Fixed
 

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the naming of "Shiny for Python" and "Shiny for R" content types. (#2664)
+- Fixed an issue where end-to-end tests could not run on some Mac systems due to Docker files not being built for the correct platform.
 - Fixed an issue where disabling keychain credential storage would not work as expected. (#2697)
 - Fixed inconsistent runtime discovery and selection at deploy time. (#2648)
 

--- a/install-publisher.bash
+++ b/install-publisher.bash
@@ -148,7 +148,7 @@ esac
 
 # version override, swap out latest with the latest and greatest
 if [[ $VERSION_TYPE == "release" && $VERSION == "latest" ]]; then
-  VERSION="1.16.1"
+  VERSION="1.18.0"
 fi
 
 # Variables


### PR DESCRIPTION
Prep release 1.18.0.

The docs/licenses.md got a lot of spurious whitespace changes in addition to the expected updates; not sure what's up with that.