### PR TITLE
ci: fix docs-only detection by inverting to has-code filter

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,67 +7,69 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detect if only documentation files changed
+  # Detect if any code files changed (to skip CI for docs-only PRs)
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      docs-only: ${{ steps.filter.outputs.docs-only }}
+      # has-code is true if ANY non-doc file changed
+      has-code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          # docs-only is true when ALL changed files match these patterns
-          predicate-quantifier: every
+          # Detect code changes - if none, we can skip tests
+          # Using negated patterns: match anything NOT in the docs list
           filters: |
-            docs-only:
-              - '**/*.md'
-              - 'LICENSE'
-              - '.gitignore'
-              - '.gitattributes'
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.gitattributes'
 
   # Linting and formatting - always runs
   lint:
     uses: ./.github/workflows/lint.yaml
 
-  # Unit Tests - skip if docs-only changes
+  # Unit Tests - skip if no code changes
   home-view-unit-tests:
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/home-view-unit-test.yaml
 
   agent:
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/agent.yaml
 
   vscode:
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/vscode.yaml
 
-  # Build - skip if docs-only changes
+  # Build - skip if no code changes
   build:
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/build.yaml
 
   package:
     needs: [detect-changes, build]
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/package.yaml
 
   archive:
     needs: [detect-changes, build]
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/archive.yaml
 
-  # E2E Tests - skip if docs-only changes
+  # E2E Tests - skip if no code changes
   e2e:
     needs: [detect-changes, home-view-unit-tests, agent, vscode, package]
     if: |
       always() &&
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.has-code == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     uses: ./.github/workflows/e2e.yaml
@@ -78,16 +80,16 @@ jobs:
     if: |
       always() &&
       github.actor != 'dependabot[bot]' &&
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.has-code == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     uses: ./.github/workflows/upload.yaml
     secrets: inherit
 
-  # License generation - skip if docs-only changes
+  # License generation - skip if no code changes
   generate-licenses:
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: needs.detect-changes.outputs.has-code == 'true'
     uses: ./.github/workflows/generate-licenses.yaml
     with:
       pr_changes: false # No PRs on PRs, infinite loop


### PR DESCRIPTION
## Summary

Fixes docs-only detection which was completely broken due to issues with `dorny/paths-filter`'s `predicate-quantifier` feature.

### Problems Found

1. **Missing input definition**: The `predicate-quantifier` input isn't declared in `action.yml` for v3, causing "Unexpected input" warnings
   - Original feature PR: [dorny/paths-filter#224](https://github.com/dorny/paths-filter/pull/224) - added code but missed `action.yml`
   - Fix PR merged but not released: [dorny/paths-filter#279](https://github.com/dorny/paths-filter/pull/279)
   - Open issues about this: [#226](https://github.com/dorny/paths-filter/pull/226), [#236](https://github.com/dorny/paths-filter/pull/236), [#259](https://github.com/dorny/paths-filter/pull/259)

2. **Broken implementation**: Even when the input is accepted, [the implementation](https://github.com/dorny/paths-filter/blob/de90cc6fb38fc0963ad72b210f1f284cd68cea36/src/filter.ts#L105-L114) is wrong:
   - **Expected**: "Return true if ALL changed files match at least one pattern"
   - **Actual**: "A file matches only if it matches ALL patterns" ([L110-111](https://github.com/dorny/paths-filter/blob/de90cc6fb38fc0963ad72b210f1f284cd68cea36/src/filter.ts#L110-L111): `patterns.every(aPredicate)` checks if a single file matches every pattern)
   
   This meant `CHANGELOG.md` was rejected because it doesn't match `LICENSE`, `.gitignore`, etc.

### Solution

Invert the logic from detecting "docs-only" to detecting "has-code":

```yaml
# Old (broken): docs-only is true if ALL files are docs
docs-only:
  - '**/*.md'
  - 'LICENSE'
  # predicate-quantifier: every  # broken!

# New (works): has-code is true if ANY file is NOT a doc
code:
  - '**'
  - '!**/*.md'
  - '!LICENSE'
  - '!.gitignore'
  - '!.gitattributes'
```

With the default `some` quantifier:
- `has-code = true` if any file matches (i.e., any non-doc file exists)
- CI runs when `has-code == 'true'`
- CI skips when only doc files changed

## Test plan

- [ ] PRs with only `.md` file changes skip tests
- [ ] PRs with code changes run tests
- [ ] No more "Unexpected input" warnings

🤖 Generated with [Claude Code](https://claude.ai/code)