### PR TITLE
remove alert from R Packges header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added more prominent status messages when rendering Quarto documents. #2940
 
+### Fixed
+
+- The "R Packages" section no longer shows you an alert if you aren't using renv. (3095)
+
 ## [1.22.0]
 
 ### Added

--- a/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
+++ b/extensions/vscode/webviews/homeView/src/components/views/RPackages.vue
@@ -3,7 +3,6 @@
     title="R Packages"
     data-automation="r-packages"
     :actions="rPackageActions"
-    :codicon="home.r.active.isAlertActive ? `codicon-alert` : ``"
   >
     <WelcomeView v-if="showWelcomeView">
       <template v-if="missingOrInvalidPackageFile">

--- a/extensions/vscode/webviews/homeView/src/stores/home.ts
+++ b/extensions/vscode/webviews/homeView/src/stores/home.ts
@@ -346,13 +346,6 @@ export const useHomeStore = defineStore("home", () => {
         );
       }),
 
-      isAlertActive: computed((): boolean => {
-        return (
-          r.active.isMissingPackageFile.value ||
-          r.active.isEmptyRequirements.value
-        );
-      }),
-
       isInProject: computed(() => {
         return rProject.value;
       }),
@@ -386,7 +379,6 @@ export const useHomeStore = defineStore("home", () => {
     return (
       !config.active.isAlertActive.value &&
       (credential.active.isAlertActive.value ||
-        r.active.isAlertActive.value ||
         python.active.isAlertActive.value)
     );
   });


### PR DESCRIPTION
Remove alert icon from R Packages header that showed when there was no `renv` infrastructure.

## Intent

# Resolves #3088 

## Type of Change

- - [x] Bug Fix <!-- A change which fixes an existing issue -->

## Approach

Remove the alert from `RPackages.vue` and `home.ts`.

## User Impact

## Automated Tests

As far as I can tell, no automated tests cover this alert.

## Directions for Reviewers

- Run the extension in an R project which isn't using `renv`, confirm there is no alert icon in the R Packages header.

## Checklist

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
