### PR TITLE
fix: Clear up Config Alternatives field when creating configuration

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -150,6 +150,8 @@ func (c *Config) ForceProductTypeCompliance() {
 	}
 	// unset the field to ensure it doesn't appear in the object undergoing schema validation
 	c.EntrypointObjectRef = ""
+	// unset alternatives so it doesn't interfere with schema validation
+	c.Alternatives = nil
 }
 
 type ProductType string

--- a/internal/config/types_compliance_test.go
+++ b/internal/config/types_compliance_test.go
@@ -94,7 +94,19 @@ func (s *ConfigProductTypeComplianceSuite) TestConnectCloudWithMalformedPythonVe
 // No changes should be made to the configuration.
 func (s *ConfigProductTypeComplianceSuite) TestProductTypeConnect() {
 	cfg := &Config{
-		ProductType: ProductTypeConnect,
+		Alternatives: []Config{
+			{
+				Python: &Python{
+					Version:               "3.9.7",
+					PackageManager:        "pip",
+					PackageFile:           "requirements.txt",
+					RequiresPythonVersion: ">=3.9.0",
+				},
+			},
+		},
+		Entrypoint:          "some-entrypoint.py",
+		EntrypointObjectRef: "some-ref",
+		ProductType:         ProductTypeConnect,
 		Python: &Python{
 			Version:               "3.9.7",
 			PackageManager:        "pip",
@@ -125,6 +137,10 @@ func (s *ConfigProductTypeComplianceSuite) TestProductTypeConnect() {
 	originalJupyter := *cfg.Jupyter
 
 	cfg.ForceProductTypeCompliance()
+
+	// Verify fields taht interfere with schema validation are cleared
+	s.Equal("", cfg.EntrypointObjectRef)
+	s.Nil(cfg.Alternatives)
 
 	// Verify all fields remain unchanged for ProductTypeConnect
 	s.Equal(original.ProductType, cfg.ProductType)


### PR DESCRIPTION
## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Resolves #2937

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Automated Tests

Added coverage on unit tests

## Directions for Reviewers

Deploying a Quarto project should be possible.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
