### PR TITLE
Fixing the events for Connect Cloud publishing

### DIFF
--- a/extensions/vscode/src/api/types/events.ts
+++ b/extensions/vscode/src/api/types/events.ts
@@ -690,6 +690,9 @@ export function isPublishCreateDeploymentFailure(
 
 export interface PublishDeployContentStart extends EventStreamMessage {
   type: "publish/deployContent/start";
+  data: {
+    localId: string;
+  };
 }
 export type OnPublishDeployContentStartCallback = (
   msg: PublishDeployContentStart,
@@ -702,6 +705,9 @@ export function isPublishDeployContentStart(
 
 export interface PublishDeployContentLog extends EventStreamMessage {
   type: "publish/deployContent/log";
+  data: {
+    localId: string;
+  };
 }
 export type OnPublishDeployContentLogCallback = (
   msg: PublishDeployContentLog,
@@ -714,6 +720,9 @@ export function isPublishDeployContentLog(
 
 export interface PublishDeployContentSuccess extends EventStreamMessage {
   type: "publish/deployContent/success";
+  data: {
+    localId: string;
+  };
 }
 export type OnPublishDeployContentSuccessCallback = (
   msg: PublishDeployContentSuccess,
@@ -741,6 +750,9 @@ export function isPublishDeployContentFailure(
 
 export interface PublishUpdateContentStart extends EventStreamMessage {
   type: "publish/updateContent/start";
+  data: {
+    localId: string;
+  };
 }
 export type OnPublishUpdateContentStartCallback = (
   msg: PublishUpdateContentStart,
@@ -764,6 +776,9 @@ export function isPublishUpdateContentLog(
 
 export interface PublishUpdateContentSuccess extends EventStreamMessage {
   type: "publish/updateContent/success";
+  data: {
+    localId: string;
+  };
 }
 export type OnPublishUpdateContentSuccessCallback = (
   msg: PublishUpdateContentSuccess,

--- a/internal/publish/connect_cloud/publish_to_server.go
+++ b/internal/publish/connect_cloud/publish_to_server.go
@@ -75,6 +75,7 @@ func (c *ServerPublisher) PublishToServer(contentID internal_types.ContentID, bu
 	if err != nil {
 		return err
 	}
+	log.Info("Getting content logs...")
 
 	// refetch the content to get the new revision's log channel
 	content, err := c.client.GetContent(c.content.ID)

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -121,7 +121,7 @@ func PostDeploymentHandlerFunc(
 		w.WriteHeader(http.StatusAccepted)
 		json.NewEncoder(w).Encode(response)
 
-		log := log.WithArgs("local_id", localID)
+		log := log.WithArgs("localId", localID)
 		newState.LocalID = localID
 
 		publisher, err := publisherFactory(newState, rInterpreter, pythonInterpreter, emitter, log)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2853 

The intent of this PR is to make the new events for publishing to Connect Cloud visible in the event progress pop-up in the bottom right corner of the editor as the publishing happens.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The actual root cause of the bug was a legitimate change in the order of events for publishing. What was happening was:
- Event A starts - displays active event label for event A
- Event B starts - displays active event label for event B (hides active label for event A)
- Event B ends - displays inactive event label for event B
- Event A continues to happen sending log events while displaying the inactive event label for event B 
- ...
- Event A ends - event progress box is hidden because this was the last event and the active event label for event A was visible for like 1 millisecond or less at the very beginning

The fix was to expose the `localId` for the `log` events from the agent as it is done for all the `start` events so the progress label for the event that is currently logging will override what is being displayed in the progress event popup. It also looks like this was the intent from the beginning and then there was some conversion of `snake-case` to `camelCase` where this must have been missed because the code was present in the codebase to expose the `local-id` just using the wrong case. 

Since this PR exposes the `localId` for ALL the `log` events, I checked that there were no adverse effects for publishing to Connect and I did not see anything outside of what happens currently without this code change.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

None.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

This branch passes all E2E tests in CI.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

- [ ] Verify that publishing to Connect displays all the expected events in the expected order.
- [ ] Verify that publishing to Connect Cloud displays all the expected events in the expected order.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
