### PR TITLE
feat(rendering): Introduce render button for Quarto rendered projects

### DIFF
--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -79,6 +79,8 @@ export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
     msg.kind === HostToWebviewMessageType.PUBLISH_START ||
     msg.kind === HostToWebviewMessageType.PUBLISH_FINISH_SUCCESS ||
     msg.kind === HostToWebviewMessageType.PUBLISH_FINISH_FAILURE ||
+    msg.kind === HostToWebviewMessageType.CONTENT_RENDER_FINISHED ||
+    msg.kind === HostToWebviewMessageType.CONTENT_RENDER_FAILURE ||
     msg.kind === HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION ||
     msg.kind === HostToWebviewMessageType.SAVE_SELECTION ||
     msg.kind === HostToWebviewMessageType.REFRESH_FILES ||

--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -22,6 +22,8 @@ export enum HostToWebviewMessageType {
   PUBLISH_START = "publishStart",
   PUBLISH_FINISH_SUCCESS = "publishFinishSuccess",
   PUBLISH_FINISH_FAILURE = "publishFinishFailure",
+  CONTENT_RENDER_FINISHED = "contentRenderFinished",
+  CONTENT_RENDER_FAILURE = "contentRenderFailure",
   UPDATE_CONTENTRECORD_SELECTION = "updateContentRecordSelection",
   SAVE_SELECTION = "saveSelection",
   REFRESH_FILES = "refreshFiles",
@@ -53,6 +55,8 @@ export type HostToWebviewMessage =
   | PublishStartMsg
   | PublishFinishSuccessMsg
   | PublishFinishFailureMsg
+  | ContentRenderFinishedMsg
+  | ContentRenderFailureMsg
   | UpdateContentRecordSelectionMsg
   | SaveSelectionMsg
   | RefreshFilesMsg
@@ -126,6 +130,10 @@ export type PublishFinishFailureMsg = AnyHostToWebviewMessage<
     };
   }
 >;
+export type ContentRenderFinishedMsg =
+  AnyHostToWebviewMessage<HostToWebviewMessageType.CONTENT_RENDER_FINISHED>;
+export type ContentRenderFailureMsg =
+  AnyHostToWebviewMessage<HostToWebviewMessageType.CONTENT_RENDER_FAILURE>;
 export type UpdateContentRecordSelectionMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION,
   {

--- a/extensions/vscode/src/types/messages/webviewToHostMessages.ts
+++ b/extensions/vscode/src/types/messages/webviewToHostMessages.ts
@@ -32,6 +32,7 @@ export enum WebviewToHostMessageType {
   UPDATE_SELECTION_IS_PRE_CONTENT_RECORD = "UpdateSelectionIsPreContentRecordMsg",
   UPDATE_SELECTION_IS_CONNECT_CONTENT_RECORD = "UpdateSelectionIsConnectContentRecordMsg",
   COPY_SYSTEM_INFO = "copySystemInfo",
+  RENDER_CONTENT = "renderContent",
 }
 
 export type AnyWebviewToHostMessage<
@@ -72,7 +73,8 @@ export type WebviewToHostMessage =
   | UpdateSelectionCredentialStateMsg
   | UpdateSelectionIsPreContentRecordMsg
   | UpdateSelectionIsConnectContentRecordMsg
-  | CopySystemInfoMsg;
+  | CopySystemInfoMsg
+  | RenderContentMsg;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
@@ -106,7 +108,8 @@ export function isWebviewToHostMessage(msg: any): msg is WebviewToHostMessage {
       WebviewToHostMessageType.UPDATE_SELECTION_IS_PRE_CONTENT_RECORD ||
     msg.kind ===
       WebviewToHostMessageType.UPDATE_SELECTION_IS_CONNECT_CONTENT_RECORD ||
-    msg.kind === WebviewToHostMessageType.COPY_SYSTEM_INFO
+    msg.kind === WebviewToHostMessageType.COPY_SYSTEM_INFO ||
+    msg.kind === WebviewToHostMessageType.RENDER_CONTENT
   );
 }
 
@@ -259,3 +262,6 @@ export type UpdateSelectionIsConnectContentRecordMsg = AnyWebviewToHostMessage<
 
 export type CopySystemInfoMsg =
   AnyWebviewToHostMessage<WebviewToHostMessageType.COPY_SYSTEM_INFO>;
