### PR TITLE
feat: add delete button to credentials

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added schema and agent support for publishing to Connect Cloud. (#2729, #2747, #2771)
 - Introduced Posit Connect Cloud support behind a configuration option. This feature is
   still in active development but works end-to-end for publishing to Connect Cloud. (#2810)
+- Added a delete button to credentials. (#2862)
 
 ## [1.18.1]
 

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -25,7 +25,7 @@ export enum WebviewToHostMessageType {
   NEW_DEPLOYMENT = "newDeployment",
   NEW_CREDENTIAL_FOR_DEPLOYMENT = "newCredentialForDeployment",
   NEW_CREDENTIAL = "newCredential",
-	DELETE_CREDENTIAL = "deleteCredential",
+  DELETE_CREDENTIAL = "deleteCredential",
   VIEW_PUBLISHING_LOG = "viewPublishingLog",
   SHOW_ASSOCIATE_GUID = "ShowAssociateGUID",
   UPDATE_SELECTION_CREDENTIAL_STATE = "UpdateSelectionCredentialStateMsg",
@@ -64,7 +64,7 @@ export type WebviewToHostMessage =
   | NewDeploymentMsg
   | NewCredentialForDeploymentMsg
   | NewCredentialMsg
-	| DeleteCredentialMsg
+  | DeleteCredentialMsg
   | ViewPublishingLog
   | ShowAssociateGUIDMsg
   | UpdateSelectionCredentialStateMsg
@@ -94,7 +94,7 @@ export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
     msg.kind === WebviewToHostMessageType.NEW_DEPLOYMENT ||
     msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL_FOR_DEPLOYMENT ||
     msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL ||
-		msg.kind === WebviewToHostMessageType.DELETE_CREDENTIAL ||
+    msg.kind === WebviewToHostMessageType.DELETE_CREDENTIAL ||
     msg.kind === WebviewToHostMessageType.VIEW_PUBLISHING_LOG ||
     msg.kind === WebviewToHostMessageType.SHOW_ASSOCIATE_GUID ||
     msg.kind === WebviewToHostMessageType.UPDATE_SELECTION_CREDENTIAL_STATE ||
@@ -218,7 +218,7 @@ export type DeleteCredentialMsg = AnyWebviewToHostMessage<
   WebviewToHostMessageType.DELETE_CREDENTIAL,
   {
     credentialGUID: string;
-		credentialName: string;
+    credentialName: string;
   }
 >;
 

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -25,6 +25,7 @@ export enum WebviewToHostMessageType {
   NEW_DEPLOYMENT = "newDeployment",
   NEW_CREDENTIAL_FOR_DEPLOYMENT = "newCredentialForDeployment",
   NEW_CREDENTIAL = "newCredential",
+	DELETE_CREDENTIAL = "deleteCredential",
   VIEW_PUBLISHING_LOG = "viewPublishingLog",
   SHOW_ASSOCIATE_GUID = "ShowAssociateGUID",
   UPDATE_SELECTION_CREDENTIAL_STATE = "UpdateSelectionCredentialStateMsg",
@@ -63,6 +64,7 @@ export type WebviewToHostMessage =
   | NewDeploymentMsg
   | NewCredentialForDeploymentMsg
   | NewCredentialMsg
+	| DeleteCredentialMsg
   | ViewPublishingLog
   | ShowAssociateGUIDMsg
   | UpdateSelectionCredentialStateMsg
@@ -92,6 +94,7 @@ export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
     msg.kind === WebviewToHostMessageType.NEW_DEPLOYMENT ||
     msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL_FOR_DEPLOYMENT ||
     msg.kind === WebviewToHostMessageType.NEW_CREDENTIAL ||
+		msg.kind === WebviewToHostMessageType.DELETE_CREDENTIAL ||
     msg.kind === WebviewToHostMessageType.VIEW_PUBLISHING_LOG ||
     msg.kind === WebviewToHostMessageType.SHOW_ASSOCIATE_GUID ||
     msg.kind === WebviewToHostMessageType.UPDATE_SELECTION_CREDENTIAL_STATE ||
@@ -210,6 +213,14 @@ export type NewCredentialForDeploymentMsg =
 
 export type NewCredentialMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.NEW_CREDENTIAL>;
+
+export type DeleteCredentialMsg = AnyWebviewToHostMessage<
+  WebviewToHostMessageType.DELETE_CREDENTIAL,
+  {
+    credentialGUID: string;
+		credentialName: string;
+  }
+>;
 
 export type ViewPublishingLog =
   AnyWebviewToHostMessage<WebviewToHostMessageType.VIEW_PUBLISHING_LOG>;

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -187,6 +187,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         return this.showNewCredentialForDeployment();
       case WebviewToHostMessageType.NEW_CREDENTIAL:
         return this.showNewCredential();
+			case WebviewToHostMessageType.DELETE_CREDENTIAL:
+				return this.deleteCredential(msg.content);
       case WebviewToHostMessageType.VIEW_PUBLISHING_LOG:
         return this.showPublishingLog();
       case WebviewToHostMessageType.SHOW_ASSOCIATE_GUID:

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -187,8 +187,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         return this.showNewCredentialForDeployment();
       case WebviewToHostMessageType.NEW_CREDENTIAL:
         return this.showNewCredential();
-			case WebviewToHostMessageType.DELETE_CREDENTIAL:
-				return this.deleteCredential(msg.content);
+      case WebviewToHostMessageType.DELETE_CREDENTIAL:
+        return this.deleteCredential(msg.content);
       case WebviewToHostMessageType.VIEW_PUBLISHING_LOG:
         return this.showPublishingLog();
       case WebviewToHostMessageType.SHOW_ASSOCIATE_GUID:

--- a/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
@@ -15,19 +15,19 @@
       :description="getDescription(credential)"
       :data-automation="`${credential.name}-list`"
       codicon="posit-publisher-icons-posit-logo"
-			:actions="[
-      	{
-					label: 'Delete Credential',
-					codicon: 'codicon-trash',
-					fn: () => sendMsg({
-						kind: WebviewToHostMessageType.DELETE_CREDENTIAL,
-						content: {
-							credentialGUID: credential.guid,
-							credentialName: credential.name,
-						}
-					}),
-				},
-			]"
+      :actions="[
+        {
+          label: 'Delete Credential',
+          codicon: 'codicon-trash',
+          fn: () => sendMsg({
+            kind: WebviewToHostMessageType.DELETE_CREDENTIAL,
+            content: {
+              credentialGUID: credential.guid,
+              credentialName: credential.name,
+            }
+          }),
+        },
+      ]"
       align-icon-with-twisty
       :data-vscode-context="vscodeContext(credential)"
     />

--- a/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/Credentials.vue
@@ -15,6 +15,19 @@
       :description="getDescription(credential)"
       :data-automation="`${credential.name}-list`"
       codicon="posit-publisher-icons-posit-logo"
+			:actions="[
+      	{
+					label: 'Delete Credential',
+					codicon: 'codicon-trash',
+					fn: () => sendMsg({
+						kind: WebviewToHostMessageType.DELETE_CREDENTIAL,
+						content: {
+							credentialGUID: credential.guid,
+							credentialName: credential.name,
+						}
+					}),
+				},
+			]"
       align-icon-with-twisty
       :data-vscode-context="vscodeContext(credential)"
     />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
Resolves #2862

Adds a delete button for credentials. Currently, a user needs to right-click to access that functionality.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach
Using the `WebviewToHostMessageType`, I added the functionality of `deleteCredential` as an action.

## User Impact
This will allow users to see the delete button on hover instead of right clicking.

<details>
  <summary>Example</summary>

https://github.com/user-attachments/assets/69ee2ff7-e2df-44c2-88a4-3eed3f3edf5a

</details> 

## Automated Tests
An E2E test for the delete credential functionality has been added

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
