### PR TITLE
Remove 'Inject secrets as environment variables' from todo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,6 @@ What's not supported yet but is on our to-do list:
 
 - Deploy to servers other than Connect
 - Show more information in the UI such as changes since last deployment
-- Inject secrets as environment variables
 - More metadata such as tags, thumbnail image, etc
 - Configure permissions for sharing
 - Option to export a `manifest.json` for compatibility with prior tool


### PR DESCRIPTION
Just updates the docs to remove injecting secrets from the list of things not supported yet. We do support secrets!

https://github.com/posit-dev/publisher/blob/main/docs/vscode.md#secrets