+
+export type RenderContentMsg =
+  AnyWebviewToHostMessage<WebviewToHostMessageType.RENDER_CONTENT>;

--- a/extensions/vscode/src/utils/quartoProjectHelper.test.ts
+++ b/extensions/vscode/src/utils/quartoProjectHelper.test.ts
@@ -12,14 +12,12 @@ const mockQuartoCheck = vi.fn().mockResolvedValue(0);
 const mockRenderCmd = vi.fn().mockResolvedValue(0);
 vi.mock("./window", () => {
   return {
-    runTerminalCommand: vi
-      .fn()
-      .mockImplementation((cmd: string, show: boolean = false) => {
-        if (cmd === "quarto --version") {
-          return mockQuartoCheck(cmd);
-        }
-        return mockRenderCmd(cmd, show);
-      }),
+    runTerminalCommand: vi.fn().mockImplementation((cmd: string) => {
+      if (cmd === "quarto --version") {
+        return mockQuartoCheck(cmd);
+      }
+      return mockRenderCmd(cmd);
+    }),
   };
 });
 
@@ -139,10 +137,7 @@ describe("QuartoProjectHelper", () => {
           ".",
         );
         await helper.verifyRenderedOutput();
-        expect(mockRenderCmd).toHaveBeenCalledWith(
-          "quarto render . --to html",
-          true,
-        );
+        expect(mockRenderCmd).toHaveBeenCalledWith("quarto render . --to html");
       });
 
       test("fails to render project, attempts to render standalone document", async () => {
@@ -162,13 +157,9 @@ describe("QuartoProjectHelper", () => {
           ".",
         );
         await helper.verifyRenderedOutput();
-        expect(mockRenderCmd).toHaveBeenCalledWith(
-          "quarto render . --to html",
-          true,
-        );
+        expect(mockRenderCmd).toHaveBeenCalledWith("quarto render . --to html");
         expect(mockRenderCmd).toHaveBeenCalledWith(
           "quarto render index.qmd --to html",
-          true,
         );
       });
     });
