### PR TITLE
Refreshing the credentials when creating a new deployment failed but creating a new credential succeeded

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -63,7 +63,7 @@ export async function newDeployment(
   viewId: string,
   projectDir = ".",
   entryPointFile?: string,
-): Promise<DeploymentObjects | undefined> {
+): Promise<DeploymentObjects> {
   // ***************************************************************
   // API Calls and results
   // ***************************************************************
@@ -120,6 +120,12 @@ export async function newDeployment(
   const newDeploymentData: NewDeploymentData = {
     entrypoint: {},
   };
+
+  const getDeploymentObjects = (): DeploymentObjects => ({
+    contentRecord: newContentRecord,
+    configuration: newConfig,
+    credential: newOrSelectedCredential,
+  });
 
   const newCredentialForced = (): boolean => {
     return credentials.length === 0;
@@ -665,7 +671,7 @@ export async function newDeployment(
     );
   } catch {
     // errors have already been displayed by the underlying promises..
-    return undefined;
+    return getDeploymentObjects();
   }
   await collectInputs();
 
@@ -691,7 +697,7 @@ export async function newDeployment(
     isMissingCredentialData()
   ) {
     console.log("User has dismissed the New Deployment flow. Exiting.");
-    return undefined;
+    return getDeploymentObjects();
   }
 
   if (!newOrSelectedCredential && newDeploymentData.existingCredentialName) {
@@ -703,14 +709,14 @@ export async function newDeployment(
       window.showErrorMessage(
         `Internal Error: NewDeployment Unable to find credential: ${newDeploymentData.existingCredentialName}`,
       );
-      return undefined;
+      return getDeploymentObjects();
     }
   } else if (!newOrSelectedCredential) {
     // we are not creating a credential but also do not have a required existing value
     window.showErrorMessage(
       "Internal Error: NewDeployment Unexpected type guard failure @2",
     );
-    return undefined;
+    return getDeploymentObjects();
   }
 
   // Create the Config File
@@ -751,7 +757,7 @@ export async function newDeployment(
       error,
     );
     window.showErrorMessage(`Failed to create config file. ${summary}`);
-    return undefined;
+    return getDeploymentObjects();
   }
 
   try {
@@ -794,7 +800,7 @@ export async function newDeployment(
     window.showErrorMessage(
       `Failed to create pre-deployment record. ${summary}`,
     );
-    return undefined;
+    return getDeploymentObjects();
   }
 
   try {
@@ -819,9 +825,5 @@ export async function newDeployment(
     );
   }
 
-  return {
-    contentRecord: newContentRecord,
-    configuration: newConfig,
-    credential: newOrSelectedCredential,
-  };
+  return getDeploymentObjects();
 }

--- a/extensions/vscode/src/types/shared.ts
+++ b/extensions/vscode/src/types/shared.ts
@@ -25,9 +25,9 @@ export type DeploymentSelectorState = DeploymentSelector & {
 export type SelectionState = DeploymentSelectorState | null;
 
 export type DeploymentObjects = {
-  contentRecord: ContentRecord | PreContentRecord;
-  configuration: Configuration;
-  credential: Credential;
+  contentRecord?: ContentRecord | PreContentRecord;
+  configuration?: Configuration;
+  credential?: Credential;
 };
 
 export class RExecutable {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves #2939 

The intent of this PR is to refresh the credential list in the homeView when creating a new deployment failed but creating a new credential succeeded.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

To avoid forcing a credential refresh regardless of having created a new credential or not while creating a new deployment, I have changed the return type of `newDeployment()` to always return an object that may contain undefined properties for all things needed for creating a new deployment. The approach was to declare a new deployment creation successful only when all properties are present, otherwise, check the credential property to trigger a credential refresh only if necessary.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

The user will see newly created credentials while creating a new deployment even if creating that new deployment ends up failing.

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

E2E tests pass on CI for this branch.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

- [ ] Verify newly created credentials are visible in the credentials list while creating a new deployment even if creating that new deployment ends up failing.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
