### PR TITLE
feat: set default for auto open logs on failure to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a delete button for Credentials in the Credentials View (#2862)
 - When opened, the Publisher logs scroll to and expand the first failed stage
   if a stage is marked as failed (#2857, #2858)
-- Added a configuration option that, when enabled, will auto open Publisher logs
-  on a failed deploy (#2860)
+- Added a configuration option that will auto open Publisher logs on a failed deploy (#2860)
 - Use server hostname as the default credential name for new Connect credentials
   (#2922)
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -69,7 +69,7 @@
           "positPublisher.autoOpenLogsOnFailure": {
             "markdownDescription": "Opens Publisher logs automatically on a failed deploy",
             "type": "boolean",
-            "default": false
+            "default": true
           }
         }
       }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -245,11 +245,11 @@ export const extensionSettings = {
     return value !== undefined ? value : false;
   },
   autoOpenLogsOnFailure(): boolean {
-    // get value from extension configuration - defaults to false
+    // get value from extension configuration - defaults to true
     const configuration = workspace.getConfiguration("positPublisher");
     const value: boolean | undefined = configuration.get<boolean>(
       "autoOpenLogsOnFailure",
     );
-    return value !== undefined ? value : false;
+    return value !== undefined ? value : true;
   },
 };


### PR DESCRIPTION
## Intent
This PR sets the default of the auto opening logs when there is a deployment failure to `true`.

## Type of Change
- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## User Impact
This has been turned on for user testing purposes. Depending on that feedback, we will make changes to the default.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
