### PR TITLE
chore(ci): Group minor and patch dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,30 +7,44 @@ version: 2
 updates:
   # npm
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/extensions/vscode"
+      - "/extensions/vscode/webviews/homeView"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/extensions/vscode"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/extensions/vscode/webviews/homeView"
-    schedule:
-      interval: "weekly"
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/test/e2e"
     schedule:
       interval: "weekly"
+    groups:
+      npm-e2e-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # go
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # python
   - package-ecosystem: "pip"


### PR DESCRIPTION
This PR uses the [`groups`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) and [`directories`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--) keys in the `dependabot.yml` to group our `npm` and `go` package dependency update PRs from dependabot.

The way this is setup we will get:
- a single PR for the `npm` packages that have minor and/or patch updates each week
- a single PR for the `go` packages that have minor and/or patch updates each week
- a PR per dependency that has a major upgrade

This should make it a bit easier to review the minor and patch dependency updates from dependabot. Plus reduce the number of automatic license file updates.

#### References

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->
