### PR TITLE
fix: Set config defaults when missing from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the Python and R Packages views incorrectly stating the default package
+  files were missing even when they were present (#2882, #2884)
+
 ## [1.19.0]
 
 ### Fixed

--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -202,24 +202,24 @@ export function UpdateConfigWithDefaults(
   // Fill in empty definitions with the current defaults
   // but only if the section is defined (which indicates the dependency)
   if (config.configuration.r !== undefined) {
-    if (config.configuration.r.version === "") {
+    if (!config.configuration.r.version) {
       config.configuration.r.version = defaults.r.version;
     }
-    if (config.configuration.r.packageFile === "") {
+    if (!config.configuration.r.packageFile) {
       config.configuration.r.packageFile = defaults.r.packageFile;
     }
-    if (config.configuration.r.packageManager === "") {
+    if (!config.configuration.r.packageManager) {
       config.configuration.r.packageManager = defaults.r.packageManager;
     }
   }
   if (config.configuration.python !== undefined) {
-    if (config.configuration.python.version === "") {
+    if (!config.configuration.python.version) {
       config.configuration.python.version = defaults.python.version;
     }
-    if (config.configuration.python.packageFile === "") {
+    if (!config.configuration.python.packageFile) {
       config.configuration.python.packageFile = defaults.python.packageFile;
     }
-    if (config.configuration.python.packageManager === "") {
+    if (!config.configuration.python.packageManager) {
       config.configuration.python.packageManager =
         defaults.python.packageManager;
     }


### PR DESCRIPTION
This PR fixes the Python Packages and R Packages views from incorrectly stating that the package files were missing by ensuring that the defaults are loaded into the active configuration state in the extension.

They were not loaded in making the `homeView` think that there was no `packageFile` for both Python and R.

<details>
  <summary>Preview</summary>
  
<img width="2366" height="1350" alt="CleanShot 2025-08-29 at 10 59 19@2x" src="https://github.com/user-attachments/assets/4bb32b1a-92d7-4a30-8870-5b9283e12723" />

</details>

Note: If the `package_file` was set in the `[r]` or `[python]` sections this bug didn't occur since we didn't need to load defaults. The configuration API would include that data.

## Intent

Resolves #2882, #2884

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Initially, I saw that the state in the `homeView` pinia store `home` did not have the `packageFile` set. I did this by just showing the state in the view to confirm.

Next, I looked into where `updatePythonPackages` was being called since that is where we set the Python data for the store.

https://github.com/posit-dev/publisher/blob/cf31dae294f5226915b8feb66561f48a47b44e2e/extensions/vscode/webviews/homeView/src/stores/home.ts#L271

The API difference looked fishy - the configuration response differed between `v1.18.1` and `main`. Before #2787 we returned empty strings:

```
...
"python": {
    "packageFile": "",
    "packageManager": "",
    "requiresPython": "",
    "version": ""
},
```

after we didn't. Empty values were omitted

```
...
python: {}
```

But why did it work in `v1.18.1`?

https://github.com/posit-dev/publisher/blob/ec937e2cd6472fb6e43e62b36e7e16a716632a62/extensions/vscode/src/state.ts#L237

When we load in the selected configuration we get the configuration, but we also call the interpreters API endpoint to get defaults and fill them in the configuration so the state reflects what Publisher will do and not just what is in the configuration file.

`UpdateConfigWithDefaults` was expecting those empty strings rather than just checking for `falsey` values.

## User Impact

The views now show packages as expected and do not incorrectly communicate that a package file is missing.

## Directions for Reviewers

Check that `requirements.txt` and `renv.lock` defaults work.

Check that when setting the `package_file` manually the view updates as expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
