### PR TITLE
chore: Remove remnents of credentials from environment variable support

### DIFF
--- a/internal/accounts/account_source.go
+++ b/internal/accounts/account_source.go
@@ -7,14 +7,12 @@ type AccountSource string
 const (
 	AccountSourceRsconnectPython AccountSource = "rsconnect-python"
 	AccountSourceRsconnect       AccountSource = "rsconnect"
-	AccountSourceEnvironment     AccountSource = "environment"
 	AccountSourceKeychain        AccountSource = "keychain"
 )
 
 var sourceDescriptions = map[AccountSource]string{
 	AccountSourceRsconnectPython: "rsconnect-python",
 	AccountSourceRsconnect:       "RStudio IDE/rsconnect",
-	AccountSourceEnvironment:     "CONNECT_SERVER environment variable",
 }
 
 func (source AccountSource) Description() string {

--- a/internal/accounts/account_source_test.go
+++ b/internal/accounts/account_source_test.go
@@ -20,6 +20,5 @@ func TestAccountSourceSuite(t *testing.T) {
 func (s *AccountSourceSuite) TestDescription() {
 	s.Equal("rsconnect-python", AccountSourceRsconnectPython.Description())
 	s.Equal("RStudio IDE/rsconnect", AccountSourceRsconnect.Description())
-	s.Equal("CONNECT_SERVER environment variable", AccountSourceEnvironment.Description())
 	s.Equal("hey", AccountSource("hey").Description())
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -61,13 +61,7 @@ func getDefaultAccount(accountList []accounts.Account) (*accounts.Account, error
 	if len(accountList) == 0 {
 		return nil, errNoAccounts
 	} else if len(accountList) > 1 {
-		// If an account was provided via environment variables, use it.
-		for _, acct := range accountList {
-			if acct.Source == accounts.AccountSourceEnvironment {
-				return &acct, nil
-			}
-		}
-		// Otherwise we don't have a way to choose
+		// we don't have a way to choose
 		return nil, errMultipleAccounts
 	}
 	return &accountList[0], nil

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -740,16 +740,6 @@ func (s *StateSuite) TestGetDefaultAccountOne() {
 	s.NoError(err)
 }
 
-func (s *StateSuite) TestGetDefaultAccountFromEnv() {
-	other := accounts.Account{}
-	expected := accounts.Account{
-		Source: accounts.AccountSourceEnvironment,
-	}
-	actual, err := getDefaultAccount([]accounts.Account{other, expected})
-	s.Equal(&expected, actual)
-	s.NoError(err)
-}
-
 func (s *StateSuite) TestGetDefaultAccountMultiple() {
 	acct1 := accounts.Account{}
 	acct2 := accounts.Account{}


### PR DESCRIPTION
This PR follows on the heels of https://github.com/posit-dev/publisher/pull/2789#pullrequestreview-3102130529, as it is cleaning up the dead code related to supporting environment variables as a credential.

To verify, I have run the normal building steps and then executed the existing e2e tests, which include validation for credential support. If CI passes, we should be good with the removal of this code.
