### PR TITLE
fix: resolve nightly test failures

### DIFF
--- a/internal/clients/connect_cloud_logs/client_connect_cloud_logs_test.go
+++ b/internal/clients/connect_cloud_logs/client_connect_cloud_logs_test.go
@@ -65,12 +65,12 @@ func (s *ConnectCloudLogsClientSuite) TestWatchLogsWithSSEServer() {
 	mockLogLogger := loggingtest.NewMockLogger()
 	mockLogLogger.On("Info", "Test build info message").Once()
 	mockLogLogger.On("Error", "Test build error message").Once()
-	// For the last expected call, we'll signal the processed channel to indicate that all logs were processed
-	mockLogLogger.On("Debug", "Test build debug message").Once().Run(func(args mock.Arguments) {
+	mockLogLogger.On("Debug", "Test build debug message").Once()
+	// Signal on the LAST expected call to ensure all messages are processed before assertions
+	mockLogLogger.On("Info", "Test runtime message").Once().Run(func(args mock.Arguments) {
 		// Signal that all messages have been processed
 		close(processed)
 	})
-	mockLogLogger.On("Info", "Test runtime message").Once()
 
 	// Create our logs client with the SSE client
 	logsClient := &ConnectCloudLogsClient{

--- a/test/scripts/check-positron-extension.sh
+++ b/test/scripts/check-positron-extension.sh
@@ -4,16 +4,28 @@ set -euo pipefail
 # Check if publisher extension is installed in workbench-release
 # This command is designed to work from any directory (Cypress or command line)
 
-# Read expected version from package.json, with fallback
+# Determine the expected installed version
+# The build process (set-version.py) only updates package.json for exact semver versions (X.Y.Z).
+# For non-release versions (e.g., 1.31.7-7-gabcdef), it leaves package.json at 99.0.0.
+# We need to match this logic to know what version the extension will actually install as.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PACKAGE_JSON="$SCRIPT_DIR/../../extensions/vscode/package.json"
+REPO_ROOT="$SCRIPT_DIR/../.."
 
-if [ -f "$PACKAGE_JSON" ]; then
-    EXPECTED_VERSION=$(grep -o '"version": *"[^"]*"' "$PACKAGE_JSON" | cut -d'"' -f4)
+# Get the git-derived version (same as build process)
+GIT_VERSION=$(cd "$REPO_ROOT" && git describe --tags 2>/dev/null | sed 's/^v//')
+
+if [ -z "$GIT_VERSION" ]; then
+    echo "Warning: Could not determine version from git tags, falling back to 99.0.0"
+    EXPECTED_VERSION="99.0.0"
+elif [[ "$GIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # Exact semver version (e.g., 1.32.0) - set-version.py will update package.json
+    EXPECTED_VERSION="$GIT_VERSION"
 else
-    echo "Warning: package.json not found at $PACKAGE_JSON, falling back to hardcoded version"
+    # Non-release version (e.g., 1.31.7-7-gabcdef) - set-version.py skips, stays at 99.0.0
     EXPECTED_VERSION="99.0.0"
 fi
+
+echo "Git version: $GIT_VERSION, Expected installed version: $EXPECTED_VERSION"
 mkdir -p ./logs/workbench-extension
 INSTALL_LOG="./logs/workbench-extension/workbench-extension-check.log"
 


### PR DESCRIPTION
## Summary

Fixes two issues causing nightly test failures since Feb 20.

## Fixes

### 1. E2E: Fix `check-positron-extension.sh` version detection

PR #3577 fixed `install-positron-extension.sh` to use git-based version detection, but forgot to update `check-positron-extension.sh`. 

**Before:** Check script looked for `posit.publisher-99.0.0` (from package.json)
**After:** Check script now correctly looks for `posit.publisher-1.35.0` (from git tag)

The logic now matches the install script:
- Exact semver tags (e.g., `1.35.0`) → use tag version
- Non-release versions (e.g., `1.34.0-7-gabcdef`) → use `99.0.0`

### 2. Unit test: Fix flaky SSE log test race condition

`TestWatchLogsWithSSEServer` was failing intermittently with:
```
FAIL: 3 out of 4 expectation(s) were met.
```

**Root cause:** The test closed the `processed` channel on the 3rd mock call (Debug), but the 4th call (runtime Info) hadn't executed yet when `AssertExpectations` ran.

**Fix:** Moved `close(processed)` to the last expected call.

## Test plan

- [x] Unit test passes 5x in a row locally
- [ ] Nightly workflow passes after merge

🤖 Generated with [Claude Code](https://claude.ai/code)