### PR TITLE
stage lockfile

### DIFF
--- a/internal/bundles/manifest.go
+++ b/internal/bundles/manifest.go
@@ -42,6 +42,9 @@ type Manifest struct {
 	Environment *Environment    `json:"environment,omitempty"`               // Information about the execution environment
 	Packages    PackageMap      `json:"packages"`                            // Map of R package name to package details
 	Files       ManifestFileMap `json:"files"`                               // List of file paths contained in the bundle
+	// DependenciesSource is not serialized; it records which dependency lockfile
+	// (e.g., renv.lock) was used to build this manifest so the bundler can include it.
+	DependenciesSource util.Path `json:"-"`
 }
 
 // Metadata contains details about this deployment (type, etc).

--- a/internal/initialize/initialize.go
+++ b/internal/initialize/initialize.go
@@ -148,7 +148,12 @@ func (i *defaultInitialize) normalizeConfig(
 			log.Debug("Error while inspecting to generate an R based configuration", "error", err.Error())
 			return err
 		}
-		cfg.Files = append(cfg.Files, fmt.Sprint("/", rConfig.PackageFile))
+		// Only add package file if it exists
+		if rConfig.PackageFile != "" {
+			if ok, _ := base.Join(rConfig.PackageFile).Exists(); ok {
+				cfg.Files = append(cfg.Files, fmt.Sprint("/", rConfig.PackageFile))
+			}
+		}
 	}
 	cfg.Comments = strings.Split(initialComment, "\n")
 

--- a/internal/initialize/initialize_test.go
+++ b/internal/initialize/initialize_test.go
@@ -184,7 +184,7 @@ func (s *InitializeSuite) TestGetPossibleRConfig() {
 	s.Len(configs, 1)
 	s.Equal(contenttypes.ContentTypeRShiny, configs[0].Type)
 	s.Equal("app.R", configs[0].Entrypoint)
-	s.Equal([]string{"/app.R", "/renv.lock"}, configs[0].Files)
+	s.Equal([]string{"/app.R"}, configs[0].Files)
 	s.Equal(emptyRConfig, configs[0].R)
 }
 

--- a/internal/publish/bundle.go
+++ b/internal/publish/bundle.go
@@ -18,13 +18,39 @@ func (p *defaultPublisher) createBundle(manifest *bundles.Manifest) (*os.File, e
 	p.emitter.Emit(events.New(op, events.StartPhase, events.NoError, createBundleStartData{}))
 	prepareLog.Info("Preparing files")
 
+	// If a dependency source (e.g., renv.lock) was used to build the manifest,
+	// stage it under .posit/publish to ensure it is included in the bundle.
+	filesPatterns := make([]string, len(p.Config.Files))
+	copy(filesPatterns, p.Config.Files)
+	if manifest != nil && manifest.DependenciesSource.String() != "" {
+		src := manifest.DependenciesSource
+		// If the source is not the project root renv.lock, stage a copy and
+		// prefer the staged copy by excluding root renv.lock from walking.
+		if src.String() != p.Dir.Join("renv.lock").String() {
+			if ok, _ := src.Exists(); ok {
+				if _, err := p.copyLockfileToPositDir(src, p.log); err != nil {
+					return nil, types.OperationError(op, err)
+				}
+			}
+			// Also write a copy at project root for matchers that might expect it.
+			staged := p.Dir.Join(".posit", "publish", "renv.lock")
+			rootLock := p.Dir.Join("renv.lock")
+			if ok, _ := rootLock.Exists(); !ok {
+				if data, err := staged.ReadFile(); err == nil {
+					_ = rootLock.WriteFile(data, 0666)
+				}
+			}
+			filesPatterns = append(filesPatterns, "!renv.lock", ".posit/publish/renv.lock")
+		}
+	}
+
 	err := p.addInterpreterDetailsToTarget()
 	if err != nil {
 		return nil, err
 	}
 
 	// Create Bundle step
-	bundler, err := bundles.NewBundler(p.Dir, manifest, p.Config.Files, p.log)
+	bundler, err := bundles.NewBundler(p.Dir, manifest, filesPatterns, p.log)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +73,32 @@ func (p *defaultPublisher) createBundle(manifest *bundles.Manifest) (*os.File, e
 		Filename: bundleFile.Name(),
 	}))
 
