### PR TITLE
security: replace secrets: inherit with explicit secret passing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,14 +27,20 @@ jobs:
   e2e:
     needs: [package, agent, vscode]
     uses: ./.github/workflows/e2e.yaml
-    secrets: inherit
+    secrets:
+      CONNECT_LICENSE: ${{ secrets.CONNECT_LICENSE }}
+      CONNECT_LICENSE_FILE: ${{ secrets.CONNECT_LICENSE_FILE }}
+      WORKBENCH_LICENSE: ${{ secrets.WORKBENCH_LICENSE }}
+      GH_DOWNLOAD_TOKEN: ${{ secrets.GH_DOWNLOAD_TOKEN }}
+      PCC_USER_CCQA3: ${{ secrets.PCC_USER_CCQA3 }}
 
   upload:
     needs:
       - archive
       - package
     uses: ./.github/workflows/upload.yaml
-    secrets: inherit
+    secrets:
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 
   # License generation
   generate-licenses:
@@ -42,7 +48,9 @@ jobs:
     with:
       pr_changes: true
       fail_on_forbidden: true
-    secrets: inherit
+    secrets:
+      POSIT_CONNECT_PROJECTS_APP_ID: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+      POSIT_CONNECT_PROJECTS_PEM: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
 
   # Slack notification on failure
   slack-notification:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,12 @@ jobs:
   e2e:
     needs: [package]
     uses: ./.github/workflows/e2e.yaml
-    secrets: inherit
+    secrets:
+      CONNECT_LICENSE: ${{ secrets.CONNECT_LICENSE }}
+      CONNECT_LICENSE_FILE: ${{ secrets.CONNECT_LICENSE_FILE }}
+      WORKBENCH_LICENSE: ${{ secrets.WORKBENCH_LICENSE }}
+      GH_DOWNLOAD_TOKEN: ${{ secrets.GH_DOWNLOAD_TOKEN }}
+      PCC_USER_CCQA3: ${{ secrets.PCC_USER_CCQA3 }}
 
   # Extensions
   vscode:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,8 @@ jobs:
       - archive
       - package
     uses: ./.github/workflows/upload.yaml
-    secrets: inherit
+    secrets:
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
   release:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Summary

Replace `secrets: inherit` with explicit secret declarations across all workflows that were using it.

## Why

`secrets: inherit` passes **all** repository secrets to called workflows. This violates the principle of least privilege - if a called workflow is compromised, it would have access to every secret in the repository.

By explicitly declaring which secrets each workflow needs, we limit the blast radius of any potential compromise.

## Changes

| Workflow | Called Workflow | Secrets Now Passed |
|----------|-----------------|-------------------|
| `main.yaml` | `e2e.yaml` | CONNECT_LICENSE, CONNECT_LICENSE_FILE, WORKBENCH_LICENSE, GH_DOWNLOAD_TOKEN, PCC_USER_CCQA3 |
| `main.yaml` | `upload.yaml` | AWS_ROLE_TO_ASSUME |
| `main.yaml` | `generate-licenses.yaml` | POSIT_CONNECT_PROJECTS_APP_ID, POSIT_CONNECT_PROJECTS_PEM |
| `nightly.yaml` | `e2e.yaml` | CONNECT_LICENSE, CONNECT_LICENSE_FILE, WORKBENCH_LICENSE, GH_DOWNLOAD_TOKEN, PCC_USER_CCQA3 |
| `release.yaml` | `upload.yaml` | AWS_ROLE_TO_ASSUME |

## Verification

```bash
$ grep -l "secrets: inherit" .github/workflows/*.yaml
# No output - all instances removed
```

## Test plan

- [ ] Verify main branch CI still passes (e2e, upload, license generation)
- [ ] Verify nightly workflow still runs successfully
- [ ] Verify release workflow still works on next tag push

🤖 Generated with [Claude Code](https://claude.ai/code)