### PR TITLE
feat(rendering): More prominent Quarto rendering status messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added more prominent status messages when rendering Quarto documents. #2940
+
 ## [1.22.0]
 
 ### Added

--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -142,8 +142,12 @@ export type PublishFinishFailureMsg = AnyHostToWebviewMessage<
 >;
 export type ContentRenderFinishedMsg =
   AnyHostToWebviewMessage<HostToWebviewMessageType.CONTENT_RENDER_FINISHED>;
-export type ContentRenderFailureMsg =
-  AnyHostToWebviewMessage<HostToWebviewMessageType.CONTENT_RENDER_FAILURE>;
+export type ContentRenderFailureMsg = AnyHostToWebviewMessage<
+  HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+  {
+    error: string;
+  }
+>;
 export type UpdateContentRecordSelectionMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION,
   {

--- a/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
+++ b/extensions/vscode/src/types/messages/hostToWebviewMessages.ts
@@ -24,7 +24,7 @@ export enum HostToWebviewMessageType {
   PUBLISH_START = "publishStart",
   PUBLISH_FINISH_SUCCESS = "publishFinishSuccess",
   PUBLISH_FINISH_FAILURE = "publishFinishFailure",
-  CONTENT_RENDER_FINISHED = "contentRenderFinished",
+  CONTENT_RENDER_SUCCESS = "contentRenderSuccess",
   CONTENT_RENDER_FAILURE = "contentRenderFailure",
   UPDATE_CONTENTRECORD_SELECTION = "updateContentRecordSelection",
   SAVE_SELECTION = "saveSelection",
@@ -59,7 +59,7 @@ export type HostToWebviewMessage =
   | PublishStartMsg
   | PublishFinishSuccessMsg
   | PublishFinishFailureMsg
-  | ContentRenderFinishedMsg
+  | ContentRenderSuccessMsg
   | ContentRenderFailureMsg
   | UpdateContentRecordSelectionMsg
   | SaveSelectionMsg
@@ -85,7 +85,7 @@ export function isHostToWebviewMessage(msg: any): msg is HostToWebviewMessage {
     msg.kind === HostToWebviewMessageType.PUBLISH_START ||
     msg.kind === HostToWebviewMessageType.PUBLISH_FINISH_SUCCESS ||
     msg.kind === HostToWebviewMessageType.PUBLISH_FINISH_FAILURE ||
-    msg.kind === HostToWebviewMessageType.CONTENT_RENDER_FINISHED ||
+    msg.kind === HostToWebviewMessageType.CONTENT_RENDER_SUCCESS ||
     msg.kind === HostToWebviewMessageType.CONTENT_RENDER_FAILURE ||
     msg.kind === HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION ||
     msg.kind === HostToWebviewMessageType.SAVE_SELECTION ||
@@ -140,8 +140,8 @@ export type PublishFinishFailureMsg = AnyHostToWebviewMessage<
     };
   }
 >;
-export type ContentRenderFinishedMsg =
-  AnyHostToWebviewMessage<HostToWebviewMessageType.CONTENT_RENDER_FINISHED>;
+export type ContentRenderSuccessMsg =
+  AnyHostToWebviewMessage<HostToWebviewMessageType.CONTENT_RENDER_SUCCESS>;
 export type ContentRenderFailureMsg = AnyHostToWebviewMessage<
   HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
   {

--- a/extensions/vscode/src/views/renders.test.ts
+++ b/extensions/vscode/src/views/renders.test.ts
@@ -116,6 +116,9 @@ describe("renderQuartoContent", () => {
       );
       expect(conduitSendMsgSpy).toHaveBeenCalledWith({
         kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+        content: {
+          error: "Unknown error trying to render Quarto content.",
+        },
       });
     });
 
@@ -135,6 +138,10 @@ describe("renderQuartoContent", () => {
       );
       expect(conduitSendMsgSpy).toHaveBeenCalledWith({
         kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+        content: {
+          error:
+            "Cannot render Quarto content. Quarto is not available on the system.",
+        },
       });
     });
 
@@ -150,10 +157,13 @@ describe("renderQuartoContent", () => {
       expect(quartoHelperRenderSpy).toHaveBeenCalled();
       expect(window.showInformationMessage).not.toHaveBeenCalled();
       expect(window.showErrorMessage).toHaveBeenCalledWith(
-        "Failed to render Quarto content. Error: Could not render Quarto project.",
+        "Could not render Quarto project.",
       );
       expect(conduitSendMsgSpy).toHaveBeenCalledWith({
         kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+        content: {
+          error: "Could not render Quarto project.",
+        },
       });
     });
 