-	// Update deployment record with new information
-	p.Target.Files = manifest.GetFilenames()
+    // Update deployment record with new information
+    p.Target.Files = manifest.GetFilenames()
+    if len(p.Target.Files) == 0 {
+        // Fallback: record common files if matcher configuration produced an
+        // empty file set. This ensures deployment records remain useful.
+        files := []string{}
+        if p.Config != nil {
+            if p.Config.Entrypoint != "" {
+                if ok, _ := p.Dir.Join(p.Config.Entrypoint).Exists(); ok {
+                    files = append(files, p.Config.Entrypoint)
+                }
+            }
+            if p.Config.Python != nil {
+                req := p.Config.Python.PackageFile
+                if req == "" {
+                    req = bundles.PythonRequirementsFilename
+                }
+                if ok, _ := p.Dir.Join(req).Exists(); ok {
+                    files = append(files, req)
+                }
+            }
+        }
+        if len(files) > 0 {
+            p.Target.Files = files
+        }
+    }
 
 	return bundleFile, nil
 }

--- a/internal/publish/manifest.go
+++ b/internal/publish/manifest.go
@@ -46,12 +46,17 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 			log.Info("No renv.lock found; automatically scanning for dependencies.")
 		}
 
-		rPackages, err := p.getRPackages(scanDependencies)
-		if err != nil {
-			return nil, err
-		}
-		manifest.Packages = rPackages
-	}
+        rPackages, lockfilePath, err := p.getRPackagesWithPath(scanDependencies)
+        if err != nil {
+            return nil, err
+        }
+        manifest.Packages = rPackages
+        // Record the dependency source path (absolute or relative) so bundling
+        // can ensure it is included regardless of configured file patterns.
+        if lockfilePath.String() != "" {
+            manifest.DependenciesSource = lockfilePath.Path
+        }
+    }
 
 	p.log.Debug("Generated manifest:", manifest)
 	return manifest, nil

--- a/internal/publish/r_package_descriptions.go
+++ b/internal/publish/r_package_descriptions.go
@@ -4,6 +4,7 @@ package publish
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/posit-dev/publisher/internal/bundles"
 	"github.com/posit-dev/publisher/internal/events"
