### PR TITLE
feat: Add automatic detection of dependencies when no renv.lock file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- R dependencies are automatically detected when a project does not include an
+  `renv.lock` file.
+
 ### Fixed
 
 - Fixed the Python and R Packages views incorrectly stating the default package

--- a/internal/publish/manifest.go
+++ b/internal/publish/manifest.go
@@ -4,6 +4,9 @@ package publish
 
 import (
 	"github.com/posit-dev/publisher/internal/bundles"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/interpreters"
+	"github.com/posit-dev/publisher/internal/logging"
 )
 
 func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
@@ -11,13 +14,45 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 	p.log.Debug("Built manifest from config", "config", p.ConfigName)
 
 	if p.Config.R != nil {
-		rPackages, err := p.getRPackages(false)
+		scanDependencies := false
+
+		// Prefer a configured package file when present; otherwise
+		// use the interpreter's discovery (which falls back to renv.lock).
+		if p.Config.R.PackageFile != "" {
+			lockExists, err := p.Dir.Join(p.Config.R.PackageFile).Exists()
+			scanDependencies = (err != nil) || !lockExists
+			if err != nil {
+				p.log.Debug("Error checking existence of configured R lockfile", "lockfile", p.Config.R.PackageFile, "error", err)
+			}
+		} else {
+			rInterp, err := interpreters.NewRInterpreter(p.Dir, p.r, p.log, nil, nil, nil)
+			if err != nil {
+				// If interpreter initialization fails, default to scanning.
+				// And report an error to user, it's probably not a good thing
+				// if their configured interpreter doesn't work.
+				scanDependencies = true
+				p.log.WithArgs(logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp).
+					Error("Error initializing R interpreter for lockfile detection", "error", err)
+			} else {
+				_, exists, err := rInterp.GetLockFilePath()
+				scanDependencies = (err != nil) || !exists
+			}
+		}
+
+		if scanDependencies {
+			// Displays a log message under the package collection activity
+			// So that the user knows we automatically detected dependencies.
+			log := p.log.WithArgs(logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp)
+			log.Info("No renv.lock found; dependencies will be automatically detected.")
+		}
+
+		rPackages, err := p.getRPackages(scanDependencies)
 		if err != nil {
 			return nil, err
 		}
 		manifest.Packages = rPackages
 	}
-	p.log.Debug("Generated manifest:", manifest)
 
+	p.log.Debug("Generated manifest:", manifest)
 	return manifest, nil
 }

--- a/internal/publish/manifest.go
+++ b/internal/publish/manifest.go
@@ -43,7 +43,7 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 			// Displays a log message under the package collection activity
 			// So that the user knows we automatically detected dependencies.
 			log := p.log.WithArgs(logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp)
-			log.Info("No renv.lock found; dependencies will be automatically detected.")
+			log.Info("No renv.lock found; automatically scanning for dependencies.")
 		}
 
 		rPackages, err := p.getRPackages(scanDependencies)

