### PR TITLE
docs: Update e2e test CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,22 +182,20 @@ Run the following commands from the `test/e2e` subdirectory:
 source .venv/bin/activate
 ```
 
-Build the publisher and start the Cypress interactive test runner:
+Build the publisher and start the Cypress tests headlessly:
 
 ```bash
 just build-images
 just dev
 ```
 
-This will start the Cypress test runner, which will open a browser window and allow you to run the end-to-end tests against the Posit Publisher VSCode extension.
-
-Use VSCode to modify the tests in the `test/e2e/tests` directory. Saving changes will automatically re-run the tests in the Cypress test runner.
-
-Tests can also be run in headless mode with:
+To run the interactive test runner, which will open a browser window and allow you to run the end-to-end tests against the Posit Publisher VSCode extension, use:
 
 ```bash
-npx cypress run
+npm run cypress:open
 ```
+
+Saving changes to test files in `test/e2e/tests` will automatically re-run the tests in the Cypress test runner.
 
 When done, you can deactivate the virtual environment with:
 


### PR DESCRIPTION
Updates our CONTRIBUTING guide with the new Cypress setup that runs headlessly by default, and adds a note about how to run the interactive test runner UI.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [x] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->
