### PR TITLE
feat: Dismiss select deployment with focus out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added endpoints for performing OAuth Device Authorization Grant with Posit Cloud login. (#2692)
 - Added support to publishing schema for Connect Cloud. (#2729, #2747)
 
+### Changed
+
+- The "Select Deployment" input can now be dismissed by focusing another element
+  similar to other inputs. (#2780)
+
 ## [1.18.1]
 
 ### Fixed

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1288,7 +1288,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
             quickPick.activeItems = lastMatches;
           }
           quickPick.title = "Select Deployment";
-          quickPick.ignoreFocusOut = true;
           quickPick.matchOnDescription = true;
           quickPick.matchOnDetail = true;
           quickPick.show();


### PR DESCRIPTION
This PR addresses a piece of feedback from @wch while working through an issue where the expectation was that the "Select Deployment" input would dismiss when focus changed similar to other VS Code inputs.

This PR only changes the "Select Deployment" quick pick since it doesn't have any user input we expect outside of VS Code (like we do for API keys in the Credential flow).

## Intent

Part of #2358

## Approach

Removed `quickPick.ignoreFocusOut = true;` so it defaults to `false`

## User Impact

Users can now dismiss the "Select Deployment" input by clicking away from it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