--- a/internal/publish/manifest_test.go
+++ b/internal/publish/manifest_test.go
@@ -130,6 +130,7 @@ func (s *ManifestSuite) TestCreateManifest_WithLockfile_UsesLockfile() {
 	s.NoError(err)
 	s.NotNil(manifest)
 	s.Equal(expectedPackages, manifest.Packages)
+	packageMapper.AssertNotCalled(s.T(), "ScanDependencies", mock.Anything, mock.Anything)
 }
 
 func (s *ManifestSuite) TestCreateManifest_EmptyPackageFile_WithDetectedLockfile() {

--- a/internal/publish/manifest_test.go
+++ b/internal/publish/manifest_test.go
@@ -5,6 +5,7 @@ package publish
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -40,19 +41,17 @@ func TestManifestSuite(t *testing.T) {
 	suite.Run(t, new(ManifestSuite))
 }
 
-func (s *ManifestSuite) TestCreateManifest() {
+func (s *ManifestSuite) TestCreateManifest_WithoutLockfile_ScansDependencies() {
 	log := logging.New()
 	emitter := events.NewNullEmitter()
 	packageMapper := &mockManifestPackageMapper{}
 
-	// Create a config with R configuration
+	// Intentionally reference renv.lock but do not create it, to assert scanning is triggered.
 	cfg := &config.Config{
-		R: &config.R{},
+		R: &config.R{PackageFile: "renv.lock"},
 	}
 
-	stateStore := &state.State{
-		Config: cfg,
-	}
+	stateStore := &state.State{Config: cfg}
 	helper := publishhelper.NewPublishHelper(stateStore, log)
 
 	publisher := &defaultPublisher{
@@ -62,7 +61,11 @@ func (s *ManifestSuite) TestCreateManifest() {
 		PublishHelper:  helper,
 	}
 
-	// Mock the getRPackages call
+	dir := util.NewAbsolutePath("/mem/manifest-test", afero.NewMemMapFs())
+	_ = dir.MkdirAll(0o777)
+	stateStore.Dir = dir
+
+	// Expect: scanning produces a lockfile and we pass that to GetManifestPackages.
 	expectedPackages := bundles.PackageMap{
 		"testpkg": bundles.Package{
 			Description: dcf.Record{
@@ -71,7 +74,133 @@ func (s *ManifestSuite) TestCreateManifest() {
 			},
 		},
 	}
-	packageMapper.On("GetManifestPackages", mock.Anything, mock.Anything, mock.Anything).Return(expectedPackages, nil)
+	generated := dir.Join("scanned.lock")
+	packageMapper.On("ScanDependencies", []string{dir.String()}, mock.Anything).Return(generated, nil)
+	packageMapper.On("GetManifestPackages", dir, generated, mock.Anything).Return(expectedPackages, nil)
+
+	manifest, err := publisher.createManifest()
+
+	s.NoError(err)
+	s.NotNil(manifest)
+	s.Equal(expectedPackages, manifest.Packages)
+}
+
+func (s *ManifestSuite) TestCreateManifest_WithLockfile_UsesLockfile() {
+	log := logging.New()
+	emitter := events.NewNullEmitter()
+	packageMapper := &mockManifestPackageMapper{}
+
+	// Provide an explicit lockfile to assert scanning is skipped.
+	cfg := &config.Config{
+		R: &config.R{PackageFile: "renv.lock"},
+	}
+
+	stateStore := &state.State{Config: cfg}
+	helper := publishhelper.NewPublishHelper(stateStore, log)
+
+	publisher := &defaultPublisher{
+		log:            log,
+		emitter:        emitter,
+		rPackageMapper: packageMapper,
+		PublishHelper:  helper,
+	}
+
+	dir := util.NewAbsolutePath("/mem/manifest-test-with", afero.NewMemMapFs())
+	_ = dir.MkdirAll(0o777)
+	stateStore.Dir = dir
+
+	lockfile := dir.Join("renv.lock")
+	_ = lockfile.WriteFile([]byte("{}"), 0o644)
+
+	expectedPackages := bundles.PackageMap{
+		"testpkg": bundles.Package{
+			Description: dcf.Record{
+				"Package": "testpkg",
+				"Version": "1.0.0",
+			},
+		},
+	}
+
+	// Expect GetManifestPackages to be called with the explicit lockfile;
+	// ScanDependencies must not be invoked in this case.
+	packageMapper.On("GetManifestPackages", dir, lockfile, mock.Anything).Return(expectedPackages, nil)
+
+	manifest, err := publisher.createManifest()
+
+	s.NoError(err)
+	s.NotNil(manifest)
+	s.Equal(expectedPackages, manifest.Packages)
+}
+
+func (s *ManifestSuite) TestCreateManifest_EmptyPackageFile_WithDetectedLockfile() {
+	log := logging.New()
+	emitter := events.NewNullEmitter()
+	packageMapper := &mockManifestPackageMapper{}
+
+	// packageFile empty: createManifest should detect the lockfile path.
+	cfg := &config.Config{
+		R: &config.R{PackageFile: ""},
+	}
+
+	stateStore := &state.State{Config: cfg}
+	helper := publishhelper.NewPublishHelper(stateStore, log)
+
+	publisher := &defaultPublisher{
+		log:            log,
+		emitter:        emitter,
+		rPackageMapper: packageMapper,
+		PublishHelper:  helper,
+	}
+
+	dir := util.NewAbsolutePath("/mem/manifest-empty-detect", afero.NewMemMapFs())
+	_ = dir.MkdirAll(0o777)
+	stateStore.Dir = dir
+
+	lockfile := dir.Join("renv.lock")
+	_ = lockfile.WriteFile([]byte("{}"), 0o644)
+
+	expectedPackages := bundles.PackageMap{
+		"testpkg": bundles.Package{Description: dcf.Record{"Package": "testpkg", "Version": "1.0.0"}},
+	}
+
+	// Expect: use detected lockfile path; do not scan.
+	packageMapper.On("GetManifestPackages", dir, lockfile, mock.Anything).Return(expectedPackages, nil)
+
+	manifest, err := publisher.createManifest()
+
+	s.NoError(err)
+	s.NotNil(manifest)
+	s.Equal(expectedPackages, manifest.Packages)
+	packageMapper.AssertNotCalled(s.T(), "ScanDependencies", mock.Anything, mock.Anything)
+}
+
+func (s *ManifestSuite) TestCreateManifest_EmptyPackageFile_NoLockfile_ScansDependencies() {
+	log := logging.New()
+	emitter := events.NewNullEmitter()
+	packageMapper := &mockManifestPackageMapper{}
+
+	cfg := &config.Config{R: &config.R{PackageFile: ""}}
+	stateStore := &state.State{Config: cfg}
+	helper := publishhelper.NewPublishHelper(stateStore, log)
+
+	publisher := &defaultPublisher{
+		log:            log,
+		emitter:        emitter,
+		rPackageMapper: packageMapper,
+		PublishHelper:  helper,
+	}
+
+	// No lockfile present: expect scanning.
+	dir := util.NewAbsolutePath("/mem/manifest-empty-scan", afero.NewMemMapFs())
+	_ = dir.MkdirAll(0o777)
+	stateStore.Dir = dir
+
+	expectedPackages := bundles.PackageMap{
+		"testpkg": bundles.Package{Description: dcf.Record{"Package": "testpkg", "Version": "1.0.0"}},
+	}
+	generated := dir.Join("scanned.lock")
+	packageMapper.On("ScanDependencies", []string{dir.String()}, mock.Anything).Return(generated, nil)
+	packageMapper.On("GetManifestPackages", dir, generated, mock.Anything).Return(expectedPackages, nil)
 
 	manifest, err := publisher.createManifest()
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -394,6 +394,9 @@ func (s *PublishConnectSuite) publishWithClient(
 	mockPyIntr.On("GetPythonExecutable").Return(util.NewAbsolutePath("/path/to/python", nil), nil)
 
 	rPackageMapper := &mockPackageMapper{}
+	// Allow optional scanning when lockfile is not detected (createManifest may trigger it).
+	generated := s.cwd.Join("scanned.lock")
+	rPackageMapper.On("ScanDependencies", []string{s.cwd.String()}, mock.Anything).Return(generated, nil).Maybe()
 	if errsMock.rPackageErr != nil {
 		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything).Return(nil, errsMock.rPackageErr)
 	} else {
@@ -879,6 +882,9 @@ func (s *PublishConnectCloudSuite) publishWithCloudClient(
 
 	// Mock R package mapper
 	rPackageMapper := &mockPackageMapper{}
+	// Allow optional scanning when lockfile is not detected (createManifest may trigger it).
+	generated := s.cwd.Join("scanned.lock")
+	rPackageMapper.On("ScanDependencies", []string{s.cwd.String()}, mock.Anything).Return(generated, nil).Maybe()
 	if errsMock.rPackageErr != nil {
 		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything).Return(nil, errsMock.rPackageErr)
 	} else {


### PR DESCRIPTION
## Intent

As part of https://github.com/posit-dev/publisher/issues/2838 this adds the step where the previously implemented dependencies scanning utilities are actually used when the project doesn't provide an renv.lock file.

## Type of Change

- - [x] New Feature <!-- A change which adds additional functionality -->

## Approach

The function generating the manifest will now check if a lockfile exists, if it doesn't it will ask `getRPackages` to scan for dependencies.

## User Impact

Users should no longer need to create an renv to be able to deploy projects.

## Automated Tests

There are 4 tests checking for the various combination of cases, the two case where scanning is triggered are
 - A lockfile was configured but doesn't exist
 - A lockfile was not configured and it doesn't exist

## Checklist

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
