### PR TITLE
fix: add checkout before local action in release workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Verify tag is on main branch
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/verify-tag-ancestry
   build:
     needs: verify-tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Verify tag is on main branch
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/verify-tag-ancestry
   build:
     needs: verify-tag


### PR DESCRIPTION
## Summary
- Adds `actions/checkout@v6` before the `verify-tag-ancestry` local action in both `publish.yaml` and `release.yaml` workflows

## Problem
The `v1.35.1` release failed because the `verify-tag` job tried to use a local composite action (`./.github/actions/verify-tag-ancestry`) without first checking out the repository. GitHub Actions needs to read the `action.yaml` file to understand what the action does, but that file doesn't exist until the repo is checked out.

Error: `Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/publisher/publisher/.github/actions/verify-tag-ancestry'`

See: https://github.com/posit-dev/publisher/actions/runs/22340709438

## Test plan
- [ ] Manually trigger the release workflow with a test tag to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)