### PR TITLE
security: pin critical GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -16,7 +16,7 @@ jobs:
           ]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       # setup-just doesn't support Windows ARM64, so install via cargo

--- a/.github/workflows/archive.yaml
+++ b/.github/workflows/archive.yaml
@@ -5,17 +5,17 @@ jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: bin
           path: bin
       - run: chmod -R +x ./bin
       - run: just archive
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         id: upload
         with:
           name: archives

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,12 +5,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: just build
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         id: upload
         with:
           name: bin

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,7 +42,7 @@ jobs:
       ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Tidy CI environment
@@ -102,7 +102,7 @@ jobs:
           driver: docker
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: dist
           path: dist
@@ -231,7 +231,7 @@ jobs:
           CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
       - name: Upload Cypress screenshots on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()
         with:
           name: cypress-screenshots-${{ matrix.name || matrix.connect-version }}
@@ -239,7 +239,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: "[DEBUG] Upload Cypress videos"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always() && (env.DEBUG_CYPRESS == 'true' || env.VARS_DEBUG_CYPRESS == 'true' || env.ACTIONS_STEP_DEBUG == 'true')
         with:
           name: cypress-videos-${{ matrix.name || matrix.connect-version }}
@@ -319,7 +319,7 @@ jobs:
           sudo chown -R $USER:$USER test/e2e/logs
 
       - name: Save test logs as artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure() && steps.run_tests.outcome == 'failure'
         with:
           name: e2e-logs-${{ matrix.name || matrix.connect-version }}

--- a/.github/workflows/generate-licenses.yaml
+++ b/.github/workflows/generate-licenses.yaml
@@ -62,7 +62,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/home-view-unit-test.yaml
+++ b/.github/workflows/home-view-unit-test.yaml
@@ -7,7 +7,7 @@ jobs:
       run:
         working-directory: extensions/vscode/webviews/homeView
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@v6
         with:
           node-version: "22"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: extractions/setup-just@v3
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/nightly-prerelease.yaml
+++ b/.github/workflows/nightly-prerelease.yaml
@@ -14,7 +14,7 @@ jobs:
       current-sha: ${{ steps.check-tag.outputs.sha }}
       latest-tag: ${{ steps.fetch-tag.outputs.latest_tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 500
           ref: main
@@ -61,7 +61,7 @@ jobs:
     outputs:
       next-version: ${{ steps.calculate.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: main
@@ -133,7 +133,7 @@ jobs:
           # Tags are part of repository contents, so we need this permission
           permission-contents: write
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -5,17 +5,17 @@ jobs:
   vscode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: bin
           path: bin
       - run: chmod -R +x ./bin
       - run: just package
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         id: upload
         with:
           name: dist

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,12 +26,12 @@ jobs:
           - windows-amd64
           - windows-arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: extractions/setup-just@v3
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: dist
           path: dist
@@ -62,12 +62,12 @@ jobs:
           - windows-amd64
           - windows-arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: extractions/setup-just@v3
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,7 @@ jobs:
       # has-code is true if ANY non-doc file changed
       has-code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,15 +26,15 @@ jobs:
       - archive
       - package
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: extractions/setup-just@v3
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: archives
           path: archives
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/schema-upload.yaml
+++ b/.github/workflows/schema-upload.yaml
@@ -16,7 +16,7 @@ jobs:
   upload-schemas:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -14,15 +14,15 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: archives
           path: archives
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -18,7 +18,7 @@ jobs:
           ]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

Pin the most security-critical actions to specific commit SHAs to prevent supply chain attacks.

## Pinned Actions

| Action | Version | SHA |
|--------|---------|-----|
| actions/checkout | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| actions/upload-artifact | v6 | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` |
| actions/download-artifact | v7 | `37930b1c2abaa49bbe596cd826c3c89aef350131` |

## Why These Actions

These are prioritized because they're high-risk:
- **checkout**: Runs arbitrary code from the repository - a compromised checkout action could inject malicious code
- **upload/download-artifact**: Handle build artifacts that get released - a compromised action could swap artifacts

## Why SHA Pinning

Version tags (like `@v6`) can be moved to point at different commits. If an action's repository is compromised, attackers could push malicious code and move the tag to include it. SHA pinning ensures you always get the exact code you reviewed.

Version comments are preserved (e.g., `# v6`) for maintainability.

## Future Work

Consider pinning remaining third-party actions in follow-up PRs, prioritizing by risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)