### PR TITLE
feat: auto expand failing section in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   easily copy system information - extension version, IDE, and platform details
   (#2835)
 - Added a delete button for Credentials in the Credentials View (#2862)
+- Introduced auto expansion for a log item when a deployment fails (#2857)
 
 ### Changed
 

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -243,6 +243,10 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
           stage.status = LogStageStatus.neverStarted;
         } else if (stage.status === LogStageStatus.inProgress) {
           stage.status = failedOrCanceledStatus;
+          if (stage.status === LogStageStatus.failed) {
+            this.publishingStage.collapseState =
+              TreeItemCollapsibleState.Expanded;
+          }
         }
       });
 
@@ -441,10 +445,14 @@ export class LogsTreeStageItem extends TreeItem {
   constructor(stage: LogStage) {
     let collapsibleState = stage.collapseState;
     if (collapsibleState === undefined) {
-      collapsibleState =
-        stage.events.length || stage.stages.length
-          ? TreeItemCollapsibleState.Collapsed
-          : TreeItemCollapsibleState.None;
+      if (stage.status === LogStageStatus.failed) {
+        collapsibleState = TreeItemCollapsibleState.Expanded;
+      } else {
+        collapsibleState =
+          stage.events.length || stage.stages.length
+            ? TreeItemCollapsibleState.Collapsed
+            : TreeItemCollapsibleState.None;
+      }
     }
 
     super(stage.inactiveLabel, collapsibleState);


### PR DESCRIPTION
## Intent
Resolves #2857
Auto expands the failing section which allows a customer to see what exactly is the cause of the deployment failure. 

## Type of Change
- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests
WIP

## Directions for Reviewers
1. Comment out line 5 in the `simple.py` from the `sample-content/fastapi-simple` directory
2. Select `simple.py` as the entrypoint
3. Deploy the app
4. View the logs and check if the failed section automatically expands without clicking the dropdown arrow

## Checklist
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
