### PR TITLE
Fixing the missing credential message on the homeView

### DIFF
--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -113,7 +113,7 @@
         v-if="home.config.active.isCredentialMissing"
         data-automation="missing-creds"
       >
-        No credential was found for the deployment's server.
+        {{ missingCredentialMessage }}
         <a
           class="webview-link"
           role="button"
@@ -412,6 +412,18 @@ const credentialSubTitle = computed(() => {
     return `Missing Credential for ${home.selectedContentRecord?.serverUrl}`;
   }
   return "Missing Credential";
+});
+
+const missingCredentialMessage = computed(() => {
+  const serverType =
+    home.selectedContentRecord?.serverType || ServerType.CONNECT;
+  const productType = getProductType(serverType);
+  if (isConnectCloudProduct(productType)) {
+    return "No credential was found for the deployment's account.";
+  } else if (isConnectProduct(productType)) {
+    return "No credential was found for the deployment's server.";
+  }
+  return "";
 });
 
 const entrypointSubTitle = computed(() => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2932 

The intent of this PR is to adjust the missing credential message to the product type.
- Connect: "No credential was found for the deployment's server."
- Connect Cloud: "No credential was found for the deployment's account."

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Simple approach, determine the product based on the server type and adjust the message accordingly.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

The user will see a more accurate message for missing credentials of Connect Cloud deployments.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

E2E tests pass on CI for this branch.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

- [ ] Verify the messaging is more appropriate for Connect Cloud deployments missing the credential.
- [ ] Verify the messaging is correct for Connect deployments missing the credential.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
