### PR TITLE
chore: upgrade github action versions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -3,7 +3,7 @@ description: "Sets up the workflow"
 runs:
   using: "composite"
   steps:
-    - uses: extractions/setup-just@v2
+    - uses: extractions/setup-just@v3
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod

--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -9,10 +9,10 @@ jobs:
         runner: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v3
 
       # Install R with rig for our funcitonal tests to ensure we are compatible with it.
       # We aren't used r-lib/actions here becuase rig, especially on windows, installs in

--- a/.github/workflows/archive.yaml
+++ b/.github/workflows/archive.yaml
@@ -5,11 +5,11 @@ jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: bin
           path: bin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -9,11 +9,11 @@ jobs:
       FUZZBUCKET_CREDENTIALS: ${{ secrets.FUZZBUCKET_CREDENTIALS }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v3
       - run: just bats fuzzbucket-stop

--- a/.github/workflows/contract-deps.yaml
+++ b/.github/workflows/contract-deps.yaml
@@ -9,12 +9,12 @@ jobs:
       FUZZBUCKET_CREDENTIALS: ${{ secrets.FUZZBUCKET_CREDENTIALS }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v3
       - run: echo "${FUZZBUCKET_SSH_KEY}" > test/bats/fuzzbucket-ssh-key && chmod 600 test/bats/fuzzbucket-ssh-key
       - run: just bats fuzzbucket-start

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,13 +39,13 @@ jobs:
         working-directory: test/e2e
         run: npm ci
 
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v3
 
       - name: Build publisher binary
         run: just build
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist

--- a/.github/workflows/home-view-unit-test.yaml
+++ b/.github/workflows/home-view-unit-test.yaml
@@ -7,7 +7,7 @@ jobs:
       run:
         working-directory: extensions/vscode/webviews/homeView
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,8 +4,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v5
+      - uses: extractions/setup-just@v3
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -5,11 +5,11 @@ jobs:
   vscode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: bin
           path: bin

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,12 +25,12 @@ jobs:
           - linux-arm64
           - windows-amd64
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v5
+      - uses: extractions/setup-just@v3
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist
@@ -60,12 +60,12 @@ jobs:
           - linux-arm64
           - windows-amd64
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v5
+      - uses: extractions/setup-just@v3
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,15 +26,15 @@ jobs:
       - archive
       - package
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v2
-      - uses: actions/download-artifact@v4
+      - uses: extractions/setup-just@v3
+      - uses: actions/download-artifact@v5
         with:
           name: archives
           path: archives
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -14,15 +14,15 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: archives
           path: archives
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist

--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -11,7 +11,7 @@ jobs:
         runner: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Upgrades the GitHub actions we use in various workflows.

Specifically:
- [`extractions/setup-just`](https://github.com/extractions/setup-just) now at `v3`
- [`actions/checkout`](https://github.com/actions/checkout) now at `v5`
- [`actions/download-artifact`](https://github.com/actions/download-artifact) now at `v5`
  - Looking at [the release notes](https://github.com/actions/download-artifact/releases/tag/v5.0.0) we did not need to worry about the breaking changes since we already download artifacts by `name`

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

