### PR TITLE
Fix Authorization header for Connect Cloud API client

### DIFF
--- a/internal/accounts/account.go
+++ b/internal/accounts/account.go
@@ -20,7 +20,7 @@ type Account struct {
 	CloudEnvironment    types.CloudEnvironment `json:"cloud_environment"`  // Environment for Connect Cloud (production, staging, development)
 	CloudAccountID      string                 `json:"cloud_account_id"`   // Account ID for Connect Cloud
 	CloudAccountName    string                 `json:"cloud_account_name"` // Account name for Connect Cloud
-	CloudAccessToken    string                 `json:"-"`                  // Access token for OAuth authentication
+	CloudAccessToken    types.CloudAuthToken   `json:"-"`                  // Access token for OAuth authentication
 	CloudRefreshToken   string                 `json:"-"`                  // Refresh token for OAuth authentication
 	Token               string                 `json:"-"`                  // Token ID for token-based authentication
 	PrivateKey          string                 `json:"-"`                  // Base64-encoded private key for signing requests

--- a/internal/clients/cloud_auth/oauth.go
+++ b/internal/clients/cloud_auth/oauth.go
@@ -1,5 +1,7 @@
 package cloud_auth
 
+import "github.com/posit-dev/publisher/internal/types"
+
 // Copyright (C) 2025 by Posit Software, PBC.
 
 type TokenRequest struct {
@@ -9,9 +11,9 @@ type TokenRequest struct {
 }
 
 type TokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int    `json:"expires_in"`
-	TokenType    string `json:"token_type"`
-	Scope        string `json:"scope"`
+	AccessToken  types.CloudAuthToken `json:"access_token"`
+	RefreshToken string               `json:"refresh_token"`
+	ExpiresIn    int                  `json:"expires_in"`
+	TokenType    string               `json:"token_type"`
+	Scope        string               `json:"scope"`
 }

--- a/internal/clients/connect_cloud/client_connect_cloud.go
+++ b/internal/clients/connect_cloud/client_connect_cloud.go
@@ -99,7 +99,7 @@ func (c *ConnectCloudClient) refreshCred() error {
 	c.account.CloudRefreshToken = resp.RefreshToken
 
 	// Set the client to one with the new token.
-	c.client = c.httpClientFactory(getBaseURL(c.account.CloudEnvironment), c.timeout, fmt.Sprintf("Bearer %s", resp.AccessToken))
+	c.client = c.httpClientFactory(getBaseURL(c.account.CloudEnvironment), c.timeout, resp.AccessToken)
 	return nil
 }
 

--- a/internal/clients/connect_cloud/client_connect_cloud.go
+++ b/internal/clients/connect_cloud/client_connect_cloud.go
@@ -48,12 +48,12 @@ func NewConnectCloudClientWithAuth(
 	log logging.Logger,
 	timeout time.Duration,
 	account *accounts.Account,
-	authToken string,
+	authToken types.CloudAuthToken,
 ) (APIClient, error) {
 	if account != nil {
-		authToken = fmt.Sprintf("Bearer %s", account.CloudAccessToken)
+		authToken = account.CloudAccessToken
 	}
-	httpClient := http_client.NewBasicHTTPClientWithBearerAuth(getBaseURL(environment), timeout, authToken)
+	httpClient := http_client.NewBasicHTTPClientWithBearerAuth(getBaseURL(environment), timeout, string(authToken))
 	credService, err := credentials.NewCredentialsService(log)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (c *ConnectCloudClient) refreshCred() error {
 	c.account.CloudRefreshToken = resp.RefreshToken
 
 	// Set the client to one with the new token.
-	c.client = c.httpClientFactory(getBaseURL(c.account.CloudEnvironment), c.timeout, resp.AccessToken)
+	c.client = c.httpClientFactory(getBaseURL(c.account.CloudEnvironment), c.timeout, string(resp.AccessToken))
 	return nil
 }
 

--- a/internal/clients/connect_cloud/client_connect_cloud_test.go
+++ b/internal/clients/connect_cloud/client_connect_cloud_test.go
@@ -356,9 +356,9 @@ func (s *ConnectCloudClientSuite) TestCreateContentWithRetryAuth() {
 	}
 
 	//Factory is called to create a new client with the refresh
-	httpClientFactory := func(baseURL string, timeout time.Duration, authHeaderValue string) http_client.HTTPClient {
+	httpClientFactory := func(baseURL string, timeout time.Duration, authToken string) http_client.HTTPClient {
 		// Verify that the new token is used for the auth header
-		s.Equal("Bearer NEW_ACCESS_TOKEN", authHeaderValue)
+		s.Equal("NEW_ACCESS_TOKEN", authToken)
 		return secondHttpClient
 	}
 

--- a/internal/clients/connect_cloud/client_connect_cloud_test.go
+++ b/internal/clients/connect_cloud/client_connect_cloud_test.go
@@ -396,6 +396,6 @@ func (s *ConnectCloudClientSuite) TestCreateContentWithRetryAuth() {
 	mockCredService.AssertExpectations(s.T())
 
 	// Verify account was updated with new tokens
-	s.Equal("NEW_ACCESS_TOKEN", account.CloudAccessToken)
+	s.Equal(types.CloudAuthToken("NEW_ACCESS_TOKEN"), account.CloudAccessToken)
 	s.Equal("NEW_REFRESH_TOKEN", account.CloudRefreshToken)
 }

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -61,7 +61,7 @@ type Credential struct {
 	AccountID        string                 `json:"accountId"`
 	AccountName      string                 `json:"accountName"`
 	RefreshToken     string                 `json:"refreshToken"`
-	AccessToken      string                 `json:"accessToken"`
+	AccessToken      types.CloudAuthToken   `json:"accessToken"`
 	CloudEnvironment types.CloudEnvironment `json:"cloudEnvironment"`
 
 	// Token authentication fields
@@ -86,7 +86,7 @@ type CredentialV2 struct {
 	AccountID        string                 `json:"accountId"`
 	AccountName      string                 `json:"accountName"`
 	RefreshToken     string                 `json:"refreshToken"`
-	AccessToken      string                 `json:"accessToken"`
+	AccessToken      types.CloudAuthToken   `json:"accessToken"`
 	CloudEnvironment types.CloudEnvironment `json:"cloudEnvironment"`
 }
 
@@ -247,7 +247,7 @@ type CreateCredentialDetails struct {
 	AccountID        string
 	AccountName      string
 	RefreshToken     string
-	AccessToken      string
+	AccessToken      types.CloudAuthToken
 	CloudEnvironment types.CloudEnvironment
 
 	// Token authentication fields

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/posit-dev/publisher/internal/server_type"
 	"github.com/posit-dev/publisher/internal/types"
 
-	"github.com/posit-dev/publisher/internal/logging/loggingtest"
-	"github.com/posit-dev/publisher/internal/util/utiltest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 	"github.com/zalando/go-keyring"
+
+	"github.com/posit-dev/publisher/internal/logging/loggingtest"
+	"github.com/posit-dev/publisher/internal/util/utiltest"
 )
 
 type CredentialsServiceTestSuite struct {
@@ -325,7 +326,7 @@ func (s *CreateCredentialDetailsTestSuite) TestToCredential() {
 	s.Equal(cred.AccountID, "")
 	s.Equal(cred.AccountName, "")
 	s.Equal(cred.RefreshToken, "")
-	s.Equal(cred.AccessToken, "")
+	s.Equal(cred.AccessToken, types.CloudAuthToken(""))
 	s.Equal(cred.CloudEnvironment, types.CloudEnvironment(""))
 	s.Equal(cred.Token, "")
 	s.Equal(cred.PrivateKey, "")
@@ -377,7 +378,7 @@ func (s *CreateCredentialDetailsTestSuite) TestToCredential_TokenAuth() {
 	s.Equal(cred.AccountID, "")
 	s.Equal(cred.AccountName, "")
 	s.Equal(cred.RefreshToken, "")
-	s.Equal(cred.AccessToken, "")
+	s.Equal(cred.AccessToken, types.CloudAuthToken(""))
 }
 
 func (s *CreateCredentialDetailsTestSuite) TestToCredential_InvalidTokenAuth() {

--- a/internal/credentials/file.go
+++ b/internal/credentials/file.go
@@ -39,7 +39,7 @@ type fileCredential struct {
 	AccountID        string                 `toml:"account_id,omitempty"`
 	AccountName      string                 `toml:"account_name,omitempty"`
 	RefreshToken     string                 `toml:"refresh_token,omitempty"`
-	AccessToken      string                 `toml:"access_token,omitempty"`
+	AccessToken      types.CloudAuthToken   `toml:"access_token,omitempty"`
 	CloudEnvironment types.CloudEnvironment `toml:"cloud_environment,omitempty"`
 
 	// Token authentication fields

--- a/internal/credentials/file_test.go
+++ b/internal/credentials/file_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/posit-dev/publisher/internal/server_type"
+	"github.com/posit-dev/publisher/internal/types"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
@@ -550,7 +551,7 @@ func (s *FileCredentialsServiceSuite) TestSet() {
 	s.Equal(newcred4.AccountID, "0de62804-2b0b-4e11-8a52-a402bda89ff4")
 	s.Equal(newcred4.AccountName, "cloudy")
 	s.Equal(newcred4.RefreshToken, "some_refresh_token")
-	s.Equal(newcred4.AccessToken, "some_access_token")
+	s.Equal(newcred4.AccessToken, types.CloudAuthToken("some_access_token"))
 
 	creds, err = cs.load()
 	s.NoError(err)

--- a/internal/credentials/keyring_test.go
+++ b/internal/credentials/keyring_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/posit-dev/publisher/internal/server_type"
+	"github.com/posit-dev/publisher/internal/types"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/zalando/go-keyring"
 
 	"github.com/posit-dev/publisher/internal/logging/loggingtest"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
-	"github.com/stretchr/testify/suite"
-	"github.com/zalando/go-keyring"
 )
 
 type KeyringCredentialsTestSuite struct {
@@ -80,7 +82,7 @@ func (s *KeyringCredentialsTestSuite) TestSet() {
 	s.Equal(cred.AccountID, "0de62804-2b0b-4e11-8a52-a402bda89ff4")
 	s.Equal(cred.AccountName, "cloudy")
 	s.Equal(cred.RefreshToken, "some_refresh_token")
-	s.Equal(cred.AccessToken, "some_access_token")
+	s.Equal(cred.AccessToken, types.CloudAuthToken("some_access_token"))
 }
 
 func (s *KeyringCredentialsTestSuite) TestSetURLCollisionError() {

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -762,7 +762,7 @@ func (s *PublishConnectCloudSuite) publishWithCloudClient(
 
 	// Create mock Cloud client
 	cloudClient := connect_cloud.NewMockClient()
-	cloudClientFactory = func(env types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authorizationHeader string) (connect_cloud.APIClient, error) {
+	cloudClientFactory = func(env types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authToken types.CloudAuthToken) (connect_cloud.APIClient, error) {
 		return cloudClient, nil
 	}
 

--- a/internal/services/api/get_connect_cloud_accounts.go
+++ b/internal/services/api/get_connect_cloud_accounts.go
@@ -14,6 +14,7 @@ import (
 	"github.com/posit-dev/publisher/internal/clients/http_client"
 	"github.com/posit-dev/publisher/internal/cloud"
 	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/types"
 )
 
 type connectCloudAccountsBodyAccount struct {
@@ -36,8 +37,9 @@ func GetConnectCloudAccountsFunc(log logging.Logger) http.HandlerFunc {
 			http.Error(w, "Invalid Authorization header", http.StatusUnauthorized)
 			return
 		}
+		authToken := types.CloudAuthToken(authSplit[1])
 
-		client, err := connectCloudClientFactory(environment, log, 10*time.Second, nil, authSplit[1])
+		client, err := connectCloudClientFactory(environment, log, 10*time.Second, nil, authToken)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error creating client: %v", err), http.StatusInternalServerError)
 			return

--- a/internal/services/api/get_connect_cloud_accounts_test.go
+++ b/internal/services/api/get_connect_cloud_accounts_test.go
@@ -74,7 +74,7 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts() {
 	}
 	client.On("GetAccounts").Return(accountsResponse, nil)
 
-	connectCloudClientFactory = func(environment types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authValue string) (connect_cloud.APIClient, error) {
+	connectCloudClientFactory = func(environment types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authValue types.CloudAuthToken) (connect_cloud.APIClient, error) {
 		return client, nil
 	}
 
@@ -136,8 +136,8 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts_GetCurrentUse
 		http_client.NewHTTPError("https://foo.bar", "GET", http.StatusBadRequest, "uh oh"), nil))
 	// No need to mock GetAccounts since the function returns after GetCurrentUser fails
 
-	connectCloudClientFactory = func(environment types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authValue string) (connect_cloud.APIClient, error) {
-		s.Equal(authValue, "token123")
+	connectCloudClientFactory = func(environment types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authValue types.CloudAuthToken) (connect_cloud.APIClient, error) {
+		s.Equal(authValue, types.CloudAuthToken("token123"))
 		return client, nil
 	}
 
@@ -168,7 +168,7 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts_NoUserForLuci
 	// Mock the GetCurrentUser call to return the no_user_for_lucid_user error
 	client.On("GetCurrentUser").Return((*connect_cloud.UserResponse)(nil), agentErr)
 
-	connectCloudClientFactory = func(environment types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authValue string) (connect_cloud.APIClient, error) {
+	connectCloudClientFactory = func(environment types.CloudEnvironment, log logging.Logger, timeout time.Duration, account *accounts.Account, authValue types.CloudAuthToken) (connect_cloud.APIClient, error) {
 		return client, nil
 	}
 
@@ -209,7 +209,7 @@ func (s *GetConnectCloudAccountsSuite) TestGetConnectCloudAccounts_GetAccountsEr
 		events.ServerErrorCode,
 		http_client.NewHTTPError("https://foo.bar", "GET", http.StatusBadRequest, "uh oh"), nil))
 
-	connectCloudClientFactory = func(_ types.CloudEnvironment, _ logging.Logger, _ time.Duration, _ *accounts.Account, _ string) (connect_cloud.APIClient, error) {
+	connectCloudClientFactory = func(_ types.CloudEnvironment, _ logging.Logger, _ time.Duration, _ *accounts.Account, _ types.CloudAuthToken) (connect_cloud.APIClient, error) {
 		return client, nil
 	}
 

--- a/internal/services/api/post_connect_cloud_oauth_token.go
+++ b/internal/services/api/post_connect_cloud_oauth_token.go
@@ -19,9 +19,9 @@ type connectCloudOAuthTokenRequestBody struct {
 }
 
 type connectCloudOAuthTokenResponseBody struct {
-	AccessToken  string `json:"accessToken"`
-	RefreshToken string `json:"refreshToken"`
-	ExpiresIn    int    `json:"expiresIn"`
+	AccessToken  types.CloudAuthToken `json:"accessToken"`
+	RefreshToken string               `json:"refreshToken"`
+	ExpiresIn    int                  `json:"expiresIn"`
 }
 
 func PostConnectCloudOAuthTokenHandlerFunc(log logging.Logger) http.HandlerFunc {

--- a/internal/services/api/post_credentials.go
+++ b/internal/services/api/post_credentials.go
@@ -27,10 +27,10 @@ type PostCredentialsRequest struct {
 	SnowflakeConnection string `json:"snowflakeConnection"`
 
 	// Connect Cloud fields
-	AccountID    string `json:"accountId"`
-	AccountName  string `json:"accountName"`
-	RefreshToken string `json:"refreshToken"`
-	AccessToken  string `json:"accessToken"`
+	AccountID    string               `json:"accountId"`
+	AccountName  string               `json:"accountName"`
+	RefreshToken string               `json:"refreshToken"`
+	AccessToken  types.CloudAuthToken `json:"accessToken"`
 
 	// Token authentication fields
 	Token      string `json:"token"`

--- a/internal/types/cloud.go
+++ b/internal/types/cloud.go
@@ -9,3 +9,5 @@ const (
 	CloudEnvironmentStaging     CloudEnvironment = "staging"
 	CloudEnvironmentProduction  CloudEnvironment = "production"
 )
+
+type CloudAuthToken string


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent



<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

We ended up sending `Bearer Bearer` in the Authorization header again, I think as a result of a bad merge. This PR fixes that, and also includes a refactor to make types more meaningful.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

bug fix for Connect Cloud paths.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Fixes automated tests to expect the correct data.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

Initiate a deploy using an existing credential - previously this would error with a 401.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
