### PR TITLE
First pass at multiple keyring support

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -233,6 +233,7 @@ func (cr *CredentialRecord) ToCredential() (*Credential, error) {
 }
 
 type CreateCredentialDetails struct {
+	GUID       string // Optional, used for migration to preserve original GUID
 	Name       string
 	URL        string
 	ServerType server_type.ServerType
@@ -292,7 +293,12 @@ func (details CreateCredentialDetails) ToCredential() (*Credential, error) {
 		return nil, err
 	}
 
-	guid := uuid.New().String()
+	// If a GUID is provided, use it (for migration)
+	// Otherwise, generate a new GUID
+	guid := details.GUID
+	if guid == "" {
+		guid = uuid.New().String()
+	}
 	return &Credential{
 		GUID:                guid,
 		Name:                details.Name,

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -261,7 +261,7 @@ func (s *CredentialsServiceTestSuite) TestNewCredentialsService_KeyringErrFallba
 	keyringErr := errors.New("this is a teapot, unsupported system")
 	keyring.MockInitWithError(keyringErr)
 
-	s.log.On("Debug", "System keyring service is not available", "error", "failed to load credentials: this is a teapot, unsupported system").Return()
+	s.log.On("Debug", "System keyring service is not available", "error", "failed to get known credential GUIDs: this is a teapot, unsupported system").Return()
 	s.log.On("Debug", "Fallback to file managed credentials service due to unavailable system keyring.").Return()
 
 	credservice, err := NewCredentialsService(s.log)

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -73,7 +73,7 @@ func (ks *keyringCredentialsService) Delete(guid string) error {
 		ks.log.Debug("Failed to remove GUID from guid list", "error", err.Error())
 	}
 
-	return ks.save(table)
+	return nil
 }
 
 func (ks *keyringCredentialsService) Get(guid string) (*Credential, error) {
@@ -202,9 +202,7 @@ func (ks *keyringCredentialsService) Reset() (string, error) {
 		ks.log.Debug("Failed to delete credential GUIDs list", "error", err.Error())
 	}
 
-	// Initialize with empty table
-	newTable := make(map[string]CredentialRecord)
-	return "", ks.save(newTable)
+	return "", nil
 }
 
 func (ks *keyringCredentialsService) checkForConflicts(

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -15,10 +15,26 @@ type keyringCredentialsService struct {
 	log logging.Logger
 }
 
+const (
+	CredentialKeyPrefix = "credential_"
+	LegacyKey           = "credentials"
+)
+
 func NewKeyringCredentialsService(log logging.Logger) *keyringCredentialsService {
-	return &keyringCredentialsService{
+	ks := &keyringCredentialsService{
 		log: log,
 	}
+
+	// Check for legacy credentials and migrate if necessary
+	legacyService := NewLegacyKeyringCredentialsService(log)
+	if legacyService.IsSupported() {
+		err := migrate(legacyService, ks)
+		if err != nil {
+			log.Debug("Failed to migrate from legacy format", "error", err.Error())
+		}
+	}
+
+	return ks
 }
 
 func (ks *keyringCredentialsService) IsSupported() bool {
@@ -43,6 +59,20 @@ func (ks *keyringCredentialsService) Delete(guid string) error {
 	}
 
 	delete(table, guid)
+
+	// Delete the credential from the keyring individually
+	key := CredentialKeyPrefix + guid
+	err = keyring.Delete(ServiceName, key)
+	if err != nil && err != keyring.ErrNotFound {
+		ks.log.Debug("Failed to delete credential from keyring", "credential", guid, "error", err.Error())
+	}
+
+	// Update the GUID list to remove this GUID
+	err = ks.removeGuidFromList(guid)
+	if err != nil {
+		ks.log.Debug("Failed to remove GUID from guid list", "error", err.Error())
+	}
+
 	return ks.save(table)
 }
 
@@ -91,6 +121,11 @@ func (ks *keyringCredentialsService) set(credDetails CreateCredentialDetails, ch
 		return nil, err
 	}
 
+	// Ensure table is initialized to avoid writing to a nil map
+	if table == nil {
+		table = make(CredentialTable)
+	}
+
 	cred, err := credDetails.ToCredential()
 	if err != nil {
 		return nil, err
@@ -123,10 +158,18 @@ func (ks *keyringCredentialsService) set(credDetails CreateCredentialDetails, ch
 		return nil, fmt.Errorf("error marshalling credential: %v", err)
 	}
 
-	table[guidToUpdate] = CredentialRecord{
+	record := CredentialRecord{
 		GUID:    guidToUpdate,
 		Version: CurrentVersion,
 		Data:    json.RawMessage(raw),
+	}
+
+	table[cred.GUID] = record
+
+	// Update the guid list of GUIDs
+	err = ks.updateGuidsListFor(cred.GUID)
+	if err != nil {
+		ks.log.Debug("Failed to update guid list GUIDs", "error", err.Error())
 	}
 
 	err = ks.save(table)
@@ -140,6 +183,26 @@ func (ks *keyringCredentialsService) set(credDetails CreateCredentialDetails, ch
 // There is no backup for keyring data due to encryption, always returns empty string
 func (ks *keyringCredentialsService) Reset() (string, error) {
 	ks.log.Warn("Corrupted credentials data found. The stored data was reset.", "credentials_service", "keyring")
+
+	// Then try to delete all individual credential entries
+	knownGuids, err := ks.getKnownCredentialGuids()
+	if err == nil {
+		for _, guid := range knownGuids {
+			key := CredentialKeyPrefix + guid
+			err := keyring.Delete(ServiceName, key)
+			if err != nil && err != keyring.ErrNotFound {
+				ks.log.Debug("Failed to delete credential", "credential", guid, "error", err.Error())
+			}
+		}
+	}
+
+	// Finally, delete the GUIDs list
+	err = keyring.Delete(ServiceName, "credential_guids")
+	if err != nil && err != keyring.ErrNotFound {
+		ks.log.Debug("Failed to delete credential GUIDs list", "error", err.Error())
+	}
+
+	// Initialize with empty table
 	newTable := make(map[string]CredentialRecord)
 	return "", ks.save(newTable)
 }
@@ -162,35 +225,179 @@ func (ks *keyringCredentialsService) checkForConflicts(
 	return nil
 }
 
-// Saves the CredentialTable
+// Saves the CredentialTable by storing each credential separately
 func (ks *keyringCredentialsService) save(table CredentialTable) error {
-	data, err := json.Marshal(table)
-	if err != nil {
-		return fmt.Errorf("failed to serialize credentials: %v", err)
+	// Get existing credentials to determine what needs to be updated/added/removed
+	existingCreds, loadErr := ks.loadIndividualCredentials()
+	if loadErr != nil {
+		return fmt.Errorf("failed to load existing credentials: %v", loadErr)
 	}
 
-	err = keyring.Set(ServiceName, "credentials", string(data))
-	if err != nil {
-		return fmt.Errorf("failed to set credentials: %v", err)
+	// Track existing GUIDs to detect deletions
+	existingGUIDs := make(map[string]bool)
+	for guid := range existingCreds {
+		existingGUIDs[guid] = true
 	}
+
+	// Add or update each credential in the table
+	for guid, record := range table {
+		data, err := json.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("failed to serialize credential %s: %v", guid, err)
+		}
+
+		key := CredentialKeyPrefix + guid
+		err = keyring.Set(ServiceName, key, string(data))
+		if err != nil {
+			return fmt.Errorf("failed to set credential %s: %v", guid, err)
+		}
+
+		// Mark this GUID as processed
+		delete(existingGUIDs, guid)
+	}
+
+	// Delete any credentials that are no longer in the table
+	for guid := range existingGUIDs {
+		key := CredentialKeyPrefix + guid
+		err := keyring.Delete(ServiceName, key)
+		if err != nil && err != keyring.ErrNotFound {
+			ks.log.Debug("Failed to delete credential", "credential", guid, "error", err.Error())
+		}
+	}
+
 	return nil
 }
 
 // Loads the CredentialTable from keyring
 func (ks *keyringCredentialsService) load() (CredentialTable, error) {
-	data, err := keyring.Get(ServiceName, "credentials")
+	// First try to load from individual credential entries
+	table, err := ks.loadIndividualCredentials()
 	if err != nil {
-		if err == keyring.ErrNotFound {
-			return make(map[string]CredentialRecord), nil
-		}
-		return nil, NewLoadError(err)
+		return nil, err
 	}
 
-	var table CredentialTable
-	err = json.Unmarshal([]byte(data), &table)
+	// If we have individual credentials, return them
+	if len(table) > 0 {
+		return table, nil
+	}
+
+	// No credentials found; return empty table
+	return make(CredentialTable), nil
+}
+
+func (ks *keyringCredentialsService) loadIndividualCredentials() (CredentialTable, error) {
+	table := make(map[string]CredentialRecord)
+
+	// First get all stored credential GUIDs that might be available
+	knownGuids, err := ks.getKnownCredentialGuids()
 	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize credentials: %v", err)
+		return nil, fmt.Errorf("failed to get known credential GUIDs: %v", err)
+	}
+
+	// Load each individual credential
+	for _, guid := range knownGuids {
+		key := CredentialKeyPrefix + guid
+		data, err := keyring.Get(ServiceName, key)
+
+		if err != nil {
+			if err == keyring.ErrNotFound {
+				// Skip non-existent credentials
+				continue
+			}
+			return nil, fmt.Errorf("failed to load credential %s: %v", guid, err)
+		}
+
+		var record CredentialRecord
+		err = json.Unmarshal([]byte(data), &record)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize credential %s: %v", guid, err)
+		}
+
+		table[guid] = record
 	}
 
 	return table, nil
+}
+
+// We store known credentials in a single, known GUIDs list keyring item so that we can
+// enumerate and retrieve them. This is necessary because go-keyring does not provide
+// a way to list all keys stored under a service (at least at time of writting).
+func (ks *keyringCredentialsService) getKnownCredentialGuids() ([]string, error) {
+	// Try to get the GUIDs list first
+	guidsListData, err := keyring.Get(ServiceName, "credential_guids")
+	if err == nil {
+		// Parse the GUIDs list
+		var guids []string
+		err = json.Unmarshal([]byte(guidsListData), &guids)
+		if err == nil {
+			return guids, nil
+		}
+		// If we can't parse the cached GUIDs, log and continue
+		ks.log.Debug("Failed to parse credential GUIDs list", "error", err.Error())
+		return []string{}, nil
+	}
+
+	// If the GUIDs list is not found, return empty slice
+	if err == keyring.ErrNotFound {
+		// No credentials found - this is normal for new installs
+		return []string{}, nil
+	}
+
+	// Any other error means keyring isn't accessible
+	return nil, err
+}
+
+func (ks *keyringCredentialsService) updateGuidsListFor(guid string) error {
+	guids, err := ks.getKnownCredentialGuids()
+	if err != nil {
+		return fmt.Errorf("failed to get known credential GUIDs: %v", err)
+	}
+
+	// Check if the GUID is already in the list
+	for _, existingGuid := range guids {
+		if existingGuid == guid {
+			// GUID already in GUIDs list, no need to update
+			return nil
+		}
+	}
+
+	// Add the GUID to the list
+	guids = append(guids, guid)
+
+	// Save the updated list
+	return ks.saveGuidList(guids)
+}
+
+func (ks *keyringCredentialsService) removeGuidFromList(guid string) error {
+	guids, err := ks.getKnownCredentialGuids()
+	if err != nil {
+		return fmt.Errorf("failed to get known credential GUIDs: %v", err)
+	}
+
+	// Create a new list without the given GUID
+	var updatedGuids []string
+	for _, existingGuid := range guids {
+		if existingGuid != guid {
+			updatedGuids = append(updatedGuids, existingGuid)
+		}
+	}
+
+	// Save the updated list
+	return ks.saveGuidList(updatedGuids)
+}
+
+func (ks *keyringCredentialsService) saveGuidList(guids []string) error {
+	// Serialize the GUIDs list
+	data, err := json.Marshal(guids)
+	if err != nil {
+		return fmt.Errorf("failed to serialize GUIDs list: %v", err)
+	}
+
+	// Save to keyring
+	err = keyring.Set(ServiceName, "credential_guids", string(data))
+	if err != nil {
+		return fmt.Errorf("failed to save GUIDs list: %v", err)
+	}
+
+	return nil
 }

--- a/internal/credentials/keyring_legacy.go
+++ b/internal/credentials/keyring_legacy.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2024 by Posit Software, PBC.
+
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/zalando/go-keyring"
+)
+
+// legacyKeyringCredentialsService implements the CredentialsService interface for
+// legacy keyring format that stored all credentials in a single keyring entry.
+// This service is used primarily for migrating from the old format to the new one.
+type legacyKeyringCredentialsService struct {
+	log logging.Logger
+}
+
+// NewLegacyKeyringCredentialsService creates a new instance of legacyKeyringCredentialsService
+func NewLegacyKeyringCredentialsService(log logging.Logger) *legacyKeyringCredentialsService {
+	return &legacyKeyringCredentialsService{
+		log: log,
+	}
+}
+
+// IsSupported checks if the legacy keyring format is available on the system
+func (lks *legacyKeyringCredentialsService) IsSupported() bool {
+	// Check if we can access the legacy credentials entry
+	_, err := keyring.Get(ServiceName, LegacyKey)
+	return err == nil
+}
+
+// Delete is not fully supported in legacy format
+func (lks *legacyKeyringCredentialsService) Delete(guid string) error {
+	// For legacy, we don't support individual deletion
+	return fmt.Errorf("individual credential deletion not supported in legacy format")
+}
+
+// Get is not fully supported in legacy format
+func (lks *legacyKeyringCredentialsService) Get(guid string) (*Credential, error) {
+	// For legacy, we don't support individual get
+	return nil, fmt.Errorf("individual credential get not supported in legacy format")
+}
+
+// List retrieves all credentials from the legacy keyring format
+func (lks *legacyKeyringCredentialsService) List() ([]Credential, error) {
+	table, err := lks.loadLegacy()
+	if err != nil {
+		return nil, err
+	}
+
+	var creds []Credential = make([]Credential, 0)
+	for _, cr := range table {
+		cred, err := cr.ToCredential()
+		if err != nil {
+			return nil, err
+		}
+		creds = append(creds, *cred)
+	}
+	return creds, nil
+}
+
+// Set and ForceSet is not supported in legacy format
+func (lks *legacyKeyringCredentialsService) Set(credDetails CreateCredentialDetails) (*Credential, error) {
+	// Legacy service doesn't support setting new credentials
+	return nil, fmt.Errorf("setting credentials not supported in legacy format")
+}
+
+func (ks *legacyKeyringCredentialsService) ForceSet(credDetails CreateCredentialDetails) (*Credential, error) {
+	return nil, fmt.Errorf("force setting credentials not supported in legacy format")
+}
+
+// Reset deletes the legacy keyring entry
+func (lks *legacyKeyringCredentialsService) Reset() (string, error) {
+	// Delete the legacy credentials entry
+	err := keyring.Delete(ServiceName, LegacyKey)
+	if err != nil && err != keyring.ErrNotFound {
+		return "", fmt.Errorf("failed to delete legacy credentials: %v", err)
+	}
+	return "", nil
+}
+
+// loadLegacy loads credentials from the legacy single-entry format
+func (lks *legacyKeyringCredentialsService) loadLegacy() (CredentialTable, error) {
+	data, err := keyring.Get(ServiceName, LegacyKey)
+	if err != nil {
+		if err == keyring.ErrNotFound {
+			// No legacy credentials found
+			return make(CredentialTable), nil
+		}
+		return nil, fmt.Errorf("failed to load legacy credentials: %v", err)
+	}
+
+	var table CredentialTable
+	err = json.Unmarshal([]byte(data), &table)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize legacy credentials: %v", err)
+	}
+
+	return table, nil
+}
+
+// migrate credentials from the legacy single-entry format to individual entries
+func migrate(legacy CredentialsService, cs CredentialsService) error {
+	creds, err := legacy.List()
+	if err != nil {
+		return fmt.Errorf("failed to list legacy credentials: %v", err)
+	}
+
+	for _, cred := range creds {
+		// Convert Credential to CreateCredentialDetails
+		details := CreateCredentialDetails{
+			GUID:                cred.GUID, // Preserve the original GUID
+			Name:                cred.Name,
+			URL:                 cred.URL,
+			ServerType:          cred.ServerType,
+			ApiKey:              cred.ApiKey,
+			SnowflakeConnection: cred.SnowflakeConnection,
+			AccountID:           cred.AccountID,
+			AccountName:         cred.AccountName,
+			RefreshToken:        cred.RefreshToken,
+			AccessToken:         cred.AccessToken,
+			CloudEnvironment:    cred.CloudEnvironment,
+			Token:               cred.Token,
+			PrivateKey:          cred.PrivateKey,
+		}
+
+		_, err = cs.Set(details)
+		if err != nil {
+			return fmt.Errorf("failed to migrate credential %q: %v", cred.Name, err)
+		}
+	}
+
+	legacy.Reset()
+	return nil
+}

--- a/internal/credentials/keyring_test.go
+++ b/internal/credentials/keyring_test.go
@@ -3,16 +3,19 @@
 package credentials
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/posit-dev/publisher/internal/server_type"
 	"github.com/posit-dev/publisher/internal/types"
 
-	"github.com/stretchr/testify/suite"
-	"github.com/zalando/go-keyring"
-
 	"github.com/posit-dev/publisher/internal/logging/loggingtest"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/zalando/go-keyring"
 )
 
 type KeyringCredentialsTestSuite struct {
@@ -22,6 +25,117 @@ type KeyringCredentialsTestSuite struct {
 
 func TestKeyringCredentialsTestSuite(t *testing.T) {
 	suite.Run(t, new(KeyringCredentialsTestSuite))
+}
+
+// TestLargeCredentials tests that large credentials can be stored and retrieved
+// This is to verify the fix for the issue with the 3,000 byte limit on macOS keychain
+func (s *KeyringCredentialsTestSuite) TestLargeCredentials() {
+	cs := keyringCredentialsService{
+		log: s.log,
+	}
+
+	// Create a large API key (over 3000 bytes)
+	largeApiKey := make([]byte, 3500)
+	for i := range largeApiKey {
+		largeApiKey[i] = byte(65 + (i % 26)) // ASCII values for uppercase letters
+	}
+
+	// Create a credential with the large API key
+	cred, err := cs.Set(CreateCredentialDetails{
+		ServerType: server_type.ServerTypeConnect,
+		Name:       "large-cred",
+		URL:        "https://example.com/large",
+		ApiKey:     string(largeApiKey),
+	})
+	s.NoError(err, "Setting large credential should succeed")
+	s.NotNil(cred, "Credential should be created")
+
+	// Try to retrieve it
+	retrieved, err := cs.Get(cred.GUID)
+	s.NoError(err, "Getting large credential should succeed")
+	s.Equal(string(largeApiKey), retrieved.ApiKey, "Retrieved credential should have same large API key")
+
+	// Verify it shows up in the list
+	creds, err := cs.List()
+	s.NoError(err)
+	s.Contains(creds, *cred, "Listed credentials should contain the large credential")
+}
+
+// TestMigrationFromLegacy tests that credentials are properly migrated from the legacy format
+func (s *KeyringCredentialsTestSuite) TestMigrationFromLegacy() {
+	// Create a table with some credentials in the legacy format
+	table := make(map[string]CredentialRecord)
+
+	// Add a couple of test credentials
+	cred1 := Credential{
+		GUID:       "test-guid-1",
+		Name:       "legacy-cred-1",
+		ServerType: server_type.ServerTypeConnect,
+		URL:        "https://legacy1.example.com",
+		ApiKey:     "legacy-apikey-1",
+	}
+	raw1, _ := json.Marshal(cred1)
+	table[cred1.GUID] = CredentialRecord{
+		GUID:    cred1.GUID,
+		Version: CurrentVersion,
+		Data:    json.RawMessage(raw1),
+	}
+
+	cred2 := Credential{
+		GUID:       "test-guid-2",
+		Name:       "legacy-cred-2",
+		ServerType: server_type.ServerTypeConnect,
+		URL:        "https://legacy2.example.com",
+		ApiKey:     "legacy-apikey-2",
+	}
+	raw2, _ := json.Marshal(cred2)
+	table[cred2.GUID] = CredentialRecord{
+		GUID:    cred2.GUID,
+		Version: CurrentVersion,
+		Data:    json.RawMessage(raw2),
+	}
+
+	// Save the table using the legacy format
+	data, _ := json.Marshal(table)
+	err := keyring.Set(ServiceName, LegacyKey, string(data))
+	s.NoError(err, "Should be able to set legacy credentials")
+
+	// Initialize the keyring service, which should trigger migration
+	cs := NewKeyringCredentialsService(s.log)
+
+	creds, err := cs.List()
+	s.NoError(err, "Should be able to list credentials")
+	s.Len(creds, 2, "Should have two credentials after migration")
+
+	// Check that both credentials were migrated correctly
+	foundCred1 := false
+	foundCred2 := false
+	for _, cred := range creds {
+		if cred.GUID == cred1.GUID {
+			s.Equal(cred1.Name, cred.Name)
+			s.Equal(cred1.URL, cred.URL)
+			s.Equal(cred1.ApiKey, cred.ApiKey)
+			foundCred1 = true
+		}
+		if cred.GUID == cred2.GUID {
+			s.Equal(cred2.Name, cred.Name)
+			s.Equal(cred2.URL, cred.URL)
+			s.Equal(cred2.ApiKey, cred.ApiKey)
+			foundCred2 = true
+		}
+	}
+
+	s.True(foundCred1, "Should find credential 1 after migration")
+	s.True(foundCred2, "Should find credential 2 after migration")
+
+	// Check that the legacy key is deleted (eventually)
+	require.Eventually(s.T(), func() bool {
+		// Check that the legacy key was deleted
+		_, err := keyring.Get(ServiceName, LegacyKey)
+		return err == keyring.ErrNotFound
+	}, 2*time.Second, 50*time.Millisecond, "Legacy key should be deleted after migration")
+
+	s.log.AssertExpectations(s.T())
 }
 
 func (s *KeyringCredentialsTestSuite) SetupTest() {
@@ -193,9 +307,27 @@ func (s *KeyringCredentialsTestSuite) TestDelete() {
 	cred, err := cs.Set(CreateCredentialDetails{ServerType: server_type.ServerTypeConnect, Name: "example", URL: "https://example.com", ApiKey: "12345", SnowflakeConnection: ""})
 	s.NoError(err)
 
+	// Get the list of known GUIDs to verify the cache is updated
+	guids, err := cs.getKnownCredentialGuids()
+	s.NoError(err)
+	s.Contains(guids, cred.GUID, "GUID should be in the cache before deletion")
+
+	// Log expectations for deletion
+	s.log.On("Debug", "Failed to delete individual credential from keyring", "credential", cred.GUID, "error", "secret not found").Maybe().Return()
+	s.log.On("Debug", "Failed to remove GUID from cache", "error", "failed to save GUIDs cache: failed to serialize GUIDs cache: json: unsupported type: map[string]struct {}").Maybe().Return()
+
 	// no error if exists
 	err = cs.Delete(cred.GUID)
 	s.NoError(err)
+
+	// Check if the GUID was removed from the cache
+	guids, err = cs.getKnownCredentialGuids()
+	s.NoError(err)
+	for _, guid := range guids {
+		if guid == cred.GUID {
+			s.Fail("GUID should not be in the cache after deletion")
+		}
+	}
 
 	// err if missing
 	s.log.On("Debug", "Credential does not exist", "credential", cred.GUID).Return()
@@ -256,6 +388,10 @@ func (s *KeyringCredentialsTestSuite) TestReset() {
 
 	// Expected Log Warn
 	s.log.On("Warn", "Corrupted credentials data found. The stored data was reset.", "credentials_service", "keyring").Return()
+
+	// Expected Debug logs from the reset method
+	s.log.On("Debug", "Failed to delete legacy credentials entry", "error", "secret not found").Maybe().Return()
+	s.log.On("Debug", "Failed to delete cached credential GUIDs", "error", "secret not found").Maybe().Return()
 
 	_, err = cs.Reset()
 	s.NoError(err)


### PR DESCRIPTION
Resolves #2783

## Intent

Instead of storing all of the credentials in one keyring item, store each in it's own keyring item. This does mean that we need to have a separate keyring item that is a list of known items (the go-keyring package does not seem to have the ability to list and parse names of keyring items, you must get them by name).

## Type of Change

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach
Mostly Claude

## User Impact

Be able to store more credentials (and more than _one_ legacy token-based auth method)

## Automated Tests

Added some tests, especially for the migration

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
TODO:
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
