### PR TITLE
Tweaking the wording on the cancel deploy info message and some other minor fixes

### DIFF
--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -17,6 +17,7 @@ export enum HostToWebviewMessageType {
   REFRESH_CONTENTRECORD_DATA = "refreshContentRecordData",
   REFRESH_CONFIG_DATA = "refreshConfigData",
   REFRESH_CREDENTIAL_DATA = "refreshCredentialData",
+  PUBLISH_CANCEL = "publishCancel",
   PUBLISH_START = "publishStart",
   PUBLISH_FINISH_SUCCESS = "publishFinishSuccess",
   PUBLISH_FINISH_FAILURE = "publishFinishFailure",
@@ -46,6 +47,7 @@ export type HostToWebviewMessage =
   | RefreshContentRecordDataMsg
   | RefreshConfigDataMsg
   | RefreshCredentialDataMsg
+  | PublishCancelMsg
   | PublishStartMsg
   | PublishFinishSuccessMsg
   | PublishFinishFailureMsg
@@ -66,6 +68,7 @@ export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
     msg.kind === HostToWebviewMessageType.REFRESH_CONTENTRECORD_DATA ||
     msg.kind === HostToWebviewMessageType.REFRESH_CONFIG_DATA ||
     msg.kind === HostToWebviewMessageType.REFRESH_CREDENTIAL_DATA ||
+    msg.kind === HostToWebviewMessageType.PUBLISH_CANCEL ||
     msg.kind === HostToWebviewMessageType.PUBLISH_START ||
     msg.kind === HostToWebviewMessageType.PUBLISH_FINISH_SUCCESS ||
     msg.kind === HostToWebviewMessageType.PUBLISH_FINISH_FAILURE ||
@@ -104,6 +107,8 @@ export type RefreshCredentialDataMsg = AnyHostToWebviewMessage<
     credentials: Credential[];
   }
 >;
+export type PublishCancelMsg =
+  AnyHostToWebviewMessage<HostToWebviewMessageType.PUBLISH_CANCEL>;
 export type PublishStartMsg =
   AnyHostToWebviewMessage<HostToWebviewMessageType.PUBLISH_START>;
 export type PublishFinishSuccessMsg =

--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -12,6 +12,8 @@ import {
 import { EventStream, UnregisterCallback } from "src/events";
 import { getSummaryStringFromError } from "src/utils/errors";
 import { getProductName } from "src/utils/multiStepHelpers";
+import { HostToWebviewMessageType } from "src/types/messages/hostToWebviewMessages";
+import { WebviewConduit } from "src/utils/webviewConduit";
 
 type UpdateActiveContentRecordCB = (
   contentRecord: ContentRecord | PreContentRecord | PreContentRecordWithConfig,
@@ -24,6 +26,8 @@ export function deployProject(
   stream: EventStream,
   updateActiveContentRecordCB: UpdateActiveContentRecordCB,
 ) {
+  const webviewConduit = new WebviewConduit();
+
   window.withProgress(
     {
       location: ProgressLocation.Notification,
@@ -75,7 +79,7 @@ export function deployProject(
               // and other non-defined attributes
               localId: localID,
               canceled: "true",
-              message: `Deployment has been dismissed, but will continue to be processed on the ${productName} Server.`,
+              message: `Deployment has been dismissed, but may continue to be processed on the ${productName} Server.`,
             },
             error: "Deployment has been dismissed.",
           });
@@ -86,6 +90,10 @@ export function deployProject(
             error,
           );
           window.showErrorMessage(`Unable to dismiss deployment: ${summary}`);
+        } finally {
+          webviewConduit.sendMsg({
+            kind: HostToWebviewMessageType.PUBLISH_CANCEL,
+          });
         }
         resolveCB();
       });

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -247,7 +247,7 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
         }
       });
 
-      const showLogsOption = "View Log";
+      const showLogsOption = "View Publishing Log";
       const options = [showLogsOption];
       const enhancedError = findErrorMessageSplitOption(msg.data.message);
       if (enhancedError && enhancedError.buttonStr) {
@@ -421,7 +421,10 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     const root = new LogsTreeStageItem(this.publishingStage);
 
     for (const stage of this.publishingStage.stages) {
-      if (stage.status === LogStageStatus.failed) {
+      if (
+        stage.status === LogStageStatus.failed ||
+        stage.status === LogStageStatus.canceled
+      ) {
         const stageItem = new LogsTreeStageItem(stage, root);
 
         if (stage.events.length) {
@@ -453,9 +456,8 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
 
     if (revealItem) {
       treeView.reveal(revealItem, {
-        select: false,
-        focus: false,
-        expand: 2,
+        select: true,
+        focus: true,
       });
     }
   }

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -66,6 +66,8 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
       return onRefreshConfigDataMsg(msg);
     case HostToWebviewMessageType.REFRESH_CREDENTIAL_DATA:
       return onRefreshCredentialDataMsg(msg);
+    case HostToWebviewMessageType.PUBLISH_CANCEL:
+      return onPublishCancelMsg();
     case HostToWebviewMessageType.PUBLISH_START:
       return onPublishStartMsg();
     case HostToWebviewMessageType.PUBLISH_FINISH_SUCCESS:
@@ -163,6 +165,12 @@ const onRefreshConfigDataMsg = (msg: RefreshConfigDataMsg) => {
 const onRefreshCredentialDataMsg = (msg: RefreshCredentialDataMsg) => {
   const home = useHomeStore();
   home.credentials = msg.content.credentials;
+};
+const onPublishCancelMsg = () => {
+  const home = useHomeStore();
+  home.publishInProgress = false;
+  // TODO: add
+  // home.publishInitiated = false;
 };
 const onPublishStartMsg = () => {
   const home = useHomeStore();

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -166,7 +166,7 @@
           </div>
           <p class="progress-log-anchor">
             <a class="webview-link" role="button" @click="onViewPublishingLog">
-              View Log
+              View Publishing Log
             </a>
           </p>
         </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2873 

The intent of this PR is to tweak the wording on the cancel deploy info message and button labeling so it is more obvious that:
- Clicking the button will just open the publisher logs panel (if it isn't already opened) in your editor.
- The deployment "may" or "may not" continue in the server when cancelled depending on how fast the cancel button was clicked. At least this is the case for Connect Cloud where if you click the button fast enough, the publish won't happen in the server at all.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

The approach to the wording and labeling changes were simple enough. However, while trying out the deployment cancelling I did find a case where the "Deploy Your Project" button stays disabled when the R environment is broken and the users cancels the deployment right away. I added a new message type to handle this scenario: `PUBLISH_CANCEL`, which will clear the decks for the "Deploy Your Project" button to become enabled again as expected upon deployment cancellation.

Separately, I did a minor tweak to the logs panel so it will auto select and focus on the last error line when there is a failure to deploy in the logs panel. I also included this behavior for cancelled deployments, so the last cancelled line will be auto selected and focused on the logs panel.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

- Better messaging and button labeling for the user when cancelling a deployment.
- Targeted log line selecting and focusing on the logs panel for errors and deployment cancellations.
- Re-enablement of the "Deploy Your Project" button after deployment cancellation with a broken R environment.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

E2E tests pass on CI for this branch.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

- Verify there is better messaging and button labeling for the user when cancelling a deployment for both Connect Cloud and Connect deployments.
- Verify there is targeted log line selecting and focusing on the logs panel for errors and deployment cancellations for both Connect Cloud and Connect deployments.
- Verify the "Deploy Your Project" button is correctly re-enabled after deployment cancellation with a broken R environment for both Connect Cloud and Connect deployments.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
