### PR TITLE
fix: Disable view deployment logs in palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed the "Posit Publisher: View Deployment Logs in Connect" incorrectly being
+  available in the Command Palette (#2899)
+
 ### Added
 
 - Added script to always enable the PCC flag for publisher e2e tests prior to running
 - Added staging.json config for test user details and ability to retrieve from AWS and GH secrets (CI)
 - Added Cypress E2E Test for PCC Oauth and credential adding
 - Added repeat-cypress-headless.sh script for easily repeating e2e tests
-
-### Added
-
 - Added Cypress E2E CI Setup and Test Reliability Improvements (#2721)
 - Added endpoints for performing OAuth Device Authorization Grant with Posit Cloud login. (#2692)
 - Added support for one-click token authentication with Connect. (#2769)

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -320,6 +320,10 @@
           "when": "false"
         },
         {
+          "command": "posit.publisher.logs.visit",
+          "when": "false"
+        },
+        {
           "command": "posit.publisher.homeView.edit.Configuration",
           "when": "false"
         },


### PR DESCRIPTION
This disables the `posit.publisher.logs.visit` command (View Deployment Logs in Connect) in the command palette since it doesn't work without a passed URL.

## Intent

Fixes #2899

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact

Can no longer incorrectly activate the command in the command palette getting an unhelpful error.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
