### PR TITLE
chore: Add uv files to test/e2e/.gitignore

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,7 @@
 go_cover.out
 go_coverage.html
+
+# uv files
+uv.lock
+pyproject.toml
+.python-version


### PR DESCRIPTION
Minor change to include some uv generated files in the `test/e2e` directory's `.gitignore` so if you use `uv` to manage your `venv` you don't have lingering files for git.