@@ -173,6 +183,10 @@ describe("renderQuartoContent", () => {
       );
       expect(conduitSendMsgSpy).toHaveBeenCalledWith({
         kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+        content: {
+          error:
+            "Unknown error trying to render Quarto content. Error: system is down",
+        },
       });
     });
   });

--- a/extensions/vscode/src/views/renders.test.ts
+++ b/extensions/vscode/src/views/renders.test.ts
@@ -95,7 +95,7 @@ describe("renderQuartoContent", () => {
       "Finished rendering Quarto content.",
     );
     expect(conduitSendMsgSpy).toHaveBeenCalledWith({
-      kind: HostToWebviewMessageType.CONTENT_RENDER_FINISHED,
+      kind: HostToWebviewMessageType.CONTENT_RENDER_SUCCESS,
     });
   });
 

--- a/extensions/vscode/src/views/renders.ts
+++ b/extensions/vscode/src/views/renders.ts
@@ -38,23 +38,21 @@ export const renderQuartoContent = async (
       kind: HostToWebviewMessageType.CONTENT_RENDER_FINISHED,
     });
   } catch (err: unknown) {
+    let errMsg = "Unknown error trying to render Quarto content.";
+    if (err instanceof ErrorNoQuarto) {
+      errMsg =
+        "Cannot render Quarto content. Quarto is not available on the system.";
+    } else if (err instanceof ErrorQuartoRender) {
+      errMsg = err.message;
+    } else if (err instanceof Error) {
+      errMsg = `Unknown error trying to render Quarto content. Error: ${err.message}`;
+    }
+    window.showErrorMessage(errMsg);
     conduit.sendMsg({
       kind: HostToWebviewMessageType.CONTENT_RENDER_FAILURE,
+      content: {
+        error: errMsg,
+      },
     });
-    if (err instanceof ErrorNoQuarto) {
-      window.showErrorMessage(
-        "Cannot render Quarto content. Quarto is not available on the system.",
-      );
-    } else if (err instanceof ErrorQuartoRender) {
-      window.showErrorMessage(
-        `Failed to render Quarto content. Error: ${err.message}`,
-      );
-    } else if (err instanceof Error) {
-      window.showErrorMessage(
-        `Unknown error trying to render Quarto content. Error: ${err.message}`,
-      );
-    } else {
-      window.showErrorMessage("Unknown error trying to render Quarto content.");
-    }
   }
 };

