### PR TITLE
fix(e2e): use Python 3.11 instead of 3.11.3 for embedded deployments

### DIFF
--- a/test/e2e/tests/embedded-deployments.cy.js
+++ b/test/e2e/tests/embedded-deployments.cy.js
@@ -52,7 +52,7 @@ describe("Embedded Deployments Section", () => {
         },
       )
         .then((tomlFiles) => {
-          return cy.writeTomlFile(tomlFiles.config.path, "version = '3.11.3'");
+          return cy.writeTomlFile(tomlFiles.config.path, "version = '3.11'");
         })
         .deployCurrentlySelected();
 
@@ -94,7 +94,7 @@ describe("Embedded Deployments Section", () => {
         },
       )
         .then((tomlFiles) => {
-          return cy.writeTomlFile(tomlFiles.config.path, "version = '3.11.3'");
+          return cy.writeTomlFile(tomlFiles.config.path, "version = '3.11'");
         })
         .deployCurrentlySelected();
 


### PR DESCRIPTION
## Summary

- Fix Python version mismatch in embedded-deployments.cy.js tests
- Changed `version = '3.11.3'` to `version = '3.11'`

## Problem

The Connect server in the e2e environment has Python 3.11.11 installed, not 3.11.3. When the test specified the exact version `3.11.3`, the deployment would fail during environment restore with a `ModuleNotFound` error because Connect couldn't find a matching Python installation.

## Solution

Use the minor version (`3.11`) instead of the patch version (`3.11.3`), which allows Connect to match with the available Python 3.11.11 installation.

## Test plan

- [ ] Verify embedded-deployments.cy.js tests pass in CI

🤖 Generated with [Claude Code](https://claude.ai/code)