### PR TITLE
fix: add support for Remote* fields in lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The "R Packages" section no longer shows you an alert if you aren't using renv. (3095)
+- When `renv.lock` contains packages installed from GitHub or Bitbucket the deploy
+  process should respect `RemoteHost`, `RemoteRepo`, `RemoteUsername` and
+  `RemoteUrl` and `RemoteSubdir` fields (#3147)
 
 ## [1.22.0]
 

--- a/internal/inspect/dependencies/renv/lockfile.go
+++ b/internal/inspect/dependencies/renv/lockfile.go
@@ -49,6 +49,11 @@ type Package struct {
 	RemoteReposName   string        `toml:"remote_repos_name,omitempty" json:"remoteReposName,omitempty"`
 	RemotePkgPlatform string        `toml:"remote_pkg_platform,omitempty" json:"remotePkgPlatform,omitempty"`
 	RemoteSha         string        `toml:"remote_sha,omitempty" json:"remoteSha,omitempty"`
+	RemoteHost        string        `toml:"remote_host,omitempty" json:"remoteHost,omitempty"`
+	RemoteRepo        string        `toml:"remote_repo,omitempty" json:"remoteRepo,omitempty"`
+	RemoteUsername    string        `toml:"remote_username,omitempty" json:"remoteUsername,omitempty"`
+	RemoteSubdir      string        `toml:"remote_subdir,omitempty" json:"remoteSubdir,omitempty"`
+	RemoteUrl         string        `toml:"remote_url,omitempty" json:"remoteUrl,omitempty"`
 
 	// Additional fields from renv.lock that we want to copy to the manifest
 	Type               string   `toml:"type,omitempty" json:"Type,omitempty"`

--- a/internal/inspect/dependencies/renv/manifest_packages.go
+++ b/internal/inspect/dependencies/renv/manifest_packages.go
@@ -147,6 +147,9 @@ func toManifestPackage(pkg *Package, repos []Repository, availablePackages, bioc
 		}
 	case "Bitbucket", "GitHub", "GitLab":
 		out.Source = strings.ToLower(pkg.Source)
+		if repo := remotePkgRefOrDerived(*pkg); repo != "" {
+			out.Repository = firstNonEmpty(remoteRepoURL(out.Source, repo), pkg.RemoteUrl)
+		}
 	case "Local", "unknown":
 		out.Source = ""
 		out.Repository = ""


### PR DESCRIPTION
## Intent

Closes #3147

## Type of Change

- - [x] Bug Fix <!-- A change which fixes an existing issue -->

## Approach

When loading the lockfile, the `Remote*` fields are now loaded and when generating the `manifest.json` those are added to the `Description` of the package.

## User Impact

Should fix the reported error:

```
Hi all - i'm trying to publish to Connect using a dev version of pins. I installed it using pak::pak("rstudio/pins-r") but i'm hitting this error when publishing:
```

## Automated Tests

There is a test verifying that the generated manifest does indeed have the fields.

## Directions for Reviewers

The implementation is based on https://github.com/rstudio/packrat/blob/b3127db3cea2144b1e3bd9c17de1da277b4776e9/R/github.R#L72-L98

Which confirms that `Remote*` fields are all we should need.

## Checklist

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
