### PR TITLE
security: add tag ancestry verification to release workflows

### DIFF
--- a/.github/actions/verify-tag-ancestry/action.yaml
+++ b/.github/actions/verify-tag-ancestry/action.yaml
@@ -1,0 +1,18 @@
+name: Verify Tag Ancestry
+description: Verify that the triggering tag points to a commit on the main branch
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Verify tag points to commit on main
+      shell: bash
+      run: |
+        git fetch origin main
+        if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+          echo "::error::Tag must point to a commit on the main branch. This tag points to a commit not reachable from main."
+          exit 1
+        fi
+        echo "✅ Verified: Tag points to commit on main branch"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,17 +12,7 @@ jobs:
     name: Verify tag is on main branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Verify tag points to commit on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
-            echo "::error::Tag must point to a commit on the main branch. This tag points to a commit not reachable from main."
-            exit 1
-          fi
-          echo "✅ Verified: Tag points to commit on main branch"
+      - uses: ./.github/actions/verify-tag-ancestry
   build:
     needs: verify-tag
     uses: ./.github/workflows/build.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,17 +11,7 @@ jobs:
     name: Verify tag is on main branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Verify tag points to commit on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
-            echo "::error::Tag must point to a commit on the main branch. This tag points to a commit not reachable from main."
-            exit 1
-          fi
-          echo "✅ Verified: Tag points to commit on main branch"
+      - uses: ./.github/actions/verify-tag-ancestry
   build:
     needs: verify-tag
     uses: ./.github/workflows/build.yaml


### PR DESCRIPTION
## Summary

- Add `verify-tag` job to `release.yaml` and `publish.yaml`
- Ensures tagged commits are on the `main` branch before proceeding with build/release

## Why

Without this check, someone with write access could:
1. Create a branch with unauthorized changes
2. Push a tag (e.g., `v99.0.0`) pointing to that branch
3. Trigger a release of code that was never merged to main

## How It Works

The verification step runs:
```bash
git merge-base --is-ancestor ${{ github.sha }} origin/main
```

This checks if the tagged commit is reachable from main's history:
- ✅ Tag on HEAD of main → passes
- ✅ Tag on older commit on main → passes  
- ✅ Tag on commit from merged PR → passes
- ❌ Tag on unmerged branch → fails
- ❌ Tag on arbitrary commit → fails

## Changes

| Workflow | Change |
|----------|--------|
| `release.yaml` | Added `verify-tag` job, `build` now depends on it |
| `publish.yaml` | Added `verify-tag` job, `build` now depends on it |

## Test plan

- [ ] Verify normal releases still work (tag on main)
- [ ] Verify workflow fails if tag points to non-main commit (can test manually)

🤖 Generated with [Claude Code](https://claude.ai/code)