### PR TITLE
feat: Raw deployment logs in file view

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -68,24 +68,14 @@
     ],
     "commands": [
       {
-        "command": "posit.publisher.logs.treeview",
+        "command": "posit.publisher.logs.fileview",
         "title": "See Raw Logs",
-        "icon": "$(list-unordered)"
-      },
-      {
-        "command": "posit.publisher.logs.webview",
-        "title": "See Summarized Logs",
-        "icon": "$(list-tree)"
+        "icon": "$(list-flat)"
       },
       {
         "command": "posit.publisher.logs.copy",
         "title": "Copy Logs",
         "icon": "$(copy)"
-      },
-      {
-        "command": "posit.publisher.logs.save",
-        "title": "Save & Open Logs",
-        "icon": "$(save)"
       },
       {
         "command": "posit.publisher.init-project",
@@ -279,24 +269,14 @@
       ],
       "view/title": [
         {
-          "command": "posit.publisher.logs.treeview",
+          "command": "posit.publisher.logs.fileview",
           "when": "view == posit.publisher.logs",
-          "group": "navigation@3"
-        },
-        {
-          "command": "posit.publisher.logs.webview",
-          "when": "view == posit.publisher.rawlogs",
           "group": "navigation@3"
         },
         {
           "command": "posit.publisher.logs.copy",
           "when": "view == posit.publisher.logs || view == posit.publisher.rawlogs",
           "group": "navigation@2"
-        },
-        {
-          "command": "posit.publisher.logs.save",
-          "when": "view == posit.publisher.logs || view == posit.publisher.rawlogs",
-          "group": "navigation@1"
         },
         {
           "command": "posit.publisher.files.refresh",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -43,10 +43,8 @@ const baseContexts = {
 const logsCommands = {
   Visit: "posit.publisher.logs.visit",
   // Added automatically by VSCode with view registration
-  Treeview: "posit.publisher.logs.treeview",
-  Webview: "posit.publisher.logs.webview",
+  Fileview: "posit.publisher.logs.fileview",
   Copy: "posit.publisher.logs.copy",
-  Save: "posit.publisher.logs.save",
   TreeviewFocus: "posit.publisher.logs.focus",
   WebviewFocus: "posit.publisher.rawlogs.focus",
   ToggleVisibility: "posit.publisher.logs.toggleVisibility",

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -144,33 +144,12 @@ async function initializeExtension(context: ExtensionContext) {
     LogsViewMode.tree,
   );
 
-  // Handler function to toggle the logs view mode
-  const toggleLogsViewModeHandler = () => {
-    // Get the current logs view mode from the context
-    const currentMode = context.globalState.get(
-      LOGS_VIEWMODE_CONTEXT,
-      LogsViewMode.tree,
-    );
-    const newMode =
-      currentMode === LogsViewMode.tree
-        ? LogsViewMode.webview
-        : LogsViewMode.tree;
-
-    // Update the context key, which automatically toggles the logs view's visibility
-    commands.executeCommand("setContext", LOGS_VIEWMODE_CONTEXT, newMode);
-
-    // Save the setting for persistence
-    context.globalState.update(LOGS_VIEWMODE_CONTEXT, newMode);
-  };
-
   context.subscriptions.push(
-    commands.registerCommand(Commands.Logs.Treeview, toggleLogsViewModeHandler),
-    commands.registerCommand(Commands.Logs.Webview, toggleLogsViewModeHandler),
-    commands.registerCommand(Commands.Logs.Copy, LogsViewProvider.copyLogs),
     commands.registerCommand(
-      Commands.Logs.Save,
-      LogsViewProvider.writeAndOpenLogsFile,
+      Commands.Logs.Fileview,
+      LogsViewProvider.openRawLogFileView,
     ),
+    commands.registerCommand(Commands.Logs.Copy, LogsViewProvider.copyLogs),
     commands.registerCommand(Commands.InitProject, async (viewId: string) => {
       setInitializationInProgressContext(InitializationInProgress.true);
       await homeViewProvider.showNewDeploymentMultiStep(viewId);


### PR DESCRIPTION
## Intent

Resolves #2996 

Open the deployment raw logs in file view.

<details>
<summary>
Screencapture
</summary>

https://github.com/user-attachments/assets/447fce9e-7952-4540-b940-00f6fd2beac5

</details>

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [x] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Use the VSCode's files API a bit differently to how it is now to open an unsaved version of the logs as a file.

## User Impact

- Logs open directly as a new file. User can select right away desired portions of it, search through it and save it if wanted.
- Log file follows the stream of logs.
- Less buttons.

## Directions for Reviewers

- Start a deployment, open the raw logs
  - If deployment is still ongoing, logs file will be following the stream and automatically scrolling.
  - If deployment finished, full logs data will be shown.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
