### PR TITLE
feat: Revealing first failing stage in Publisher logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   easily copy system information - extension version, IDE, and platform details
   (#2835)
 - Added a delete button for Credentials in the Credentials View (#2862)
+- When opened, the Publisher logs scroll to and expand the first failed stage
+  if a stage is marked as failed (#2857, #2858)
 
 ### Changed
 

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -429,9 +429,7 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
   /**
    * Reveals the first failing LogsTreeStageItem in the tree view.
    */
-  public async revealFailingState(
-    treeView: TreeView<LogsTreeItem>,
-  ): Promise<void> {
+  public revealFailingState(treeView: TreeView<LogsTreeItem>): void {
     const failureItem = this.findFirstFailureItem();
 
     if (failureItem) {

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -10,6 +10,7 @@ import {
   TreeDataProvider,
   TreeItem,
   TreeItemCollapsibleState,
+  TreeView,
   Uri,
   commands,
   env,
@@ -376,8 +377,9 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
    * @returns The child elements of the parent element.
    */
   getChildren(element?: LogsTreeItem): ProviderResult<Array<LogsTreeItem>> {
+    const root = new LogsTreeStageItem(this.publishingStage);
     if (element === undefined) {
-      return [new LogsTreeStageItem(this.publishingStage)];
+      return [root];
     }
 
     // Map the events array to LogsTreeItem instances and return them as children
@@ -386,16 +388,15 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       let count = 0;
       element.stages.forEach((stage: LogStage) => {
         if (stage.status !== LogStageStatus.notApplicable) {
-          result.push(new LogsTreeStageItem(stage));
+          result.push(new LogsTreeStageItem(stage, root));
         }
       });
       result.push(
         ...element.events.map(
           (e) =>
             new LogsTreeLogItem(
-              e,
+              { msg: e, id: `${element.id}/${count++}`, parent: element },
               TreeItemCollapsibleState.None,
-              `${element.id}/${count++}`,
             ),
         ),
       );
@@ -403,6 +404,43 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     }
 
     return [];
+  }
+
+  getParent(element: LogsTreeItem): ProviderResult<LogsTreeItem> {
+    return element.parent;
+  }
+
+  /**
+   * Returns the first LogsTreeStageItem with `LogStageStatus.failed`
+   * Returns undefined if no LogsTreeStageItems have the `LogStageStatus.failed`
+   */
+  private findFirstFailureItem(): LogsTreeStageItem | undefined {
+    const root = new LogsTreeStageItem(this.publishingStage);
+
+    for (const stage of this.publishingStage.stages) {
+      if (stage.status === LogStageStatus.failed) {
+        return new LogsTreeStageItem(stage, root);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Reveals the first failing LogsTreeStageItem in the tree view.
+   */
+  public async revealFailingState(
+    treeView: TreeView<LogsTreeItem>,
+  ): Promise<void> {
+    const failureItem = this.findFirstFailureItem();
+
+    if (failureItem) {
+      treeView.reveal(failureItem, {
+        select: false,
+        focus: false,
+        expand: 2,
+      });
+    }
   }
 
   /**
@@ -417,9 +455,16 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     this.registerEvents();
 
     // Create a tree view with the specified view name and options
+    const treeView = window.createTreeView(Views.Logs, {
+      treeDataProvider: this,
+    });
+
     this.context.subscriptions.push(
-      window.createTreeView(Views.Logs, {
-        treeDataProvider: this,
+      treeView,
+      treeView.onDidChangeVisibility((e) => {
+        if (e.visible) {
+          this.revealFailingState(treeView);
+        }
       }),
       commands.registerCommand(
         Commands.Logs.Visit,
@@ -437,8 +482,9 @@ export class LogsTreeStageItem extends TreeItem {
   stages: LogStage[] = [];
   events: EventStreamMessage[] = [];
   stage: LogStage;
+  parent?: LogsTreeStageItem;
 
-  constructor(stage: LogStage) {
+  constructor(stage: LogStage, parent?: LogsTreeStageItem) {
     let collapsibleState = stage.collapseState;
     if (collapsibleState === undefined) {
       collapsibleState =
@@ -450,6 +496,7 @@ export class LogsTreeStageItem extends TreeItem {
     super(stage.inactiveLabel, collapsibleState);
     this.id = stage.inactiveLabel;
     this.stage = stage;
+    this.parent = parent;
 
     this.stages = stage.stages;
     this.events = stage.events;
@@ -521,10 +568,15 @@ export class LogsTreeStageItem extends TreeItem {
  * Represents a tree item for displaying logs in the tree view.
  */
 export class LogsTreeLogItem extends TreeItem {
+  parent: LogsTreeStageItem;
+
   constructor(
-    msg: EventStreamMessage,
+    {
+      msg,
+      id,
+      parent,
+    }: { msg: EventStreamMessage; id: string; parent: LogsTreeStageItem },
     state: TreeItemCollapsibleState = TreeItemCollapsibleState.None,
-    id: string,
   ) {
     if (msg.data.message) {
       msg.data.message = msg.data.message.replaceAll("\n", " ");
@@ -532,6 +584,7 @@ export class LogsTreeLogItem extends TreeItem {
     super(displayEventStreamMessage(msg), state);
     this.id = id;
     this.tooltip = JSON.stringify(msg);
+    this.parent = parent;
     if (!isPublishSuccess(msg) && !isPublishFailure(msg)) {
       this.iconPath = new ThemeIcon("debug-stackframe-dot");
     }


### PR DESCRIPTION
This PR introduces a new feature: when the "posit-publisher-logs" panel `TreeView` is revealed the first failing deployment stage (if one exists) will be revealed.

Revealing it:
- scrolls it into view
- expands other `TreeViewItems` if necessary
- expands the `LogsTreeStageItem` itself

## Intent

Resolves #2857 #2858

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach was to use the [TreeView `reveal()` method](https://code.visualstudio.com/api/references/vscode-api#TreeView.reveal) alongside an [`onDidChangeVisibility` listener](https://code.visualstudio.com/api/references/vscode-api#TreeView.onDidChangeVisibility) on the TreeView.

When the TreeView is shown we try to grab the first `LogsTreeStageItem` has the `LogStateStatus.failed` status.

If one exists we `reveal()` it.

To accomplish this the two `TreeItem` types (`LogsTreeItemLogItem` and `LogsTreeStageItem`) needed to track their `parent` `TreeItem`s to implement `TreeDataProvider`'s optional `getParent` method which is necessary for the `reveal()` method to function.

With all of this in place the Publisher Logs reveal the first failing stage.

## User Impact

When opening the Publisher Logs the first stage is shown quickly getting users to the most relevant bit of the logs (a failure) as quickly as possible

## Directions for Reviewers

Deploy a project without an error and check that the logs view behaves normally.

Deploy a project that causes a failure in the logs and open the Publisher logs using any method you'd like. The failing stage should be in view even if the logs are very small.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