@@ -209,17 +200,14 @@ describe("QuartoProjectHelper", () => {
           ".",
         );
         await helper.verifyRenderedOutput();
-        expect(mockRenderCmd).toHaveBeenCalledWith(
-          "quarto render . --to html",
-          true,
-        );
+        expect(mockRenderCmd).toHaveBeenCalledWith("quarto render . --to html");
       });
     });
   });
 
   describe("multi-level workspace", () => {
     const projectDir = path.join("march-reports", "src");
-    const entrypoint = path.join(projectDir, "index.qmd");
+    const sourceEntrypoint = "index.qmd";
 
     describe("single doc rendering", () => {
       test("rendering exists, does not call extension", async () => {
@@ -232,9 +220,9 @@ describe("QuartoProjectHelper", () => {
 
         const helper = new QuartoProjectHelper(
           mockFilesApi,
-          path.join("march-reports", "src", "index.qmd"),
+          sourceEntrypoint,
           "index.html",
-          path.join("march-reports", "src"),
+          projectDir,
         );
         await helper.verifyRenderedOutput();
         expect(mockRenderCmd).not.toHaveBeenCalled();
@@ -250,14 +238,13 @@ describe("QuartoProjectHelper", () => {
 
         const helper = new QuartoProjectHelper(
           mockFilesApi,
-          entrypoint,
+          sourceEntrypoint,
           "index.html",
           projectDir,
         );
         await helper.verifyRenderedOutput();
         expect(mockRenderCmd).toHaveBeenCalledWith(
           `quarto render ${projectDir} --to html`,
-          true,
         );
       });
 
@@ -273,18 +260,16 @@ describe("QuartoProjectHelper", () => {
 
         const helper = new QuartoProjectHelper(
           mockFilesApi,
-          entrypoint,
+          sourceEntrypoint,
           "index.html",
           projectDir,
         );
         await helper.verifyRenderedOutput();
         expect(mockRenderCmd).toHaveBeenCalledWith(
           `quarto render ${projectDir} --to html`,
-          true,
         );
         expect(mockRenderCmd).toHaveBeenCalledWith(
-          `quarto render ${entrypoint} --to html`,
-          true,
+          `quarto render ${path.join(projectDir, sourceEntrypoint)} --to html`,
         );
       });
     });
@@ -302,7 +287,7 @@ describe("QuartoProjectHelper", () => {
 
         const helper = new QuartoProjectHelper(
           mockFilesApi,
-          entrypoint,
+          sourceEntrypoint,
           outputDir,
           projectDir,
         );
@@ -320,14 +305,13 @@ describe("QuartoProjectHelper", () => {
 
         const helper = new QuartoProjectHelper(
           mockFilesApi,
-          entrypoint,
+          sourceEntrypoint,
           outputDir,
           projectDir,
         );
         await helper.verifyRenderedOutput();
         expect(mockRenderCmd).toHaveBeenCalledWith(
           `quarto render ${projectDir} --to html`,
-          true,
         );
       });
     });

--- a/extensions/vscode/src/utils/quartoProjectHelper.ts
+++ b/extensions/vscode/src/utils/quartoProjectHelper.ts
@@ -129,11 +129,12 @@ export class QuartoProjectHelper {
 
   renderProject() {
     const command = `quarto render ${this.projectDir} --to html`;
-    return runTerminalCommand(command, true);
+    return runTerminalCommand(command);
   }
 
   renderDocument() {
-    const command = `quarto render ${this.entrypoint} --to html`;
-    return runTerminalCommand(command, true);
+    const fullEntryPath = path.join(this.projectDir, this.entrypoint);
+    const command = `quarto render ${fullEntryPath} --to html`;
+    return runTerminalCommand(command);
   }
 }

--- a/extensions/vscode/src/views/deployHandlers.test.ts
+++ b/extensions/vscode/src/views/deployHandlers.test.ts
@@ -13,13 +13,15 @@ const windowMethodsMocks = {
   showErrorMessageWithTroubleshoot: vi.fn(),
   showInformationMsg: vi.fn(),
   runTerminalCommand: vi.fn(),
+  openTerminalCommand: vi.fn(),
   taskWithProgressMsg: vi.fn((_: string, cb: () => void) => cb()),
 };
 
 vi.mock("src/utils/window", () => {
   return {
-    runTerminalCommand: (c: string, show: boolean = false) =>
-      windowMethodsMocks.runTerminalCommand(c, show),
+    runTerminalCommand: (c: string) => windowMethodsMocks.runTerminalCommand(c),
+    openTerminalCommand: (c: string) =>
+      windowMethodsMocks.openTerminalCommand(c),
     showInformationMsg: (m: string) => windowMethodsMocks.showInformationMsg(m),
     taskWithProgressMsg: (m: string, cb: () => void) =>
       windowMethodsMocks.taskWithProgressMsg(m, cb),
@@ -97,9 +99,8 @@ describe("Deploy Handlers", () => {
         expect(
           windowMethodsMocks.showErrorMessageWithTroubleshoot,
         ).toHaveBeenCalledWith(errData.message, errData.actionLabel);
-        expect(windowMethodsMocks.runTerminalCommand).toHaveBeenCalledWith(
-          "/user/lib/R renv::status();",
-          true,
+        expect(windowMethodsMocks.openTerminalCommand).toHaveBeenCalledWith(
+          "/user/lib/R renv::status()",
         );
 
         // No progrss indicator is shown when we open the terminal
@@ -145,8 +146,7 @@ describe("Deploy Handlers", () => {
           );
           // Terminal command executed
           expect(windowMethodsMocks.runTerminalCommand).toHaveBeenCalledWith(
-            `${command}; exit $?`,
-            false,
+            command,
           );
           expect(windowMethodsMocks.showInformationMsg).toHaveBeenCalledWith(
             "Finished setting up renv.",

--- a/extensions/vscode/src/views/deployHandlers.ts
+++ b/extensions/vscode/src/views/deployHandlers.ts
@@ -10,6 +10,7 @@ import {
 import {
   showErrorMessageWithTroubleshoot,
   showInformationMsg,
+  openTerminalCommand,
   runTerminalCommand,
   taskWithProgressMsg,
 } from "src/utils/window";
@@ -52,12 +53,15 @@ export class DeploymentFailureRenvHandler implements DeploymentFailureHandler {
 
     // If renv status is the action, then run the command and open the terminal
     if (action === "renvstatus") {
-      return runTerminalCommand(`${command};`, true);
+      return openTerminalCommand(command);
     }
 
     try {
-      await taskWithProgressMsg("Setting up renv for this project...", () =>
-        runTerminalCommand(`${command}; exit $?`),
+      await taskWithProgressMsg(
+        "Setting up renv for this project...",
+        async () => {
+          await runTerminalCommand(command);
+        },
       );
       showInformationMsg("Finished setting up renv.");
     } catch (_) {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -46,6 +46,7 @@ import { getSummaryStringFromError } from "src/utils/errors";
 import { getNonce } from "src/utils/getNonce";
 import { getUri } from "src/utils/getUri";
 import { deployProject } from "src/views/deployProgress";
+import { renderQuartoContent } from "src/views/renders";
 import { WebviewConduit } from "src/utils/webviewConduit";
 import { fileExists, relativeDir, isRelativePathRoot } from "src/utils/files";
 import { Utils as uriUtils } from "vscode-uri";
@@ -208,6 +209,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         );
       case WebviewToHostMessageType.COPY_SYSTEM_INFO:
         return await this.copySystemInfo();
+      case WebviewToHostMessageType.RENDER_CONTENT:
+        return await this.renderContent();
       default:
         window.showErrorMessage(
           `Internal Error: onConduitMessage unhandled msg: ${JSON.stringify(msg)}`,
@@ -225,6 +228,32 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
 
   private async copySystemInfo() {
     return await commands.executeCommand(Commands.HomeView.CopySystemInfo);
+  }
+
+  private async renderContent() {
+    let projectDir: string;
+    let sourceEntrypoint: string;
+    let renderedEntrypoint: string;
+    const activeConfig = await this.state.getSelectedConfiguration();
+
+    if (activeConfig === undefined) {
+      console.error("homeView::renderContent: No active configuration.");
+      return;
+    }
+
+    if (activeConfig && !isConfigurationError(activeConfig)) {
+      projectDir = activeConfig.projectDir;
+      sourceEntrypoint = activeConfig.configuration.source || "";
+      renderedEntrypoint = activeConfig.configuration.entrypoint || "";
+    } else {
+      window.showErrorMessage(
+        "Failed to render Quarto content. Deployment configuration is in error.",
+      );
+      return;
+    }
+
+    // Currently we only support rendering content with Quarto
+    renderQuartoContent(projectDir, sourceEntrypoint, renderedEntrypoint);
   }
 
   private async updateSelectionCredentialState(state: string) {

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -253,7 +253,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     }
 
     // Currently we only support rendering content with Quarto
-    renderQuartoContent(projectDir, sourceEntrypoint, renderedEntrypoint);
+    renderQuartoContent(
+      this.webviewConduit,
+      projectDir,
+      sourceEntrypoint,
+      renderedEntrypoint,
+    );
   }
 
   private async updateSelectionCredentialState(state: string) {

--- a/extensions/vscode/src/views/renders.test.ts
+++ b/extensions/vscode/src/views/renders.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, beforeEach, test, vi } from "vitest";
 import { window, ProgressLocation } from "vscode";
 import { HostToWebviewMessageType } from "src/types/messages/hostToWebviewMessages";
+import { WebviewConduit } from "src/utils/webviewConduit";
 import {
   ErrorNoQuarto,
   ErrorQuartoRender,
@@ -77,6 +78,7 @@ describe("renderQuartoContent", () => {
 
   test("calls to render with progress notification and emits webview render message", async () => {
     await renderQuartoContent(
+      new WebviewConduit(),
       "project-dir",
       "index.qmd",
       "output_dir/index.html",
@@ -101,6 +103,7 @@ describe("renderQuartoContent", () => {
     test("any error emits webview render failure message", async () => {
       quartoHelperRenderSpy.mockRejectedValueOnce("unknown rejection");
       await renderQuartoContent(
+        new WebviewConduit(),
         "project-dir",
         "index.qmd",
         "output_dir/index.html",
@@ -119,6 +122,7 @@ describe("renderQuartoContent", () => {
     test("ErrorNoQuarto", async () => {
       quartoHelperRenderSpy.mockRejectedValueOnce(new ErrorNoQuarto());
       await renderQuartoContent(
+        new WebviewConduit(),
         "project-dir",
         "index.qmd",
         "output_dir/index.html",
@@ -137,6 +141,7 @@ describe("renderQuartoContent", () => {
     test("ErrorQuartoRender", async () => {
       quartoHelperRenderSpy.mockRejectedValueOnce(new ErrorQuartoRender());
       await renderQuartoContent(
+        new WebviewConduit(),
         "project-dir",
         "index.qmd",
         "output_dir/index.html",
@@ -155,6 +160,7 @@ describe("renderQuartoContent", () => {
     test("Unknown Error", async () => {
       quartoHelperRenderSpy.mockRejectedValueOnce(new Error("system is down"));
       await renderQuartoContent(
+        new WebviewConduit(),
         "project-dir",
         "index.qmd",
         "output_dir/index.html",

--- a/extensions/vscode/src/views/renders.test.ts
+++ b/extensions/vscode/src/views/renders.test.ts
@@ -1,0 +1,173 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { describe, expect, beforeEach, test, vi } from "vitest";
+import { window, ProgressLocation } from "vscode";
+import { HostToWebviewMessageType } from "src/types/messages/hostToWebviewMessages";
+import {
+  ErrorNoQuarto,
+  ErrorQuartoRender,
+} from "src/utils/quartoProjectHelper";
+import { renderQuartoContent } from "./renders";
+
+vi.mock("vscode", () => {
+  // mock Disposable
+  const disposableMock = vi.fn();
+  disposableMock.prototype.dispose = vi.fn();
+
+  // mock window
+  const windowMock = {
+    showErrorMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+    withProgress: vi.fn().mockImplementation(async (_, progressCallback) => {
+      await progressCallback();
+    }),
+  };
+
+  return {
+    Disposable: disposableMock,
+    window: windowMock,
+    ProgressLocation: {
+      SourceControl: 1,
+      Window: 10,
+      Notification: 15,
+    },
+  };
+});
+
+vi.mock("src/api", () => ({
+  useApi() {
+    return { files: {} };
+  },
+}));
+
+const quartoHelperRenderSpy = vi.fn();
+vi.mock("src/utils/quartoProjectHelper", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("src/utils/quartoProjectHelper")>();
+
+  class mockQuartoHelper {
+    render() {
+      return quartoHelperRenderSpy();
+    }
+  }
+
+  return {
+    ...actual, // Spread the original module's exports
+    QuartoProjectHelper: mockQuartoHelper,
+  };
+});
+
+const conduitSendMsgSpy = vi.fn();
+vi.mock("src/utils/webviewConduit", () => {
+  class mockWebviewConduit {
+    sendMsg(param: { kind: HostToWebviewMessageType }) {
+      conduitSendMsgSpy(param);
+    }
+  }
+
+  return {
+    WebviewConduit: mockWebviewConduit,
+  };
+});
+
+describe("renderQuartoContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls to render with progress notification and emits webview render message", async () => {
+    await renderQuartoContent(
+      "project-dir",
+      "index.qmd",
+      "output_dir/index.html",
+    );
+    expect(window.withProgress).toHaveBeenCalledWith(
+      {
+        location: ProgressLocation.Notification,
+        title: "Rendering Quarto content",
+      },
+      expect.any(Function),
+    );
+    expect(quartoHelperRenderSpy).toHaveBeenCalled();
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      "Finished rendering Quarto content.",
+    );
+    expect(conduitSendMsgSpy).toHaveBeenCalledWith({
+      kind: HostToWebviewMessageType.CONTENT_RENDER_FINISHED,
+    });
+  });
+
+  describe("errors", () => {
+    test("any error emits webview render failure message", async () => {
+      quartoHelperRenderSpy.mockRejectedValueOnce("unknown rejection");
+      await renderQuartoContent(
+        "project-dir",
+        "index.qmd",
+        "output_dir/index.html",
+      );
+
+      expect(quartoHelperRenderSpy).toHaveBeenCalled();
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "Unknown error trying to render Quarto content.",
+      );
+      expect(conduitSendMsgSpy).toHaveBeenCalledWith({
+        kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+      });
+    });
+
+    test("ErrorNoQuarto", async () => {
+      quartoHelperRenderSpy.mockRejectedValueOnce(new ErrorNoQuarto());
+      await renderQuartoContent(
+        "project-dir",
+        "index.qmd",
+        "output_dir/index.html",
+      );
+
+      expect(quartoHelperRenderSpy).toHaveBeenCalled();
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "Cannot render Quarto content. Quarto is not available on the system.",
+      );
+      expect(conduitSendMsgSpy).toHaveBeenCalledWith({
+        kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+      });
+    });
+
+    test("ErrorQuartoRender", async () => {
+      quartoHelperRenderSpy.mockRejectedValueOnce(new ErrorQuartoRender());
+      await renderQuartoContent(
+        "project-dir",
+        "index.qmd",
+        "output_dir/index.html",
+      );
+
+      expect(quartoHelperRenderSpy).toHaveBeenCalled();
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "Failed to render Quarto content. Error: Could not render Quarto project.",
+      );
+      expect(conduitSendMsgSpy).toHaveBeenCalledWith({
+        kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+      });
+    });
+
+    test("Unknown Error", async () => {
+      quartoHelperRenderSpy.mockRejectedValueOnce(new Error("system is down"));
+      await renderQuartoContent(
+        "project-dir",
+        "index.qmd",
+        "output_dir/index.html",
+      );
+
+      expect(quartoHelperRenderSpy).toHaveBeenCalled();
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "Unknown error trying to render Quarto content. Error: system is down",
+      );
+      expect(conduitSendMsgSpy).toHaveBeenCalledWith({
+        kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+      });
+    });
+  });
+});

--- a/extensions/vscode/src/views/renders.ts
+++ b/extensions/vscode/src/views/renders.ts
@@ -11,12 +11,11 @@ import {
 } from "src/utils/quartoProjectHelper";
 
 export const renderQuartoContent = async (
+  conduit: WebviewConduit,
   projectDir: string,
   sourceEntrypoint: string,
   renderedEntrypoint: string,
 ) => {
-  const webviewConduit = new WebviewConduit();
-
   try {
     await window.withProgress(
       {
@@ -35,11 +34,11 @@ export const renderQuartoContent = async (
       },
     );
     window.showInformationMessage("Finished rendering Quarto content.");
-    webviewConduit.sendMsg({
+    conduit.sendMsg({
       kind: HostToWebviewMessageType.CONTENT_RENDER_FINISHED,
     });
   } catch (err: unknown) {
-    webviewConduit.sendMsg({
+    conduit.sendMsg({
       kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
     });
     if (err instanceof ErrorNoQuarto) {

--- a/extensions/vscode/src/views/renders.ts
+++ b/extensions/vscode/src/views/renders.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { window, ProgressLocation } from "vscode";
+import { useApi } from "src/api";
+import { HostToWebviewMessageType } from "src/types/messages/hostToWebviewMessages";
+import { WebviewConduit } from "src/utils/webviewConduit";
+import {
+  ErrorNoQuarto,
+  ErrorQuartoRender,
+  QuartoProjectHelper,
+} from "src/utils/quartoProjectHelper";
+
+export const renderQuartoContent = async (
+  projectDir: string,
+  sourceEntrypoint: string,
+  renderedEntrypoint: string,
+) => {
+  const webviewConduit = new WebviewConduit();
+
+  try {
+    await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Rendering Quarto content",
+      },
+      async () => {
+        const api = await useApi();
+        const quartoHelper = new QuartoProjectHelper(
+          api.files,
+          sourceEntrypoint,
+          renderedEntrypoint,
+          projectDir,
+        );
+        await quartoHelper.render();
+      },
+    );
+    window.showInformationMessage("Finished rendering Quarto content.");
+    webviewConduit.sendMsg({
+      kind: HostToWebviewMessageType.CONTENT_RENDER_FINISHED,
+    });
+  } catch (err: unknown) {
+    webviewConduit.sendMsg({
+      kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+    });
+    if (err instanceof ErrorNoQuarto) {
+      window.showErrorMessage(
+        "Cannot render Quarto content. Quarto is not available on the system.",
+      );
+    } else if (err instanceof ErrorQuartoRender) {
+      window.showErrorMessage(
+        `Failed to render Quarto content. Error: ${err.message}`,
+      );
+    } else if (err instanceof Error) {
+      window.showErrorMessage(
+        `Unknown error trying to render Quarto content. Error: ${err.message}`,
+      );
+    } else {
+      window.showErrorMessage("Unknown error trying to render Quarto content.");
+    }
+  }
+};

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -76,6 +76,10 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
       return onPublishFinishSuccessMsg();
     case HostToWebviewMessageType.PUBLISH_FINISH_FAILURE:
       return onPublishFinishFailureMsg(msg);
+    case HostToWebviewMessageType.CONTENT_RENDER_FINISHED:
+      return onContentRenderFinished();
+    case HostToWebviewMessageType.CONTENT_RENDER_FAILURE:
+      return onContentRenderFailure();
     case HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION:
       return onUpdateContentRecordSelectionMsg(msg);
     case HostToWebviewMessageType.SAVE_SELECTION:
@@ -193,6 +197,14 @@ const onPublishFinishFailureMsg = (msg: PublishFinishFailureMsg) => {
   home.publishInProgress = false;
   home.lastContentRecordResult = `Last Deployment Failed`;
   home.lastContentRecordMsg = msg.content.data.message;
+};
+const onContentRenderFinished = () => {
+  const home = useHomeStore();
+  home.contentRenderInProgress = false;
+};
+const onContentRenderFailure = () => {
+  const home = useHomeStore();
+  home.contentRenderFailed = false;
 };
 const onUpdateContentRecordSelectionMsg = (
   msg: UpdateContentRecordSelectionMsg,

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -77,9 +77,9 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
     case HostToWebviewMessageType.PUBLISH_FINISH_FAILURE:
       return onPublishFinishFailureMsg(msg);
     case HostToWebviewMessageType.CONTENT_RENDER_FINISHED:
-      return onContentRenderFinished();
+      return onContentRenderFinishedMsg();
     case HostToWebviewMessageType.CONTENT_RENDER_FAILURE:
-      return onContentRenderFailure();
+      return onContentRenderFailureMsg();
     case HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION:
       return onUpdateContentRecordSelectionMsg(msg);
     case HostToWebviewMessageType.SAVE_SELECTION:
@@ -198,13 +198,14 @@ const onPublishFinishFailureMsg = (msg: PublishFinishFailureMsg) => {
   home.lastContentRecordResult = `Last Deployment Failed`;
   home.lastContentRecordMsg = msg.content.data.message;
 };
-const onContentRenderFinished = () => {
+const onContentRenderFinishedMsg = () => {
   const home = useHomeStore();
   home.contentRenderInProgress = false;
+  console.log("MESSAGE RECEIVED, render in progress set to false");
 };
-const onContentRenderFailure = () => {
+const onContentRenderFailureMsg = () => {
   const home = useHomeStore();
-  home.contentRenderFailed = false;
+  home.contentRenderFailed = true;
 };
 const onUpdateContentRecordSelectionMsg = (
   msg: UpdateContentRecordSelectionMsg,

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -1,9 +1,7 @@
 <template>
   <vscode-button
     :data-automation="`deploy-button`"
-    :disabled="
-      !haveResources || home.publishInProgress || home.publishInitiated
-    "
+    :disabled="disableDeploy"
     @click="deploy"
   >
     Deploy Your Project
@@ -28,6 +26,14 @@ const haveResources = computed(
     Boolean(home.serverCredential),
 );
 
+const disableDeploy = computed(
+  () =>
+    !haveResources.value ||
+    home.publishInProgress ||
+    home.publishInitiated ||
+    home.contentRenderInProgress,
+);
+
 const deploy = () => {
   if (
     !home.selectedContentRecord ||
@@ -39,6 +45,9 @@ const deploy = () => {
     );
     return;
   }
+
+  // If there is any render error message, clear that up
+  home.contentRenderFailed = false;
 
   // stop the user from double clicking the deploy button by mistake
   home.publishInitiated = true;

--- a/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
+++ b/extensions/vscode/webviews/homeView/src/components/EvenEasierDeploy.vue
@@ -123,6 +123,8 @@
         >.
       </p>
 
+      <RenderButton v-if="isRenderableContent" class="w-full render-btn" />
+
       <DeployButton class="w-full" />
     </template>
     <div v-else class="deployment-control" v-on="{ click: onSelectDeployment }">
@@ -272,6 +274,7 @@ import { useHomeStore } from "src/stores/home";
 import QuickPickItem, { IconDetail } from "src/components/QuickPickItem.vue";
 import ActionToolbar from "src/components/ActionToolbar.vue";
 import DeployButton from "src/components/DeployButton.vue";
+import RenderButton from "src/components/RenderButton.vue";
 import TextStringWithAnchor from "./TextStringWithAnchor.vue";
 import {
   AgentError,
@@ -496,6 +499,14 @@ const isDismissedContentRecord = computed(() => {
   return Boolean(home.selectedContentRecord?.dismissedAt);
 });
 
+const isRenderableContent = computed(() => {
+  return Boolean(
+    home.selectedConfiguration &&
+      !isConfigurationError(home.selectedConfiguration) &&
+      home.selectedConfiguration.configuration.source,
+  );
+});
+
 const toolTipText = computed(() => {
   let entrypoint = "unknown";
   if (
@@ -674,6 +685,10 @@ const viewContent = () => {
 
 :deep(.action-item) {
   margin-right: 4px;
+}
+
+.render-btn {
+  margin-bottom: 0.5rem;
 }
 
 .add-deployment-btn {

--- a/extensions/vscode/webviews/homeView/src/components/RenderButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/RenderButton.vue
@@ -1,0 +1,23 @@
+<template>
+  <vscode-button
+    :data-automation="`render-button`"
+    :disabled="home.contentRenderInProgress"
+    @click="render"
+  >
+    Render Your Project
+  </vscode-button>
+</template>
+
+<script setup lang="ts">
+import { useHomeStore } from "src/stores/home";
+import { useHostConduitService } from "src/HostConduitService";
+import { WebviewToHostMessageType } from "../../../../src/types/messages/webviewToHostMessages";
+
+const home = useHomeStore();
+const hostConduit = useHostConduitService();
+const render = () => {
+  home.contentRenderFailed = false;
+  home.contentRenderInProgress = true;
+  hostConduit.sendMsg({ kind: WebviewToHostMessageType.RENDER_CONTENT });
+};
+</script>

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -30,6 +30,8 @@ export const useHomeStore = defineStore("home", () => {
   const platformFileSeparator = ref<string>("/");
   const publishInProgress = ref(false);
   const publishInitiated = ref(false);
+  const contentRenderInProgress = ref(false);
+  const contentRenderFailed = ref(false);
 
   const contentRecords = ref<(ContentRecord | PreContentRecord)[]>([]);
   const configurations = ref<Configuration[]>([]);
@@ -465,6 +467,8 @@ export const useHomeStore = defineStore("home", () => {
     showDisabledOverlay,
     publishInProgress,
     publishInitiated,
+    contentRenderInProgress,
+    contentRenderFailed,
     contentRecords,
     configurations,
     configurationsInError,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Related and closes #2948 

This PR introduces a new button to help users to render Quarto projects on demand. This, only available for Quarto projects where the option "Publish rendered document only" was selected when creating the deployment.

**Note:**
This PR does not end with the Quarto rendering work. Items to address in a subsequent PR:
- Disable `Deploy Your Project` button if the project rendering entrypoint does not exist.
- Use the deployment status message (where we show `Not Yet Deployed` or `Last Deployment Successful`) to also communicate more prominently the result of the rendering (render successful or render failed).

<details>
<summary>
Screenshot
</summary>
<img width="1207" height="627" alt="Screenshot 2025-09-05 at 1 08 55 p m" src="https://github.com/user-attachments/assets/f750cb53-4827-43b3-9353-213b5665cc83" />
</details>


<details>
<summary>
Video : Starts rendering
</summary>
https://github.com/user-attachments/assets/591d5317-e107-4c6c-a401-b67c1da2177f
</details>


<details>
<summary>
Video : Finishes rendering
</summary>
https://github.com/user-attachments/assets/797644a0-e4b6-47e0-8f3a-1ab21c91590b
</details>

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

- Include new `host <-> webview` conduit messaging to trigger Quarto renderings.
- Adjust `QuartoProjectHelper` to use the latest `source` config field to render.
- Create a `renderQuartoContent` method that uses the `QuartoProjectHelper` and emits `host -> webview` messages.
- Update the `home` store to track if a rendering is in progress or failed.
- Add a new button `<RenderButton>` method that uses the `QuartoProjectHelper` and emits `webview -> host` message to trigger the renderings.
- Adjust `<DeployButton>` so it gets disables while rendering.

## User Impact

A new button shows up to allow rendering Quarto projects where the option "Publish rendered document only" was selected when creating the deployment.

## Automated Tests

Added and updated unit tests as needed.

## Directions for Reviewers

Try out creating a new deployment for Quarto where the option `"Publish rendered document only"` is chosen. Then, try out the "Render Your Project" button.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
