### PR TITLE
fix: use correct Slack webhook secret in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_PUBLISHER }}
           webhook-type: incoming-webhook
           payload: |
             {


### PR DESCRIPTION
Tiny tweak:

Update the Slack notification step to use SLACK_WEBHOOK_PUBLISHER instead of SLACK_RELEASE_WEBHOOK_URL.

