### PR TITLE
check for existing credential by combination of URL and account name

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -79,8 +79,11 @@ type CredentialV0 struct {
 }
 
 func (c *Credential) ConflictCheck(compareWith Credential) error {
-	if compareWith.URL == c.URL {
-		return NewURLCollisionError(c.Name, c.URL)
+	if compareWith.URL == c.URL && compareWith.AccountID == c.AccountID {
+		// Connect/Snowflake credentials have unique URLs and empty AccountID.
+		// Connect Cloud credentials may have duplicate URLs, but their account IDs must be unique. AccountName is also
+		// unique, but may become unstable in the future if we allow users to change it.
+		return NewIdentityCollisionError(c.Name, c.URL, c.AccountName)
 	}
 	if compareWith.Name == c.Name {
 		return NewNameCollisionError(c.Name, c.URL)

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -28,7 +28,7 @@ func (s *CredentialsServiceTestSuite) SetupTest() {
 	s.log = loggingtest.NewMockLogger()
 }
 
-func (s *CredentialsServiceTestSuite) TestCredential() {
+func (s *CredentialsServiceTestSuite) TestCredential_ConflictCheck_Connect() {
 	cred := Credential{
 		GUID:   "18cd5640-bee5-4b2a-992a-a2725ab6103d",
 		Name:   "friedtofu",
@@ -56,7 +56,9 @@ func (s *CredentialsServiceTestSuite) TestCredential() {
 		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
 	})
 	s.EqualError(err, "URL value conflicts with existing credential (friedtofu) URL: https://a1.connect-server:3939/connect")
+}
 
+func (s *CredentialsServiceTestSuite) TestCredential_ConflictCheck_ConnectCloud() {
 	cloudCred := Credential{
 		GUID:         "18cd5640-bee5-4b2a-992a-a2725ab6103d",
 		Name:         "friedtofu",
@@ -66,7 +68,7 @@ func (s *CredentialsServiceTestSuite) TestCredential() {
 		RefreshToken: "refresh-token",
 		AccessToken:  "access-token",
 	}
-	err = cloudCred.ConflictCheck(Credential{
+	err := cloudCred.ConflictCheck(Credential{
 		GUID:         "18cd5640-bee5-4b2a-992a-a2725ab6103d",
 		Name:         "nofriedtofu",
 		URL:          "https://api.connect.posit.cloud",
@@ -76,6 +78,17 @@ func (s *CredentialsServiceTestSuite) TestCredential() {
 		AccessToken:  "access-token",
 	})
 	s.EqualError(err, "URL value conflicts with existing credential (friedtofu) URL: https://api.connect.posit.cloud, account name: fried tofu")
+
+	err = cloudCred.ConflictCheck(Credential{
+		GUID:         "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+		Name:         "nofriedtofu",
+		URL:          "https://api.connect.posit.cloud",
+		AccountID:    "456",
+		AccountName:  "friedpotato",
+		RefreshToken: "refresh-token",
+		AccessToken:  "access-token",
+	})
+	s.NoError(err)
 }
 
 func (s *CredentialsServiceTestSuite) TestCredentialRecord() {

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -56,6 +56,26 @@ func (s *CredentialsServiceTestSuite) TestCredential() {
 		ApiKey: "abcdeC2aqbh7dg8TO43XPu7r56YDh000",
 	})
 	s.EqualError(err, "URL value conflicts with existing credential (friedtofu) URL: https://a1.connect-server:3939/connect")
+
+	cloudCred := Credential{
+		GUID:         "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+		Name:         "friedtofu",
+		URL:          "https://api.connect.posit.cloud",
+		AccountID:    "123",
+		AccountName:  "fried tofu",
+		RefreshToken: "refresh-token",
+		AccessToken:  "access-token",
+	}
+	err = cloudCred.ConflictCheck(Credential{
+		GUID:         "18cd5640-bee5-4b2a-992a-a2725ab6103d",
+		Name:         "nofriedtofu",
+		URL:          "https://api.connect.posit.cloud",
+		AccountID:    "123",
+		AccountName:  "friedtofu",
+		RefreshToken: "refresh-token",
+		AccessToken:  "access-token",
+	})
+	s.EqualError(err, "URL value conflicts with existing credential (friedtofu) URL: https://api.connect.posit.cloud, account name: fried tofu")
 }
 
 func (s *CredentialsServiceTestSuite) TestCredentialRecord() {

--- a/internal/credentials/errors.go
+++ b/internal/credentials/errors.go
@@ -54,18 +54,23 @@ func (e *NotFoundError) Error() string {
 	return fmt.Sprintf("credential not found: %s", e.GUID)
 }
 
-// URL is used by another credential
-type URLCollisionError struct {
-	Name string
-	URL  string
+// Credential has already been defined
+type CredentialIdentityCollision struct {
+	Name        string
+	URL         string
+	AccountName string
 }
 
-func NewURLCollisionError(name, url string) *URLCollisionError {
-	return &URLCollisionError{name, url}
+func NewIdentityCollisionError(name, url, accountName string) *CredentialIdentityCollision {
+	return &CredentialIdentityCollision{Name: name, URL: url, AccountName: accountName}
 }
 
-func (e *URLCollisionError) Error() string {
-	return fmt.Sprintf("URL value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
+func (e *CredentialIdentityCollision) Error() string {
+	msg := fmt.Sprintf("URL value conflicts with existing credential (%s) URL: %s", e.Name, e.URL)
+	if e.AccountName != "" {
+		msg += fmt.Sprintf(", account name: %s", e.AccountName)
+	}
+	return msg
 }
 
 // Name is used by another credential

--- a/internal/credentials/keyring_test.go
+++ b/internal/credentials/keyring_test.go
@@ -92,7 +92,7 @@ func (s *KeyringCredentialsTestSuite) TestSetURLCollisionError() {
 	s.NoError(err)
 	_, err = cs.Set(CreateCredentialDetails{ServerType: server_type.ServerTypeConnect, Name: "example", URL: "https://example.com", ApiKey: "12345", SnowflakeConnection: ""})
 	s.Error(err)
-	s.IsType(&URLCollisionError{}, err)
+	s.IsType(&CredentialIdentityCollision{}, err)
 }
 
 func (s *KeyringCredentialsTestSuite) TestGet() {
@@ -158,7 +158,7 @@ func (s *KeyringCredentialsTestSuite) TestSetCollisions() {
 	// URL collision
 	_, err = cs.Set(CreateCredentialDetails{ServerType: server_type.ServerTypeConnect, Name: "another_example", URL: "https://example.com", ApiKey: "12345", SnowflakeConnection: ""})
 	s.Error(err)
-	s.IsType(&URLCollisionError{}, err)
+	s.IsType(&CredentialIdentityCollision{}, err)
 }
 
 func (s *KeyringCredentialsTestSuite) TestList() {

--- a/internal/services/api/post_credentials.go
+++ b/internal/services/api/post_credentials.go
@@ -70,7 +70,7 @@ func PostCredentialFuncHandler(log logging.Logger) http.HandlerFunc {
 			AccessToken:         body.AccessToken,
 		})
 		if err != nil {
-			if _, ok := err.(*credentials.URLCollisionError); ok {
+			if _, ok := err.(*credentials.CredentialIdentityCollision); ok {
 				http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
 				return
 			}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Currently we have checks in place to prevent users from creating new credentials for the same server URL. However, we want users to be able to create multiple credentials for Connect Cloud (but not with the same account). That means we have to compare both the credential URL and account instead of just the URL.

We'll also have to make changes in the extension code, which performs a similar validation.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Updated the `ConflictCheck` method to check AccountID in addition to URL.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

none.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Added assertions for:
- When a user creates a duplicate cloud credential
- When a user creates a non-duplicate cloud credential with the same URL

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Run the following curls:
```
curl -X POST localhost:9001/api/credentials -d '{"name": "foo", "serverType": "connect_cloud", "url": "https://api.connect.posit.cloud", "accountId": "123", "accountName": "my account", "refreshToken": "blah", "accessToken": "blah"}'

^ should succeed

curl -X POST localhost:9001/api/credentials -d '{"name": "foo", "serverType": "connect_cloud", "url": "https://api.connect.posit.cloud", "accountId": "123", "accountName": "my account", "refreshToken": "blah", "accessToken": "blah"}'

^ should fail

curl -X POST localhost:9001/api/credentials -d '{"name": "foo 2", "serverType": "connect_cloud", "url": "https://api.connect.posit.cloud", "accountId": "456", "accountName": "my account 2", "refreshToken": "blah", "accessToken": "blah"}'

^ should succeed

```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