--- a/extensions/vscode/src/views/renders.ts
+++ b/extensions/vscode/src/views/renders.ts
@@ -35,7 +35,7 @@ export const renderQuartoContent = async (
     );
     window.showInformationMessage("Finished rendering Quarto content.");
     conduit.sendMsg({
-      kind: HostToWebviewMessageType.CONTENT_RENDER_FINISHED,
+      kind: HostToWebviewMessageType.CONTENT_RENDER_SUCCESS,
     });
   } catch (err: unknown) {
     let errMsg = "Unknown error trying to render Quarto content.";

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -207,7 +207,6 @@ const onPublishFinishFailureMsg = (msg: PublishFinishFailureMsg) => {
 const onContentRenderFinishedMsg = () => {
   const home = useHomeStore();
   home.contentRenderInProgress = false;
-  console.log("MESSAGE RECEIVED, render in progress set to false");
 };
 const onContentRenderFailureMsg = () => {
   const home = useHomeStore();

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -6,6 +6,7 @@ import {
   HostToWebviewMessage,
   HostToWebviewMessageType,
   PublishFinishFailureMsg,
+  ContentRenderFailureMsg,
   RefreshConfigDataMsg,
   RefreshCredentialDataMsg,
   RefreshContentRecordDataMsg,
@@ -81,7 +82,7 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
     case HostToWebviewMessageType.CONTENT_RENDER_FINISHED:
       return onContentRenderFinishedMsg();
     case HostToWebviewMessageType.CONTENT_RENDER_FAILURE:
-      return onContentRenderFailureMsg();
+      return onContentRenderFailureMsg(msg);
     case HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION:
       return onUpdateContentRecordSelectionMsg(msg);
     case HostToWebviewMessageType.SAVE_SELECTION:
@@ -206,11 +207,13 @@ const onPublishFinishFailureMsg = (msg: PublishFinishFailureMsg) => {
 };
 const onContentRenderFinishedMsg = () => {
   const home = useHomeStore();
+  home.contentRenderFinished = true;
   home.contentRenderInProgress = false;
 };
-const onContentRenderFailureMsg = () => {
+const onContentRenderFailureMsg = (msg: ContentRenderFailureMsg) => {
   const home = useHomeStore();
-  home.contentRenderFailed = true;
+  home.contentRenderError = msg.content.error;
+  home.contentRenderInProgress = false;
 };
 const onUpdateContentRecordSelectionMsg = (
   msg: UpdateContentRecordSelectionMsg,

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -79,8 +79,8 @@ const onMessageFromHost = (msg: HostToWebviewMessage): void => {
       return onPublishFinishSuccessMsg();
     case HostToWebviewMessageType.PUBLISH_FINISH_FAILURE:
       return onPublishFinishFailureMsg(msg);
-    case HostToWebviewMessageType.CONTENT_RENDER_FINISHED:
-      return onContentRenderFinishedMsg();
+    case HostToWebviewMessageType.CONTENT_RENDER_SUCCESS:
+      return onContentRenderSuccessMsg();
     case HostToWebviewMessageType.CONTENT_RENDER_FAILURE:
       return onContentRenderFailureMsg(msg);
     case HostToWebviewMessageType.UPDATE_CONTENTRECORD_SELECTION:
@@ -205,14 +205,16 @@ const onPublishFinishFailureMsg = (msg: PublishFinishFailureMsg) => {
   home.lastContentRecordResult = `Last Deployment Failed`;
   home.lastContentRecordMsg = msg.content.data.message;
 };
-const onContentRenderFinishedMsg = () => {
+const onContentRenderSuccessMsg = () => {
   const home = useHomeStore();
-  home.contentRenderFinished = true;
+  home.contentRenderError = undefined;
+  home.contentRenderSuccess = true;
   home.contentRenderInProgress = false;
 };
 const onContentRenderFailureMsg = (msg: ContentRenderFailureMsg) => {
   const home = useHomeStore();
   home.contentRenderError = msg.content.error;
+  home.contentRenderSuccess = false;
   home.contentRenderInProgress = false;
 };
 const onUpdateContentRecordSelectionMsg = (

--- a/extensions/vscode/webviews/homeView/src/HostConduitService.ts
+++ b/extensions/vscode/webviews/homeView/src/HostConduitService.ts
@@ -207,6 +207,7 @@ const onPublishFinishFailureMsg = (msg: PublishFinishFailureMsg) => {
 const onContentRenderFinishedMsg = () => {
   const home = useHomeStore();
   home.contentRenderInProgress = false;
+  console.log("MESSAGE RECEIVED, render in progress set to false");
 };
 const onContentRenderFailureMsg = () => {
   const home = useHomeStore();

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -46,11 +46,12 @@ const deploy = () => {
     return;
   }
 
-  // If there is any render error message, clear that up
-  home.contentRenderFailed = false;
-
   // stop the user from double clicking the deploy button by mistake
   home.publishInitiated = true;
+
+  // If there is any render process flags, clear that up
+  home.contentRenderFinished = false;
+  home.contentRenderError = undefined;
 
   // Only send up secrets that have values
   const secrets: Record<string, string> = {};

--- a/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/DeployButton.vue
@@ -50,7 +50,7 @@ const deploy = () => {
   home.publishInitiated = true;
 
   // If there is any render process flags, clear that up
-  home.contentRenderFinished = false;
+  home.contentRenderSuccess = undefined;
   home.contentRenderError = undefined;
 
   // Only send up secrets that have values

--- a/extensions/vscode/webviews/homeView/src/components/ProcessProgress.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ProcessProgress.vue
@@ -25,7 +25,7 @@ const renderInProgressMsg = computed(() => {
   // We currently only render content with Quarto
   // but if we get to a point of rendering with Rmd or by other means
   // Here is a good place to identify the "source" and use an appropriate label
-  return "Quarto is running to output your content";
+  return "Quarto is running to generate your content";
 });
 
 const contextMenuVSCodeContext = computed((): string => {

--- a/extensions/vscode/webviews/homeView/src/components/ProcessProgress.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ProcessProgress.vue
@@ -1,0 +1,99 @@
+<!-- Copyright (C) 2025 by Posit Software, PBC. -->
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { isPreContentRecord } from "../../../../src/api";
+import { useHomeStore } from "src/stores/home";
+
+const emit = defineEmits<{
+  viewLog: [];
+}>();
+
+const home = useHomeStore();
+
+const processProgressLabel = computed(() => {
+  if (home.publishInProgress) {
+    return "Deployment in Progress...";
+  }
+  if (home.contentRenderInProgress) {
+    return "Rendering Content...";
+  }
+  return "";
+});
+
+const renderInProgressMsg = computed(() => {
+  // We currently only render content with Quarto
+  // but if we get to a point of rendering with Rmd or by other means
+  // Here is a good place to identify the "source" and use an appropriate label
+  return "Quarto is running to output your content";
+});
+
+const contextMenuVSCodeContext = computed((): string => {
+  return home.publishInProgress ||
+    isPreContentRecord(home.selectedContentRecord)
+    ? "homeview-active-contentRecord-more-menu"
+    : "homeview-last-contentRecord-more-menu";
+});
+</script>
+
+<template>
+  <div class="process-in-progress">
+    <vscode-progress-ring class="process-in-progress__ring" />
+    <div class="flex-grow">
+      <div class="process-in-progress__title-block">
+        <h4
+          class="process-in-progress__title"
+          data-automation="deployment-progress"
+        >
+          {{ processProgressLabel }}
+        </h4>
+        <ActionToolbar
+          v-if="home.publishInProgress"
+          title="Logs"
+          :actions="[]"
+          :context-menu="contextMenuVSCodeContext"
+        />
+      </div>
+      <p v-if="home.publishInProgress" class="process-in-progress__log-anchor">
+        <a class="webview-link" role="button" @click="emit('viewLog')">
+          View Publishing Log
+        </a>
+      </p>
+      <p
+        v-if="home.contentRenderInProgress"
+        class="process-in-progress__render-msg"
+      >
+        {{ renderInProgressMsg }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.process-in-progress {
+  display: flex;
+
+  &__ring {
+    flex-grow: 0;
+    margin-top: 1.33em;
+    margin-right: 10px;
+  }
+
+  &__title-block {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  &__title {
+    margin-block-start: 1.33em;
+    margin-bottom: 5px;
+  }
+
+  &__log-anchor,
+  &__render-msg {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/ProcessSummary.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ProcessSummary.vue
@@ -1,0 +1,193 @@
+<!-- Copyright (C) 2025 by Posit Software, PBC. -->
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { ServerType, isPreContentRecord } from "../../../../src/api";
+import {
+  getProductType,
+  isConnectProduct,
+} from "../../../../src/utils/multiStepHelpers";
+import { ErrorMessageSplitOptions } from "../../../../src/utils/errorEnhancer";
+import { useHomeStore } from "src/stores/home";
+import { formatDateString } from "src/utils/date";
+import TextStringWithAnchor from "./TextStringWithAnchor.vue";
+
+const emit = defineEmits<{
+  associateDeployment: [];
+  viewContent: [];
+  errorLinkClick: [splitOptionId: number];
+}>();
+
+const home = useHomeStore();
+
+const isDismissedContentRecord = computed(() => {
+  return Boolean(home.selectedContentRecord?.dismissedAt);
+});
+
+const isPreContentRecordWithID = computed(() => {
+  return (
+    isPreContentRecord(home.selectedContentRecord) &&
+    Boolean(home.selectedContentRecord.id)
+  );
+});
+
+const isPreContentRecordWithoutID = computed(() => {
+  return (
+    isPreContentRecord(home.selectedContentRecord) &&
+    !isPreContentRecordWithID.value
+  );
+});
+
+const isConnectPreContentRecord = computed(() => {
+  const serverType =
+    home.selectedContentRecord?.serverType || ServerType.CONNECT;
+  const productType = getProductType(serverType);
+  return isConnectProduct(productType);
+});
+
+const lastStatusDescription = computed(() => {
+  if (home.contentRenderError) {
+    return "Content Render Failed";
+  }
+  if (home.contentRenderFinished) {
+    return "Content Render Finished";
+  }
+  if (!home.selectedContentRecord) {
+    return undefined;
+  }
+  if (isDismissedContentRecord.value) {
+    return "Last Deployment Dismissed";
+  }
+  if (home.selectedContentRecord.deploymentError) {
+    return "Last Deployment Failed";
+  }
+  if (isPreContentRecord(home.selectedContentRecord)) {
+    return isPreContentRecordWithID.value
+      ? "Not Yet Updated"
+      : "Not Yet Deployed";
+  }
+  return "Last Deployment Successful";
+});
+
+const successfulRenderMsg = computed(() => {
+  // We currently only render content with Quarto
+  // but if we get to a point of rendering with Rmd or by other means
+  // Here is a good place to identify the "source" and use an appropriate label
+  return "Successfully rendered with Quarto";
+});
+
+const contextMenuVSCodeContext = computed((): string => {
+  return home.publishInProgress ||
+    isPreContentRecord(home.selectedContentRecord)
+    ? "homeview-active-contentRecord-more-menu"
+    : "homeview-last-contentRecord-more-menu";
+});
+</script>
+
+<template>
+  <div class="last-action-summary" data-automation="deploy-status">
+    <h4 class="last-action-summary__title">
+      {{ lastStatusDescription }}
+    </h4>
+    <ActionToolbar
+      v-if="!home.contentRenderFinished"
+      title="Logs"
+      :actions="[]"
+      :context-menu="contextMenuVSCodeContext"
+    />
+  </div>
+  <template v-if="home.contentRenderFinished">
+    <div>
+      {{ successfulRenderMsg }}
+    </div>
+  </template>
+  <template v-else-if="home.contentRenderError">
+    <div class="last-action-summary__error">
+      <div class="alert-border border-warning text-warning">
+        <span class="codicon codicon-alert" />
+      </div>
+      <div>
+        {{ home.contentRenderError }}
+      </div>
+    </div>
+  </template>
+  <template v-else-if="home.selectedContentRecord && isDismissedContentRecord">
+    <div class="date-time">
+      {{ formatDateString(home.selectedContentRecord.dismissedAt) }}
+    </div>
+  </template>
+  <template v-else>
+    <div v-if="isPreContentRecordWithoutID && isConnectPreContentRecord">
+      Is this already deployed to a Connect server? You can
+      <a class="webview-link" role="button" @click="emit('associateDeployment')"
+        >update that previous deployment</a
+      >.
+    </div>
+    <div v-if="isPreContentRecordWithID">
+      <a class="webview-link" role="button" @click="emit('viewContent')"
+        >This deployment</a
+      >
+      will be updated when deployed.
+    </div>
+    <div
+      v-if="
+        home.selectedContentRecord &&
+        !isPreContentRecord(home.selectedContentRecord)
+      "
+      class="date-time"
+    >
+      {{ formatDateString(home.selectedContentRecord.deployedAt) }}
+    </div>
+    <div
+      v-if="home.selectedContentRecord?.deploymentError"
+      class="last-action-summary__error"
+    >
+      <div class="alert-border border-warning text-warning">
+        <span class="codicon codicon-alert" />
+      </div>
+      <TextStringWithAnchor
+        :message="home.selectedContentRecord?.deploymentError?.msg"
+        :splitOptions="ErrorMessageSplitOptions"
+        class="last-action-summary__error-anchor text-description"
+        @click="emit('errorLinkClick', $event)"
+      />
+    </div>
+  </template>
+</template>
+
+<style lang="scss" scoped>
+.last-action-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+
+  &__title {
+    margin-block-start: 1.33em;
+    margin-bottom: 5px;
+  }
+
+  &__error {
+    display: flex;
+    align-items: stretch;
+    margin-top: 10px;
+
+    .alert-border {
+      display: flex;
+      align-items: center;
+      border-right-width: 1px;
+      border-right-style: solid;
+      padding-right: 5px;
+      margin-right: 7px;
+    }
+
+    &-anchor {
+      min-width: 0;
+      word-wrap: break-word;
+    }
+  }
+}
+
+.date-time {
+  margin-bottom: 20px;
+}
+</style>

--- a/extensions/vscode/webviews/homeView/src/components/ProcessSummary.vue
+++ b/extensions/vscode/webviews/homeView/src/components/ProcessSummary.vue
@@ -117,8 +117,8 @@ const contextMenuVSCodeContext = computed((): string => {
     </div>
   </template>
   <template v-else>
-    <div v-if="isPreContentRecordWithoutID && isConnectPreContentRecord">
-      Is this already deployed to a Connect server? You can
+    <div v-if="isPreContentRecordWithoutID">
+      Is this already deployed to a server? You can
       <a class="webview-link" role="button" @click="emit('associateDeployment')"
         >update that previous deployment</a
       >.

--- a/extensions/vscode/webviews/homeView/src/components/RenderButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/RenderButton.vue
@@ -16,8 +16,9 @@ import { WebviewToHostMessageType } from "../../../../src/types/messages/webview
 const home = useHomeStore();
 const hostConduit = useHostConduitService();
 const render = () => {
-  home.contentRenderFailed = false;
+  home.contentRenderError = undefined;
   home.contentRenderInProgress = true;
+  home.contentRenderFinished = false;
   hostConduit.sendMsg({ kind: WebviewToHostMessageType.RENDER_CONTENT });
 };
 </script>

--- a/extensions/vscode/webviews/homeView/src/components/RenderButton.vue
+++ b/extensions/vscode/webviews/homeView/src/components/RenderButton.vue
@@ -17,8 +17,8 @@ const home = useHomeStore();
 const hostConduit = useHostConduitService();
 const render = () => {
   home.contentRenderError = undefined;
+  home.contentRenderSuccess = undefined;
   home.contentRenderInProgress = true;
-  home.contentRenderFinished = false;
   hostConduit.sendMsg({ kind: WebviewToHostMessageType.RENDER_CONTENT });
 };
 </script>

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -35,7 +35,7 @@ export const useHomeStore = defineStore("home", () => {
   const publishInProgress = ref(false);
   const publishInitiated = ref(false);
   const contentRenderInProgress = ref(false);
-  const contentRenderFinished = ref(false);
+  const contentRenderSuccess = ref<boolean | undefined>(undefined);
   const contentRenderError = ref<string | undefined>(undefined);
 
   const contentRecords = ref<(ContentRecord | PreContentRecord)[]>([]);
@@ -470,7 +470,7 @@ export const useHomeStore = defineStore("home", () => {
     publishInProgress,
     publishInitiated,
     contentRenderInProgress,
-    contentRenderFinished,
+    contentRenderSuccess,
     contentRenderError,
     contentRecords,
     configurations,

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -35,7 +35,8 @@ export const useHomeStore = defineStore("home", () => {
   const publishInProgress = ref(false);
   const publishInitiated = ref(false);
   const contentRenderInProgress = ref(false);
-  const contentRenderFailed = ref(false);
+  const contentRenderFinished = ref(false);
+  const contentRenderError = ref<string | undefined>(undefined);
 
   const contentRecords = ref<(ContentRecord | PreContentRecord)[]>([]);
   const configurations = ref<Configuration[]>([]);
@@ -469,7 +470,8 @@ export const useHomeStore = defineStore("home", () => {
     publishInProgress,
     publishInitiated,
     contentRenderInProgress,
-    contentRenderFailed,
+    contentRenderFinished,
+    contentRenderError,
     contentRecords,
     configurations,
     configurationsInError,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Resolves #2940 

This PR aims to communicate more prominently the result of the rendering.
- Render was successful
- Render failed

<details>
<summary>
Screenshots
</summary>

**Rendering content**
<img width="538" height="388" alt="Screenshot 2025-09-08 at 11 43 59 a m" src="https://github.com/user-attachments/assets/7ef4753e-87d2-4a79-a57d-7790a7aeac64" />

---

**Successful render**
<img width="666" height="422" alt="Screenshot 2025-09-08 at 11 44 13 a m" src="https://github.com/user-attachments/assets/2f6836d5-49ba-4fa5-943a-886ced3353ce" />

---

**Render failed**
<img width="583" height="389" alt="Screenshot 2025-09-08 at 12 35 32 p m" src="https://github.com/user-attachments/assets/675ec1ce-cb22-4b70-822d-82059a041e4b" />

</details>

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

- Create two new components to handle the messaging (pulled out from `EvenEasierDeploy`), `<ProcessSummary>` and `<ProcessProgress>`
- Enhance the render events between `host <-> view` to communicate more details of the render process and use the new components to display such status.

## User Impact

User will have more prominent messaging about the end result of rendering Quarto projects.

## Automated Tests

Added and updated unit tests

## Directions for Reviewers

For Quarto projects deployed as static content (choosing "Publish rendered document" when creating the deployment), try using the "Render Your Project" button and notice that the status of the rendering is more noticeable now.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
