### PR TITLE
feat: Use Positron configured repositories if available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added "Set Up renv" button to initialize the environment, install
   dependencies, and create a lockfile when no valid R lockfile file is present (#3000, #3048)
 - Added support for managing OAuth integration content requirements directly from the "Integration Requests" pane in the Publisher UI. Auto-association of OAuth integrations is supported when deploying to Posit Connect 2025.09.0 or later with a license that includes OAuth integrations. (#3016)
-- Added a "Render Your Project" button that shows up for HTML project deployments rendered by Quarto
-  to easily update and publish the rendered output (#2948)
+- Added a "Render Your Project" button that shows up for HTML project deployments
+  rendered by Quarto to easily update and publish the rendered output (#2948)
+- Added support for Positron repositories configuration when detecting dependencies,
+  allowing dependencies to be installed with the configured CRAN repository.
 
 ### Fixed
 

--- a/extensions/vscode/src/api/index.ts
+++ b/extensions/vscode/src/api/index.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
 export { initApi, useApi } from "./client";
-export type { PositronSettings } from "./types/positron";
+export type { PositronSettings, RPackageRepository } from "./types/positron";
 
 export * from "./types/credentials";
 export * from "./types/configurations";

--- a/extensions/vscode/src/api/index.ts
+++ b/extensions/vscode/src/api/index.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
 export { initApi, useApi } from "./client";
+export type { PositronSettings } from "./types/positron";
 
 export * from "./types/credentials";
 export * from "./types/configurations";

--- a/extensions/vscode/src/api/resources/ContentRecords.ts
+++ b/extensions/vscode/src/api/resources/ContentRecords.ts
@@ -8,6 +8,7 @@ import {
   ContentRecord,
   Environment,
 } from "../types/contentRecords";
+import type { PositronSettings } from "../types/positron";
 import { PythonExecutable, RExecutable } from "../../types/shared";
 
 export class ContentRecords {
@@ -78,7 +79,7 @@ export class ContentRecords {
     r: RExecutable | undefined,
     python: PythonExecutable | undefined,
     secrets?: Record<string, string>,
-    positron?: import("../types/positron").PositronSettings,
+    positron?: PositronSettings,
   ) {
     const data = {
       account: accountName,

--- a/extensions/vscode/src/api/resources/ContentRecords.ts
+++ b/extensions/vscode/src/api/resources/ContentRecords.ts
@@ -78,12 +78,14 @@ export class ContentRecords {
     r: RExecutable | undefined,
     python: PythonExecutable | undefined,
     secrets?: Record<string, string>,
+    positron?: import("../types/positron").PositronSettings,
   ) {
     const data = {
       account: accountName,
       config: configName,
       secrets: secrets,
       insecure: insecure,
+      positron,
     };
     const encodedTarget = encodeURIComponent(targetName);
     return this.client.post<{ localId: string }>(

--- a/extensions/vscode/src/api/resources/Packages.ts
+++ b/extensions/vscode/src/api/resources/Packages.ts
@@ -74,11 +74,13 @@ export class Packages {
     dir: string,
     r: RExecutable | undefined,
     saveName?: string,
+    positron?: import("../types/positron").PositronSettings,
   ) {
     return this.client.post<void>(
       "packages/r/scan",
       {
         saveName,
+        positron,
       },
       {
         params: {

--- a/extensions/vscode/src/api/resources/Packages.ts
+++ b/extensions/vscode/src/api/resources/Packages.ts
@@ -6,6 +6,7 @@ import {
   PythonPackagesResponse,
   ScanPythonPackagesResponse,
 } from "../types/packages";
+import type { PositronSettings } from "../types/positron";
 import { PythonExecutable, RExecutable } from "../../types/shared";
 
 export class Packages {
@@ -74,7 +75,7 @@ export class Packages {
     dir: string,
     r: RExecutable | undefined,
     saveName?: string,
-    positron?: import("../types/positron").PositronSettings,
+    positron?: PositronSettings,
   ) {
     return this.client.post<void>(
       "packages/r/scan",

--- a/extensions/vscode/src/api/resources/RepoOptionsForwarding.test.ts
+++ b/extensions/vscode/src/api/resources/RepoOptionsForwarding.test.ts
@@ -4,6 +4,7 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 import { AxiosInstance } from "axios";
 import { Packages } from "./Packages";
 import { ContentRecords } from "./ContentRecords";
+import type { PositronSettings } from "../types/positron";
 
 describe("Repo options forwarding to API requests", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -18,7 +19,9 @@ describe("Repo options forwarding to API requests", () => {
       rPath: "/usr/bin/R",
     } as unknown as import("../../types/shared").RExecutable;
     const saveName = "renv.lock";
-    const positron = { r: { defaultRepositories: "posit-ppm" } };
+    const positron: PositronSettings = {
+      r: { defaultRepositories: "posit-ppm" },
+    };
 
     mockPost.mockResolvedValue({ status: 200, data: {} });
     await api.createRRequirementsFile(dir, r, saveName, positron);
@@ -47,7 +50,7 @@ describe("Repo options forwarding to API requests", () => {
       pythonPath: "/usr/bin/python",
     } as unknown as import("../../types/shared").PythonExecutable;
     const secrets = { token: "xyz" };
-    const positron = {
+    const positron: PositronSettings = {
       r: {
         defaultRepositories: "auto",
         packageManagerRepository: "https://example/cran",

--- a/extensions/vscode/src/api/resources/RepoOptionsForwarding.test.ts
+++ b/extensions/vscode/src/api/resources/RepoOptionsForwarding.test.ts
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { AxiosInstance } from "axios";
+import { Packages } from "./Packages";
+import { ContentRecords } from "./ContentRecords";
+
+describe("Repo options forwarding to API requests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("Packages.createRRequirementsFile forwards positron settings", async () => {
+    const mockPost = vi.fn();
+    const axiosMock = { post: mockPost } as unknown as AxiosInstance;
+    const api = new Packages(axiosMock);
+
+    const dir = "/proj";
+    const r = {
+      rPath: "/usr/bin/R",
+    } as unknown as import("../../types/shared").RExecutable;
+    const saveName = "renv.lock";
+    const positron = { r: { defaultRepositories: "posit-ppm" } };
+
+    mockPost.mockResolvedValue({ status: 200, data: {} });
+    await api.createRRequirementsFile(dir, r, saveName, positron);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "packages/r/scan",
+      { saveName, positron },
+      { params: { dir, r: "/usr/bin/R" } },
+    );
+  });
+
+  test("ContentRecords.publish forwards positron settings", async () => {
+    const mockPost = vi.fn();
+    const axiosMock = { post: mockPost } as unknown as AxiosInstance;
+    const api = new ContentRecords(axiosMock);
+
+    const targetName = "My Deployment";
+    const accountName = "acct";
+    const configName = "cfg";
+    const insecure = false;
+    const dir = "/proj";
+    const r = {
+      rPath: "/usr/bin/R",
+    } as unknown as import("../../types/shared").RExecutable;
+    const python = {
+      pythonPath: "/usr/bin/python",
+    } as unknown as import("../../types/shared").PythonExecutable;
+    const secrets = { token: "xyz" };
+    const positron = {
+      r: {
+        defaultRepositories: "auto",
+        packageManagerRepository: "https://example/cran",
+      },
+    };
+
+    mockPost.mockResolvedValue({ status: 200, data: { localId: "1" } });
+    await api.publish(
+      targetName,
+      accountName,
+      configName,
+      insecure,
+      dir,
+      r,
+      python,
+      secrets,
+      positron,
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "deployments/My%20Deployment",
+      { account: accountName, config: configName, secrets, insecure, positron },
+      { params: { dir, r: "/usr/bin/R", python: "/usr/bin/python" } },
+    );
+  });
+});

--- a/extensions/vscode/src/api/types/positron.ts
+++ b/extensions/vscode/src/api/types/positron.ts
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+export type PositronRSettings = {
+  // One of: 'auto' | 'rstudio' | 'posit-ppm' | 'none'
+  // Future-proof: allow custom URL string type too
+  defaultRepositories: string;
+  packageManagerRepository?: string;
+};
+
+export type PositronSettings = {
+  r?: PositronRSettings;
+};

--- a/extensions/vscode/src/api/types/positron.ts
+++ b/extensions/vscode/src/api/types/positron.ts
@@ -1,9 +1,15 @@
 // Copyright (C) 2025 by Posit Software, PBC.
 
+export type RPackageRepository =
+  | "auto"
+  | "rstudio"
+  | "posit-ppm"
+  | "none"
+  | string;
+
 export type PositronRSettings = {
   // One of: 'auto' | 'rstudio' | 'posit-ppm' | 'none'
-  // Future-proof: allow custom URL string type too
-  defaultRepositories: string;
+  defaultRepositories: RPackageRepository;
   packageManagerRepository?: string;
 };
 

--- a/extensions/vscode/src/utils/positronSettings.ts
+++ b/extensions/vscode/src/utils/positronSettings.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 by Posit Software, PBC.
 
 import { workspace } from "vscode";
-import type { PositronSettings } from "src/api";
+import type { PositronSettings, RPackageRepository } from "src/api";
 
 // Returns Positron repo settings derived from VS Code configuration.
 // - Always includes r.defaultRepositories (defaults to "auto").
@@ -10,7 +10,7 @@ export function getPositronRepoSettings(): PositronSettings {
   const cfg = workspace.getConfiguration("positron.r");
   const defaultRepos = (
     cfg.get<string>("defaultRepositories") || "auto"
-  ).trim();
+  ).trim() as RPackageRepository;
   const ppmRepo = (cfg.get<string>("packageManagerRepository") || "").trim();
 
   return {

--- a/extensions/vscode/src/utils/positronSettings.ts
+++ b/extensions/vscode/src/utils/positronSettings.ts
@@ -1,0 +1,24 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { workspace } from "vscode";
+import type { PositronSettings } from "src/api";
+
+// Returns Positron repo settings derived from VS Code configuration.
+// - Always includes r.defaultRepositories (defaults to "auto").
+// - Adds r.packageManagerRepository only when defaultRepositories === "auto" and the repo is set.
+export function getPositronRepoSettings(): PositronSettings {
+  const cfg = workspace.getConfiguration("positron.r");
+  const defaultRepos = (
+    cfg.get<string>("defaultRepositories") || "auto"
+  ).trim();
+  const ppmRepo = (cfg.get<string>("packageManagerRepository") || "").trim();
+
+  return {
+    r: {
+      defaultRepositories: defaultRepos,
+      ...(defaultRepos === "auto" && ppmRepo
+        ? { packageManagerRepository: ppmRepo }
+        : {}),
+    },
+  };
+}

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -292,6 +292,11 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const r = await getRInterpreterPath();
       const python = await getPythonInterpreterPath();
 
+      // Collect IDE-controlled repo settings
+      const cfg = workspace.getConfiguration("positron.r");
+      const defaultRepos = cfg.get<string>("defaultRepositories") || "auto";
+      const ppmRepo = cfg.get<string>("packageManagerRepository");
+
       const response = await api.contentRecords.publish(
         deploymentName,
         credentialName,
@@ -301,6 +306,15 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         r,
         python,
         secrets,
+        {
+          r: {
+            defaultRepositories: defaultRepos,
+            // only attach ppm if defined
+            ...(defaultRepos === "auto" && ppmRepo
+              ? { packageManagerRepository: ppmRepo }
+              : {}),
+          },
+        },
       );
       deployProject(
         deploymentName,
@@ -974,10 +988,23 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           const api = await useApi();
           const r = await getRInterpreterPath();
 
+          // Collect IDE-controlled repo settings
+          const cfg = workspace.getConfiguration("positron.r");
+          const defaultRepos = cfg.get<string>("defaultRepositories") || "auto";
+          const ppmRepo = cfg.get<string>("packageManagerRepository");
+
           return await api.packages.createRRequirementsFile(
             activeConfiguration.projectDir,
             r,
             relPathPackageFile,
+            {
+              r: {
+                defaultRepositories: defaultRepos,
+                ...(defaultRepos === "auto" && ppmRepo
+                  ? { packageManagerRepository: ppmRepo }
+                  : {}),
+              },
+            },
           );
         },
       );

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -19,6 +19,7 @@ import {
   window,
   workspace,
 } from "vscode";
+import { getPositronRepoSettings } from "src/utils/positronSettings";
 import { isAxiosError } from "axios";
 import { Mutex } from "async-mutex";
 
@@ -293,9 +294,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const python = await getPythonInterpreterPath();
 
       // Collect IDE-controlled repo settings
-      const { getPositronRepoSettings } = await import(
-        "src/utils/positronSettings"
-      );
       const positron = getPositronRepoSettings();
 
       const response = await api.contentRecords.publish(
@@ -982,9 +980,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           const r = await getRInterpreterPath();
 
           // Collect IDE-controlled repo settings
-          const { getPositronRepoSettings } = await import(
-            "src/utils/positronSettings"
-          );
           const positron = getPositronRepoSettings();
 
           return await api.packages.createRRequirementsFile(

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -293,9 +293,10 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const python = await getPythonInterpreterPath();
 
       // Collect IDE-controlled repo settings
-      const cfg = workspace.getConfiguration("positron.r");
-      const defaultRepos = cfg.get<string>("defaultRepositories") || "auto";
-      const ppmRepo = cfg.get<string>("packageManagerRepository");
+      const { getPositronRepoSettings } = await import(
+        "src/utils/positronSettings"
+      );
+      const positron = getPositronRepoSettings();
 
       const response = await api.contentRecords.publish(
         deploymentName,
@@ -306,15 +307,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         r,
         python,
         secrets,
-        {
-          r: {
-            defaultRepositories: defaultRepos,
-            // only attach ppm if defined
-            ...(defaultRepos === "auto" && ppmRepo
-              ? { packageManagerRepository: ppmRepo }
-              : {}),
-          },
-        },
+        positron,
       );
       deployProject(
         deploymentName,
@@ -989,22 +982,16 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           const r = await getRInterpreterPath();
 
           // Collect IDE-controlled repo settings
-          const cfg = workspace.getConfiguration("positron.r");
-          const defaultRepos = cfg.get<string>("defaultRepositories") || "auto";
-          const ppmRepo = cfg.get<string>("packageManagerRepository");
+          const { getPositronRepoSettings } = await import(
+            "src/utils/positronSettings"
+          );
+          const positron = getPositronRepoSettings();
 
           return await api.packages.createRRequirementsFile(
             activeConfiguration.projectDir,
             r,
             relPathPackageFile,
-            {
-              r: {
-                defaultRepositories: defaultRepos,
-                ...(defaultRepos === "auto" && ppmRepo
-                  ? { packageManagerRepository: ppmRepo }
-                  : {}),
-              },
-            },
+            positron,
           );
         },
       );

--- a/internal/clients/connect/client_connect.go
+++ b/internal/clients/connect/client_connect.go
@@ -571,4 +571,3 @@ func (c *ConnectClient) GetIntegrations(log logging.Logger) ([]Integration, erro
 	}
 	return integrations, nil
 }
-

--- a/internal/clients/connect/mock_client.go
+++ b/internal/clients/connect/mock_client.go
@@ -127,4 +127,3 @@ func (m *MockClient) GetSettings(base util.AbsolutePath, cfg *config.Config, log
 	}
 	return args.Get(0).(*AllSettings), args.Error(1)
 }
-

--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -38,7 +38,6 @@ type defaultPackageMapper struct {
 	scanner             RDependencyScanner
 }
 
-// NewPackageMapper allows passing repository options used during dependency scanning.
 func NewPackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, repoOpts *RepoOptions) (PackageMapper, error) {
 	if lockfileOnly {
 		return NewLockfilePackageMapper(base, rExecutable, log), nil

--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -38,21 +38,22 @@ type defaultPackageMapper struct {
 	scanner             RDependencyScanner
 }
 
+// NewPackageMapper allows passing repository options used during dependency scanning.
 func NewPackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, repoOpts *RepoOptions) (PackageMapper, error) {
-	if lockfileOnly {
-		return NewLockfilePackageMapper(base, rExecutable, log), nil
-	}
+    if lockfileOnly {
+        return NewLockfilePackageMapper(base, rExecutable, log), nil
+    }
 
 	lister, err := NewAvailablePackageLister(base, rExecutable, log, nil, nil)
 
-	return &defaultPackageMapper{
-		rInterpreterFactory: func() (interpreters.RInterpreter, error) {
-			return interpreters.NewRInterpreter(base, rExecutable, log, nil, nil, nil)
-		},
-		rExecutable: rExecutable,
-		lister:      lister,
-		scanner:     NewRDependencyScanner(log, repoOpts),
-	}, err
+    return &defaultPackageMapper{
+        rInterpreterFactory: func() (interpreters.RInterpreter, error) {
+            return interpreters.NewRInterpreter(base, rExecutable, log, nil, nil, nil)
+        },
+        rExecutable: rExecutable,
+        lister:      lister,
+        scanner:     NewRDependencyScanner(log, repoOpts),
+    }, err
 }
 
 func findAvailableVersion(pkgName PackageName, availablePackages []AvailablePackage) string {

--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -38,7 +38,7 @@ type defaultPackageMapper struct {
 	scanner             RDependencyScanner
 }
 
-func NewPackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool) (PackageMapper, error) {
+func NewPackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, repoOpts *RepoOptions) (PackageMapper, error) {
 	if lockfileOnly {
 		return NewLockfilePackageMapper(base, rExecutable, log), nil
 	}
@@ -51,7 +51,7 @@ func NewPackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging
 		},
 		rExecutable: rExecutable,
 		lister:      lister,
-		scanner:     NewRDependencyScanner(log),
+		scanner:     NewRDependencyScanner(log, repoOpts),
 	}, err
 }
 

--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -40,20 +40,20 @@ type defaultPackageMapper struct {
 
 // NewPackageMapper allows passing repository options used during dependency scanning.
 func NewPackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, repoOpts *RepoOptions) (PackageMapper, error) {
-    if lockfileOnly {
-        return NewLockfilePackageMapper(base, rExecutable, log), nil
-    }
+	if lockfileOnly {
+		return NewLockfilePackageMapper(base, rExecutable, log), nil
+	}
 
 	lister, err := NewAvailablePackageLister(base, rExecutable, log, nil, nil)
 
-    return &defaultPackageMapper{
-        rInterpreterFactory: func() (interpreters.RInterpreter, error) {
-            return interpreters.NewRInterpreter(base, rExecutable, log, nil, nil, nil)
-        },
-        rExecutable: rExecutable,
-        lister:      lister,
-        scanner:     NewRDependencyScanner(log, repoOpts),
-    }, err
+	return &defaultPackageMapper{
+		rInterpreterFactory: func() (interpreters.RInterpreter, error) {
+			return interpreters.NewRInterpreter(base, rExecutable, log, nil, nil, nil)
+		},
+		rExecutable: rExecutable,
+		lister:      lister,
+		scanner:     NewRDependencyScanner(log, repoOpts),
+	}, err
 }
 
 func findAvailableVersion(pkgName PackageName, availablePackages []AvailablePackage) string {

--- a/internal/inspect/dependencies/renv/manifest_packages_from_lockfile.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_from_lockfile.go
@@ -27,12 +27,12 @@ type LockfilePackageMapper struct {
 }
 
 func NewLockfilePackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger) *LockfilePackageMapper {
-    return &LockfilePackageMapper{
-        base:        base,
-        rExecutable: rExecutable,
-        log:         log,
-        scanner:     NewRDependencyScanner(log, nil),
-    }
+	return &LockfilePackageMapper{
+		base:        base,
+		rExecutable: rExecutable,
+		log:         log,
+		scanner:     NewRDependencyScanner(log, nil),
+	}
 }
 
 // GetManifestPackages implements the PackageMapper interface for LockfilePackageMapper.

--- a/internal/inspect/dependencies/renv/manifest_packages_from_lockfile.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_from_lockfile.go
@@ -27,12 +27,12 @@ type LockfilePackageMapper struct {
 }
 
 func NewLockfilePackageMapper(base util.AbsolutePath, rExecutable util.Path, log logging.Logger) *LockfilePackageMapper {
-	return &LockfilePackageMapper{
-		base:        base,
-		rExecutable: rExecutable,
-		log:         log,
-		scanner:     NewRDependencyScanner(log),
-	}
+    return &LockfilePackageMapper{
+        base:        base,
+        rExecutable: rExecutable,
+        log:         log,
+        scanner:     NewRDependencyScanner(log, nil),
+    }
 }
 
 // GetManifestPackages implements the PackageMapper interface for LockfilePackageMapper.

--- a/internal/inspect/dependencies/renv/manifest_packages_from_lockfile_test.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_from_lockfile_test.go
@@ -368,7 +368,7 @@ License: GPL-2 | GPL-3
 	defer os.Setenv("R_LIBS", origLibs)
 
 	// Legacy path
-	legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	legacyPkgs, err := legacyMapper.GetManifestPackages(base, lockfilePath, s.log)
@@ -400,7 +400,7 @@ func (s *LockfilePackageMapperSuite) TestBioconductor_LockfileCompatibility() {
 	defer os.Setenv("R_LIBS", origLibs)
 
 	// Legacy path
-	legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	// If Bioconductor repos are not resolvable in this environment, skip

--- a/internal/inspect/dependencies/renv/manifest_packages_from_lockfile_test.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_from_lockfile_test.go
@@ -368,7 +368,7 @@ License: GPL-2 | GPL-3
 	defer os.Setenv("R_LIBS", origLibs)
 
 	// Legacy path
-legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	legacyPkgs, err := legacyMapper.GetManifestPackages(base, lockfilePath, s.log)
@@ -400,7 +400,7 @@ func (s *LockfilePackageMapperSuite) TestBioconductor_LockfileCompatibility() {
 	defer os.Setenv("R_LIBS", origLibs)
 
 	// Legacy path
-legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	legacyMapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	// If Bioconductor repos are not resolvable in this environment, skip

--- a/internal/inspect/dependencies/renv/manifest_packages_test.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_test.go
@@ -76,7 +76,7 @@ func (s *ManifestPackagesSuite) TestCRAN() {
 	libPath := base.Join("renv_library")
 	otherlibPath := util.NewAbsolutePath("/nonexistent", afero.NewMemMapFs())
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -115,7 +115,7 @@ func (s *ManifestPackagesSuite) TestBioconductor() {
 	libPath := base.Join("renv_library")
 	otherlibPath := util.NewAbsolutePath("/nonexistent", afero.NewMemMapFs())
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -180,7 +180,7 @@ func (s *ManifestPackagesSuite) TestVersionMismatch() {
 	lockfilePath := base.Join("renv.lock")
 	libPath := base.Join("renv_library")
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -210,7 +210,7 @@ func (s *ManifestPackagesSuite) TestDevVersion() {
 	lockfilePath := base.Join("renv.lock")
 	libPath := base.Join("renv_library")
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -239,7 +239,7 @@ func (s *ManifestPackagesSuite) TestMissingDescriptionFile() {
 	base := s.testdata.Join("cran_project")
 	lockfilePath := base.Join("renv.lock")
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -264,7 +264,7 @@ func (s *ManifestPackagesSuite) TestMissingLockfile_BubblesUpRenvError() {
 	base := s.testdata.Join("cran_project")
 	lockfilePath := base.Join("does-not-exist.lock")
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	// Override interpeter factory to use a mock
@@ -304,7 +304,7 @@ func (s *ManifestPackagesSuite) TestLockFile_CreateFromScanner() {
 	base := s.testdata.Join("cran_project")
 	// Generate a lockfile via the scanner and ensure we use it.
 
-	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false)
+mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	// Override scanner to return the known renv.lock in cran_project

--- a/internal/inspect/dependencies/renv/manifest_packages_test.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_test.go
@@ -76,7 +76,7 @@ func (s *ManifestPackagesSuite) TestCRAN() {
 	libPath := base.Join("renv_library")
 	otherlibPath := util.NewAbsolutePath("/nonexistent", afero.NewMemMapFs())
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -115,7 +115,7 @@ func (s *ManifestPackagesSuite) TestBioconductor() {
 	libPath := base.Join("renv_library")
 	otherlibPath := util.NewAbsolutePath("/nonexistent", afero.NewMemMapFs())
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -180,7 +180,7 @@ func (s *ManifestPackagesSuite) TestVersionMismatch() {
 	lockfilePath := base.Join("renv.lock")
 	libPath := base.Join("renv_library")
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -210,7 +210,7 @@ func (s *ManifestPackagesSuite) TestDevVersion() {
 	lockfilePath := base.Join("renv.lock")
 	libPath := base.Join("renv_library")
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -239,7 +239,7 @@ func (s *ManifestPackagesSuite) TestMissingDescriptionFile() {
 	base := s.testdata.Join("cran_project")
 	lockfilePath := base.Join("renv.lock")
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	lister := &mockPackageLister{}
@@ -264,7 +264,7 @@ func (s *ManifestPackagesSuite) TestMissingLockfile_BubblesUpRenvError() {
 	base := s.testdata.Join("cran_project")
 	lockfilePath := base.Join("does-not-exist.lock")
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	// Override interpeter factory to use a mock
@@ -304,7 +304,7 @@ func (s *ManifestPackagesSuite) TestLockFile_CreateFromScanner() {
 	base := s.testdata.Join("cran_project")
 	// Generate a lockfile via the scanner and ensure we use it.
 
-mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
+	mapper, err := NewPackageMapper(base, util.Path{}, s.log, false, nil)
 	s.NoError(err)
 
 	// Override scanner to return the known renv.lock in cran_project

--- a/internal/inspect/dependencies/renv/project_dependencies.go
+++ b/internal/inspect/dependencies/renv/project_dependencies.go
@@ -170,7 +170,7 @@ func repoURLFrom(mode, ppm string) string {
 	}
 }
 
-func repoURLFromOptions(opts *RepoOptions) string {
+func RepoURLFromOptions(opts *RepoOptions) string {
 	if opts == nil {
 		// Unconfigured defaults to CRAN via "auto" mode
 		return repoURLFrom("auto", "")
@@ -182,19 +182,13 @@ func repoURLFromOptions(opts *RepoOptions) string {
 	return repoURLFrom(mode, strings.TrimSpace(opts.PackageManagerRepository))
 }
 
-// RepoURLFromOptions returns the repository URL to use for dependency scanning
-// given the provided options. When opts is nil, it returns the default CRAN URL.
-func RepoURLFromOptions(opts *RepoOptions) string {
-	return repoURLFromOptions(opts)
-}
-
 // generateRepoSetupCode inspects provided options to produce an R snippet
 // that configures options(repos=...) consistent with (a subset of) Positron IDE
 // behavior. Keeping this separate from ScanDependenciesInDir keeps dependency
 // scanning logic focused.
 // Returns empty string if no explicit repos config should be applied.
 func generateRepoSetupCode(opts *RepoOptions) string {
-	repoURL := repoURLFromOptions(opts)
+	repoURL := RepoURLFromOptions(opts)
 	if repoURL == "" {
 		return ""
 	}

--- a/internal/inspect/dependencies/renv/project_dependencies.go
+++ b/internal/inspect/dependencies/renv/project_dependencies.go
@@ -3,14 +3,14 @@ package renv
 // Copyright (C) 2025 by Posit Software, PBC.
 
 import (
-    "fmt"
-    "path/filepath"
-    "strings"
+	"fmt"
+	"path/filepath"
+	"strings"
 
-    "github.com/posit-dev/publisher/internal/executor"
-    "github.com/posit-dev/publisher/internal/interpreters"
-    "github.com/posit-dev/publisher/internal/logging"
-    "github.com/posit-dev/publisher/internal/util"
+	"github.com/posit-dev/publisher/internal/executor"
+	"github.com/posit-dev/publisher/internal/interpreters"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util"
 )
 
 // RDependencyScanner generates a temporary renv.lock by invoking R
@@ -37,11 +37,11 @@ type defaultRDependencyScanner struct {
 // the scanner may fallback to environment variables for compatibility.
 // NewRDependencyScanner constructs a scanner with explicit options.
 func NewRDependencyScanner(log logging.Logger, repoOpts *RepoOptions) *defaultRDependencyScanner {
-    return &defaultRDependencyScanner{
-        rExecutor: executor.NewExecutor(),
-        log:       log,
-        repoOpts:  repoOpts,
-    }
+	return &defaultRDependencyScanner{
+		rExecutor: executor.NewExecutor(),
+		log:       log,
+		repoOpts:  repoOpts,
+	}
 }
 
 func (s *defaultRDependencyScanner) ScanDependencies(paths []string, rExecutable string) (util.AbsolutePath, error) {
@@ -172,15 +172,15 @@ func repoURLFrom(mode, ppm string) string {
 }
 
 func repoURLFromOptions(opts *RepoOptions) string {
-    if opts == nil {
-        // Unconfigured defaults to CRAN via "auto" mode
-        return repoURLFrom("auto", "")
-    }
-    mode := strings.ToLower(strings.TrimSpace(opts.DefaultRepositories))
-    if mode == "" {
-        mode = "auto"
-    }
-    return repoURLFrom(mode, strings.TrimSpace(opts.PackageManagerRepository))
+	if opts == nil {
+		// Unconfigured defaults to CRAN via "auto" mode
+		return repoURLFrom("auto", "")
+	}
+	mode := strings.ToLower(strings.TrimSpace(opts.DefaultRepositories))
+	if mode == "" {
+		mode = "auto"
+	}
+	return repoURLFrom(mode, strings.TrimSpace(opts.PackageManagerRepository))
 }
 
 // generateRepoSetupCode inspects provided options to produce an R snippet

--- a/internal/inspect/dependencies/renv/project_dependencies.go
+++ b/internal/inspect/dependencies/renv/project_dependencies.go
@@ -32,9 +32,8 @@ type defaultRDependencyScanner struct {
 	repoOpts  *RepoOptions
 }
 
-// NewRDependencyScanner creates a dependency scanner. If repoOpts is provided,
-// it is used to generate repository configuration in the R script; otherwise
-// NewRDependencyScanner creates a dependency scanner.
+// NewRDependencyScanner creates a dependency scanner. If repoOpts is non-nil,
+// the scanner configures R repositories accordingly.
 func NewRDependencyScanner(log logging.Logger, repoOpts *RepoOptions) *defaultRDependencyScanner {
 	return &defaultRDependencyScanner{
 		rExecutor: executor.NewExecutor(),
@@ -143,10 +142,11 @@ func (s *defaultRDependencyScanner) toRPathsVector(paths []string) (string, erro
 // RepoOptions defines how to set R repositories during dependency scanning.
 // Values mirror VS Code setting `positron.r.defaultRepositories`.
 type RepoOptions struct {
+	// RDefaultRepositories selects which R repository set to prefer.
 	// One of: "auto", "rstudio", "posit-ppm", "none", or a full http(s) URL.
-	DefaultRepositories string
-	// Optional custom PPM repo. Used when DefaultRepositories == "auto".
-	PackageManagerRepository string
+	RDefaultRepositories string
+	// RPackageManagerRepository is an optional custom PPM base URL, used when RDefaultRepositories == "auto".
+	RPackageManagerRepository string
 }
 
 func repoURLFrom(mode, ppm string) string {
@@ -175,11 +175,11 @@ func RepoURLFromOptions(opts *RepoOptions) string {
 		// Unconfigured defaults to CRAN via "auto" mode
 		return repoURLFrom("auto", "")
 	}
-	mode := strings.ToLower(strings.TrimSpace(opts.DefaultRepositories))
+	mode := strings.ToLower(strings.TrimSpace(opts.RDefaultRepositories))
 	if mode == "" {
 		mode = "auto"
 	}
-	return repoURLFrom(mode, strings.TrimSpace(opts.PackageManagerRepository))
+	return repoURLFrom(mode, strings.TrimSpace(opts.RPackageManagerRepository))
 }
 
 // generateRepoSetupCode inspects provided options to produce an R snippet

--- a/internal/inspect/dependencies/renv/project_dependencies.go
+++ b/internal/inspect/dependencies/renv/project_dependencies.go
@@ -35,12 +35,13 @@ type defaultRDependencyScanner struct {
 // NewRDependencyScanner creates a dependency scanner. If repoOpts is provided,
 // it is used to generate repository configuration in the R script; otherwise
 // the scanner may fallback to environment variables for compatibility.
+// NewRDependencyScanner constructs a scanner with explicit options.
 func NewRDependencyScanner(log logging.Logger, repoOpts *RepoOptions) *defaultRDependencyScanner {
-	return &defaultRDependencyScanner{
-		rExecutor: executor.NewExecutor(),
-		log:       log,
-		repoOpts:  repoOpts,
-	}
+    return &defaultRDependencyScanner{
+        rExecutor: executor.NewExecutor(),
+        log:       log,
+        repoOpts:  repoOpts,
+    }
 }
 
 func (s *defaultRDependencyScanner) ScanDependencies(paths []string, rExecutable string) (util.AbsolutePath, error) {

--- a/internal/inspect/dependencies/renv/project_dependencies.go
+++ b/internal/inspect/dependencies/renv/project_dependencies.go
@@ -34,8 +34,7 @@ type defaultRDependencyScanner struct {
 
 // NewRDependencyScanner creates a dependency scanner. If repoOpts is provided,
 // it is used to generate repository configuration in the R script; otherwise
-// the scanner may fallback to environment variables for compatibility.
-// NewRDependencyScanner constructs a scanner with explicit options.
+// NewRDependencyScanner creates a dependency scanner.
 func NewRDependencyScanner(log logging.Logger, repoOpts *RepoOptions) *defaultRDependencyScanner {
 	return &defaultRDependencyScanner{
 		rExecutor: executor.NewExecutor(),
@@ -181,6 +180,12 @@ func repoURLFromOptions(opts *RepoOptions) string {
 		mode = "auto"
 	}
 	return repoURLFrom(mode, strings.TrimSpace(opts.PackageManagerRepository))
+}
+
+// RepoURLFromOptions returns the repository URL to use for dependency scanning
+// given the provided options. When opts is nil, it returns the default CRAN URL.
+func RepoURLFromOptions(opts *RepoOptions) string {
+	return repoURLFromOptions(opts)
 }
 
 // generateRepoSetupCode inspects provided options to produce an R snippet

--- a/internal/inspect/dependencies/renv/project_dependencies_functional_test.go
+++ b/internal/inspect/dependencies/renv/project_dependencies_functional_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+package renv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/posit-dev/publisher/internal/interpreters"
+	"github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/util"
+	"github.com/stretchr/testify/suite"
+)
+
+type RepoOptionsFunctionalSuite struct {
+	suite.Suite
+	base util.AbsolutePath
+	log  logging.Logger
+}
+
+func TestRepoOptionsFunctionalSuite(t *testing.T) {
+	suite.Run(t, new(RepoOptionsFunctionalSuite))
+}
+
+func (s *RepoOptionsFunctionalSuite) SetupTest() {
+	dir, err := os.MkdirTemp("", "repoopts-scan-*")
+	s.Require().NoError(err)
+	s.base = util.NewAbsolutePath(dir, nil)
+	s.log = logging.New()
+}
+
+func (s *RepoOptionsFunctionalSuite) TearDownTest() {
+	os.RemoveAll(s.base.String())
+}
+
+func (s *RepoOptionsFunctionalSuite) TestScannerRespectsRepoOptions() {
+	rInterp, err := interpreters.NewRInterpreter(s.base, util.Path{}, s.log, nil, nil, nil)
+	s.Require().NoError(err)
+
+	rExec, err := rInterp.GetRExecutable()
+	s.Require().NoError(err)
+
+	// Require renv to be available
+	aerr := rInterp.IsRenvInstalled(rExec.String())
+	s.Require().Nil(aerr)
+
+	// Use explicit options (posit-ppm) and compute expected URL
+	opts := &RepoOptions{RDefaultRepositories: "posit-ppm"}
+	expected := RepoURLFromOptions(opts)
+	s.Require().NotEmpty(expected)
+
+	scanner := NewRDependencyScanner(s.log, opts)
+	lockfileName := "renv.lock"
+	_, err = scanner.SetupRenvInDir(s.base.String(), lockfileName, rExec.String())
+	s.Require().NoError(err)
+
+	lockPath := util.NewAbsolutePath(filepath.Join(s.base.String(), lockfileName), s.base.Fs())
+	lf, err := ReadLockfile(lockPath)
+	s.Require().NoError(err)
+
+	found := false
+	for _, r := range lf.R.Repositories {
+		if string(r.URL) == expected {
+			found = true
+			break
+		}
+	}
+	s.True(found)
+}

--- a/internal/inspect/dependencies/renv/project_dependencies_test.go
+++ b/internal/inspect/dependencies/renv/project_dependencies_test.go
@@ -68,7 +68,7 @@ func (s *RDependencyScannerSuite) TestScanDependencies() {
 		}
 	})
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	scanner.rExecutor = s.exec
 
 	lockfilePath, err := scanner.ScanDependencies([]string{s.cwd.String()}, s.rExecPath)
@@ -100,7 +100,7 @@ func (s *RDependencyScannerSuite) TestScanDependenciesInDir() {
 		_ = lock.WriteFile([]byte("{}"), 0666)
 	})
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	scanner.rExecutor = s.exec
 
 	// Test with a different lockfile name
@@ -125,7 +125,7 @@ func (s *RDependencyScannerSuite) TestErrWhenLockfileNotCreated() {
 		mock.Anything,
 	).Return([]byte("ok"), []byte(""), nil)
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	scanner.rExecutor = s.exec
 
 	_, err := scanner.ScanDependencies([]string{s.cwd.String()}, s.rExecPath)
@@ -184,7 +184,7 @@ func (s *RDependencyScannerFunctionalSuite) TestScanDependenciesFunctional() {
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependencies([]string{base.String()}, rExec.String())
 	s.NoError(err)
 
@@ -238,7 +238,7 @@ func (s *RDependencyScannerFunctionalSuite) TestFunctional_NoMirror() {
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependencies([]string{base.String()}, rExec.String())
 	s.NoError(err)
 	exists, e2 := lockfilePath.Exists()
@@ -269,7 +269,7 @@ func (s *RDependencyScannerFunctionalSuite) TestFunctional_PathsFilter() {
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependencies([]string{included.String()}, rExec.String())
 	s.NoError(err)
 
@@ -321,7 +321,7 @@ func (s *RDependencyScannerFunctionalSuite) TestScanDependenciesInDirFunctional(
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependenciesInDir([]string{base.String()}, base.Path, "different.lockfile", rExec.String())
 	s.NoError(err)
 
@@ -374,7 +374,7 @@ func (s *RDependencyScannerFunctionalSuite) TestSetupRenvInDirWithExistingInfraF
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.SetupRenvInDir(base.String(), "", rExec.String())
 	s.NoError(err)
 
@@ -468,7 +468,7 @@ func (s *RDependencyScannerFunctionalSuite) TestSetupRenvWithSubdirLockfileInfra
 
 	lockfileName := filepath.Join("nested", "different.lockfile")
 
-scanner := NewRDependencyScanner(s.log, nil)
+	scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.SetupRenvInDir(base.String(), lockfileName, rExec.String())
 	s.NoError(err)
 

--- a/internal/inspect/dependencies/renv/project_dependencies_test.go
+++ b/internal/inspect/dependencies/renv/project_dependencies_test.go
@@ -68,7 +68,7 @@ func (s *RDependencyScannerSuite) TestScanDependencies() {
 		}
 	})
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	scanner.rExecutor = s.exec
 
 	lockfilePath, err := scanner.ScanDependencies([]string{s.cwd.String()}, s.rExecPath)
@@ -100,7 +100,7 @@ func (s *RDependencyScannerSuite) TestScanDependenciesInDir() {
 		_ = lock.WriteFile([]byte("{}"), 0666)
 	})
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	scanner.rExecutor = s.exec
 
 	// Test with a different lockfile name
@@ -125,7 +125,7 @@ func (s *RDependencyScannerSuite) TestErrWhenLockfileNotCreated() {
 		mock.Anything,
 	).Return([]byte("ok"), []byte(""), nil)
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	scanner.rExecutor = s.exec
 
 	_, err := scanner.ScanDependencies([]string{s.cwd.String()}, s.rExecPath)
@@ -184,7 +184,7 @@ func (s *RDependencyScannerFunctionalSuite) TestScanDependenciesFunctional() {
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependencies([]string{base.String()}, rExec.String())
 	s.NoError(err)
 
@@ -238,7 +238,7 @@ func (s *RDependencyScannerFunctionalSuite) TestFunctional_NoMirror() {
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependencies([]string{base.String()}, rExec.String())
 	s.NoError(err)
 	exists, e2 := lockfilePath.Exists()
@@ -269,7 +269,7 @@ func (s *RDependencyScannerFunctionalSuite) TestFunctional_PathsFilter() {
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependencies([]string{included.String()}, rExec.String())
 	s.NoError(err)
 
@@ -321,7 +321,7 @@ func (s *RDependencyScannerFunctionalSuite) TestScanDependenciesInDirFunctional(
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.ScanDependenciesInDir([]string{base.String()}, base.Path, "different.lockfile", rExec.String())
 	s.NoError(err)
 
@@ -374,7 +374,7 @@ func (s *RDependencyScannerFunctionalSuite) TestSetupRenvInDirWithExistingInfraF
 	s.NoError(err)
 	s.NotEmpty(rExec.String())
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.SetupRenvInDir(base.String(), "", rExec.String())
 	s.NoError(err)
 
@@ -468,7 +468,7 @@ func (s *RDependencyScannerFunctionalSuite) TestSetupRenvWithSubdirLockfileInfra
 
 	lockfileName := filepath.Join("nested", "different.lockfile")
 
-	scanner := NewRDependencyScanner(s.log)
+scanner := NewRDependencyScanner(s.log, nil)
 	lockfilePath, err := scanner.SetupRenvInDir(base.String(), lockfileName, rExec.String())
 	s.NoError(err)
 

--- a/internal/publish/manifest.go
+++ b/internal/publish/manifest.go
@@ -58,7 +58,3 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 	p.log.Debug("Generated manifest:", manifest)
 	return manifest, nil
 }
-
-// defaultRepoURLFromOptions mirrors the repository selection used during scanning
-// to provide accurate logging for which default repository is in use.
-// removed duplicate repo selection logic; logging now uses renv.RepoURLFromOptions

--- a/internal/publish/manifest.go
+++ b/internal/publish/manifest.go
@@ -4,7 +4,6 @@ package publish
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/posit-dev/publisher/internal/bundles"
 	"github.com/posit-dev/publisher/internal/events"
@@ -36,7 +35,7 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 			// so that the user knows we automatically detected dependencies
 			// and which default repository is being used.
 			log := p.log.WithArgs(logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp)
-			repoURL := defaultRepoURLFromOptions(p.RepoOptions)
+			repoURL := renv.RepoURLFromOptions(p.RepoOptions)
 			repoText := repoURL
 			if repoText == "" {
 				repoText = "none"
@@ -62,30 +61,4 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 
 // defaultRepoURLFromOptions mirrors the repository selection used during scanning
 // to provide accurate logging for which default repository is in use.
-func defaultRepoURLFromOptions(opts *renv.RepoOptions) string {
-	if opts == nil {
-		return "https://cloud.r-project.org"
-	}
-	mode := strings.ToLower(strings.TrimSpace(opts.DefaultRepositories))
-	ppm := strings.TrimRight(strings.TrimSpace(opts.PackageManagerRepository), "/")
-	if mode == "" || mode == "auto" {
-		if ppm != "" {
-			return ppm
-		}
-		return "https://cloud.r-project.org"
-	}
-	switch mode {
-	case "posit-ppm":
-		return "https://packagemanager.posit.co/cran/latest"
-	case "rstudio":
-		return "https://cran.rstudio.com"
-	case "none":
-		return ""
-	default:
-		// Allow custom URLs
-		if strings.HasPrefix(mode, "http://") || strings.HasPrefix(mode, "https://") {
-			return strings.TrimRight(opts.DefaultRepositories, "/")
-		}
-		return "https://cloud.r-project.org"
-	}
-}
+// removed duplicate repo selection logic; logging now uses renv.RepoURLFromOptions

--- a/internal/publish/manifest.go
+++ b/internal/publish/manifest.go
@@ -3,13 +3,13 @@ package publish
 // Copyright (C) 2025 by Posit Software, PBC.
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 
-    "github.com/posit-dev/publisher/internal/bundles"
-    "github.com/posit-dev/publisher/internal/events"
-    "github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
-    "github.com/posit-dev/publisher/internal/logging"
+	"github.com/posit-dev/publisher/internal/bundles"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+	"github.com/posit-dev/publisher/internal/logging"
 )
 
 func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
@@ -35,13 +35,13 @@ func (p *defaultPublisher) createManifest() (*bundles.Manifest, error) {
 			// Displays a log message under the package collection activity
 			// so that the user knows we automatically detected dependencies
 			// and which default repository is being used.
-            log := p.log.WithArgs(logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp)
-            repoURL := defaultRepoURLFromOptions(p.RepoOptions)
-            repoText := repoURL
-            if repoText == "" {
-                repoText = "none"
-            }
-            log.Info(fmt.Sprintf("No renv.lock found; automatically scanning for dependencies. Default repo: %s", repoText))
+			log := p.log.WithArgs(logging.LogKeyOp, events.PublishGetRPackageDescriptionsOp)
+			repoURL := defaultRepoURLFromOptions(p.RepoOptions)
+			repoText := repoURL
+			if repoText == "" {
+				repoText = "none"
+			}
+			log.Info(fmt.Sprintf("No renv.lock found; automatically scanning for dependencies. Default repo: %s", repoText))
 		}
 
 		rPackages, lockfilePath, err := p.getRPackagesWithPath(scanDependencies)

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -106,7 +106,7 @@ func NewFromState(
 		packagesFromLibrary = *s.Config.R.PackagesFromLibrary
 	}
 	lockfileOnly := !packagesFromLibrary
-	packageManager, err := rPackageMapperFactory(s.Dir, rexec.Path, log, lockfileOnly)
+	packageManager, err := rPackageMapperFactory(s.Dir, rexec.Path, log, lockfileOnly, s.RepoOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create R package mapper: %w", err)
 	}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -145,7 +145,7 @@ func (s *BasePublishSuite) TearDownTest() {
 	cloudClientFactory = connect_cloud.NewConnectCloudClientWithAuth
 	connect_cloud2.UploadAPIClientFactory = connect_cloud_upload.NewConnectCloudUploadClient
 	connect_cloud2.LogsClientFactory = connect_cloud_logs.NewConnectCloudLogsClient
-	rPackageMapperFactory = renv.NewPackageMapper
+    rPackageMapperFactory = renv.NewPackageMapper
 }
 
 func (s *PublishConnectSuite) TestNewFromState() {
@@ -413,9 +413,9 @@ func (s *PublishConnectSuite) publishWithClient(
 		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything).Return(pkgMap, nil)
 	}
 
-	rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool) (renv.PackageMapper, error) {
-		return rPackageMapper, nil
-	}
+    rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, _ *renv.RepoOptions) (renv.PackageMapper, error) {
+        return rPackageMapper, nil
+    }
 
 	publisher, err := NewFromState(stateStore, mockRIntr, mockPyIntr, emitter, s.log)
 	s.NoError(err)
@@ -910,9 +910,9 @@ func (s *PublishConnectCloudSuite) publishWithCloudClient(
 	}
 
 	// Replace factory function
-	rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool) (renv.PackageMapper, error) {
-		return rPackageMapper, nil
-	}
+    rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, _ *renv.RepoOptions) (renv.PackageMapper, error) {
+        return rPackageMapper, nil
+    }
 
 	// Create config
 	cfg := config.New()

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -145,7 +145,7 @@ func (s *BasePublishSuite) TearDownTest() {
 	cloudClientFactory = connect_cloud.NewConnectCloudClientWithAuth
 	connect_cloud2.UploadAPIClientFactory = connect_cloud_upload.NewConnectCloudUploadClient
 	connect_cloud2.LogsClientFactory = connect_cloud_logs.NewConnectCloudLogsClient
-    rPackageMapperFactory = renv.NewPackageMapper
+	rPackageMapperFactory = renv.NewPackageMapper
 }
 
 func (s *PublishConnectSuite) TestNewFromState() {
@@ -413,9 +413,9 @@ func (s *PublishConnectSuite) publishWithClient(
 		rPackageMapper.On("GetManifestPackages", mock.Anything, mock.Anything).Return(pkgMap, nil)
 	}
 
-    rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, _ *renv.RepoOptions) (renv.PackageMapper, error) {
-        return rPackageMapper, nil
-    }
+	rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, _ *renv.RepoOptions) (renv.PackageMapper, error) {
+		return rPackageMapper, nil
+	}
 
 	publisher, err := NewFromState(stateStore, mockRIntr, mockPyIntr, emitter, s.log)
 	s.NoError(err)
@@ -910,9 +910,9 @@ func (s *PublishConnectCloudSuite) publishWithCloudClient(
 	}
 
 	// Replace factory function
-    rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, _ *renv.RepoOptions) (renv.PackageMapper, error) {
-        return rPackageMapper, nil
-    }
+	rPackageMapperFactory = func(base util.AbsolutePath, rExecutable util.Path, log logging.Logger, lockfileOnly bool, _ *renv.RepoOptions) (renv.PackageMapper, error) {
+		return rPackageMapper, nil
+	}
 
 	// Create config
 	cfg := config.New()

--- a/internal/publish/r_functional_test.go
+++ b/internal/publish/r_functional_test.go
@@ -128,7 +128,7 @@ func (s *RPublishFunctionalSuite) TestGetRPackagesFunctional() {
 		s.Run(tc.name, func() {
 			s.T().Logf("Testing %s: %s", tc.name, tc.description)
 
-            mapper, err := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log, tc.lockfileOnly, nil)
+			mapper, err := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log, tc.lockfileOnly, nil)
 			s.Require().NoError(err)
 
 			publisher := &defaultPublisher{

--- a/internal/publish/r_functional_test.go
+++ b/internal/publish/r_functional_test.go
@@ -128,7 +128,7 @@ func (s *RPublishFunctionalSuite) TestGetRPackagesFunctional() {
 		s.Run(tc.name, func() {
 			s.T().Logf("Testing %s: %s", tc.name, tc.description)
 
-			mapper, err := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log, tc.lockfileOnly)
+            mapper, err := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log, tc.lockfileOnly, nil)
 			s.Require().NoError(err)
 
 			publisher := &defaultPublisher{
@@ -228,7 +228,7 @@ func (s *RPublishFunctionalSuite) TestPublishWithClientFunctional() {
 			s.T().Logf("Testing integration with %s", tc.name)
 
 			// Create mapper for this test case
-			packageMapper, mapperErr := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log, tc.lockfileOnly)
+			packageMapper, mapperErr := renv.NewPackageMapper(s.testProjectDir, util.Path{}, s.log, tc.lockfileOnly, nil)
 			s.Require().NoError(mapperErr)
 
 			serverPublisher, err := createServerPublisher(

--- a/internal/services/api/positron_helpers.go
+++ b/internal/services/api/positron_helpers.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+)
+
+// repoOptsFromPositron converts inbound Positron settings to renv.RepoOptions.
+// Returns nil if no Positron R settings were provided.
+func repoOptsFromPositron(ps *positronSettings) *renv.RepoOptions {
+	if ps == nil || ps.R == nil {
+		return nil
+	}
+	mode := strings.TrimSpace(ps.R.DefaultRepositories)
+	ppm := strings.TrimSpace(ps.R.PackageManagerRepository)
+	return &renv.RepoOptions{
+		RDefaultRepositories:      mode,
+		RPackageManagerRepository: ppm,
+	}
+}

--- a/internal/services/api/positron_settings.go
+++ b/internal/services/api/positron_settings.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
 package api
 
 import (

--- a/internal/services/api/positron_settings.go
+++ b/internal/services/api/positron_settings.go
@@ -6,6 +6,16 @@ import (
 	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
 )
 
+// positronSettings represents the inbound VS Code settings payload for Positron.
+type positronSettings struct {
+	R *positronRSettings `json:"r,omitempty"`
+}
+
+type positronRSettings struct {
+	DefaultRepositories      string `json:"defaultRepositories"`
+	PackageManagerRepository string `json:"packageManagerRepository,omitempty"`
+}
+
 // repoOptsFromPositron converts inbound Positron settings to renv.RepoOptions.
 // Returns nil if no Positron R settings were provided.
 func repoOptsFromPositron(ps *positronSettings) *renv.RepoOptions {

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -29,15 +29,6 @@ type PostDeploymentRequestBody struct {
 	Positron    *positronSettings `json:"positron,omitempty"`
 }
 
-type positronSettings struct {
-	R *positronRSettings `json:"r,omitempty"`
-}
-
-type positronRSettings struct {
-	DefaultRepositories      string `json:"defaultRepositories"`
-	PackageManagerRepository string `json:"packageManagerRepository,omitempty"`
-}
-
 type PostDeploymentsReponse struct {
 	LocalID state.LocalDeploymentID `json:"localId"` // Unique ID of this publishing operation. Only valid for this run of the agent.
 }

--- a/internal/services/api/post_deployment.go
+++ b/internal/services/api/post_deployment.go
@@ -12,7 +12,6 @@ import (
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/deployment"
 	"github.com/posit-dev/publisher/internal/events"
-	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/publish"
 	"github.com/posit-dev/publisher/internal/state"
@@ -79,13 +78,7 @@ func PostDeploymentHandlerFunc(
 			return
 		}
 		// Convert optional Positron settings to RepoOptions for downstream scanning
-		var repoOpts *renv.RepoOptions
-		if b.Positron != nil && b.Positron.R != nil {
-			repoOpts = &renv.RepoOptions{
-				DefaultRepositories:      b.Positron.R.DefaultRepositories,
-				PackageManagerRepository: b.Positron.R.PackageManagerRepository,
-			}
-		}
+		repoOpts := repoOptsFromPositron(b.Positron)
 
 		newState, err := stateFactory(projectDir, b.AccountName, b.ConfigName, name, "", accountList, b.Secrets, b.Insecure, rInterpreter, pythonInterpreter, log, repoOpts)
 		if err != nil {

--- a/internal/services/api/post_deployment_test.go
+++ b/internal/services/api/post_deployment_test.go
@@ -3,13 +3,13 @@ package api
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
-	"errors"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"strings"
-	"testing"
+    "errors"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "net/url"
+    "strings"
+    "testing"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/afero"
@@ -20,8 +20,9 @@ import (
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/contenttypes"
 	"github.com/posit-dev/publisher/internal/deployment"
-	"github.com/posit-dev/publisher/internal/events"
-	"github.com/posit-dev/publisher/internal/interpreters"
+    "github.com/posit-dev/publisher/internal/events"
+    "github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+    "github.com/posit-dev/publisher/internal/interpreters"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/publish"
 	"github.com/posit-dev/publisher/internal/state"
@@ -108,16 +109,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 		s.Equal("/bin/my_python", pythonInterpreter.GetPreferredPath())
 		return publisher, nil
 	}
-	stateFactory = func(
-		path util.AbsolutePath,
-		accountName, configName, targetName, saveName string,
-		accountList accounts.AccountList,
-		secrets map[string]string,
-		insecure bool,
-		rInterpreter interpreters.RInterpreter,
-		pythonInterpreter interpreters.PythonInterpreter,
-		log logging.Logger,
-	) (*state.State, error) {
+    stateFactory = func(
+        path util.AbsolutePath,
+        accountName, configName, targetName, saveName string,
+        accountList accounts.AccountList,
+        secrets map[string]string,
+        insecure bool,
+        rInterpreter interpreters.RInterpreter,
+        pythonInterpreter interpreters.PythonInterpreter,
+        log logging.Logger,
+        repoOpts *renv.RepoOptions,
+    ) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)
@@ -162,18 +164,19 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncStateErr()
 	s.NoError(err)
 	req.Body = io.NopCloser(strings.NewReader("{}"))
 
-	stateFactory = func(
-		path util.AbsolutePath,
-		accountName, configName, targetName, saveName string,
-		accountList accounts.AccountList,
-		secrets map[string]string,
-		insecure bool,
-		rInterpreter interpreters.RInterpreter,
-		pythonInterpreter interpreters.PythonInterpreter,
-		log logging.Logger,
-	) (*state.State, error) {
-		return nil, errors.New("test error from state factory")
-	}
+    stateFactory = func(
+        path util.AbsolutePath,
+        accountName, configName, targetName, saveName string,
+        accountList accounts.AccountList,
+        secrets map[string]string,
+        insecure bool,
+        rInterpreter interpreters.RInterpreter,
+        pythonInterpreter interpreters.PythonInterpreter,
+        log logging.Logger,
+        repoOpts *renv.RepoOptions,
+    ) (*state.State, error) {
+        return nil, errors.New("test error from state factory")
+    }
 
 	handler := PostDeploymentHandlerFunc(s.cwd, log, nil, events.NewNullEmitter())
 	handler(rec, req)
@@ -233,16 +236,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncPublishErr
 	lister := &accounts.MockAccountList{}
 	req.Body = io.NopCloser(strings.NewReader(`{"account": "local", "config": "default", "insecure": false}`))
 
-	stateFactory = func(
-		path util.AbsolutePath,
-		accountName, configName, targetName, saveName string,
-		accountList accounts.AccountList,
-		secrets map[string]string,
-		insecure bool,
-		rInterpreter interpreters.RInterpreter,
-		pythonInterpreter interpreters.PythonInterpreter,
-		log logging.Logger,
-	) (*state.State, error) {
+    stateFactory = func(
+        path util.AbsolutePath,
+        accountName, configName, targetName, saveName string,
+        accountList accounts.AccountList,
+        secrets map[string]string,
+        insecure bool,
+        rInterpreter interpreters.RInterpreter,
+        pythonInterpreter interpreters.PythonInterpreter,
+        log logging.Logger,
+        repoOpts *renv.RepoOptions,
+    ) (*state.State, error) {
 
 		st := state.Empty()
 		st.Account = &accounts.Account{}
@@ -292,16 +296,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentSubdir() {
 	publisherFactory = func(*state.State, interpreters.RInterpreter, interpreters.PythonInterpreter, events.Emitter, logging.Logger) (publish.Publisher, error) {
 		return publisher, nil
 	}
-	stateFactory = func(
-		path util.AbsolutePath,
-		accountName, configName, targetName, saveName string,
-		accountList accounts.AccountList,
-		secrets map[string]string,
-		insecure bool,
-		rInterpreter interpreters.RInterpreter,
-		pythonInterpreter interpreters.PythonInterpreter,
-		log logging.Logger,
-	) (*state.State, error) {
+    stateFactory = func(
+        path util.AbsolutePath,
+        accountName, configName, targetName, saveName string,
+        accountList accounts.AccountList,
+        secrets map[string]string,
+        insecure bool,
+        rInterpreter interpreters.RInterpreter,
+        pythonInterpreter interpreters.PythonInterpreter,
+        log logging.Logger,
+        repoOpts *renv.RepoOptions,
+    ) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)
@@ -346,16 +351,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWithSecret
 		return publisher, nil
 	}
 
-	stateFactory = func(
-		path util.AbsolutePath,
-		accountName, configName, targetName, saveName string,
-		accountList accounts.AccountList,
-		secrets map[string]string,
-		insecure bool,
-		rInterpreter interpreters.RInterpreter,
-		pythonInterpreter interpreters.PythonInterpreter,
-		log logging.Logger,
-	) (*state.State, error) {
+    stateFactory = func(
+        path util.AbsolutePath,
+        accountName, configName, targetName, saveName string,
+        accountList accounts.AccountList,
+        secrets map[string]string,
+        insecure bool,
+        rInterpreter interpreters.RInterpreter,
+        pythonInterpreter interpreters.PythonInterpreter,
+        log logging.Logger,
+        repoOpts *renv.RepoOptions,
+    ) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)

--- a/internal/services/api/post_deployment_test.go
+++ b/internal/services/api/post_deployment_test.go
@@ -3,13 +3,13 @@ package api
 // Copyright (C) 2023 by Posit Software, PBC.
 
 import (
-    "errors"
-    "io"
-    "net/http"
-    "net/http/httptest"
-    "net/url"
-    "strings"
-    "testing"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/afero"
@@ -20,9 +20,9 @@ import (
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/contenttypes"
 	"github.com/posit-dev/publisher/internal/deployment"
-    "github.com/posit-dev/publisher/internal/events"
-    "github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
-    "github.com/posit-dev/publisher/internal/interpreters"
+	"github.com/posit-dev/publisher/internal/events"
+	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
+	"github.com/posit-dev/publisher/internal/interpreters"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/publish"
 	"github.com/posit-dev/publisher/internal/state"
@@ -109,17 +109,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFunc() {
 		s.Equal("/bin/my_python", pythonInterpreter.GetPreferredPath())
 		return publisher, nil
 	}
-    stateFactory = func(
-        path util.AbsolutePath,
-        accountName, configName, targetName, saveName string,
-        accountList accounts.AccountList,
-        secrets map[string]string,
-        insecure bool,
-        rInterpreter interpreters.RInterpreter,
-        pythonInterpreter interpreters.PythonInterpreter,
-        log logging.Logger,
-        repoOpts *renv.RepoOptions,
-    ) (*state.State, error) {
+	stateFactory = func(
+		path util.AbsolutePath,
+		accountName, configName, targetName, saveName string,
+		accountList accounts.AccountList,
+		secrets map[string]string,
+		insecure bool,
+		rInterpreter interpreters.RInterpreter,
+		pythonInterpreter interpreters.PythonInterpreter,
+		log logging.Logger,
+		repoOpts *renv.RepoOptions,
+	) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)
@@ -164,19 +164,19 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncStateErr()
 	s.NoError(err)
 	req.Body = io.NopCloser(strings.NewReader("{}"))
 
-    stateFactory = func(
-        path util.AbsolutePath,
-        accountName, configName, targetName, saveName string,
-        accountList accounts.AccountList,
-        secrets map[string]string,
-        insecure bool,
-        rInterpreter interpreters.RInterpreter,
-        pythonInterpreter interpreters.PythonInterpreter,
-        log logging.Logger,
-        repoOpts *renv.RepoOptions,
-    ) (*state.State, error) {
-        return nil, errors.New("test error from state factory")
-    }
+	stateFactory = func(
+		path util.AbsolutePath,
+		accountName, configName, targetName, saveName string,
+		accountList accounts.AccountList,
+		secrets map[string]string,
+		insecure bool,
+		rInterpreter interpreters.RInterpreter,
+		pythonInterpreter interpreters.PythonInterpreter,
+		log logging.Logger,
+		repoOpts *renv.RepoOptions,
+	) (*state.State, error) {
+		return nil, errors.New("test error from state factory")
+	}
 
 	handler := PostDeploymentHandlerFunc(s.cwd, log, nil, events.NewNullEmitter())
 	handler(rec, req)
@@ -236,17 +236,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncPublishErr
 	lister := &accounts.MockAccountList{}
 	req.Body = io.NopCloser(strings.NewReader(`{"account": "local", "config": "default", "insecure": false}`))
 
-    stateFactory = func(
-        path util.AbsolutePath,
-        accountName, configName, targetName, saveName string,
-        accountList accounts.AccountList,
-        secrets map[string]string,
-        insecure bool,
-        rInterpreter interpreters.RInterpreter,
-        pythonInterpreter interpreters.PythonInterpreter,
-        log logging.Logger,
-        repoOpts *renv.RepoOptions,
-    ) (*state.State, error) {
+	stateFactory = func(
+		path util.AbsolutePath,
+		accountName, configName, targetName, saveName string,
+		accountList accounts.AccountList,
+		secrets map[string]string,
+		insecure bool,
+		rInterpreter interpreters.RInterpreter,
+		pythonInterpreter interpreters.PythonInterpreter,
+		log logging.Logger,
+		repoOpts *renv.RepoOptions,
+	) (*state.State, error) {
 
 		st := state.Empty()
 		st.Account = &accounts.Account{}
@@ -296,17 +296,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentSubdir() {
 	publisherFactory = func(*state.State, interpreters.RInterpreter, interpreters.PythonInterpreter, events.Emitter, logging.Logger) (publish.Publisher, error) {
 		return publisher, nil
 	}
-    stateFactory = func(
-        path util.AbsolutePath,
-        accountName, configName, targetName, saveName string,
-        accountList accounts.AccountList,
-        secrets map[string]string,
-        insecure bool,
-        rInterpreter interpreters.RInterpreter,
-        pythonInterpreter interpreters.PythonInterpreter,
-        log logging.Logger,
-        repoOpts *renv.RepoOptions,
-    ) (*state.State, error) {
+	stateFactory = func(
+		path util.AbsolutePath,
+		accountName, configName, targetName, saveName string,
+		accountList accounts.AccountList,
+		secrets map[string]string,
+		insecure bool,
+		rInterpreter interpreters.RInterpreter,
+		pythonInterpreter interpreters.PythonInterpreter,
+		log logging.Logger,
+		repoOpts *renv.RepoOptions,
+	) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)
@@ -351,17 +351,17 @@ func (s *PostDeploymentHandlerFuncSuite) TestPostDeploymentHandlerFuncWithSecret
 		return publisher, nil
 	}
 
-    stateFactory = func(
-        path util.AbsolutePath,
-        accountName, configName, targetName, saveName string,
-        accountList accounts.AccountList,
-        secrets map[string]string,
-        insecure bool,
-        rInterpreter interpreters.RInterpreter,
-        pythonInterpreter interpreters.PythonInterpreter,
-        log logging.Logger,
-        repoOpts *renv.RepoOptions,
-    ) (*state.State, error) {
+	stateFactory = func(
+		path util.AbsolutePath,
+		accountName, configName, targetName, saveName string,
+		accountList accounts.AccountList,
+		secrets map[string]string,
+		insecure bool,
+		rInterpreter interpreters.RInterpreter,
+		pythonInterpreter interpreters.PythonInterpreter,
+		log logging.Logger,
+		repoOpts *renv.RepoOptions,
+	) (*state.State, error) {
 
 		s.Equal(s.cwd, path)
 		s.Equal("myTargetName", targetName)

--- a/internal/services/api/post_packages_r_scan.go
+++ b/internal/services/api/post_packages_r_scan.go
@@ -21,15 +21,6 @@ type PostPackagesRScanRequest struct {
 	Positron *positronSettings `json:"positron,omitempty"`
 }
 
-type positronSettings struct {
-	R *positronRSettings `json:"r,omitempty"`
-}
-
-type positronRSettings struct {
-	DefaultRepositories      string `json:"defaultRepositories"`
-	PackageManagerRepository string `json:"packageManagerRepository,omitempty"`
-}
-
 type PostPackagesRScanHandler struct {
 	base               util.AbsolutePath
 	log                logging.Logger

--- a/internal/services/api/post_packages_r_scan.go
+++ b/internal/services/api/post_packages_r_scan.go
@@ -31,11 +31,11 @@ func NewPostPackagesRScanHandler(
 	base util.AbsolutePath,
 	log logging.Logger,
 ) *PostPackagesRScanHandler {
-	return &PostPackagesRScanHandler{
-		base:               base,
-		log:                log,
-		rDependencyScanner: renv.NewRDependencyScanner(log, nil),
-	}
+    return &PostPackagesRScanHandler{
+        base:               base,
+        log:                log,
+        rDependencyScanner: renv.NewRDependencyScanner(log, nil),
+    }
 }
 
 func (h *PostPackagesRScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -75,13 +75,13 @@ func (h *PostPackagesRScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 	}
 	// Choose scanner: if Positron settings were provided, build a scanner with options;
 	// otherwise use the handler's default (for testability and backward-compat).
-	scanner := h.rDependencyScanner
-	if b.Positron != nil && b.Positron.R != nil {
-		scanner = renv.NewRDependencyScanner(h.log, &renv.RepoOptions{
-			DefaultRepositories:      b.Positron.R.DefaultRepositories,
-			PackageManagerRepository: b.Positron.R.PackageManagerRepository,
-		})
-	}
+    scanner := h.rDependencyScanner
+    if b.Positron != nil && b.Positron.R != nil {
+        scanner = renv.NewRDependencyScanner(h.log, &renv.RepoOptions{
+            DefaultRepositories:      b.Positron.R.DefaultRepositories,
+            PackageManagerRepository: b.Positron.R.PackageManagerRepository,
+        })
+    }
 
 	_, err = scanner.SetupRenvInDir(projectDir.String(), lockfileRelPath.String(), rExecutablePath.String())
 	if err != nil {

--- a/internal/services/api/post_packages_r_scan.go
+++ b/internal/services/api/post_packages_r_scan.go
@@ -87,6 +87,3 @@ func (h *PostPackagesRScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 
 	w.WriteHeader(http.StatusNoContent)
 }
-
-// repoOptsFromPositron converts inbound Positron settings to renv.RepoOptions.
-// Returns nil if no Positron R settings were provided.

--- a/internal/services/api/post_packages_r_scan.go
+++ b/internal/services/api/post_packages_r_scan.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
-	"strings"
 
 	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
 	"github.com/posit-dev/publisher/internal/interpreters"
@@ -91,14 +90,3 @@ func (h *PostPackagesRScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 
 // repoOptsFromPositron converts inbound Positron settings to renv.RepoOptions.
 // Returns nil if no Positron R settings were provided.
-func repoOptsFromPositron(ps *positronSettings) *renv.RepoOptions {
-	if ps == nil || ps.R == nil {
-		return nil
-	}
-	mode := strings.TrimSpace(ps.R.DefaultRepositories)
-	ppm := strings.TrimSpace(ps.R.PackageManagerRepository)
-	return &renv.RepoOptions{
-		DefaultRepositories:      mode,
-		PackageManagerRepository: ppm,
-	}
-}

--- a/internal/services/api/post_packages_r_scan.go
+++ b/internal/services/api/post_packages_r_scan.go
@@ -16,8 +16,8 @@ import (
 )
 
 type PostPackagesRScanRequest struct {
-	R        string             `json:"r"`
-	SaveName string             `json:"saveName"`
+	R        string            `json:"r"`
+	SaveName string            `json:"saveName"`
 	Positron *positronSettings `json:"positron,omitempty"`
 }
 
@@ -31,11 +31,11 @@ func NewPostPackagesRScanHandler(
 	base util.AbsolutePath,
 	log logging.Logger,
 ) *PostPackagesRScanHandler {
-    return &PostPackagesRScanHandler{
-        base:               base,
-        log:                log,
-        rDependencyScanner: renv.NewRDependencyScanner(log, nil),
-    }
+	return &PostPackagesRScanHandler{
+		base:               base,
+		log:                log,
+		rDependencyScanner: renv.NewRDependencyScanner(log, nil),
+	}
 }
 
 func (h *PostPackagesRScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -75,13 +75,13 @@ func (h *PostPackagesRScanHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 	}
 	// Choose scanner: if Positron settings were provided, build a scanner with options;
 	// otherwise use the handler's default (for testability and backward-compat).
-    scanner := h.rDependencyScanner
-    if b.Positron != nil && b.Positron.R != nil {
-        scanner = renv.NewRDependencyScanner(h.log, &renv.RepoOptions{
-            DefaultRepositories:      b.Positron.R.DefaultRepositories,
-            PackageManagerRepository: b.Positron.R.PackageManagerRepository,
-        })
-    }
+	scanner := h.rDependencyScanner
+	if b.Positron != nil && b.Positron.R != nil {
+		scanner = renv.NewRDependencyScanner(h.log, &renv.RepoOptions{
+			DefaultRepositories:      b.Positron.R.DefaultRepositories,
+			PackageManagerRepository: b.Positron.R.PackageManagerRepository,
+		})
+	}
 
 	_, err = scanner.SetupRenvInDir(projectDir.String(), lockfileRelPath.String(), rExecutablePath.String())
 	if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posit-dev/publisher/internal/accounts"
 	"github.com/posit-dev/publisher/internal/config"
 	"github.com/posit-dev/publisher/internal/deployment"
+	"github.com/posit-dev/publisher/internal/inspect/dependencies/renv"
 	"github.com/posit-dev/publisher/internal/interpreters"
 	"github.com/posit-dev/publisher/internal/logging"
 	"github.com/posit-dev/publisher/internal/util"
@@ -26,6 +27,8 @@ type State struct {
 	Target      *deployment.Deployment
 	LocalID     LocalDeploymentID
 	Secrets     map[string]string
+	// RepoOptions carries IDE-controlled repository defaults (e.g. CRAN/PPM) for R.
+	RepoOptions *renv.RepoOptions
 }
 
 func loadConfig(path util.AbsolutePath, configName string) (*config.Config, error) {
@@ -104,6 +107,7 @@ func New(
 	rInterpreter interpreters.RInterpreter,
 	pythonInterpreter interpreters.PythonInterpreter,
 	log logging.Logger,
+	repoOpts *renv.RepoOptions,
 ) (*State, error) {
 	var target *deployment.Deployment
 	var account *accounts.Account
@@ -186,6 +190,7 @@ func New(
 		Config:      cfg,
 		Target:      target,
 		Secrets:     secrets,
+		RepoOptions: repoOpts,
 	}, nil
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -330,7 +330,7 @@ func (s *StateSuite) TestNew() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-    state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(state.AccountName, "")
@@ -365,7 +365,7 @@ func (s *StateSuite) TestNewNonDefaultConfig() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -386,7 +386,7 @@ func (s *StateSuite) TestNewConfigErr() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NotNil(err)
 	s.ErrorContains(err, "couldn't load configuration")
 	s.Nil(state)
@@ -435,7 +435,7 @@ func (s *StateSuite) TestNewWithTarget() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-state, err := New(s.cwd, "", "", "myTargetName", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", "", "myTargetName", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct1", state.AccountName)
@@ -487,7 +487,7 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct2", state.AccountName)
@@ -512,7 +512,7 @@ func (s *StateSuite) TestNewWithSecrets() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(secrets, state.Secrets)
@@ -539,7 +539,7 @@ func (s *StateSuite) TestNewWithInvalidSecret() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NotNil(err)
 	s.ErrorContains(err, "secret 'INVALID_SECRET' is not in the configuration")
 	s.Nil(state)
@@ -620,7 +620,7 @@ func (s *StateSuite) TestNewWithInterpreterDefaultFillsNotNeeded() {
 	rInterpreter := s.createMockRInterpreter()
 	pythonInterpreter := s.createMockPythonInterpreter()
 
-    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -655,7 +655,7 @@ func (s *StateSuite) TestNewWithInterpreterDefaultFillsNeeded() {
 	cfg.R.FillDefaults(rInterpreter)
 	cfg.Python.FillDefaults(pythonInterpreter)
 
-    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -686,7 +686,7 @@ func (s *StateSuite) TestNewWithInterpreterDefaultFillsNeededButNoInterpreters()
 	rInterpreter := s.createMockRMissingInterpreter()
 	pythonInterpreter := s.createMockPythonMissingInterpreter()
 
-    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -717,7 +717,7 @@ func (s *StateSuite) TestNewWithInterpreterNoInterpreterSections() {
 	rInterpreter := s.createMockRInterpreter()
 	pythonInterpreter := s.createMockPythonInterpreter()
 
-state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
+	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -330,7 +330,7 @@ func (s *StateSuite) TestNew() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log)
+    state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(state.AccountName, "")
@@ -365,7 +365,7 @@ func (s *StateSuite) TestNewNonDefaultConfig() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, mockRInterpreter, mockPythonInterpreter, s.log)
+    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -386,7 +386,7 @@ func (s *StateSuite) TestNewConfigErr() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log)
+state, err := New(s.cwd, "", "", "", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NotNil(err)
 	s.ErrorContains(err, "couldn't load configuration")
 	s.Nil(state)
@@ -435,7 +435,7 @@ func (s *StateSuite) TestNewWithTarget() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", "", "myTargetName", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log)
+state, err := New(s.cwd, "", "", "myTargetName", "", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct1", state.AccountName)
@@ -487,7 +487,7 @@ func (s *StateSuite) TestNewWithTargetAndAccount() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log)
+state, err := New(s.cwd, "acct2", "", "myTargetName", "mySaveName", accts, nil, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("acct2", state.AccountName)
@@ -512,7 +512,7 @@ func (s *StateSuite) TestNewWithSecrets() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log)
+state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal(secrets, state.Secrets)
@@ -539,7 +539,7 @@ func (s *StateSuite) TestNewWithInvalidSecret() {
 	mockRInterpreter := s.createMockRInterpreter()
 	mockPythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log)
+state, err := New(s.cwd, "", "", "", "", accts, secrets, false, mockRInterpreter, mockPythonInterpreter, s.log, nil)
 	s.NotNil(err)
 	s.ErrorContains(err, "secret 'INVALID_SECRET' is not in the configuration")
 	s.Nil(state)
@@ -620,7 +620,7 @@ func (s *StateSuite) TestNewWithInterpreterDefaultFillsNotNeeded() {
 	rInterpreter := s.createMockRInterpreter()
 	pythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log)
+    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -655,7 +655,7 @@ func (s *StateSuite) TestNewWithInterpreterDefaultFillsNeeded() {
 	cfg.R.FillDefaults(rInterpreter)
 	cfg.Python.FillDefaults(pythonInterpreter)
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log)
+    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -686,7 +686,7 @@ func (s *StateSuite) TestNewWithInterpreterDefaultFillsNeededButNoInterpreters()
 	rInterpreter := s.createMockRMissingInterpreter()
 	pythonInterpreter := s.createMockPythonMissingInterpreter()
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log)
+    state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)
@@ -717,7 +717,7 @@ func (s *StateSuite) TestNewWithInterpreterNoInterpreterSections() {
 	rInterpreter := s.createMockRInterpreter()
 	pythonInterpreter := s.createMockPythonInterpreter()
 
-	state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log)
+state, err := New(s.cwd, "", configName, "", "", accts, nil, insecure, rInterpreter, pythonInterpreter, s.log, nil)
 	s.NoError(err)
 	s.NotNil(state)
 	s.Equal("", state.AccountName)


### PR DESCRIPTION
## Intent

Make sure that `renv.lock` files generated by the publisher to use the default repositories set by Positron options.

Closes https://github.com/posit-dev/publisher/issues/3038

## Type of Change

- - [x] New Feature <!-- A change which adds additional functionality -->

## Approach

Read the options from the VSCode extension and submit them to the API for scanning dependencies and performing deploys.

## User Impact

Users that use Positron should see faster deploy of packages as they can rely on ppm providing binary packages.

## Automated Tests

* Added tests to confirm that repoOptions are used when generating a new renv.lock
* Added tests to confirm that UI does submit the options to the backend.

## Checklist

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
