### PR TITLE
fix(e2e): use docker-container driver for BuildX GHA caching

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,9 +90,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # Use docker driver to keep images in local daemon where docker compose can access them
-          driver: docker
+        # Uses docker-container driver by default which supports GHA caching
+        # The build step uses load: true to make the image available to docker compose
 
       - name: Download VSIX artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

- Fix Docker build cache not working in e2e CI by using the correct BuildX driver
- The `type=gha` cache backend requires the `docker-container` driver (BuildX default), not `driver: docker`
- The `docker` driver uses the standard Docker engine which silently ignores GHA caching options

## Test plan

- [ ] Run e2e workflow and verify cache is populated on first run
- [ ] Run e2e workflow again and verify cache hit in "Build e2e base Docker image" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)