### PR TITLE
feat: create CodeCheckbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the Python and R Packages views incorrectly stating the default package
   files were missing even when they were present (#2882, #2884)
+- Fixed an issue where the package file checkbox in the Project Files view
+  would occassionally be unchecked even when the file was included (#2793)
 
 ## [1.19.0]
 

--- a/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
@@ -1,7 +1,12 @@
 <template>
-  <div class="vscode-checkbox">
+  <div class="vscode-checkbox" :class="{ disabled: disabled }">
     <label>
-      <input type="checkbox" />
+      <input
+        :checked="checked"
+        :disabled="disabled"
+        type="checkbox"
+        @change="handleChange"
+      />
       <span class="icon">
         <i class="codicon codicon-check icon-checked"></i>
         <i class="codicon codicon-chrome-minimize icon-indeterminate"></i>
@@ -12,9 +17,16 @@
 </template>
 
 <script setup lang="ts">
-/**
- * disabled
- */
+defineProps<{ checked: boolean; disabled?: boolean }>();
+
+const emit = defineEmits<{
+  changed: [checked: boolean];
+}>();
+
+const handleChange = (event: Event) => {
+  const checked = (event.target as HTMLInputElement).checked;
+  emit("changed", checked);
+};
 </script>
 
 <style lang="scss" scoped>
@@ -23,6 +35,9 @@
   flex: 1;
   position: relative;
   user-select: none;
+
+  &.disabled {
+    opacity: var(--disabled-opacity);
 }
 
 .vscode-checkbox input[type="checkbox"] {

--- a/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
@@ -17,7 +17,11 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ checked: boolean; disabled?: boolean }>();
+defineProps<{
+  checked: boolean;
+  disabled?: boolean;
+  disableOpacity?: boolean;
+}>();
 
 const emit = defineEmits<{
   changed: [checked: boolean];
@@ -36,8 +40,10 @@ const handleChange = (event: Event) => {
   position: relative;
   user-select: none;
 
+  --checkbox-opacity: v-bind('disableOpacity ? 1 : "var(--disabled-opacity)"');
+
   &.disabled {
-    opacity: var(--disabled-opacity);
+    opacity: var(--checkbox-opacity);
   }
 
   input[type="checkbox"] {

--- a/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
@@ -114,6 +114,7 @@ const handleChange = (event: Event) => {
   }
 
   .text {
+    flex-grow: 1;
     opacity: 0.9;
     padding-inline-start: calc(var(--design-unit) * 2px + 2px);
   }

--- a/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="vscode-checkbox">
+    <label>
+      <input type="checkbox" />
+      <span class="icon">
+        <i class="codicon codicon-check icon-checked"></i>
+        <i class="codicon codicon-chrome-minimize icon-indeterminate"></i>
+      </span>
+      <span class="text"><slot /></span>
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * disabled
+ */
+</script>
+
+<style lang="scss" scoped>
+.vscode-checkbox {
+  display: inline-flex;
+  flex: 1;
+  position: relative;
+  user-select: none;
+}
+
+.vscode-checkbox input[type="checkbox"] {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.vscode-checkbox .icon-checked,
+.vscode-checkbox .icon-indeterminate {
+  display: none;
+  height: 16px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 16px;
+}
+
+.vscode-checkbox .icon-checked,
+.vscode-checkbox .icon-indeterminate {
+  display: none;
+}
+
+.vscode-checkbox input[type="checkbox"]:checked ~ .icon .icon-checked {
+  display: block;
+}
+
+.vscode-checkbox
+  input[type="checkbox"]:indeterminate
+  ~ .icon
+  .icon-indeterminate {
+  display: block;
+}
+
+.vscode-checkbox .icon {
+  background-color: var(--vscode-settings-checkboxBackground);
+  background-size: 16px;
+  border: calc(var(--border-width) * 1px) solid var(--checkbox-border);
+  border-radius: calc(var(--checkbox-corner-radius) * 1px);
+  box-sizing: border-box;
+  color: var(--vscode-settings-checkboxForeground);
+  display: flex;
+  justify-content: center;
+  margin-left: 0;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  outline: none;
+  height: calc(var(--design-unit) * 4px + 2px);
+  width: calc(var(--design-unit) * 4px + 2px);
+  flex-shrink: 0;
+}
+
+.vscode-checkbox input[type="checkbox"]:invalid ~ .icon,
+.vscode-checkbox input[type="checkbox"].invalid ~ .icon {
+  background-color: var(--vscode-inputValidation-errorBackground);
+  border-color: var(--vscode-inputValidation-errorBorder, #be1100);
+}
+
+.vscode-checkbox input[type="checkbox"]:focus ~ .icon {
+  border-color: var(--vscode-focusBorder);
+}
+
+.vscode-checkbox label {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  line-height: 18px;
+}
+
+.vscode-checkbox .text {
+  opacity: 0.9;
+  padding-inline-start: calc(var(--design-unit) * 2px + 2px);
+}
+
+.vscode-checkbox-group {
+  display: flex;
+}
+
+.vscode-checkbox-group .vscode-checkbox {
+  display: block;
+}
+
+.vscode-checkbox-group .vscode-checkbox:not(:last-child) {
+  margin-right: 20px;
+}
+
+.vscode-checkbox-group.vertical {
+  flex-direction: column;
+}
+
+.vscode-checkbox-group .vscode-checkbox {
+  margin-right: 0;
+  margin-bottom: 15px;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/CodeCheckbox.vue
@@ -38,103 +38,78 @@ const handleChange = (event: Event) => {
 
   &.disabled {
     opacity: var(--disabled-opacity);
-}
+  }
 
-.vscode-checkbox input[type="checkbox"] {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
+  input[type="checkbox"] {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 
-.vscode-checkbox .icon-checked,
-.vscode-checkbox .icon-indeterminate {
-  display: none;
-  height: 16px;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 16px;
-}
+  .icon {
+    background-color: var(--vscode-settings-checkboxBackground);
+    background-size: 16px;
+    border: calc(var(--border-width) * 1px) solid var(--checkbox-border);
+    border-radius: calc(var(--checkbox-corner-radius) * 1px);
+    box-sizing: border-box;
+    color: var(--vscode-settings-checkboxForeground);
+    display: flex;
+    justify-content: center;
+    margin-left: 0;
+    padding: 0;
+    pointer-events: none;
+    position: relative;
+    outline: none;
+    height: calc(var(--design-unit) * 4px + 2px);
+    width: calc(var(--design-unit) * 4px + 2px);
+    flex-shrink: 0;
+  }
 
-.vscode-checkbox .icon-checked,
-.vscode-checkbox .icon-indeterminate {
-  display: none;
-}
-
-.vscode-checkbox input[type="checkbox"]:checked ~ .icon .icon-checked {
-  display: block;
-}
-
-.vscode-checkbox
-  input[type="checkbox"]:indeterminate
-  ~ .icon
+  .icon-checked,
   .icon-indeterminate {
-  display: block;
-}
+    display: none;
+    height: 16px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 16px;
+  }
 
-.vscode-checkbox .icon {
-  background-color: var(--vscode-settings-checkboxBackground);
-  background-size: 16px;
-  border: calc(var(--border-width) * 1px) solid var(--checkbox-border);
-  border-radius: calc(var(--checkbox-corner-radius) * 1px);
-  box-sizing: border-box;
-  color: var(--vscode-settings-checkboxForeground);
-  display: flex;
-  justify-content: center;
-  margin-left: 0;
-  padding: 0;
-  pointer-events: none;
-  position: relative;
-  outline: none;
-  height: calc(var(--design-unit) * 4px + 2px);
-  width: calc(var(--design-unit) * 4px + 2px);
-  flex-shrink: 0;
-}
+  input[type="checkbox"]:checked ~ .icon .icon-checked {
+    display: block;
+  }
 
-.vscode-checkbox input[type="checkbox"]:invalid ~ .icon,
-.vscode-checkbox input[type="checkbox"].invalid ~ .icon {
-  background-color: var(--vscode-inputValidation-errorBackground);
-  border-color: var(--vscode-inputValidation-errorBorder, #be1100);
-}
+  input[type="checkbox"]:indeterminate ~ .icon .icon-indeterminate {
+    display: block;
+  }
 
-.vscode-checkbox input[type="checkbox"]:focus ~ .icon {
-  border-color: var(--vscode-focusBorder);
-}
+  input[type="checkbox"]:invalid ~ .icon,
+  input[type="checkbox"].invalid ~ .icon {
+    background-color: var(--vscode-inputValidation-errorBackground);
+    border-color: var(--vscode-inputValidation-errorBorder, #be1100);
+  }
 
-.vscode-checkbox label {
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  line-height: 18px;
-}
+  input[type="checkbox"]:focus ~ .icon {
+    border-color: var(--vscode-focusBorder);
+  }
 
-.vscode-checkbox .text {
-  opacity: 0.9;
-  padding-inline-start: calc(var(--design-unit) * 2px + 2px);
-}
+  label {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+  }
 
-.vscode-checkbox-group {
-  display: flex;
-}
+  &.disabled label {
+    cursor: not-allowed;
+  }
 
-.vscode-checkbox-group .vscode-checkbox {
-  display: block;
-}
-
-.vscode-checkbox-group .vscode-checkbox:not(:last-child) {
-  margin-right: 20px;
-}
-
-.vscode-checkbox-group.vertical {
-  flex-direction: column;
-}
-
-.vscode-checkbox-group .vscode-checkbox {
-  margin-right: 0;
-  margin-bottom: 15px;
+  .text {
+    opacity: 0.9;
+    padding-inline-start: calc(var(--design-unit) * 2px + 2px);
+  }
 }
 </style>

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
@@ -31,21 +31,13 @@
           click: isExpandable ? toggleExpanded : undefined,
         }"
       />
-      <vscode-checkbox
-        v-if="title.includes('a')"
+      <CodeCheckbox
         :checked="checked"
         :disabled="disabled"
-        :data-automation="`checkbox-is-checked-${checked}`"
+        :disable-opacity="disableOpacity"
         class="tree-item-checkbox"
-        :class="{ 'opacity-100': disableOpacity }"
-        @click="checked ? $emit('uncheck') : $emit('check')"
+        @changed="checked ? $emit('uncheck') : $emit('check')"
       >
-        <span class="tree-item-title">{{ title }}</span>
-        <span v-if="description" class="tree-item-description">
-          {{ description }}
-        </span>
-      </vscode-checkbox>
-      <CodeCheckbox v-else class="tree-item-checkbox">
         <span class="tree-item-title">{{ title }}</span>
         <span v-if="description" class="tree-item-description">
           {{ description }}

--- a/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
+++ b/extensions/vscode/webviews/homeView/src/components/tree/TreeItemCheckbox.vue
@@ -32,8 +32,10 @@
         }"
       />
       <vscode-checkbox
+        v-if="title.includes('a')"
         :checked="checked"
         :disabled="disabled"
+        :data-automation="`checkbox-is-checked-${checked}`"
         class="tree-item-checkbox"
         :class="{ 'opacity-100': disableOpacity }"
         @click="checked ? $emit('uncheck') : $emit('check')"
@@ -43,6 +45,12 @@
           {{ description }}
         </span>
       </vscode-checkbox>
+      <CodeCheckbox v-else class="tree-item-checkbox">
+        <span class="tree-item-title">{{ title }}</span>
+        <span v-if="description" class="tree-item-description">
+          {{ description }}
+        </span>
+      </CodeCheckbox>
       <div v-if="actions" class="actions">
         <ActionToolbar :title="title" :actions="actions" />
       </div>
@@ -61,6 +69,7 @@
 import { computed } from "vue";
 
 import ActionToolbar, { ActionButton } from "src/components/ActionToolbar.vue";
+import CodeCheckbox from "src/components/CodeCheckbox.vue";
 
 export type TreeItemStyle = "emphasized" | "default" | "deemphasized";
 

--- a/extensions/vscode/webviews/homeView/src/main.ts
+++ b/extensions/vscode/webviews/homeView/src/main.ts
@@ -10,7 +10,6 @@ import {
   vsCodeOption,
   vsCodeProgressRing,
   vsCodeDivider,
-  vsCodeCheckbox,
 } from "@vscode/webview-ui-toolkit";
 
 import App from "src/App.vue";
@@ -28,7 +27,6 @@ provideVSCodeDesignSystem().register(
   vsCodeOption(),
   vsCodeProgressRing(),
   vsCodeDivider(),
-  vsCodeCheckbox(),
 );
 
 const pinia = createPinia();


### PR DESCRIPTION
Replaces the `vscode-checkbox` with a custom `CodeCheckbox` component while maintaining nearly the same styling. 

The only styling difference is using the CSS variable `--vscode-settings-checkboxForeground` which we weren't before. This will make our checkboxes look a little more native.

<details>
  <summary>Side by Side</summary>
  
<img width="1268" height="530" alt="CleanShot 2025-09-02 at 11 33 04@2x" src="https://github.com/user-attachments/assets/52300e0a-9aa3-447a-8fb5-c12659659c12" />

</details> 

<details>
  <summary>Preview</summary>
  
<img width="630" height="488" alt="CleanShot 2025-09-02 at 11 43 54@2x" src="https://github.com/user-attachments/assets/04df6388-6cd4-4940-9829-673e7c7d8205" />

</details> 

With the new component I wasn't able to reproduce #2793.

## Intent

Resolves #2793

Part of #2156

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to use the MIT licensed [VSCode Elements Lite Checkbox](https://vscode-elements.github.io/elements-lite/components/checkbox/configurator/) as a starting point.

There was no reason to include a dependency since this is just a styled component, no JS required (aside from the Vue functionality we want).

Some CSS changes were necessary to make this an exact match to what we had before.

## User Impact

Now checkboxes are much more consistently checked or unchecked depending on the state of the configuration file.

## Directions for Reviewers

Pull this down and try out the new Project Files view. The disabled states, auto-includes, colors, styling, etc should all be the same.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
