### PR TITLE
feat: Support for R packages from GitHub stored in a subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When `renv.lock` contains packages installed from GitHub or Bitbucket the deploy
   process should respect `RemoteHost`, `RemoteRepo`, `RemoteUsername` and
   `RemoteUrl` and `RemoteSubdir` fields (#3147)
+- When a package has a present `RemoteSubdir`, the field `GithubSubdir` is added too
+  to avoid issues with previous versions of Packrat not considering `RemoteSubdir` for
+  packages hosted in Github. (#3194)
 
 # Changed
 

--- a/internal/inspect/dependencies/renv/lockfile.go
+++ b/internal/inspect/dependencies/renv/lockfile.go
@@ -53,6 +53,7 @@ type Package struct {
 	RemoteRepo        string        `toml:"remote_repo,omitempty" json:"remoteRepo,omitempty"`
 	RemoteUsername    string        `toml:"remote_username,omitempty" json:"remoteUsername,omitempty"`
 	RemoteSubdir      string        `toml:"remote_subdir,omitempty" json:"remoteSubdir,omitempty"`
+	GithubSubdir      string        `toml:"github_subdir,omitempty" json:"githubSubdir,omitempty"`
 	RemoteUrl         string        `toml:"remote_url,omitempty" json:"remoteUrl,omitempty"`
 
 	// Additional fields from renv.lock that we want to copy to the manifest

--- a/internal/inspect/dependencies/renv/manifest_packages_from_lockfile.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_from_lockfile.go
@@ -160,6 +160,7 @@ func copyAllFieldsToDesc(pkg Package, manifestPkg *bundles.Package) {
 	setIf(desc, "RemoteRepo", pkg.RemoteRepo)
 	setIf(desc, "RemoteUsername", pkg.RemoteUsername)
 	setIf(desc, "RemoteSubdir", pkg.RemoteSubdir)
+	setIf(desc, "GithubSubdir", pkg.RemoteSubdir)
 	setIf(desc, "RemoteUrl", pkg.RemoteUrl)
 	desc["RemotePkgRef"] = firstNonEmpty(desc["RemotePkgRef"], remotePkgRefOrDerived(pkg))
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Resolves #2794

For R packages from GitHub that's stored in a subdirectory,  injecting a `GithubSubdir` if there is a `RemoteSubdir`.

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Directions for Reviewers

Publishing a project that uses an R package from GitHub that's stored in a subdirectory should work. e.g: Shinychat https://posit-dev.github.io/shinychat/r/

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
