### PR TITLE
chore: Release 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added endpoints for performing OAuth Device Authorization Grant with Posit Cloud login. (#2692)
 
+## [1.18.1]
+
+### Fixed
+
+- Updated software components used by Posit Publisher to address CVE-2025-7783
+  (#2741)
+
 ## [1.18.0]
 
 ### Fixed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,11 +11,11 @@ Install.
 
 Download and install the VS Code extension.
 
-- For Arm MacOS: [publisher-1.18.0-darwin-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-darwin-arm64.vsix)
-- For Intel MacOS: [publisher-1.18.0-darwin-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-darwin-amd64.vsix)
-- For Windows: [publisher-1.18.0-windows-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-windows-amd64.vsix)
-- For Arm Linux: [publisher-1.18.0-linux-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-linux-arm64.vsix)
-- For Intel Linux: [publisher-1.18.0-linux-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.0/publisher-1.18.0-linux-amd64.vsix)
+- For Arm MacOS: [publisher-1.18.1-darwin-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.1/publisher-1.18.1-darwin-arm64.vsix)
+- For Intel MacOS: [publisher-1.18.1-darwin-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.1/publisher-1.18.1-darwin-amd64.vsix)
+- For Windows: [publisher-1.18.1-windows-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.1/publisher-1.18.1-windows-amd64.vsix)
+- For Arm Linux: [publisher-1.18.1-linux-arm64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.1/publisher-1.18.1-linux-arm64.vsix)
+- For Intel Linux: [publisher-1.18.1-linux-amd64.vsix](https://cdn.posit.co/publisher/releases/tags/v1.18.1/publisher-1.18.1-linux-amd64.vsix)
 
 To learn how to install a `.vsix` file, see the [Install from a
 VSIX](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix)

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,13 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1]
+
+### Fixed
+
+- Updated software components used by Posit Publisher to address CVE-2025-7783
+  (#2741)
+
 ## [1.18.0]
 
 ### Fixed

--- a/install-publisher.bash
+++ b/install-publisher.bash
@@ -148,7 +148,7 @@ esac
 
 # version override, swap out latest with the latest and greatest
 if [[ $VERSION_TYPE == "release" && $VERSION == "latest" ]]; then
-  VERSION="1.18.0"
+  VERSION="1.18.1"
 fi
 
 # Variables


### PR DESCRIPTION
Prepares for the release of `1.18.1` to address the critical issue fixed in #2741 

Added a CHANGELOG item as recommended by @christierney in https://github.com/posit-dev/publisher/pull/2741#issuecomment-3133412135

No licenses were updated as part of this release.
