### PR TITLE
ci: fix docs-only glob pattern to match nested markdown files

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,7 +21,7 @@ jobs:
           predicate-quantifier: every
           filters: |
             docs-only:
-              - '**.md'
+              - '**/*.md'
               - 'LICENSE'
               - '.gitignore'
               - '.gitattributes'


### PR DESCRIPTION
## Summary

- Fixed the `docs-only` glob pattern in the pull request workflow from `**.md` to `**/*.md`
- The pattern `**.md` only matches markdown files at the root level, not in subdirectories
- This caused PRs with only nested markdown changes (like `.claude/commands/changelog.md`) to run the full test suite instead of just linting

## Test plan

- [ ] Verify that PRs with only markdown file changes in subdirectories correctly skip tests
- [ ] Verify that PRs with code changes still run the full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)