### PR TITLE
fix: Bring back changes in wording to include PCC

### DIFF
--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -612,7 +612,7 @@ export async function newDeployment(
       {
         iconPath: new ThemeIcon("file-code"),
         label: "Publish document with source code",
-        description: "Connect will render it for you",
+        description: "The server will render it for you",
         inspectionResult: inspectionResult,
       },
       {


### PR DESCRIPTION
## Intent

Changes in https://github.com/posit-dev/publisher/pull/2976 ignored the latest changes on Quarto static publishing label to include PCC.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
