### PR TITLE
chore: add note about needing to set up code cli

### DIFF
--- a/extensions/vscode/CONTRIBUTING.md
+++ b/extensions/vscode/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Before you begin, make sure you have the following installed:
 
 - [Visual Studio Code](https://code.visualstudio.com/download)
   - The [`connor4312.esbuild-problem-matchers`](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) extension.
+  - The `code` CLI should be installed and on your PATH. On Linux this should happen automatically; on macOS follow [these instructions](https://code.visualstudio.com/docs/setup/mac#_configure-the-path-with-vs-code).
 - [Node.js](https://nodejs.org/en)
 - [Just](https://just.systems)
 


### PR DESCRIPTION

## Intent

Adds a note to CONTRIBUTING.md about the need to separately set up the `code` CLI tool. I bumped into this because I didn't have it set up, so `just install` failed.

## Type of Change

## Approach

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
