### PR TITLE
fix(e2e): update open-connect-content test to use initializeConnect

### DIFF
--- a/test/e2e/tests/open-connect-content.cy.js
+++ b/test/e2e/tests/open-connect-content.cy.js
@@ -2,9 +2,7 @@
 
 describe("Open Connect Content", () => {
   before(() => {
-    cy.resetConnect();
-    cy.clearupDeployments();
-    cy.setAdminCredentials();
+    cy.initializeConnect();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Update `open-connect-content.cy.js` to use `cy.initializeConnect()` instead of the removed `cy.resetConnect()` command
- This test was added in #3377 after the `with_connect` branch was created, and wasn't updated when `resetConnect` was replaced with `initializeConnect`

## Test plan
- CI should pass the e2e tests that were previously failing with `TypeError: cy.resetConnect is not a function`

🤖 Generated with [Claude Code](https://claude.com/claude-code)