### PR TITLE
Fix: Proper order of checks for URL when mapping packages to manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When a package has a present `RemoteSubdir`, the field `GithubSubdir` is added too
   to avoid issues with previous versions of Packrat not considering `RemoteSubdir` for
   packages hosted in Github. (#3194)
+- Projects referencing packages with RemoteRepos by name and not URL do not hang when deploying. (#3209)
 
 # Changed
 

--- a/internal/inspect/dependencies/renv/lockfile.go
+++ b/internal/inspect/dependencies/renv/lockfile.go
@@ -107,7 +107,7 @@ func ValidateModernLockfile(lockfile *Lockfile) error {
 // and LockfilePackageMapper (lockfile-only approach) must produce identical output formats regardless
 // of whether packages reference repositories by name ("CRAN") or URL ("https://cloud.r-project.org").
 func isURL(s string) bool {
-	return len(s) > 0 && (s[0:4] == "http" || s[0:3] == "ftp") && strings.Contains(s, "://")
+	return len(s) > 0 && strings.Contains(s, "://") && (s[0:3] == "ftp" || s[0:4] == "http")
 }
 
 // Example package installed from CRAN


### PR DESCRIPTION
## Intent

Resolves #3209 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Re-order manifest package checks `isURL` to avoid out of bounds strings.

## User Impact

No panics! When users have custom package repositories where the mapping happens via remote repo name.

## Automated Tests

Added an additional check to an existing test.

## Directions for Reviewers

This one is hard to replicate locally, a project with an renv lockfile having packages with `RemoteRepos` by name and referencing a custom repo in `"Repositories"` should not hang when deploying.
@karawoo already verified this fix with a bundle while on workweek.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
