### PR TITLE
fix(logs): add visibility check before reveal

### DIFF
--- a/extensions/vscode/src/views/logs.ts
+++ b/extensions/vscode/src/views/logs.ts
@@ -287,6 +287,20 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
   private treeView?: TreeView<LogsTreeItem>;
 
   /**
+   * Reveal helper that checks visibility immediately before calling reveal.
+   * This prevents race conditions where the view is closed between the start
+   * of a reveal method and the actual reveal() call.
+   */
+  private safeReveal(
+    ...args: Parameters<TreeView<LogsTreeItem>["reveal"]>
+  ): void {
+    if (!this.treeView?.visible) {
+      return;
+    }
+    this.treeView.reveal(...args);
+  }
+
+  /**
    * Event emitter for when the tree data of the Logs view changes.
    * @private
    */
@@ -612,7 +626,7 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     const revealItem = this.getFailureItem();
 
     if (revealItem) {
-      this.treeView.reveal(revealItem, {
+      this.safeReveal(revealItem, {
         select: true,
         focus: true,
       });
@@ -636,7 +650,7 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
     const root = new LogsTreeStageItem(this.publishingStage);
     const stageItem = new LogsTreeStageItem(stage, root);
 
-    this.treeView.reveal(stageItem, { expand: true });
+    this.safeReveal(stageItem, { expand: true });
   }
 
   /**
@@ -680,7 +694,7 @@ export class LogsTreeDataProvider implements TreeDataProvider<LogsTreeItem> {
       TreeItemCollapsibleState.None,
     );
 
-    this.treeView.reveal(logItem);
+    this.safeReveal(logItem);
   }
 
   /**


### PR DESCRIPTION
This PR introduces a `safeReveal` helper that checks TreeView visibility before calling [`treeview.reveal()`](https://code.visualstudio.com/api/references/vscode-api#TreeItem), in most cases.

This drastically reduces the number of times the panel is re-opened immediately after it was closed.

For me, in testing, the timing issue occurred a handful of times in 10 deployments constantly opening and closing the panel prior to the change.

With the change it only happened twice.

## Intent

Follow up to #3386 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Checking TreeView visibility before using `reveal()` in most instances. The exception is when we _always_ want to reveal.

## User Impact

When the Publisher Logs view is not visible, by closing the panel it is inside, it is now less likely for the view to be immediately revealed again.

## Automated Tests

There aren't automated tests here as this is directly related to the VS Code API.

## Directions for Reviewers

Deploy content and close the panel containing the Logs view while the deploy is happening. Every so often it will re-open. With this change that will happen much less.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
