### PR TITLE
feat: Use hostname as initial credential name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if a stage is marked as failed (#2857, #2858)
 - Added a configuration option that, when enabled, will auto open Publisher logs
   on a failed deploy (#2860)
+- Use server hostname as the default credential name for new Connect credentials
+  (#2922)
 
 ### Changed
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -508,14 +508,13 @@ export async function newConnectCredential(
     input: MultiStepInput,
     state: MultiStepState,
   ) {
-    if (typeof state.data.url === "string") {
+    if (!state.data.name && typeof state.data.url === "string") {
       try {
         const url = new URL(state.data.url);
         // Default the name to the hostname of the given URL
         state.data.name = url.hostname;
       } catch {
-        // If URL parsing fails, fall back to empty string
-        state.data.name = "";
+        // If URL parsing fails, leave name unchanged
       }
     }
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -511,7 +511,6 @@ export async function newConnectCredential(
     if (!state.data.name && typeof state.data.url === "string") {
       try {
         const url = new URL(state.data.url);
-        // Default the name to the hostname of the given URL
         state.data.name = url.hostname;
       } catch {
         // If URL parsing fails, leave name unchanged

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -508,6 +508,17 @@ export async function newConnectCredential(
     input: MultiStepInput,
     state: MultiStepState,
   ) {
+    if (typeof state.data.url === "string") {
+      try {
+        const url = new URL(state.data.url);
+        // Default the name to the hostname of the given URL
+        state.data.name = url.hostname;
+      } catch {
+        // If URL parsing fails, fall back to empty string
+        state.data.name = "";
+      }
+    }
+
     state.data.name = await inputCredentialNameStep(
       input,
       state,


### PR DESCRIPTION
When creating a Connect credential we ask the user to input their server URL.

This PR changes that making the default value to the hostname of the URL they gave us in the earlier input step to reduce the amount of user input necessary.

## Intent

Resolves #2922

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Grabbed the `url` from the `MultiStepState` and attempt to URL parse it to grab the `url.hostname`.

If that parsing doesn't work fallback to the current behavior where there isn't a default.

## User Impact

Reduces friction when creating a Connect credential by reducing user input.

## Directions for Reviewers

Create a Connect Credential and see the default value filled in for the name!

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
