### PR TITLE
feat: Re-arrange inputConfigAlternatives deployment step so the chosen inspection result check is not hardcoded

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -151,8 +151,8 @@ export async function newDeployment(
   ): ConfigurationInspectionResult => {
     // At the moment the only alternative we handle is the rendered version alternative
     return {
-      projectDir: insRes!.projectDir,
-      configuration: insRes!.configuration!.alternatives![0],
+      projectDir: insRes.projectDir,
+      configuration: insRes.configuration!.alternatives![0],
     };
   };
 
@@ -601,21 +601,24 @@ export async function newDeployment(
   ) {
     stepHistoryFlush(step.INPUT_CONFIG_ALTERNATIVES);
 
+    if (!newDeploymentData.entrypoint.inspectionResult) {
+      return;
+    }
+
     // At the moment the only configuration alternatives we handle
     // are related to publishing the source code or the rendered version alternative
+    const inspectionResult = newDeploymentData.entrypoint.inspectionResult;
     const inspectionOptions: QuickPickItemWithInspectionResult[] = [
       {
         iconPath: new ThemeIcon("file-code"),
         label: "Publish document with source code",
         description: "Connect will render it for you",
-        inspectionResult: newDeploymentData.entrypoint.inspectionResult,
+        inspectionResult: inspectionResult,
       },
       {
         iconPath: new ThemeIcon("preview"),
         label: "Publish rendered document only",
-        inspectionResult: inspectionResultAlternative(
-          newDeploymentData.entrypoint.inspectionResult!,
-        ),
+        inspectionResult: inspectionResultAlternative(inspectionResult),
       },
     ];
 
@@ -635,7 +638,7 @@ export async function newDeployment(
     }
 
     // If wants to push rendered code, update the inspectionResult to use that config
-    if (pick.inspectionResult!.configuration.type === ContentType.HTML) {
+    if (pick.inspectionResult?.configuration.type === ContentType.HTML) {
       useAlternativeConfig();
     }
 


### PR DESCRIPTION
## Intent

Re-arrange `inputConfigAlternatives` deployment step so the chosen inspection result check is not hardcoded

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Check the `inspectResult` configuration type and do not rely on label strings.

## Directions for Reviewers

Choosing to publish the rendered version of a Quarto doc should still work.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
