### PR TITLE
chore: Update to Node 22

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: test/e2e/package-lock.json
 

--- a/.github/workflows/home-view-unit-test.yaml
+++ b/.github/workflows/home-view-unit-test.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - run: npm install --prefix ../..

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
           go-version-file: go.mod
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - run: just npm-install

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - uses: actions/download-artifact@v6
         with:
           name: dist
@@ -64,7 +64,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - uses: actions/download-artifact@v6
         with:
           name: dist

--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - id: get-date
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -27,7 +27,7 @@
         "@types/eventsource": "^1.1.15",
         "@types/mocha": "^10.0.2",
         "@types/mutexify": "^1.2.3",
-        "@types/node": "^20.14.2",
+        "@types/node": "^22.0.0",
         "@types/retry": "^0.12.5",
         "@types/vscode": "^1.87.0",
         "@types/wait-on": "^5.3.3",
@@ -1237,9 +1237,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.16.tgz",
-      "integrity": "sha512-VS6TTONVdgwJwtJr7U+ghEjpfmQdqehLLpg/iMYGOd1+ilaFjdBJwFuPggJ4EAYPDCzWfDUHoIxyVnu+tOWVuQ==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -649,7 +649,7 @@
     "@types/eventsource": "^1.1.15",
     "@types/mocha": "^10.0.2",
     "@types/mutexify": "^1.2.3",
-    "@types/node": "^20.14.2",
+    "@types/node": "^22.0.0",
     "@types/retry": "^0.12.5",
     "@types/vscode": "^1.87.0",
     "@types/wait-on": "^5.3.3",

--- a/extensions/vscode/webviews/homeView/package-lock.json
+++ b/extensions/vscode/webviews/homeView/package-lock.json
@@ -15,8 +15,8 @@
         "vue-virtual-scroller": "^2.0.0-beta.8"
       },
       "devDependencies": {
-        "@tsconfig/node20": "^20.1.4",
-        "@types/node": "^20.14.2",
+        "@tsconfig/node22": "^22.0.3",
+        "@types/node": "^22.0.0",
         "@types/vscode-webview": "^1.57.5",
         "@vitejs/plugin-vue": "^5.2.4",
         "@vitest/coverage-v8": "^3.0.4",
@@ -1432,10 +1432,10 @@
         "win32"
       ]
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
-      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.3.tgz",
+      "integrity": "sha512-9UTUkYWI58+MiZhwcQWx2TNZbzkGRss9SCyjrSYeqkMIDYq8jv2FSRknrLOjsRmcYFUsYj79m/bgQYSD/yiRxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1464,9 +1464,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.21.tgz",
-      "integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/extensions/vscode/webviews/homeView/package.json
+++ b/extensions/vscode/webviews/homeView/package.json
@@ -15,8 +15,8 @@
     "vue-virtual-scroller": "^2.0.0-beta.8"
   },
   "devDependencies": {
-    "@tsconfig/node20": "^20.1.4",
-    "@types/node": "^20.14.2",
+    "@tsconfig/node22": "^22.0.3",
+    "@types/node": "^22.0.0",
     "@types/vscode-webview": "^1.57.5",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vitest/coverage-v8": "^3.0.4",

--- a/extensions/vscode/webviews/homeView/tsconfig.json
+++ b/extensions/vscode/webviews/homeView/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@tsconfig/node20/tsconfig.json",
+    "@tsconfig/node22/tsconfig.json",
     "@vue/tsconfig/tsconfig.dom.json"
   ],
   "include": ["src/**/*", "src/**/*.vue"],


### PR DESCRIPTION
Updates our npm package files and our CI workflows to use Node 22 to match the version of Node used in Electron on the newer versions of VS Code and Positron.

VS Code updated to Electron 35 in [version `1.101`](https://code.visualstudio.com/updates/v1_101)

I didn't update the VS Code engine in our extension `package.json` since there were no breaking changes that would stop compatibility with older versions of the IDE.

## Intent

Resolves #2665

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->
