### PR TITLE
Don't run tests that use system R in short mode

### DIFF
--- a/internal/inspect/dependencies/renv/manifest_packages_from_lockfile_test.go
+++ b/internal/inspect/dependencies/renv/manifest_packages_from_lockfile_test.go
@@ -307,6 +307,10 @@ func (s *LockfilePackageMapperSuite) TestBioconductor_Functional() {
 // --- Compatibility tests ensuring lockfile-only path matches legacy path on core fields ---
 
 func (s *LockfilePackageMapperSuite) TestCRAN_LockfileCompatibility() {
+	if testing.Short() {
+		s.T().Skip("skipping compatibility test in short mode")
+	}
+
 	// Create a temporary renv.lock with real CRAN packages for compatibility testing
 	lockfileContent := `{
 		"R": {
@@ -390,6 +394,10 @@ License: GPL-2 | GPL-3
 }
 
 func (s *LockfilePackageMapperSuite) TestBioconductor_LockfileCompatibility() {
+	if testing.Short() {
+		s.T().Skip("skipping compatibility test in short mode")
+	}
+
 	base := s.testdata.Join("bioc_project")
 	lockfilePath := base.Join("renv.lock")
 	libPath := base.Join("renv_library")


### PR DESCRIPTION
These two tests fail unless one's local R setup is setup correctly. I'm adding them to our integration 

## Intent

Don't spuriously fail when running tests locally

## Type of Change
- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Skips, conditional, not in CI

## User Impact

NA

## Automated Tests

These are the tests

## Directions for Reviewers

Run it, I guess?

## Checklist

- [ ] ~I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.~
