### PR TITLE
fix: do pre-flight checks before creating deployment

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -264,15 +264,8 @@ func (p *defaultPublisher) doPublish() error {
 
 	if wasPreviouslyDeployed {
 		p.log.Info("Updating deployment", "content_id", contentID)
-	} else {
-		// Create a new deployment; we will update it with details later.
-		contentID, err = p.serverPublisher.CreateDeployment()
-		if err != nil {
-			return err
-		}
+		p.setContentInfo(p.serverPublisher.GetContentInfo(contentID))
 	}
-
-	p.setContentInfo(p.serverPublisher.GetContentInfo(contentID))
 
 	manifest, err := p.createManifest()
 	if err != nil {
@@ -282,6 +275,15 @@ func (p *defaultPublisher) doPublish() error {
 	err = p.serverPublisher.PreFlightChecks()
 	if err != nil {
 		return err
+	}
+
+	if !wasPreviouslyDeployed {
+		// Create a new deployment; we will update it with details later.
+		contentID, err = p.serverPublisher.CreateDeployment()
+		if err != nil {
+			return err
+		}
+		p.setContentInfo(p.serverPublisher.GetContentInfo(contentID))
 	}
 
 	bundleFile, err := p.createBundle(manifest)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -175,12 +175,16 @@ func (s *PublishConnectSuite) TestPublishWithClientNewUpdate() {
 
 func (s *PublishConnectSuite) TestPublishWithClientNewFailAuth() {
 	authErr := errors.New("error from TestAuthentication")
-	s.publishWithClient(nil, &publishErrsMock{authErr: authErr}, authErr)
+	s.publishWithClient(nil, &publishErrsMock{authErr: authErr}, authErr, func(options *publishTestOptions) {
+		options.expectContentID = false
+	})
 }
 
 func (s *PublishConnectSuite) TestPublishWithClientNewFailCapabilities() {
 	capabilitiesErr := errors.New("error from CheckCapabilities")
-	s.publishWithClient(nil, &publishErrsMock{capabilitiesErr: capabilitiesErr}, capabilitiesErr)
+	s.publishWithClient(nil, &publishErrsMock{capabilitiesErr: capabilitiesErr}, capabilitiesErr, func(options *publishTestOptions) {
+		options.expectContentID = false
+	})
 }
 
 func (s *PublishConnectSuite) TestPublishWithClientNewFailCreate() {
@@ -217,7 +221,9 @@ func (s *PublishConnectSuite) TestPublishWithClientNewFailValidation() {
 
 func (s *PublishConnectSuite) TestPublishWithClientNewRPackages() {
 	rPackageErr := errors.New("error from GetManifestPackages")
-	s.publishWithClient(nil, &publishErrsMock{rPackageErr: rPackageErr}, rPackageErr)
+	s.publishWithClient(nil, &publishErrsMock{rPackageErr: rPackageErr}, rPackageErr, func(options *publishTestOptions) {
+		options.expectContentID = false
+	})
 }
 
 func (s *PublishConnectSuite) TestPublishWithClientRedeployFailAuth() {
@@ -661,6 +667,17 @@ func (s *PublishConnectSuite) TestLogAppInfoErrNoContentID() {
 	s.Equal("", buf.String())
 }
 
+// TestServerUnavailableShowsHelpfulError verifies that when the server is unavailable,
+// users see the helpful error message from TestAuthentication instead of a generic HTTP
+// error from CreateDeployment.
+func (s *PublishConnectSuite) TestServerUnavailableShowsHelpfulError() {
+	helpfulErr := errors.New("could not access the server; check the server URL and try again")
+
+	s.publishWithClient(nil, &publishErrsMock{authErr: helpfulErr}, helpfulErr, func(options *publishTestOptions) {
+		options.expectContentID = false // No content created since pre-flight checks failed
+	})
+}
+
 type PublishConnectCloudSuite struct {
 	BasePublishSuite
 }
@@ -719,7 +736,9 @@ func (s *PublishConnectCloudSuite) TestPublishWithClientNewFailPublishContent() 
 
 func (s *PublishConnectCloudSuite) TestPublishWithClientNewFailRPackages() {
 	rPackageErr := errors.New("error from GetManifestPackages")
-	s.publishWithCloudClient(nil, &mockCloudError{rPackageErr: rPackageErr}, rPackageErr)
+	s.publishWithCloudClient(nil, &mockCloudError{rPackageErr: rPackageErr}, rPackageErr, func(options *cloudPublishTestOptions) {
+		options.expectContentID = false
+	})
 }
 
 func (s *PublishConnectCloudSuite) TestPublishWithClientNewFailGetContent() {
@@ -976,10 +995,10 @@ func (s *PublishConnectCloudSuite) publishWithCloudClient(
 
 		s.Equal(12, len(emitter.Events))
 		s.Equal("publish/start", emitter.Events[0].Type)
-		s.Equal("publish/createNewDeployment/start", emitter.Events[1].Type)
-		s.Equal("publish/createNewDeployment/success", emitter.Events[2].Type)
-		s.Equal("publish/getRPackageDescriptions/start", emitter.Events[3].Type)
-		s.Equal("publish/getRPackageDescriptions/success", emitter.Events[4].Type)
+		s.Equal("publish/getRPackageDescriptions/start", emitter.Events[1].Type)
+		s.Equal("publish/getRPackageDescriptions/success", emitter.Events[2].Type)
+		s.Equal("publish/createNewDeployment/start", emitter.Events[3].Type)
+		s.Equal("publish/createNewDeployment/success", emitter.Events[4].Type)
 		s.Equal("publish/createBundle/start", emitter.Events[5].Type)
 		s.Equal("publish/createBundle/success", emitter.Events[6].Type)
 		s.Equal("publish/deployContent/start", emitter.Events[7].Type)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Ensure that if the Connect server is unreachable, we surface a useful error message.

resolves #2564 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Reorders operations in `doPublish()` to run pre-flight checks before calling `CreateDeployment()` for new deployments. The deployment record is still written early to preserve dismissal functionality (from #2179), but server-side content creation now only happens after checks pass. Updated existing tests to reflect that no contentID is created when pre-flight checks fail.

## User Impact

Users will again see a helpful error message if the Connect server is unreachable.

<img width="483" height="173" alt="Screenshot 2025-11-07 at 9 55 49 AM" src="https://github.com/user-attachments/assets/1890a636-9aa2-4761-aea1-f1099a335501" />


## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
