### PR TITLE
fix: detect entrypoints in custom editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Python projects using rpy2 now correctly include an [r] section in the configuration since R is required at runtime. (#3425)
+- Fixed deploy button not appearing for Jupyter notebooks, Quarto visual mode, and diff viewers. (#2785, #3146, #3469)
 - Fixed unhelpful "Unknown Error" popup appearing on every file open/save when the Publisher backend is unavailable during startup or shutdown. (#3452)
 - Fixed the agent process auto-restarting during intentional shutdown (e.g., when VS Code closes). (#3195)
 

--- a/extensions/vscode/src/utils/getUri.ts
+++ b/extensions/vscode/src/utils/getUri.ts
@@ -1,6 +1,14 @@
 // Copyright (C) 2024 by Posit Software, PBC.
 
-import { Uri, Webview } from "vscode";
+import {
+  Tab,
+  TabInputCustom,
+  TabInputNotebook,
+  TabInputText,
+  TabInputTextDiff,
+  Uri,
+  Webview,
+} from "vscode";
 
 /**
  * A helper function which will get the webview URI of a given file or resource.
@@ -19,4 +27,48 @@ export function getUri(
   pathList: string[],
 ) {
   return webview.asWebviewUri(Uri.joinPath(extensionUri, ...pathList));
+}
+
+/**
+ * Gets the file URI from any tab input type (text, notebook, custom, diff).
+ * Returns undefined for unsupported tab types.
+ *
+ * @param tab The tab to extract the file URI from
+ * @returns The file URI, or undefined if unsupported
+ */
+export function getFileUriFromTab(tab: Tab): Uri | undefined {
+  const input = tab.input;
+  let uri: Uri | undefined;
+
+  if (input instanceof TabInputText) {
+    uri = input.uri;
+  } else if (input instanceof TabInputNotebook) {
+    uri = input.uri;
+  } else if (input instanceof TabInputCustom) {
+    uri = input.uri;
+  } else if (input instanceof TabInputTextDiff) {
+    // Use the modified file for diff views
+    uri = input.modified;
+  }
+
+  if (!uri) {
+    return undefined;
+  }
+
+  // Resolve special URI schemes (git, vscode-*) to file URIs
+  if (uri.scheme === "file") {
+    return uri;
+  }
+  if (uri.scheme === "git" || uri.scheme.startsWith("vscode-")) {
+    try {
+      return Uri.file(uri.fsPath);
+    } catch {
+      return undefined;
+    }
+  }
+  // Untitled documents are not saved files
+  if (uri.scheme === "untitled") {
+    return undefined;
+  }
+  return undefined;
 }


### PR DESCRIPTION
This PR adds the "Deploy with Posit Publisher" editor button to more places:
- diff views
- the Quarto visual mode in Positron
- and notebook views


<details>
  <summary>Preview</summary>
  
<img width="1157" height="874" alt="CleanShot 2026-02-12 at 17 06 22" src="https://github.com/user-attachments/assets/32282abb-f088-47e9-8479-cf0e4af6fefc" />

</details> 

## Intent

Fixes #2785
Fixes #3146
Fixes #3469

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

The approach here was to expand `entrypointTracker` to start looking at `TabGroups` and process `Uri`s more broadly so those various views could set the `Contexts.ActiveFileEntrypoint` context.

## User Impact

Users will now see the "Deploy with Posit Publisher" button much more consistently.

## Directions for Reviewers

Validate the various behaviors of the "Deploy with Posit Publisher' button:
- opening a valid entrypoint should show the button (after a short delay)
- swapping between entrypoint and non-entrypoint files should show the button accurately
- the "Create a New Deployment" quick-picker should respect more open entrypoints now and show them as selections when there is a editor / tab open for them (Quarto Visual mode, diff views, etc)
- clicking the button for the different entrypoint file types and options that this PR addresses should create deployments or select deployments that already exist correct

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
