### PR TITLE
docs: add CLAUDE.md files for guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# Project Overview
+
+Posit Publisher is a VSCode/Positron extension that enables deploying Python and R projects to Posit Connect. The project consists of:
+
+- **Go backend** (`cmd/publisher/`, `internal/`) - API server that handles deployments, configuration, and Connect server communication
+- **VSCode extension** (`extensions/vscode/`) - TypeScript extension providing the UI
+- **Webviews** (`extensions/vscode/webviews/homeView/`) - Vue 3 UI components for the extension sidebar
+
+# Build Commands
+
+The project uses [Just](https://github.com/casey/just) as the build tool. Run `just -l` to see all available commands.
+
+```bash
+# Full build (clean, build Go binary, package VSCode extension)
+just
+
+# Build Go binary only
+just build
+
+# Run Go unit tests (excludes functional tests)
+just test
+
+# Run all tests including functional tests
+just test ./...
+
+# Run a single Go test
+go test -run TestName ./internal/package/...
+
+# Lint Go code
+just lint
+
+# View test coverage in browser
+just cover
+
+# Format all code
+just format
+```
+
+## VSCode Extension Development
+
+```bash
+# From extensions/vscode/ directory:
+just                    # Clean, configure, and package
+just deps               # Install npm dependencies
+just lint               # Run ESLint
+just test               # Run extension tests (Mocha + Vitest)
+just package            # Package .vsix file
+
+# Rebuild webviews after changes
+npm run build --prefix webviews/homeView
+```
+
+To run the extension in development:
+
+1. Open `extensions/vscode/` as workspace in VSCode
+2. Run "Run Extension" debug configuration (F5)
+
+## E2E Tests
+
+E2E tests use Cypress and require Docker. From `test/e2e/`:
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+just build-images       # Build Docker images (first time)
+just dev                # Build publisher + run Cypress interactively
+just stop               # Stop Docker containers
+```
+
+# Architecture
+
+## Go Backend (`internal/`)
+
+Key packages:
+
+- `accounts/` - Server account/credential management
+- `bundles/` - Deployment bundle creation and manifest generation
+- `clients/` - HTTP clients for Connect API communication
+- `config/` - Configuration file parsing (`.posit/publish/*.toml`)
+- `credentials/` - Credential storage (keyring or file-based)
+- `deployment/` - Deployment record management (`.posit/publish/deployments/`)
+- `events/` - Server-Sent Events for real-time UI updates
+- `inspect/` - Project inspection (detect Python/R/Quarto content)
+- `interpreters/` - Python/R interpreter detection and version management
+- `publish/` - Core publishing logic to Connect servers
+- `schema/` - JSON schemas for configuration validation
+
+The CLI entry point (`cmd/publisher/main.go`) uses [Kong](https://github.com/alecthomas/kong) for command parsing. The `ui` command starts an HTTP API server that the VSCode extension communicates with.
+
+## VSCode Extension (`extensions/vscode/src/`)
+
+The extension spawns the Go binary as a subprocess and communicates via HTTP API. Key areas:
+
+- Views and webviews for the sidebar UI
+- File watchers for configuration changes
+- Authentication provider for Connect credentials
+
+## Configuration Files
+
+User projects contain:
+
+- `.posit/publish/*.toml` - Deployment configurations (schema: `posit-publishing-schema-v3.json`)
+- `.posit/publish/deployments/*.toml` - Deployment records tracking where content was deployed
+
+# Additional Documentation
+
+Subdirectories contain more detailed CLAUDE.md files:
+
+- `extensions/vscode/CLAUDE.md` - VSCode extension development
+- `extensions/vscode/webviews/homeView/CLAUDE.md` - Vue webview development
+
+# Testing Conventions
+
+- Go tests use [Testify](https://github.com/stretchr/testify) for assertions and mocking
+- Tests with external dependencies are skipped when using `-short` flag (e.g., `go test -short ./...`)
+- VSCode extension uses Mocha for integration tests, Vitest for unit tests
+- Mock files follow `*_mock.go` or `mock_*.go` naming
+
+# Updating Dependencies
+
+## Go dependencies
+
+```bash
+go get <dependency>@<version>
+go mod vendor
+# Commit all vendor changes
+```
+
+## NPM dependencies
+
+Handled via Dependabot PRs or manual updates. Install hooks before committing:
+
+```bash
+npm install
+npm install --prefix="test/e2e"
+```
+
+# Schema Updates
+
+Schemas in `internal/schema/schemas/`:
+
+- `posit-publishing-schema-v3.json` - Configuration schema
+- `posit-publishing-record-schema-v3.json` - Deployment record schema
+
+Non-breaking changes don't require version bumps. Update the schema file, corresponding example file, and verify unit tests pass.

--- a/extensions/vscode/CLAUDE.md
+++ b/extensions/vscode/CLAUDE.md
@@ -1,0 +1,129 @@
+# Project Overview
+
+This is the Posit Publisher VSCode extension. It provides a sidebar UI for deploying Python and R projects to Posit Connect. The extension spawns a Go backend binary (`bin/publisher`) and communicates with it via HTTP API and Server-Sent Events.
+
+# Build Commands
+
+```bash
+# Full build (install deps, configure binary, package .vsix)
+just
+
+# Install npm dependencies (also installs webview deps)
+just deps
+
+# Run ESLint
+just lint
+
+# Run all tests (Mocha integration + Vitest unit)
+just test
+
+# Package extension to .vsix
+just package
+
+# Install packaged extension to VSCode
+just install
+
+# Uninstall extension
+just uninstall
+```
+
+## Running in Development
+
+1. Open this directory (`extensions/vscode/`) as the workspace in VSCode
+2. Run the "Run Extension" debug configuration (F5)
+
+If you modify Go backend code, run `just build` from the repo root first.
+If you modify webviews, run `npm run build --prefix webviews/homeView` first.
+
+## Testing
+
+```bash
+# Run all tests
+just test
+
+# Run only Vitest unit tests
+npm run test-unit
+
+# Run only Mocha integration tests (opens VSCode test instance)
+npm test
+```
+
+Unit tests are in `src/**/*.test.ts` (excluding `src/test/`). Integration tests using VSCode APIs are in `src/test/`.
+
+# Architecture
+
+## Entry Point
+
+`src/extension.ts` - Activates on workspace open, starts the Go binary as a subprocess, initializes views and event streams.
+
+## Key Components
+
+- **Service** (`src/services.ts`) - Manages the Go binary subprocess lifecycle
+- **EventStream** (`src/events.ts`) - SSE client receiving real-time updates from Go backend
+- **PublisherState** (`src/state.ts`) - Central state management for credentials, configs, deployments
+- **HomeViewProvider** (`src/views/homeView.ts`) - Main webview provider, bridges extension and Vue webview
+- **API Client** (`src/api/`) - Axios-based HTTP client for Go backend communication
+  - `client.ts` - Axios instance with interceptors for error handling and logging
+  - `types/` - TypeScript types for API requests/responses
+  - `resources/` - Resource-specific API methods (credentials, configurations, etc.)
+
+## Views
+
+- `views/homeView.ts` - Primary sidebar webview (Vue app in `webviews/homeView/`)
+- `views/logs.ts` - Deployment log viewer
+- `views/project.ts` - Project tree view
+- `views/deployProgress.ts` - Deployment progress tracking
+
+## Communication Flow
+
+1. Extension ↔ Go Backend: HTTP REST API (via axios in `src/api/`)
+2. Go Backend → Extension: Server-Sent Events for real-time updates
+3. Extension ↔ Webview: VSCode postMessage API (typed messages in `src/types/messages/`)
+
+## Error Handling
+
+The extension uses layered error handling with type-safe error discrimination:
+
+**Error Types** (`src/utils/errorTypes.ts`):
+
+- Defines `ErrorCode` enum with specific codes (e.g., `invalidTOML`, `deployFailed`, `credentialsCorrupted`)
+- Factory function `mkErrorTypeGuard<T>()` creates type guards for each error type
+- Each error type has: type definition, predicate (`isErr<Name>()`), and message formatter (`err<Name>Message()`)
+
+**Go Backend Errors** (`src/api/types/error.ts`):
+
+- `AgentError` types with `code`, `msg`, `operation` fields
+- Type guards: `isAgentError()`, `isAgentErrorInvalidTOML()`, etc.
+
+**Error Utilities** (`src/utils/errors.ts`):
+
+- `getMessageFromError()` - Extract user-facing message from AxiosError, AgentError, or Error
+- `getSummaryStringFromError(location, error)` - Build diagnostic message with context for logging
+- `scrubErrorData()` - Remove sensitive fields before display
+
+**Display Utilities** (`src/utils/window.ts`):
+
+- `showErrorMessageWithTroubleshoot()` - Error message with troubleshooting docs link
+- `showInformationMsg()` - Informational messages
+
+**Pattern**: Use type guards to discriminate error types, extract user-friendly messages for UI, and include location context in logs.
+
+## Multi-Step Inputs
+
+`src/multiStepInputs/` contains wizard-style flows for credential creation, deployment setup, etc. These use VSCode's QuickPick and InputBox APIs.
+
+See `webviews/homeView/CLAUDE.md` for Vue webview-specific documentation.
+
+# Message Types
+
+Extension-webview communication uses typed messages:
+
+- `src/types/messages/hostToWebviewMessages.ts` - Extension → Webview
+- `src/types/messages/webviewToHostMessages.ts` - Webview → Extension
+
+# Debugging
+
+- "Run Extension" - Debug extension only (auto-launches Go binary)
+- "Run Extension using external API agent on 9001" - Debug both extension and Go backend simultaneously (requires launching Go debug session from repo root first)
+
+Debug webviews using `Developer: Open Webview Developer Tools` command in the Extension Host window.

--- a/extensions/vscode/webviews/homeView/CLAUDE.md
+++ b/extensions/vscode/webviews/homeView/CLAUDE.md
@@ -1,0 +1,131 @@
+# Project Overview
+
+This is the Home View webview for the Posit Publisher VSCode extension. It's a Vue 3 application that renders the main sidebar UI, built with Vite and using Pinia for state management.
+
+# Build Commands
+
+```bash
+# Build for production (outputs to dist/)
+npm run build
+
+# Run tests with coverage
+npm test
+
+# Install dependencies
+npm install
+# or via just:
+just deps
+```
+
+The built output (`dist/`) is loaded by the parent VSCode extension.
+
+## Development Workflow
+
+The webview does NOT support hot reload. To see changes:
+
+1. Edit code in `src/`
+2. Rebuild: `npm run build`
+3. Reload extension: Close Extension Host window and press F5 again
+
+This is required because the extension loads static files from `dist/` via VSCode URIs, not a dev server.
+
+# Architecture
+
+## Entry Point
+
+- `src/main.ts` - Vue app initialization, mounts to `#app`
+- `src/App.vue` - Root component
+- `index.html` - HTML template (Vite entry)
+
+## State Management
+
+Pinia stores in `src/stores/`:
+
+- `home.ts` - Main application state (credentials, configs, deployments, publish status)
+- `file.ts` - File listing state for deployment file selection
+
+## Host Communication
+
+`src/HostConduitService.ts` - Singleton service that manages bidirectional communication with the VSCode extension host via `postMessage`.
+
+Message types are defined in the parent extension:
+
+- `../../../src/types/messages/hostToWebviewMessages.ts` - Messages from extension
+- `../../../src/types/messages/webviewToHostMessages.ts` - Messages to extension
+
+The `useHostConduitService()` composable provides `sendMsg()` and subscribes to incoming messages on mount.
+
+## Adding Message Types
+
+To add a new message type for extension ↔ webview communication:
+
+### Host → Webview Message
+
+1. **Define type** in `../../../src/types/messages/hostToWebviewMessages.ts`:
+   - Add enum value to `HostToWebviewMessageType`
+   - Define content type (if payload needed)
+   - Add to `HostToWebviewMessage` union
+   - Add to `isHostToWebviewMessage()` type guard
+
+2. **Send from extension** in `../../../src/views/homeView.ts`:
+
+   ```typescript
+   this.webviewConduit.sendMsg({
+     kind: HostToWebviewMessageType.MY_MESSAGE,
+     content: {
+       /* typed payload */
+     },
+   });
+   ```
+
+3. **Handle in webview** in `src/HostConduitService.ts`:
+   - Add case to `onMessageFromHost()` switch statement
+   - Update Pinia store or trigger UI updates
+
+### Webview → Host Message
+
+Same pattern in reverse:
+
+1. Define in `webviewToHostMessages.ts`
+2. Send via `useHostConduitService().sendMsg()`
+3. Handle in `homeView.ts` `onConduitMessage()` switch
+
+### Files to Modify
+
+| Direction      | Type Definition            | Sender                  | Handler                 |
+| -------------- | -------------------------- | ----------------------- | ----------------------- |
+| Host → Webview | `hostToWebviewMessages.ts` | `homeView.ts`           | `HostConduitService.ts` |
+| Webview → Host | `webviewToHostMessages.ts` | `HostConduitService.ts` | `homeView.ts`           |
+
+## Components
+
+`src/components/`:
+
+- `EvenEasierDeploy.vue` - Main deployment interface
+- `views/` - Sub-views for different UI states
+- `tree/` - Tree view components for file/package lists
+- UI primitives: `DeployButton`, `ProcessProgress`, `ActionToolbar`, etc.
+
+## Styling
+
+- Uses `@vscode/webview-ui-toolkit` for VSCode-native components (prefixed `vscode-*`)
+- Custom elements with `vscode-` prefix are registered in `vite.config.ts` compiler options
+- Global styles in `src/style.css`
+- SCSS support via `sass-embedded`
+
+# Testing
+
+Tests use Vitest with jsdom environment. Coverage thresholds are enforced in CI.
+
+```bash
+# Run tests
+npm test
+
+# Coverage report is generated in coverage/
+```
+
+Test files are colocated with source (`*.test.ts`). Test utilities in `src/test/`.
+
+# VSCode API Access
+
+`src/vscode.ts` - Wrapper for `acquireVsCodeApi()` which provides the postMessage interface. This is the only way to communicate with the extension host.


### PR DESCRIPTION
This adds some `CLAUDE.md` files to the different project directories in this repo for better guidance with Claude.

I've had some pretty good luck with these over the last couple of pull requests.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Started with `claude init`, made some changes by hand, and iterated on it with Claude while resolving issues.
