### PR TITLE
fix(e2e): add waitForNetworkIdle for better test stability

### DIFF
--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -375,10 +375,13 @@ Cypress.Commands.add("waitForPublisherIframe", (timeout = 60000) => {
       });
       if ($publisherIframe.length > 0) {
         cy.log("Found publisher iframe by extensionId");
+        // Wait for network to settle after iframe is found
+        cy.waitForNetworkIdle(500);
         return cy.wrap($publisherIframe[0]);
       }
       // Fallback: use the first .webview.ready iframe
       cy.log("Falling back to first .webview.ready iframe");
+      cy.waitForNetworkIdle(500);
       return cy.wrap($iframes[0]);
     });
 });

--- a/test/e2e/support/selectors.js
+++ b/test/e2e/support/selectors.js
@@ -296,6 +296,9 @@ Cypress.Commands.add("refreshCredentials", () => {
       throw new Error("Refresh Credentials button not found");
     }
   });
+
+  // Wait for credential refresh API call to complete
+  cy.waitForNetworkIdle(500);
 });
 
 Cypress.Commands.add("toggleHelpSection", () => {

--- a/test/e2e/support/sequences.js
+++ b/test/e2e/support/sequences.js
@@ -59,6 +59,8 @@ Cypress.Commands.add(
 
     // activate the publisher extension
     cy.getPublisherSidebarIcon().click();
+    // Wait for extension to fully initialize
+    cy.waitForNetworkIdle(500);
     cy.publisherWebview()
       .findByTestId("select-deployment")
       .should("be.visible");
@@ -225,6 +227,8 @@ Cypress.Commands.add(
 
     // activate the publisher extension
     cy.getPublisherSidebarIcon().click();
+    // Wait for extension to fully initialize
+    cy.waitForNetworkIdle(500);
     cy.publisherWebview()
       .findByTestId("select-deployment")
       .should("be.visible");
@@ -368,6 +372,9 @@ Cypress.Commands.add(
 // Purpose: Click the Deploy button, wait for toasts to clear, and confirm success.
 // When to use: Immediately after createPCSDeployment/createPCCDeployment when deployment should succeed.
 Cypress.Commands.add("deployCurrentlySelected", () => {
+  // Wait for any pending network activity to settle before deploying
+  cy.waitForNetworkIdle(500);
+
   cy.publisherWebview()
     .findByTestId("deploy-button")
     .should("be.visible")


### PR DESCRIPTION
## Intent

Add cy.waitForNetworkIdle() calls at key points to ensure network activity has settled before performing actions. This reduces flakiness caused by race conditions between UI updates and API calls.

Changes:
- waitForPublisherIframe: Wait for network after iframe is found
- refreshCredentials: Wait for credential refresh API to complete
- createPCSDeployment/createPCCDeployment: Wait after activating extension
- deployCurrentlySelected: Wait before clicking deploy button

<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

More low-risk suggestions by claude to try to get things to stabilize in CI. 

<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## User Impact

n/a

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

## Automated Tests

hoping for increased stability

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
