### PR TITLE
ci: Add Slack notifications for new GitHub Discussions

### DIFF
--- a/.github/workflows/discussion-notify.yaml
+++ b/.github/workflows/discussion-notify.yaml
@@ -1,0 +1,28 @@
+name: Discussion Notifications
+
+on:
+  discussion:
+    types: [created]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_DISCUSSION_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "New discussion in Publisher: ${{ github.event.discussion.title }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New Discussion:* <${{ github.event.discussion.html_url }}|${{ github.event.discussion.title }}>\n*Category:* ${{ github.event.discussion.category.name }}\n*Author:* ${{ github.event.discussion.user.login }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that sends Slack notifications when new discussions are created
- Notifications include discussion title, category, author, and a link to the discussion

## Setup Required
1. Create a Slack Incoming Webhook for the desired channel
2. Add `SLACK_DISCUSSION_WEBHOOK_URL` secret to the repository

## Test plan
- [ ] Add the `SLACK_DISCUSSION_WEBHOOK_URL` secret to the repository
- [ ] Merge this PR and create a test discussion to verify notifications work

🤖 Generated with [Claude Code](https://claude.com/claude-code)