### PR TITLE
chore(ci): Create initial nightly-prerelease.yaml

### DIFF
--- a/.github/workflows/nightly-prerelease.yaml
+++ b/.github/workflows/nightly-prerelease.yaml
@@ -138,14 +138,21 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          # Use a PAT to ensure the tag push triggers the release workflow
-          # GITHUB_TOKEN doesn't trigger other workflows by default
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           ref: main
+
+      - name: Generate token for GitHub App
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+          private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
+          # Tags are part of repository contents, so we need this permission
+          permission-contents: write
 
       - name: Create tag
         env:
           NEXT_VERSION: ${{ needs.version.outputs.next-version }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Configure git
           git config user.name "github-actions[bot]"
@@ -154,8 +161,8 @@ jobs:
           # Create the tag
           git tag -a "$NEXT_VERSION" -m "Nightly pre-release $NEXT_VERSION"
 
-          # Push the tag (this will trigger the release workflow)
-          git push origin "$NEXT_VERSION"
+          # Use the token for authentication when pushing
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" "$NEXT_VERSION"
 
           echo "✅ Created and pushed tag: $NEXT_VERSION"
 


### PR DESCRIPTION
## Intent

Create initial workflow and supporting actions to trigger a prerelease.

Fixes: #3032

## Type of Change

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

- Leverage https://github.com/posit-dev/publisher/pull/3002 as a springboard
- Tried to include plenty of code comments and logging so humans can review and debug easily
- Leveraged native semver package functionality as much as possible

## User Impact

None, other than the potential for more frequently nightly prerelease builds in the future

## Automated Tests

None, we will have to test this in dry_run mode manually after merging

## Directions for Reviewers

- Review the code as usual
- Double-check that there's nothing that will be creating and pushing tags to the repo right now so we can safely test the workflow using dry_run once merged

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
