### PR TITLE
feat: Add theme colors to Publisher logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added endpoints for performing OAuth Device Authorization Grant with Posit Cloud login. (#2692)
 - Added support for one-click token authentication with Connect. (#2769)
 - Added schema and agent support for publishing to Connect Cloud. (#2729, #2747, #2771)
+- Added colors to the logs indicating queued, skipped, passed, and errored log
+  stage statuses. (#2382)
 
 ### Changed
 

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   ExtensionContext,
   ProviderResult,
+  ThemeColor,
   ThemeIcon,
   TreeDataProvider,
   TreeItem,
@@ -460,15 +461,24 @@ export class LogsTreeStageItem extends TreeItem {
     switch (status) {
       case LogStageStatus.notStarted:
         this.label = this.stage.inactiveLabel;
-        this.iconPath = new ThemeIcon("circle-large-outline");
+        this.iconPath = new ThemeIcon(
+          "circle-large-outline",
+          new ThemeColor("testing.iconQueued"),
+        );
         break;
       case LogStageStatus.neverStarted:
         this.label = this.stage.inactiveLabel;
-        this.iconPath = new ThemeIcon("circle-slash");
+        this.iconPath = new ThemeIcon(
+          "circle-slash",
+          new ThemeColor("testing.iconSkipped"),
+        );
         break;
       case LogStageStatus.skipped:
         this.label = `${this.stage.inactiveLabel} (skipped)`;
-        this.iconPath = new ThemeIcon("check");
+        this.iconPath = new ThemeIcon(
+          "check",
+          new ThemeColor("testing.iconSkipped"),
+        );
         break;
       case LogStageStatus.inProgress:
         this.label = this.stage.activeLabel;
@@ -476,21 +486,33 @@ export class LogsTreeStageItem extends TreeItem {
         break;
       case LogStageStatus.completed:
         this.label = this.stage.inactiveLabel;
-        this.iconPath = new ThemeIcon("check");
+        this.iconPath = new ThemeIcon(
+          "check",
+          new ThemeColor("testing.iconPassed"),
+        );
         break;
       case LogStageStatus.failed:
         this.label = this.stage.inactiveLabel;
-        this.iconPath = new ThemeIcon("error");
+        this.iconPath = new ThemeIcon(
+          "error",
+          new ThemeColor("testing.iconErrored"),
+        );
         this.collapsibleState = TreeItemCollapsibleState.Expanded;
         break;
       case LogStageStatus.canceled:
         this.label = this.stage.inactiveLabel;
-        this.iconPath = new ThemeIcon("circle-slash");
+        this.iconPath = new ThemeIcon(
+          "circle-slash",
+          new ThemeColor("testing.iconSkipped"),
+        );
         this.collapsibleState = TreeItemCollapsibleState.Expanded;
         break;
       case LogStageStatus.notApplicable:
         this.label = `${this.stage.inactiveLabel} (not applicable)`;
-        this.iconPath = new ThemeIcon("circle-slash");
+        this.iconPath = new ThemeIcon(
+          "circle-slash",
+          new ThemeColor("testing.iconSkipped"),
+        );
         break;
     }
   }


### PR DESCRIPTION
This PR introduces theme colors for the Log Stage Statuses in the Publisher Logs view.

[VS Code's theme color's for testing](https://code.visualstudio.com/api/references/theme-color#testing-colors) were utilized since there we colors available for each of the statuses we were trying to communicate already - queued, skipped, success, and errored.

<details>
  <summary>Preview</summary>
  
<img width="2100" height="698" alt="CleanShot 2025-08-14 at 15 58 51@2x" src="https://github.com/user-attachments/assets/1e1001c2-3141-4fc8-ae71-d53140ba0b8c" />

</details> 

## Intent

Resolves #2382

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Nice and straightforward approach, passed the `ThemeColor` in the `ThemeIcon` constructor.

## User Impact

Users will see color based on their selected theme in the Publisher logs making it easier to see things like errors.

## Directions for Reviewers

Publish forcing an error to see an error state in the logs. The easiest way to do this is to attempt to publish a project with a code error so it doesn't render.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
