### PR TITLE
feat: Include source field on static content configurations generated by Quarto projects

### DIFF
--- a/extensions/vscode/src/api/types/configurations.ts
+++ b/extensions/vscode/src/api/types/configurations.ts
@@ -115,6 +115,7 @@ export type ConfigurationDetails = {
   productType: ProductType;
   type: ContentType;
   entrypoint?: string;
+  source?: string;
   title?: string;
   description?: string;
   thumbnail?: string;

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -21,6 +21,7 @@ type Config struct {
 	Type                ContentType   `toml:"type" json:"type,omitempty"`
 	Entrypoint          string        `toml:"entrypoint" json:"entrypoint,omitempty"`
 	EntrypointObjectRef string        `toml:"-" json:"entrypointObjectRef,omitempty"`
+	Source              string        `toml:"source" json:"source,omitempty"`
 	Validate            *bool         `toml:"validate" json:"validate,omitempty"`
 	HasParameters       *bool         `toml:"has_parameters,omitempty" json:"hasParameters,omitempty"`
 	Files               []string      `toml:"files,multiline" json:"files"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -21,7 +21,7 @@ type Config struct {
 	Type                ContentType   `toml:"type" json:"type,omitempty"`
 	Entrypoint          string        `toml:"entrypoint" json:"entrypoint,omitempty"`
 	EntrypointObjectRef string        `toml:"-" json:"entrypointObjectRef,omitempty"`
-	Source              string        `toml:"source" json:"source,omitempty"`
+	Source              string        `toml:"source,omitempty" json:"source,omitempty"`
 	Validate            *bool         `toml:"validate" json:"validate,omitempty"`
 	HasParameters       *bool         `toml:"has_parameters,omitempty" json:"hasParameters,omitempty"`
 	Files               []string      `toml:"files,multiline" json:"files"`

--- a/internal/inspect/detectors/quarto.go
+++ b/internal/inspect/detectors/quarto.go
@@ -292,6 +292,7 @@ func (d *QuartoDetector) staticConfigFromOutputDir(base util.AbsolutePath, cfg *
 	staticCfg := config.New()
 	staticCfg.Type = contenttypes.ContentTypeHTML
 	staticCfg.Title = cfg.Title
+	staticCfg.Source = d.renderSource(cfg)
 
 	// Prep the rendered version of the entrypoint path.
 	outputDirRel := util.NewRelativePath(outputDir, nil)
@@ -338,6 +339,7 @@ func (d *QuartoDetector) staticConfigFromFilesLookup(base util.AbsolutePath, cfg
 	staticCfg := config.New()
 	staticCfg.Type = contenttypes.ContentTypeHTML
 	staticCfg.Title = cfg.Title
+	staticCfg.Source = d.renderSource(cfg)
 
 	htmlInputFiles := inspectOutput.HTMLAbsPathsFromInputList(base)
 	for _, file := range htmlInputFiles {
@@ -371,6 +373,13 @@ func (d *QuartoDetector) staticConfigFromFilesLookup(base util.AbsolutePath, cfg
 		return staticCfg
 	}
 	return nil
+}
+
+func (d *QuartoDetector) renderSource(cfg *config.Config) string {
+	if cfg.Entrypoint == "." {
+		return "_quarto.yml"
+	}
+	return cfg.Entrypoint
 }
 
 func (d *QuartoDetector) isQuartoYaml(entrypointBase string) bool {

--- a/internal/inspect/detectors/quarto_test.go
+++ b/internal/inspect/detectors/quarto_test.go
@@ -101,6 +101,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownDoc() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "quarto-doc-none.html",
+				Source:     "quarto-doc-none.qmd",
 				Title:      "quarto-doc-none",
 				Validate:   &validate,
 				Files: []string{
@@ -135,6 +136,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownProject() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "quarto-proj-none.html",
+				Source:     "quarto-proj-none.qmd",
 				Title:      "quarto-proj-none",
 				Validate:   &validate,
 				Files: []string{
@@ -168,6 +170,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMarkdownProjectWindows() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "quarto-proj-none.html",
+				Source:     "quarto-proj-none.qmd",
 				Title:      "quarto-proj-none",
 				Validate:   &validate,
 				Files: []string{
@@ -202,6 +205,7 @@ func (s *QuartoDetectorSuite) TestInferTypePythonProject() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "quarto-proj-py.html",
+				Source:     "quarto-proj-py.qmd",
 				Title:      "quarto-proj-py",
 				Validate:   &validate,
 				Files: []string{
@@ -236,6 +240,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRProject() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "quarto-proj-r.html",
+				Source:     "quarto-proj-r.qmd",
 				Title:      "quarto-proj-r",
 				Validate:   &validate,
 				Files: []string{
@@ -271,6 +276,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRAndPythonProject() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "quarto-proj-r-py.html",
+				Source:     "quarto-proj-r-py.qmd",
 				Title:      "quarto-proj-r-py",
 				Validate:   &validate,
 				Files: []string{
@@ -326,6 +332,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "_site/about.html",
+				Source:     "about.qmd",
 				Title:      "About",
 				Validate:   &validate,
 				Files: []string{
@@ -355,6 +362,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "_site/index.html",
+				Source:     "index.qmd",
 				Title:      "quarto-website-none",
 				Validate:   &validate,
 				Files: []string{
@@ -428,6 +436,7 @@ func (s *QuartoDetectorSuite) TestInferTypeQuartoWebsite_viaQuartoYml() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "_site/index.html",
+				Source:     "_quarto.yml",
 				Title:      "Content Dashboard",
 				Validate:   &validate,
 				Files: []string{
@@ -464,6 +473,7 @@ func (s *QuartoDetectorSuite) TestInferTypeRMarkdownDoc() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "static.html",
+				Source:     "static.Rmd",
 				Title:      "static",
 				Validate:   &validate,
 				Files: []string{
@@ -497,6 +507,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMultidocProject() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "document1.html",
+				Source:     "document1.qmd",
 				Title:      "quarto-proj-none-multidocument",
 				Validate:   &validate,
 				Files: []string{
@@ -524,6 +535,7 @@ func (s *QuartoDetectorSuite) TestInferTypeMultidocProject() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "document1.html",
+				Source:     "document2.qmd",
 				Title:      "quarto-proj-none-multidocument",
 				Validate:   &validate,
 				Files: []string{
@@ -561,6 +573,7 @@ func (s *QuartoDetectorSuite) TestInferTypeNotebook() {
 				Schema:     schema.ConfigSchemaURL,
 				Type:       contenttypes.ContentTypeHTML,
 				Entrypoint: "stock-report-jupyter.html",
+				Source:     "stock-report-jupyter.ipynb",
 				Title:      "Stock Report: TSLA",
 				Validate:   &validate,
 				Files: []string{

--- a/internal/schema/schemas/draft/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/draft/posit-publishing-schema-v3.json
@@ -497,7 +497,7 @@
     },
     "source": {
       "type": "string",
-      "description": "Name of the primary file that acts as the source for content that can be rendered on demand.",
+      "description": "Name of the primary file that acts as the source for content that can be rendered on demand. Only useful when deploying static content which has been rendered from Quarto, Rmarkdown or Jupyter Notebooks",
       "examples": ["report.qmd", "_quarto.yml"]
     },
     "title": {

--- a/internal/schema/schemas/draft/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/draft/posit-publishing-schema-v3.json
@@ -495,6 +495,11 @@
       "description": "Name of the primary file containing the content. For Python flask, dash, fastapi, and python-shiny projects, this specifies the object within the file in module:object format. See the documentation at https://docs.posit.co/connect/user/publishing-cli-apps/#publishing-rsconnect-python-entrypoint.",
       "examples": ["app.py", "report.qmd"]
     },
+    "source": {
+      "type": "string",
+      "description": "Name of the primary file that acts as the source for content that can be rendered on demand.",
+      "examples": ["report.qmd", "_quarto.yml"]
+    },
     "title": {
       "type": "string",
       "pattern": "^[^\t\n\f\r]{3,1000}$|",

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -398,7 +398,7 @@
     },
     "source": {
       "type": "string",
-      "description": "Name of the primary file that acts as the source for content that can be rendered on demand.",
+      "description": "Name of the primary file that acts as the source for content that can be rendered on demand. Only useful when deploying static content which has been rendered from Quarto, Rmarkdown or Jupyter Notebooks",
       "examples": ["report.qmd", "_quarto.yml"]
     },
     "title": {

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -396,6 +396,11 @@
       "description": "Name of the primary file containing the content. For Python flask, dash, fastapi, and python-shiny projects, this specifies the object within the file in module:object format. See the documentation at https://docs.posit.co/connect/user/publishing-cli-apps/#publishing-rsconnect-python-entrypoint.",
       "examples": ["app.py", "report.qmd"]
     },
+    "source": {
+      "type": "string",
+      "description": "Name of the primary file that acts as the source for content that can be rendered on demand.",
+      "examples": ["report.qmd", "_quarto.yml"]
+    },
     "title": {
       "type": "string",
       "pattern": "^[^\t\n\f\r]{3,1000}$|",


### PR DESCRIPTION

## Intent

Related to #2948 

Include a new `source` field for resulting deployment configurations of type `"html"` that are generated as alternative deployments for Quarto projects.

This to allow an upcoming `"Render"` button to render the project on demand, with the `source` field acting as the association link between the resulting `html` files and an original renderable project.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Update configuration objects, schemas and include this new field on Quarto alternative `html` configurations.

## User Impact

When creating a new deployment for a Quarto project and selecting the "Publish rendered document only" option, the `source` field will be included in the resulting configuration. Aside from that, this field is not used by the UI to trigger renders, yet.

## Automated Tests

Updated unit tests to assert this new field is included when expected.

## Directions for Reviewers

Attempt to deploy a Quarto project, select "Publish rendered document only", the `source` field must be included in the resulting configuration.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
