### PR TITLE
ci: enable containerd image store for consistent Docker cache support

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -88,6 +88,13 @@ jobs:
 
       - uses: extractions/setup-just@v3
 
+      - name: Enable containerd image store
+        run: |
+          # Enable containerd snapshotter for consistent cache export support across all runners
+          # Some ubuntu-latest runners have this enabled, others don't - this ensures consistency
+          echo '{"features":{"containerd-snapshotter":true}}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
## Summary

Fixes intermittent e2e test failures caused by inconsistent Docker cache support across GitHub Actions runners.

### Problem

Some `ubuntu-latest` runners have the containerd image store enabled while others don't. When a job lands on a runner without containerd, the Docker build fails with:

```
ERROR: failed to build: Cache export is not supported for the docker driver.
```

This explains why some matrix jobs (e.g., `preview`) pass while others (e.g., `release`) fail in the same workflow run - they got different runners.

### Solution

Explicitly enable the containerd snapshotter before setting up Docker Buildx:

```yaml
- name: Enable containerd image store
  run: |
    echo '{"features":{"containerd-snapshotter":true}}' | sudo tee /etc/docker/daemon.json
    sudo systemctl restart docker
```

This ensures consistent behavior across all runners while keeping the Docker layer caching benefits.

## Test plan

- [ ] E2E tests pass consistently across all matrix jobs

🤖 Generated with [Claude Code](https://claude.ai/code)