### PR TITLE
feat: add celebratory message when cred token is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on a failed deploy (#2860)
 - Use server hostname as the default credential name for new Connect credentials
   (#2922)
+- Added a celebratory message when credential token is connected (#2901)
 
 ### Changed
 

--- a/extensions/vscode/src/multiStepInputs/newCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newCredential.ts
@@ -6,6 +6,7 @@ import {
   MultiStepInput,
   MultiStepState,
 } from "./multiStepHelper";
+import { window } from "vscode";
 import { Credential, ServerType, ProductName } from "src/api";
 import { extensionSettings } from "src/extension";
 import { platformList } from "src/multiStepInputs/common";
@@ -167,6 +168,11 @@ export async function newCredential(
     // navigating backwards and then forward in the multi-stepper steps
     throw new AbortError();
   }
+
+  window.showInformationMessage(
+    // To prevent a large refactor for the flow, we added the as Credential declaration
+    `Successfully added ${(credential as Credential).name} 🎉`,
+  );
 
   return credential;
 }


### PR DESCRIPTION
## Intent
Resolves #2901

## Type of Change
- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact
Gives users a small celebratory notification that they successfully connected their credential token.

<details>
<summary>Screencapture</summary>

https://github.com/user-attachments/assets/0eccc954-ad55-4a6e-9dee-c309bd7a4f92

</details>

## Directions for Reviewers
1. Create a new credential and follow the steps.
2. After naming the credential, a toast on the bottom right corner should appear.

## Checklist
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
