### PR TITLE
feat(llm-tooling): troubleshootDeploymentFailure - Get and use deployment logs to troubleshoot the publishing failure

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -622,6 +622,25 @@
           }
         ]
       }
+    ],
+    "languageModelTools": [
+      {
+        "name": "publish-content_troubleshootDeploymentFailure",
+        "tags": [
+          "posit",
+          "publisher",
+          "positron-assistant"
+        ],
+        "toolReferenceName": "troubleshootDeploymentFailure",
+        "displayName": "Troubleshoot Deployment Failure",
+        "modelDescription": "When the user asks about a deployment failure to Connect or Connect Cloud (e.g., \"why did my deployment fail?\", \"troubleshoot deployment error\", or similar), use this tool proactively to retrieve and analyze the latest deployment logs, even if the user does not tell you to use it explicitly. Use the log data to provide a targeted diagnosis and troubleshooting steps, even if the user does not explicitly mention the tool.",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(search-sparkle)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      }
     ]
   },
   "scripts": {

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -21,6 +21,7 @@ import { getXDGConfigProperty } from "src/utils/config";
 import { PublisherState } from "./state";
 import { PublisherAuthProvider } from "./authProvider";
 import { copySystemInfoCommand } from "src/commands";
+import { registerLLMTooling } from "./llm";
 
 const STATE_CONTEXT = "posit.publish.state";
 
@@ -197,6 +198,9 @@ async function initializeExtension(context: ExtensionContext) {
   );
 
   context.subscriptions.push(new PublisherAuthProvider(state));
+
+  // Register LLM Tools under /llm
+  registerLLMTooling(context);
 }
 
 // This method is called when your extension is activated

--- a/extensions/vscode/src/llm/index.ts
+++ b/extensions/vscode/src/llm/index.ts
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { ExtensionContext, lm } from "vscode";
+import { PublishFailureTroubleshootTool } from "./tooling/troubleshoot/publishFailureTroubleshootTool";
+
+export function registerLLMTooling(context: ExtensionContext) {
+  context.subscriptions.push(
+    lm.registerTool(
+      "publish-content_troubleshootDeploymentFailure",
+      new PublishFailureTroubleshootTool(),
+    ),
+  );
+}

--- a/extensions/vscode/src/llm/tooling/troubleshoot/publishFailureTroubleshootTool.ts
+++ b/extensions/vscode/src/llm/tooling/troubleshoot/publishFailureTroubleshootTool.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import {
+  CancellationToken,
+  LanguageModelTool,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolResult,
+  LanguageModelTextPart,
+} from "vscode";
+import { LogsViewProvider } from "../../../views/logs";
+
+export class PublishFailureTroubleshootTool
+  implements LanguageModelTool<never>
+{
+  invoke(
+    _options: LanguageModelToolInvocationOptions<never>,
+    _token: CancellationToken,
+  ): LanguageModelToolResult {
+    const logsData = LogsViewProvider.getLogsText();
+    return new LanguageModelToolResult([new LanguageModelTextPart(logsData)]);
+  }
+}

--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -191,12 +191,12 @@ export class LogsViewProvider implements WebviewViewProvider, Disposable {
     return LogsViewProvider.getLogs().join("<br />").trim();
   }
 
-  private static getLogsText() {
-    return LogsViewProvider.getLogs().join("\n").trim();
-  }
-
   private static getLogsFilename() {
     return `publisher-logs-${new Date().toISOString().split(".").at(0)}.txt`;
+  }
+
+  public static getLogsText() {
+    return LogsViewProvider.getLogs().join("\n").trim();
   }
 
   public static refreshContent() {


### PR DESCRIPTION
## Intent

Resolves #3157 

LLM tool to allow Assistants to access the deployment logs for troubleshooting.

<details>
<summary>Screencapture - Troubleshooting deployment failure with Positron Assistant</summary>

https://github.com/user-attachments/assets/2de54560-7905-49a7-ac4f-04cb0e14f640

</details>

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

- Create and register the new troubleshooting tool when the Publisher extension is activated.
- Import and use the existing logs service provider `LogsViewProvider` to be used by this tool.

## User Impact

- Users can call the tool directly, `#troubleshootDeploymentFailure`, when working with an LLM.
- When in agent mode, this tool does not need to be referenced directly, asking "Why my deployment failed?" is enough for the LLM to determine that this tool will help to get the log data to be analyzed.

## Automated Tests

None. Testing LLM tool calling needs to be done manually.

## Directions for Reviewers

- Install the VSIX from this branch.
- Attempt to deploy a project that fails in Connect, could be because of dependencies, error rendering or something else.
- Be sure to be in `"Agent Mode"` (tools in Ask/Edit mode need to be referenced directly), ask the IDE LLM Assistant `"Why my deployment failed?"`, it can be seen that the LLM uses the new tool, ingesting the logs and providing possible solutions to the problem.

**Note:**
This tool uses `vscode.lm` APIs that work for Positron Assistant and VSCode Copilot, however it is encouraged that this is tested with Positron Assistant so we can notice if there is any deviation between platforms.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
