### PR TITLE
feat: Generate project dependencies from renv.lock during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- R manifest package generation now uses only `renv.lock` by default. To use the
+- R manifest package generation now uses only `renv.lock` file by default. To use the
   local `renv` library instead, set `[r].packages_from_library = true` in the
   configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the Python and R Packages views incorrectly stating the default package
   files were missing even when they were present (#2882, #2884)
 
+### Changed
+
+- R manifest package generation now uses only `renv.lock` by default. To use the
+  local `renv` library instead, set `[r].packages_from_library = true` in the
+  configuration.
+
 ## [1.19.0]
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,9 +159,9 @@ _Only valid when `product_type` is `connect`_
 
 Controls how Publisher retrieves dependencies for R projects.
 
-- `false` (default): Read package metadata directly from `renv.lock`. 
+- `false` (default): Read package metadata directly from `renv.lock`.
   This does not require a local `renv` library to be present in your workspace.
-- `true`: Read package metadata from the local `renv` library (legacy behavior). 
+- `true`: Read package metadata from the local `renv` library (legacy behavior).
   This requires an initialized `renv` library matching your lockfile.
 
 #### version

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,17 @@ _Only valid when `product_type` is `connect`_
 
 Package manager that will install the dependencies. Supported values are `renv` and `none`. If package-manager is `none`, dependencies will be assumed to be pre-installed on the server.
 
+#### packages_from_library
+
+_Only valid when `product_type` is `connect`_
+
+Controls how Publisher retrieves dependencies for R projects.
+
+- `false` (default): Read package metadata directly from `renv.lock`. 
+  This does not require a local `renv` library to be present in your workspace.
+- `true`: Read package metadata from the local `renv` library (legacy behavior). 
+  This requires an initialized `renv` library matching your lockfile.
+
 #### version
 
 R version. The server will use the nearest R version to run the content.

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -44,10 +44,14 @@ project needs.
 
 ### R Packages
 
-For R projects, you need an `renv.lock` file that captures the R package dependencies
-for your project. You also need an active `renv` library with those packages installed
-so the extension can gather details about them. See the
-[renv documentation](https://rstudio.github.io/renv/articles/renv.html) for more details.
+If a `renv.lock` file is provided, Publisher reads package information directly
+from the lockfile (no local `renv` library required to publish).
+
+If a lockfile is not provided Publisher will try to detect dependencies
+from the code itself.
+
+In case you want Publisher to read dependencies from the `renv` library,
+set `packages_from_library = true` under `[r]` in your configuration.
 
 ### Ready to Deploy
 
@@ -186,9 +190,11 @@ You can specify an alternate name in the deployment configuration file using the
 
 ![](https://cdn.posit.co/publisher/assets/img/r-packages.png)
 
-If your `renv.lock` file and library are out of sync, run `renv::snapshot()`
-or `renv::restore()` to update the lockfile or library, respectively. Clicking
-the "eye" icon in the R Packages view will run `renv::snapshot()` for you.
+If your `renv.lock` file and library are out of sync, you can still publish by
+default because Publisher uses the lockfile. However, it's good practice to keep
+them in sync: run `renv::snapshot()` (update lockfile from library) or
+`renv::restore()` (update library from lockfile). Clicking the "eye" icon in the
+R Packages view runs `renv::snapshot()` for you.
 
 ### Credentials
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -80,6 +80,7 @@ func (c *Config) ForceProductTypeCompliance() {
 			c.R.PackageManager = ""
 			c.R.PackageFile = ""
 			c.R.RequiresRVersion = ""
+			c.R.PackagesFromLibrary = nil
 		}
 		c.Quarto = nil
 		c.Jupyter = nil
@@ -159,6 +160,10 @@ type R struct {
 	PackageFile      string `toml:"package_file,omitempty" json:"packageFile,omitempty"`
 	PackageManager   string `toml:"package_manager,omitempty" json:"packageManager,omitempty"`
 	RequiresRVersion string `toml:"requires_r,omitempty" json:"requiresR,omitempty"`
+	// When true, generate manifest packages by reading the local renv library
+	// (legacy behavior). When false (default), generate directly from renv.lock
+	// without requiring local R libraries.
+	PackagesFromLibrary *bool `toml:"packages_from_library,omitempty" json:"packagesFromLibrary,omitempty"`
 }
 
 func (r *R) FillDefaults(

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -31,15 +31,15 @@ type Publisher interface {
 }
 
 type defaultPublisher struct {
-    log            logging.Logger
-    emitter        events.Emitter
-    rPackageMapper renv.PackageMapper
-    r              util.Path
-    python         util.Path
-    *publishhelper.PublishHelper
-    serverPublisher ServerPublisher
-    // true when using legacy library-based manifest package generation
-    rPackagesFromLibrary bool
+	log            logging.Logger
+	emitter        events.Emitter
+	rPackageMapper renv.PackageMapper
+	r              util.Path
+	python         util.Path
+	*publishhelper.PublishHelper
+	serverPublisher ServerPublisher
+	// true when using legacy library-based manifest package generation
+	rPackagesFromLibrary bool
 }
 
 type createBundleStartData struct{}
@@ -100,13 +100,13 @@ func NewFromState(
 	rexec, _ := rInterpreter.GetRExecutable()
 	pyexec, _ := pythonInterpreter.GetPythonExecutable()
 
-    // Select R package mapping strategy from config; default to lockfile-based
-    packagesFromLibrary := false
-    if s.Config != nil && s.Config.R != nil && s.Config.R.PackagesFromLibrary != nil {
-        packagesFromLibrary = *s.Config.R.PackagesFromLibrary
-    }
-    lockfileOnly := !packagesFromLibrary
-    packageManager, err := rPackageMapperFactory(s.Dir, rexec.Path, log, lockfileOnly)
+	// Select R package mapping strategy from config; default to lockfile-based
+	packagesFromLibrary := false
+	if s.Config != nil && s.Config.R != nil && s.Config.R.PackagesFromLibrary != nil {
+		packagesFromLibrary = *s.Config.R.PackagesFromLibrary
+	}
+	lockfileOnly := !packagesFromLibrary
+	packageManager, err := rPackageMapperFactory(s.Dir, rexec.Path, log, lockfileOnly)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create R package mapper: %w", err)
 	}
@@ -129,16 +129,16 @@ func NewFromState(
 		return nil, err
 	}
 
-    return &defaultPublisher{
-        log:             log,
-        emitter:         emitter,
-        rPackageMapper:  packageManager,
-        r:               rexec.Path,
-        python:          pyexec.Path,
-        PublishHelper:   helper,
-        serverPublisher: serverPublisher,
-        rPackagesFromLibrary: packagesFromLibrary,
-    }, nil
+	return &defaultPublisher{
+		log:                  log,
+		emitter:              emitter,
+		rPackageMapper:       packageManager,
+		r:                    rexec.Path,
+		python:               pyexec.Path,
+		PublishHelper:        helper,
+		serverPublisher:      serverPublisher,
+		rPackagesFromLibrary: packagesFromLibrary,
+	}, nil
 }
 
 func (p *defaultPublisher) GetDeployedContentID() (types.ContentID, bool) {

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -30,8 +30,8 @@ func (p *defaultPublisher) getRPackages(scanDependencies bool) (bundles.PackageM
 
 	var lockfilePath util.AbsolutePath
 	var lockfileString string
-    if scanDependencies {
-        log.Info("Detect dependencies from project")
+	if scanDependencies {
+		log.Info("Detect dependencies from project")
 		var scanPaths []string
 		if p.Config != nil && len(p.Config.Files) > 0 {
 			scanPaths = make([]string, 0, len(p.Config.Files))
@@ -65,12 +65,12 @@ func (p *defaultPublisher) getRPackages(scanDependencies bool) (bundles.PackageM
 	}
 
 	// Detect mapper type to decide which message to emit
-    if _, isLock := p.rPackageMapper.(*renv.LockfilePackageMapper); isLock {
-        log.Info("Loading packages from renv.lock", "lockfile", lockfilePath.String())
-    } else {
-        log.Info("Loading packages from local R library")
-    }
-    log.Debug("Collecting manifest R packages", "lockfile", lockfilePath)
+	if _, isLock := p.rPackageMapper.(*renv.LockfilePackageMapper); isLock {
+		log.Info("Loading packages from renv.lock", "lockfile", lockfilePath.String())
+	} else {
+		log.Info("Loading packages from local R library")
+	}
+	log.Debug("Collecting manifest R packages", "lockfile", lockfilePath)
 
 	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
 	if err != nil {

--- a/internal/publish/r_package_descriptions_test.go
+++ b/internal/publish/r_package_descriptions_test.go
@@ -3,19 +3,19 @@ package publish
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import (
-    "errors"
-    "testing"
+	"errors"
+	"testing"
 
-    "github.com/posit-dev/publisher/internal/publish/publishhelper"
+	"github.com/posit-dev/publisher/internal/publish/publishhelper"
 
-    "github.com/posit-dev/publisher/internal/bundles"
-    "github.com/posit-dev/publisher/internal/config"
-    "github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
-    "github.com/posit-dev/publisher/internal/events"
-    "github.com/posit-dev/publisher/internal/logging"
-    "github.com/posit-dev/publisher/internal/logging/loggingtest"
-    "github.com/posit-dev/publisher/internal/state"
-    "github.com/posit-dev/publisher/internal/types"
+	"github.com/posit-dev/publisher/internal/bundles"
+	"github.com/posit-dev/publisher/internal/config"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/logging/loggingtest"
+	"github.com/posit-dev/publisher/internal/state"
+	"github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 	"github.com/posit-dev/publisher/internal/util/dcf"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
@@ -54,9 +54,9 @@ func (s *RPackageDescSuite) SetupTest() {
 	s.packageMapper = &mockPackageMapper{}
 	s.log = loggingtest.NewMockLogger()
 
-    s.log.On("WithArgs", logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp).Return(s.log)
-    s.log.On("Info", "Collecting R package descriptions").Return()
-    s.log.On("Debug", "Collecting manifest R packages", "lockfile", mock.Anything).Return()
+	s.log.On("WithArgs", logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp).Return(s.log)
+	s.log.On("Info", "Collecting R package descriptions").Return()
+	s.log.On("Debug", "Collecting manifest R packages", "lockfile", mock.Anything).Return()
 
 	s.dirPath = util.NewAbsolutePath("bundles-rpackages-test-path", afero.NewMemMapFs())
 	s.stateStore.Dir = s.dirPath
@@ -76,10 +76,9 @@ func (s *RPackageDescSuite) SetupTest() {
 }
 
 func (s *RPackageDescSuite) TestGetRPackages() {
-    // Log only called on success
-    s.log.On("Info", "Done collecting R package descriptions").Return()
-    // Using mock mapper -> expects library message
-    s.log.On("Info", "Loading packages from local R library").Return()
+	// Log only called on success
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+	s.log.On("Info", "Loading packages from local R library").Return()
 
 	expectedLockfilePath := s.dirPath.Join("renv.lock")
 
@@ -100,10 +99,9 @@ func (s *RPackageDescSuite) TestGetRPackages() {
 }
 
 func (s *RPackageDescSuite) TestGetRPackages_PackageFilePresent() {
-    // Log only called on success
-    s.log.On("Info", "Done collecting R package descriptions").Return()
-    // Using mock mapper -> expects library message
-    s.log.On("Info", "Loading packages from local R library").Return()
+	// Log only called on success
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+	s.log.On("Info", "Loading packages from local R library").Return()
 
 	expectedLockfilePath := s.dirPath.Join("custom.lock")
 
@@ -136,6 +134,7 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesError() {
 
 	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(bundles.PackageMap{}, expectedPkgsErr)
 
+	s.log.On("Info", "Loading packages from local R library").Return()
 	publisher := s.makePublisher()
 	_, err := publisher.getRPackages(false)
 	s.NotNil(err)
@@ -159,6 +158,7 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesKnownAgentError() {
 
 	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(bundles.PackageMap{}, expectedPkgsAgentErr)
 
+	s.log.On("Info", "Loading packages from local R library").Return()
 	publisher := s.makePublisher()
 	_, err := publisher.getRPackages(false)
 	s.NotNil(err)
@@ -167,10 +167,10 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesKnownAgentError() {
 }
 
 func (s *RPackageDescSuite) TestGetRPackages_ScanDependenciesTrue_UsesScannerLockfile() {
-    // Emitted when scanDependencies=true
-    s.log.On("Info", "Detect dependencies from project").Return()
-    // Using mock mapper -> expects library message
-    s.log.On("Info", "Loading packages from local R library").Return()
+	// Emitted when scanDependencies=true
+	s.log.On("Info", "Detect dependencies from project").Return()
+	s.log.On("Info", "Loading packages from local R library").Return()
+	s.log.On("Info", "Done collecting R package descriptions").Return()
 
 	// Configure a specific package file, so we can check that it is not used.
 	s.stateStore.Config = &config.Config{
@@ -193,10 +193,10 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanDependenciesTrue_UsesScannerLoc
 }
 
 func (s *RPackageDescSuite) TestGetRPackages_ScanDependencies_UsesOnlyConfigFiles() {
-    // Emitted when scanDependencies=true
-    s.log.On("Info", "Detect dependencies from project").Return()
-    // Using mock mapper -> expects library message
-    s.log.On("Info", "Loading packages from local R library").Return()
+	// Emitted when scanDependencies=true
+	s.log.On("Info", "Detect dependencies from project").Return()
+	s.log.On("Info", "Loading packages from local R library").Return()
+	s.log.On("Info", "Done collecting R package descriptions").Return()
 
 	// Configure specific files; ensure publisher only passes these
 	s.stateStore.Config = &config.Config{
@@ -235,14 +235,13 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanDependencies_UsesOnlyConfigFile
 // library-loading log message. This test relies on the mock mapper type,
 // which exercises the library branch in getRPackages.
 func (s *RPackageDescSuite) TestGetRPackages_LogsLibraryWhenPackagesFromLibraryTrue() {
-    // Log only called on success
-    s.log.On("Info", "Done collecting R package descriptions").Return()
-    // Using mock mapper -> expects library message
-    s.log.On("Info", "Loading packages from local R library").Return()
+	// Log only called on success
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+	s.log.On("Info", "Loading packages from local R library").Return()
 
-    // Set packages_from_library=true in config (2 lines, no helper)
-    t := true
-    s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: &t}}
+	// Set packages_from_library=true in config (2 lines, no helper)
+	t := true
+	s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: &t}}
 
 	expectedLockfilePath := s.dirPath.Join("renv.lock")
 	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(s.successPackageMap, nil)
@@ -256,12 +255,15 @@ func (s *RPackageDescSuite) TestGetRPackages_LogsLibraryWhenPackagesFromLibraryT
 
 // Lockfile branch: PackagesFromLibrary=false should log lockfile message when using the lockfile mapper.
 func (s *RPackageDescSuite) TestGetRPackages_LogsLockfileWhenPackagesFromLibraryFalse() {
-    s.log.On("Info", "Done collecting R package descriptions").Return()
-    s.log.On("Info", "Loading packages from renv.lock", "lockfile", mock.Anything).Return()
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+	s.log.On("Info", "Loading packages from renv.lock", "lockfile", mock.Anything).Return()
+	s.log.On("Debug", "Reading lockfile for package manifest generation", "lockfile", mock.Anything).Return()
+	s.log.On("Debug", "Processing packages from lockfile", "package_count", mock.Anything).Return()
+	s.log.On("Debug", "Successfully generated manifest packages from lockfile", "manifest_package_count", mock.Anything).Return()
 
-    // Create a minimal renv.lock in the project dir
-    lockfile := s.dirPath.Join("renv.lock")
-    _ = lockfile.WriteFile([]byte(`{
+	// Create a minimal renv.lock in the project dir
+	lockfile := s.dirPath.Join("renv.lock")
+	_ = lockfile.WriteFile([]byte(`{
   "R": {
     "Version": "4.3.0",
     "Repositories": [{"Name":"CRAN","URL":"https://cran.rstudio.com"}]
@@ -271,33 +273,36 @@ func (s *RPackageDescSuite) TestGetRPackages_LogsLockfileWhenPackagesFromLibrary
   }
 }`), 0644)
 
-    f := false
-    s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: &f}}
+	f := false
+	s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: &f}}
 
-    // Swap in a real lockfile mapper to exercise the lockfile branch
-    helper := publishhelper.NewPublishHelper(s.stateStore, s.log)
-    publisher := &defaultPublisher{
-        log:            s.log,
-        emitter:        s.emitter,
-        rPackageMapper: renv.NewLockfilePackageMapper(s.dirPath, util.NewPath("R", s.dirPath.Fs()), s.log),
-        PublishHelper:  helper,
-    }
+	// Swap in a real lockfile mapper to exercise the lockfile branch
+	helper := publishhelper.NewPublishHelper(s.stateStore, s.log)
+	publisher := &defaultPublisher{
+		log:            s.log,
+		emitter:        s.emitter,
+		rPackageMapper: renv.NewLockfilePackageMapper(s.dirPath, util.NewPath("R", s.dirPath.Fs()), s.log),
+		PublishHelper:  helper,
+	}
 
-    packageMap, err := publisher.getRPackages(false)
-    s.NoError(err)
-    s.NotNil(packageMap)
-    s.Contains(packageMap, "R6")
-    s.log.AssertExpectations(s.T())
+	packageMap, err := publisher.getRPackages(false)
+	s.NoError(err)
+	s.NotNil(packageMap)
+	s.Contains(packageMap, "R6")
+	s.log.AssertExpectations(s.T())
 }
 
 // Lockfile branch default: PackagesFromLibrary=nil should behave like false and log lockfile message.
 func (s *RPackageDescSuite) TestGetRPackages_LogsLockfileWhenPackagesFromLibraryNil() {
-    s.log.On("Info", "Done collecting R package descriptions").Return()
-    s.log.On("Info", "Loading packages from renv.lock", "lockfile", mock.Anything).Return()
+	s.log.On("Info", "Done collecting R package descriptions").Return()
+	s.log.On("Info", "Loading packages from renv.lock", "lockfile", mock.Anything).Return()
+	s.log.On("Debug", "Reading lockfile for package manifest generation", "lockfile", mock.Anything).Return()
+	s.log.On("Debug", "Processing packages from lockfile", "package_count", mock.Anything).Return()
+	s.log.On("Debug", "Successfully generated manifest packages from lockfile", "manifest_package_count", mock.Anything).Return()
 
-    // Ensure a minimal renv.lock exists
-    lockfile := s.dirPath.Join("renv.lock")
-    _ = lockfile.WriteFile([]byte(`{
+	// Ensure a minimal renv.lock exists
+	lockfile := s.dirPath.Join("renv.lock")
+	_ = lockfile.WriteFile([]byte(`{
   "R": {
     "Version": "4.3.0",
     "Repositories": [{"Name":"CRAN","URL":"https://cran.rstudio.com"}]
@@ -307,19 +312,19 @@ func (s *RPackageDescSuite) TestGetRPackages_LogsLockfileWhenPackagesFromLibrary
   }
 }`), 0644)
 
-    s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: nil}}
+	s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: nil}}
 
-    helper := publishhelper.NewPublishHelper(s.stateStore, s.log)
-    publisher := &defaultPublisher{
-        log:            s.log,
-        emitter:        s.emitter,
-        rPackageMapper: renv.NewLockfilePackageMapper(s.dirPath, util.NewPath("R", s.dirPath.Fs()), s.log),
-        PublishHelper:  helper,
-    }
+	helper := publishhelper.NewPublishHelper(s.stateStore, s.log)
+	publisher := &defaultPublisher{
+		log:            s.log,
+		emitter:        s.emitter,
+		rPackageMapper: renv.NewLockfilePackageMapper(s.dirPath, util.NewPath("R", s.dirPath.Fs()), s.log),
+		PublishHelper:  helper,
+	}
 
-    packageMap, err := publisher.getRPackages(false)
-    s.NoError(err)
-    s.NotNil(packageMap)
-    s.Contains(packageMap, "R6")
-    s.log.AssertExpectations(s.T())
+	packageMap, err := publisher.getRPackages(false)
+	s.NoError(err)
+	s.NotNil(packageMap)
+	s.Contains(packageMap, "R6")
+	s.log.AssertExpectations(s.T())
 }

--- a/internal/publish/r_package_descriptions_test.go
+++ b/internal/publish/r_package_descriptions_test.go
@@ -3,18 +3,19 @@ package publish
 // Copyright (C) 2024 by Posit Software, PBC.
 
 import (
-	"errors"
-	"testing"
+    "errors"
+    "testing"
 
-	"github.com/posit-dev/publisher/internal/publish/publishhelper"
+    "github.com/posit-dev/publisher/internal/publish/publishhelper"
 
-	"github.com/posit-dev/publisher/internal/bundles"
-	"github.com/posit-dev/publisher/internal/config"
-	"github.com/posit-dev/publisher/internal/events"
-	"github.com/posit-dev/publisher/internal/logging"
-	"github.com/posit-dev/publisher/internal/logging/loggingtest"
-	"github.com/posit-dev/publisher/internal/state"
-	"github.com/posit-dev/publisher/internal/types"
+    "github.com/posit-dev/publisher/internal/bundles"
+    "github.com/posit-dev/publisher/internal/config"
+    "github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+    "github.com/posit-dev/publisher/internal/events"
+    "github.com/posit-dev/publisher/internal/logging"
+    "github.com/posit-dev/publisher/internal/logging/loggingtest"
+    "github.com/posit-dev/publisher/internal/state"
+    "github.com/posit-dev/publisher/internal/types"
 	"github.com/posit-dev/publisher/internal/util"
 	"github.com/posit-dev/publisher/internal/util/dcf"
 	"github.com/posit-dev/publisher/internal/util/utiltest"
@@ -53,9 +54,9 @@ func (s *RPackageDescSuite) SetupTest() {
 	s.packageMapper = &mockPackageMapper{}
 	s.log = loggingtest.NewMockLogger()
 
-	s.log.On("WithArgs", logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp).Return(s.log)
-	s.log.On("Info", "Collecting R package descriptions").Return()
-	s.log.On("Debug", "Collecting manifest R packages", "lockfile", mock.Anything).Return()
+    s.log.On("WithArgs", logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp).Return(s.log)
+    s.log.On("Info", "Collecting R package descriptions").Return()
+    s.log.On("Debug", "Collecting manifest R packages", "lockfile", mock.Anything).Return()
 
 	s.dirPath = util.NewAbsolutePath("bundles-rpackages-test-path", afero.NewMemMapFs())
 	s.stateStore.Dir = s.dirPath
@@ -75,8 +76,10 @@ func (s *RPackageDescSuite) SetupTest() {
 }
 
 func (s *RPackageDescSuite) TestGetRPackages() {
-	// Log only called on success
-	s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Log only called on success
+    s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Using mock mapper -> expects library message
+    s.log.On("Info", "Loading packages from local R library").Return()
 
 	expectedLockfilePath := s.dirPath.Join("renv.lock")
 
@@ -97,8 +100,10 @@ func (s *RPackageDescSuite) TestGetRPackages() {
 }
 
 func (s *RPackageDescSuite) TestGetRPackages_PackageFilePresent() {
-	// Log only called on success
-	s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Log only called on success
+    s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Using mock mapper -> expects library message
+    s.log.On("Info", "Loading packages from local R library").Return()
 
 	expectedLockfilePath := s.dirPath.Join("custom.lock")
 
@@ -162,8 +167,10 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanPackagesKnownAgentError() {
 }
 
 func (s *RPackageDescSuite) TestGetRPackages_ScanDependenciesTrue_UsesScannerLockfile() {
-	// Log only called on success
-	s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Emitted when scanDependencies=true
+    s.log.On("Info", "Detect dependencies from project").Return()
+    // Using mock mapper -> expects library message
+    s.log.On("Info", "Loading packages from local R library").Return()
 
 	// Configure a specific package file, so we can check that it is not used.
 	s.stateStore.Config = &config.Config{
@@ -186,8 +193,10 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanDependenciesTrue_UsesScannerLoc
 }
 
 func (s *RPackageDescSuite) TestGetRPackages_ScanDependencies_UsesOnlyConfigFiles() {
-	// Log only called on success
-	s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Emitted when scanDependencies=true
+    s.log.On("Info", "Detect dependencies from project").Return()
+    // Using mock mapper -> expects library message
+    s.log.On("Info", "Loading packages from local R library").Return()
 
 	// Configure specific files; ensure publisher only passes these
 	s.stateStore.Config = &config.Config{
@@ -220,4 +229,97 @@ func (s *RPackageDescSuite) TestGetRPackages_ScanDependencies_UsesOnlyConfigFile
 	s.NoError(err)
 	s.Equal(s.successPackageMap, packageMap)
 	s.log.AssertExpectations(s.T())
+}
+
+// Verifies that when packages_from_library=true, getRPackages emits the
+// library-loading log message. This test relies on the mock mapper type,
+// which exercises the library branch in getRPackages.
+func (s *RPackageDescSuite) TestGetRPackages_LogsLibraryWhenPackagesFromLibraryTrue() {
+    // Log only called on success
+    s.log.On("Info", "Done collecting R package descriptions").Return()
+    // Using mock mapper -> expects library message
+    s.log.On("Info", "Loading packages from local R library").Return()
+
+    // Set packages_from_library=true in config (2 lines, no helper)
+    t := true
+    s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: &t}}
+
+	expectedLockfilePath := s.dirPath.Join("renv.lock")
+	s.packageMapper.On("GetManifestPackages", s.dirPath, expectedLockfilePath).Return(s.successPackageMap, nil)
+
+	publisher := s.makePublisher()
+	packageMap, err := publisher.getRPackages(false)
+	s.NoError(err)
+	s.Equal(s.successPackageMap, packageMap)
+	s.log.AssertExpectations(s.T())
+}
+
+// Lockfile branch: PackagesFromLibrary=false should log lockfile message when using the lockfile mapper.
+func (s *RPackageDescSuite) TestGetRPackages_LogsLockfileWhenPackagesFromLibraryFalse() {
+    s.log.On("Info", "Done collecting R package descriptions").Return()
+    s.log.On("Info", "Loading packages from renv.lock", "lockfile", mock.Anything).Return()
+
+    // Create a minimal renv.lock in the project dir
+    lockfile := s.dirPath.Join("renv.lock")
+    _ = lockfile.WriteFile([]byte(`{
+  "R": {
+    "Version": "4.3.0",
+    "Repositories": [{"Name":"CRAN","URL":"https://cran.rstudio.com"}]
+  },
+  "Packages": {
+    "R6": {"Package":"R6","Version":"2.5.1","Source":"Repository","Repository":"CRAN","Hash":"abc"}
+  }
+}`), 0644)
+
+    f := false
+    s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: &f}}
+
+    // Swap in a real lockfile mapper to exercise the lockfile branch
+    helper := publishhelper.NewPublishHelper(s.stateStore, s.log)
+    publisher := &defaultPublisher{
+        log:            s.log,
+        emitter:        s.emitter,
+        rPackageMapper: renv.NewLockfilePackageMapper(s.dirPath, util.NewPath("R", s.dirPath.Fs()), s.log),
+        PublishHelper:  helper,
+    }
+
+    packageMap, err := publisher.getRPackages(false)
+    s.NoError(err)
+    s.NotNil(packageMap)
+    s.Contains(packageMap, "R6")
+    s.log.AssertExpectations(s.T())
+}
+
+// Lockfile branch default: PackagesFromLibrary=nil should behave like false and log lockfile message.
+func (s *RPackageDescSuite) TestGetRPackages_LogsLockfileWhenPackagesFromLibraryNil() {
+    s.log.On("Info", "Done collecting R package descriptions").Return()
+    s.log.On("Info", "Loading packages from renv.lock", "lockfile", mock.Anything).Return()
+
+    // Ensure a minimal renv.lock exists
+    lockfile := s.dirPath.Join("renv.lock")
+    _ = lockfile.WriteFile([]byte(`{
+  "R": {
+    "Version": "4.3.0",
+    "Repositories": [{"Name":"CRAN","URL":"https://cran.rstudio.com"}]
+  },
+  "Packages": {
+    "R6": {"Package":"R6","Version":"2.5.1","Source":"Repository","Repository":"CRAN","Hash":"abc"}
+  }
+}`), 0644)
+
+    s.stateStore.Config = &config.Config{R: &config.R{PackagesFromLibrary: nil}}
+
+    helper := publishhelper.NewPublishHelper(s.stateStore, s.log)
+    publisher := &defaultPublisher{
+        log:            s.log,
+        emitter:        s.emitter,
+        rPackageMapper: renv.NewLockfilePackageMapper(s.dirPath, util.NewPath("R", s.dirPath.Fs()), s.log),
+        PublishHelper:  helper,
+    }
+
+    packageMap, err := publisher.getRPackages(false)
+    s.NoError(err)
+    s.NotNil(packageMap)
+    s.Contains(packageMap, "R6")
+    s.log.AssertExpectations(s.T())
 }

--- a/internal/schema/schemas/draft/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/draft/posit-publishing-schema-v3.json
@@ -61,6 +61,11 @@
               "default": "",
               "description": "R interpreter version, required to run the content. If not specified it will be detected from the one in use.",
               "examples": [">3.8", "<4.3", ">=3.5.0"]
+            },
+            "packages_from_library": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, generate manifest packages from the local renv library (legacy behavior). When false (default), read packages from renv.lock."
             }
           }
         },

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -61,6 +61,11 @@
               "default": "",
               "description": "R interpreter version, required to run the content. If not specified it will be detected from the one in use.",
               "examples": [">3.8", "<4.3", ">=3.5.0"]
+            },
+            "packages_from_library": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, generate manifest packages from the local renv library (legacy behavior). When false (default), read packages from renv.lock."
             }
           }
         },


### PR DESCRIPTION
## Intent

This turns on the support for generating project dependencies directly from the `renv.lock` file without the need for an existing library. This is a step in https://github.com/posit-dev/publisher/issues/2838 to improve user experience when deploying R projects that leverages previously built blocks.

## Type of Change

- - [x] Breaking Change <!-- A breaking change which causes existing functionality to change -->

## Approach

Support for generating manifest packages from `renv.lock` was already implemented in https://github.com/posit-dev/publisher/issues/2773 this PR enables that by default and provides an option to switch it back.

Log messages were added to the deploy process to inform the user of how the packages were detected.

## User Impact

Projects providing a `renv.lock` will no longer need the local library to be in sync with the lockfile.

## Automated Tests

Tests to verify packages retrieval with both old and new behaviour are in place.

## Checklist

- [x] I have updated Documentation to cover the new option
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