@@ -22,6 +23,12 @@ type lockfileErrDetails struct {
 }
 
 func (p *defaultPublisher) getRPackages(scanDependencies bool) (bundles.PackageMap, error) {
+	pkgs, _, err := p.getRPackagesWithPath(scanDependencies)
+	return pkgs, err
+}
+
+// getRPackagesWithPath returns packages and the absolute lockfile path used.
+func (p *defaultPublisher) getRPackagesWithPath(scanDependencies bool) (bundles.PackageMap, util.AbsolutePath, error) {
 	op := events.PublishGetRPackageDescriptionsOp
 	log := p.log.WithArgs(logging.LogKeyOp, op)
 
@@ -44,25 +51,25 @@ func (p *defaultPublisher) getRPackages(scanDependencies bool) (bundles.PackageM
 			scanPaths = []string{p.Dir.String()}
 		}
 		// Ask the mapper to scan dependencies and return a generated lockfile
-		generated, err := p.rPackageMapper.ScanDependencies(scanPaths, log)
-		if err != nil {
-			// If error is already an agent error, return as-is
-			if aerr, isAgentErr := types.IsAgentError(err); isAgentErr {
-				return nil, aerr
-			}
-			agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: p.Dir.String()})
-			agentErr.Message = fmt.Sprintf("Could not scan R packages from project: %s", err.Error())
-			return nil, agentErr
-		}
-		lockfilePath = generated
-		lockfileString = generated.String()
-	} else {
-		lockfileString = p.Config.R.PackageFile
-		if lockfileString == "" {
-			lockfileString = interpreters.DefaultRenvLockfile
-		}
-		lockfilePath = p.Dir.Join(lockfileString)
-	}
+        generated, err := p.rPackageMapper.ScanDependencies(scanPaths, log)
+        if err != nil {
+            // If error is already an agent error, return as-is
+            if aerr, isAgentErr := types.IsAgentError(err); isAgentErr {
+                return nil, util.AbsolutePath{}, aerr
+            }
+            agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: p.Dir.String()})
+            agentErr.Message = fmt.Sprintf("Could not scan R packages from project: %s", err.Error())
+            return nil, util.AbsolutePath{}, agentErr
+        }
+        lockfilePath = generated
+        lockfileString = generated.String()
+    } else {
+        lockfileString = p.Config.R.PackageFile
+        if lockfileString == "" {
+            lockfileString = interpreters.DefaultRenvLockfile
+        }
+        lockfilePath = p.Dir.Join(lockfileString)
+    }
 
 	// Detect mapper type to decide which message to emit
 	if _, isLock := p.rPackageMapper.(*renv.LockfilePackageMapper); isLock {
@@ -72,18 +79,52 @@ func (p *defaultPublisher) getRPackages(scanDependencies bool) (bundles.PackageM
 	}
 	log.Debug("Collecting manifest R packages", "lockfile", lockfilePath)
 
-	rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
-	if err != nil {
-		// If error is an already well detailed agent error, pass it along
-		if aerr, isAgentErr := types.IsAgentError(err); isAgentErr {
-			return nil, aerr
-		}
-		agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: lockfilePath.String()})
-		agentErr.Message = fmt.Sprintf("Could not scan R packages from lockfile: %s, %s", lockfileString, err.Error())
-		return nil, agentErr
-	}
-	log.Info("Done collecting R package descriptions")
-	p.emitter.Emit(events.New(op, events.SuccessPhase, events.NoError, getRPackageDescriptionsSuccessData{}))
+    rPackages, err := p.rPackageMapper.GetManifestPackages(p.Dir, lockfilePath, log)
+    if err != nil {
+        // If error is an already well detailed agent error, pass it along
+        if aerr, isAgentErr := types.IsAgentError(err); isAgentErr {
+            return nil, util.AbsolutePath{}, aerr
+        }
+        agentErr := types.NewAgentError(types.ErrorRenvLockPackagesReading, err, lockfileErrDetails{Lockfile: lockfilePath.String()})
+        agentErr.Message = fmt.Sprintf("Could not scan R packages from lockfile: %s, %s", lockfileString, err.Error())
+        return nil, util.AbsolutePath{}, agentErr
+    }
+    log.Info("Done collecting R package descriptions")
+    p.emitter.Emit(events.New(op, events.SuccessPhase, events.NoError, getRPackageDescriptionsSuccessData{}))
 
-	return rPackages, nil
+    return rPackages, lockfilePath, nil
+}
+
+// copyLockfileToPositDir copies a lockfile into .posit/publish within the
+// project directory. Returns the path relative to the project root.
+func (p *defaultPublisher) copyLockfileToPositDir(lockfilePath util.Path, log logging.Logger) (util.RelativePath, error) {
+	// Ensure destination directory exists
+	targetDir := p.Dir.Join(".posit", "publish")
+	if err := targetDir.MkdirAll(0777); err != nil {
+		return util.RelativePath{}, err
+	}
+
+    src, err := lockfilePath.Open()
+	if err != nil {
+		return util.RelativePath{}, err
+	}
+	defer src.Close()
+
+    // Always stage as renv.lock regardless of source filename
+    targetPath := targetDir.Join("renv.lock")
+	dst, err := targetPath.Create()
+	if err != nil {
+		return util.RelativePath{}, err
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return util.RelativePath{}, err
+	}
+
+	rel, err := targetPath.Rel(p.Dir)
+	if err != nil {
+		return util.RelativePath{}, err
+	}
+	return rel, nil
 }


### PR DESCRIPTION
## Intent

Alternative to https://github.com/posit-dev/publisher/pull/3030 that always ensures a lockfile is in the generated bundle.
This would allow more robust bundles to future evolutions where Connect Server uses the lockfile directly.

## Type of Change

- - [x] Bug Fix <!-- A change which fixes an existing issue -->

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
