### PR TITLE
feat: Allow user to explicitly pick python package manager or server default

### DIFF
--- a/internal/bundles/manifest.go
+++ b/internal/bundles/manifest.go
@@ -86,8 +86,9 @@ type Jupyter struct {
 
 type PythonPackageManager struct {
 	Name        string `json:"name"`
-	Version     string `json:"version,omitempty"` // Package manager version
-	PackageFile string `json:"package_file"`      // Filename listing dependencies; usually "requirements.txt"
+	Version     string `json:"version,omitempty"`  // Package manager version
+	PackageFile string `json:"package_file"`       // Filename listing dependencies; usually "requirements.txt"
+	AllowUv     *bool  `json:"allow_uv,omitempty"` // Whether the package manager can be "uv"
 }
 
 type PackageMap map[string]Package
@@ -173,9 +174,28 @@ func NewManifestFromConfig(cfg *config.Config) *Manifest {
 	if cfg.Python != nil {
 		packageManager := (*PythonPackageManager)(nil)
 		if cfg.Python.PackageManager != "" {
+			// By default, let's the server decide which package manager to use.
+			// So we ask for pip, but allow the server to use uv if available.
+			//
+			// We use nil so the option is omitted from the JSON and it's
+			// compatible with older servers that did not support uv.
+			var allowUv *bool = nil
+			packageManagerName := "pip"
+			switch cfg.Python.PackageManager {
+			case "pip":
+				// The user explicitly forced pip, let's disable uv.
+				allowUv = config.BoolPtr(false)
+				packageManagerName = "pip"
+			case "uv":
+				// The user explicitly forced uv, let's enable it.
+				allowUv = config.BoolPtr(true)
+				packageManagerName = "uv"
+			}
+
 			packageManager = &PythonPackageManager{
-				Name:        cfg.Python.PackageManager,
+				Name:        packageManagerName,
 				PackageFile: cfg.Python.PackageFile,
+				AllowUv:     allowUv,
 			}
 		}
 		m.Python = &Python{

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -288,3 +288,7 @@ type ConnectCloudAccessControl struct {
 	PublicAccess       *bool                  `toml:"public_access,omitempty"  json:"publicAccess,omitempty"`
 	OrganizationAccess OrganizationAccessType `toml:"organization_access,omitempty" json:"organizationAccess,omitempty"`
 }
+
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/inspect/python.go
+++ b/internal/inspect/python.go
@@ -107,7 +107,7 @@ func (i *defaultPythonInspector) InspectPython() (*config.Python, error) {
 	return &config.Python{
 		Version:               version,
 		PackageFile:           reqFile.String(),
-		PackageManager:        "pip",
+		PackageManager:        i.pythonInterpreter.GetPackageManager(),
 		RequiresPythonVersion: python_requires,
 	}, nil
 }

--- a/internal/interpreters/python.go
+++ b/internal/interpreters/python.go
@@ -245,7 +245,7 @@ func (i *defaultPythonInterpreter) IsPythonExecutableValid() bool {
 }
 
 func (i *defaultPythonInterpreter) GetPackageManager() string {
-	return "pip"
+	return "auto"
 }
 
 func (i *defaultPythonInterpreter) GetPreferredPath() string {


### PR DESCRIPTION
## Intent

At the moment, if package_manager is not specified, the publisher will default to enforcing "pip".
Instead we want:
1. If not specified -> server default
2. if pip -> enforce pip
3. If uv -> enforce uv

## Type of Change

- - [x] New Feature <!-- A change which adds additional functionality -->

## Approach

If `python.package_manager` option is not specified, it will now default to an `"auto"` value.
This value gets then translated to `"pip"`+`"allow_uv=null"` when generating the manifest.
That means the server will be able to choose what to do based on its `DefaultPackageManager` option.

The `allow_uv=null` is because older servers didn't understand or accept the
`allow_uv` option. By setting it at null it gets omitted from the `manifest.json`
and thus retains backward compatibility.

If instead the user specified a value, that value is used and the server can accept
or refuse the deploy based on its `AllowUv` server side option.

## User Impact

When deploying against a server that defaults to `uv`, the user can now
switch back to `pip` by specifying `package_manager=pip`, previously
doing so, would have yet deployed with `uv` if that was the default server
package manager.

## Automated Tests

A test confirms that the json generated given the 3 cases is the expected one.

## Directions for Reviewers

`TestNewManifestFromConfig_PythonPackageManagerVariants_JSON`  more or less explains the expectations

## Checklist

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
