### PR TITLE
wip typescript only credentials

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -18,6 +18,7 @@
         "filenamify": "^7.0.1",
         "get-port": "^7.1.0",
         "retry": "^0.13.1",
+        "smol-toml": "^1.6.0",
         "tar-stream": "^3.1.7",
         "vscode-uri": "^3.0.8"
       },
@@ -5229,6 +5230,18 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socks": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -688,6 +688,7 @@
     "filenamify": "^7.0.1",
     "get-port": "^7.1.0",
     "retry": "^0.13.1",
+    "smol-toml": "^1.6.0",
     "tar-stream": "^3.1.7",
     "vscode-uri": "^3.0.8"
   }

--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -16,6 +16,7 @@ import { ConnectCloud } from "./resources/ConnectCloud";
 import { IntegrationRequests } from "./resources/IntegrationRequests";
 import { ConnectServer } from "./resources/ConnectServer";
 import { OpenConnectContent } from "./resources/OpenConnectContent";
+import type { CredentialsService } from "../services/credentials";
 
 class PublishingClientApi {
   private client;
@@ -35,7 +36,11 @@ class PublishingClientApi {
   connectServer: ConnectServer;
   openConnectContent: OpenConnectContent;
 
-  constructor(apiBaseUrl: string, apiServiceIsUp: Promise<boolean>) {
+  constructor(
+    apiBaseUrl: string,
+    apiServiceIsUp: Promise<boolean>,
+    credentialsServicePromise?: Promise<CredentialsService | undefined>,
+  ) {
     this.client = axios.create({
       baseURL: apiBaseUrl,
     });
@@ -66,7 +71,7 @@ class PublishingClientApi {
     this.apiServiceIsUp = apiServiceIsUp;
 
     this.configurations = new Configurations(this.client);
-    this.credentials = new Credentials(this.client);
+    this.credentials = new Credentials(this.client, credentialsServicePromise);
     this.contentRecords = new ContentRecords(this.client);
     this.files = new Files(this.client);
     this.interpreters = new Interpreters(this.client);
@@ -102,8 +107,13 @@ let api: PublishingClientApi | undefined = undefined;
 export const initApi = (
   apiServiceIsUp: Promise<boolean>,
   apiBaseUrl: string = "/api",
+  credentialsServicePromise?: Promise<CredentialsService | undefined>,
 ) => {
-  api = new PublishingClientApi(apiBaseUrl, apiServiceIsUp);
+  api = new PublishingClientApi(
+    apiBaseUrl,
+    apiServiceIsUp,
+    credentialsServicePromise,
+  );
 };
 
 // NOTE: initApi(...) must be called ahead of the first time

--- a/extensions/vscode/src/api/resources/Credentials.ts
+++ b/extensions/vscode/src/api/resources/Credentials.ts
@@ -1,22 +1,47 @@
 // Copyright (C) 2023 by Posit Software, PBC.
 
-import { AxiosInstance } from "axios";
+import { AxiosInstance, AxiosResponse } from "axios";
 import { Credential, TestResult } from "../types/credentials";
 import { ServerType } from "../types/contentRecords";
 import { CONNECT_CLOUD_ENV_HEADER } from "../../constants";
 import { StateData } from "../../multiStepInputs/multiStepHelper";
+import type { CredentialsService } from "../../services/credentials";
 
 export class Credentials {
   private client: AxiosInstance;
+  private nativeServicePromise?: Promise<CredentialsService | undefined>;
 
-  constructor(client: AxiosInstance) {
+  constructor(
+    client: AxiosInstance,
+    nativeServicePromise?: Promise<CredentialsService | undefined>,
+  ) {
     this.client = client;
+    this.nativeServicePromise = nativeServicePromise;
   }
 
   // Returns:
   // 200 - accepted
   // 500 - internal server error
-  list() {
+  async list(): Promise<AxiosResponse<Credential[]>> {
+    // Try native TypeScript service (file-based storage)
+    if (this.nativeServicePromise) {
+      const nativeService = await this.nativeServicePromise;
+      if (nativeService) {
+        const credentials = await nativeService.list();
+        // Use native service if it has credentials
+        if (credentials.length > 0) {
+          return {
+            data: credentials,
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            config: { headers: {} },
+          } as AxiosResponse<Credential[]>;
+        }
+        // Fall back to Go API if file storage is empty
+        // (credentials may be in system keyring)
+      }
+    }
     return this.client.get<Credential[]>(`credentials`);
   }
 

--- a/extensions/vscode/src/api/types/credentials.ts
+++ b/extensions/vscode/src/api/types/credentials.ts
@@ -3,16 +3,34 @@
 import { AgentError } from "./error";
 import { ServerType } from "./contentRecords";
 
+// CloudAuthToken represents an OAuth access token for Connect Cloud
+export type CloudAuthToken = string;
+
+// CloudEnvironment represents the Connect Cloud environment
+export type CloudEnvironment = string;
+
 export type Credential = {
   guid: string;
   name: string;
   url: string;
+  serverType: ServerType;
+
+  // Connect fields
   apiKey: string;
+
+  // Snowflake fields
+  snowflakeConnection: string;
+
+  // Connect Cloud fields
   accountId: string;
   accountName: string;
   refreshToken: string;
-  accessToken: string;
-  serverType: ServerType;
+  accessToken: CloudAuthToken;
+  cloudEnvironment: CloudEnvironment;
+
+  // Token authentication fields
+  token: string;
+  privateKey: string;
 };
 
 export type CredentialUser = {

--- a/extensions/vscode/src/services.ts
+++ b/extensions/vscode/src/services.ts
@@ -6,6 +6,7 @@ import { HOST } from "src";
 import { initApi } from "src/api";
 import { logger } from "src/logging";
 import { Server } from "src/servers";
+import { createCredentialsService } from "src/services/credentials";
 
 export class Service implements Disposable {
   private context: ExtensionContext;
@@ -26,7 +27,23 @@ export class Service implements Disposable {
 
     this.agentURL = `http://${HOST}:${port}/api`;
     this.server = new Server(port, this.useKeyChain);
-    initApi(this.isUp(), this.agentURL);
+
+    // Create a promise for the native credentials service
+    // This is resolved lazily when credentials.list() is called
+    const credentialsServicePromise = createCredentialsService(
+      context.secrets,
+      useKeyChain,
+    )
+      .then((service) => {
+        logger.info("Native credentials service initialized");
+        return service;
+      })
+      .catch((error) => {
+        logger.warn("Failed to initialize native credentials service", error);
+        return undefined;
+      });
+
+    initApi(this.isUp(), this.agentURL, credentialsServicePromise);
   }
 
   start = async () => {

--- a/extensions/vscode/src/services/credentials/credentialsService.ts
+++ b/extensions/vscode/src/services/credentials/credentialsService.ts
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { Credential, CreateCredentialDetails } from "./types";
+
+/**
+ * CredentialsService provides methods for managing credentials.
+ * This interface matches the Go CredentialsService interface.
+ */
+export interface CredentialsService {
+  /**
+   * Delete removes a Credential by its guid.
+   * @throws NotFoundError if the credential is not found.
+   */
+  delete(guid: string): Promise<void>;
+
+  /**
+   * Get retrieves a Credential by its guid.
+   * @throws NotFoundError if the credential is not found.
+   */
+  get(guid: string): Promise<Credential>;
+
+  /**
+   * List retrieves all Credentials.
+   */
+  list(): Promise<Credential[]>;
+
+  /**
+   * Set creates or updates a Credential.
+   * A guid is assigned to the Credential using UUIDv4 specification.
+   * @throws NameCollisionError if a credential with the same name exists.
+   * @throws IdentityCollisionError if a credential with the same URL exists.
+   * @throws IncompleteCredentialError if required fields are missing.
+   */
+  set(details: CreateCredentialDetails): Promise<Credential>;
+
+  /**
+   * ForceSet is like Set but doesn't check for conflicts with existing credentials.
+   * Used for migration and updating existing credentials.
+   */
+  forceSet(details: CreateCredentialDetails): Promise<Credential>;
+
+  /**
+   * Reset clears all credentials from storage.
+   * For file storage, returns the backup file path.
+   * For keyring storage, returns empty string (no backup possible).
+   */
+  reset(): Promise<string>;
+}

--- a/extensions/vscode/src/services/credentials/errors.ts
+++ b/extensions/vscode/src/services/credentials/errors.ts
@@ -1,0 +1,178 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+/**
+ * Error thrown when a credential is not found.
+ */
+export class NotFoundError extends Error {
+  readonly guid: string;
+
+  constructor(guid: string) {
+    super(`credential not found: ${guid}`);
+    this.name = "NotFoundError";
+    this.guid = guid;
+  }
+}
+
+/**
+ * Error thrown when credentials fail to load.
+ */
+export class LoadError extends Error {
+  readonly cause: Error;
+
+  constructor(cause: Error) {
+    super(`failed to load credentials: ${cause.message}`);
+    this.name = "LoadError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Error thrown when a credential is corrupted or cannot be parsed.
+ */
+export class CorruptedError extends Error {
+  readonly guid: string;
+
+  constructor(guid: string) {
+    super(`credential '${guid}' is corrupted`);
+    this.name = "CorruptedError";
+    this.guid = guid;
+  }
+}
+
+/**
+ * Error thrown when a credential version is not supported.
+ */
+export class VersionError extends Error {
+  readonly version: number;
+
+  constructor(version: number) {
+    super(`credential version not supported: ${version}`);
+    this.name = "VersionError";
+    this.version = version;
+  }
+}
+
+/**
+ * Error thrown when a credential's URL conflicts with an existing credential.
+ */
+export class IdentityCollisionError extends Error {
+  readonly existingName: string;
+  readonly existingUrl: string;
+  readonly existingAccountName: string;
+
+  constructor(name: string, url: string, accountName: string = "") {
+    let message = `URL value conflicts with existing credential (${name}) URL: ${url}`;
+    if (accountName) {
+      message += `, account name: ${accountName}`;
+    }
+    super(message);
+    this.name = "IdentityCollisionError";
+    this.existingName = name;
+    this.existingUrl = url;
+    this.existingAccountName = accountName;
+  }
+}
+
+/**
+ * Error thrown when a credential's name conflicts with an existing credential.
+ */
+export class NameCollisionError extends Error {
+  readonly existingName: string;
+  readonly existingUrl: string;
+
+  constructor(name: string, url: string) {
+    super(
+      `Name value conflicts with existing credential (${name}) URL: ${url}`,
+    );
+    this.name = "NameCollisionError";
+    this.existingName = name;
+    this.existingUrl = url;
+  }
+}
+
+/**
+ * Error thrown when creating a credential with incomplete fields.
+ */
+export class IncompleteCredentialError extends Error {
+  constructor() {
+    super(
+      "New credentials require non-empty Name, URL, Server Type, and either API Key, Snowflake, or Connect Cloud connection fields",
+    );
+    this.name = "IncompleteCredentialError";
+  }
+}
+
+/**
+ * Error thrown when backing up credentials fails.
+ */
+export class BackupError extends Error {
+  readonly filename: string;
+
+  constructor(filename: string, cause: Error) {
+    super(`Failed to backup credentials to ${filename}: ${cause.message}`);
+    this.name = "BackupError";
+    this.filename = filename;
+  }
+}
+
+/**
+ * Type guard for NotFoundError.
+ */
+export function isNotFoundError(error: unknown): error is NotFoundError {
+  return error instanceof NotFoundError;
+}
+
+/**
+ * Type guard for LoadError.
+ */
+export function isLoadError(error: unknown): error is LoadError {
+  return error instanceof LoadError;
+}
+
+/**
+ * Type guard for CorruptedError.
+ */
+export function isCorruptedError(error: unknown): error is CorruptedError {
+  return error instanceof CorruptedError;
+}
+
+/**
+ * Type guard for VersionError.
+ */
+export function isVersionError(error: unknown): error is VersionError {
+  return error instanceof VersionError;
+}
+
+/**
+ * Type guard for IdentityCollisionError.
+ */
+export function isIdentityCollisionError(
+  error: unknown,
+): error is IdentityCollisionError {
+  return error instanceof IdentityCollisionError;
+}
+
+/**
+ * Type guard for NameCollisionError.
+ */
+export function isNameCollisionError(
+  error: unknown,
+): error is NameCollisionError {
+  return error instanceof NameCollisionError;
+}
+
+/**
+ * Type guard for IncompleteCredentialError.
+ */
+export function isIncompleteCredentialError(
+  error: unknown,
+): error is IncompleteCredentialError {
+  return error instanceof IncompleteCredentialError;
+}
+
+/**
+ * Type guard for BackupError.
+ */
+export function isBackupError(error: unknown): error is BackupError {
+  return error instanceof BackupError;
+}

--- a/extensions/vscode/src/services/credentials/fileCredentials.test.ts
+++ b/extensions/vscode/src/services/credentials/fileCredentials.test.ts
@@ -1,0 +1,399 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+
+import { FileCredentialsService } from "./fileCredentials";
+import { ServerType } from "../../api/types/contentRecords";
+import {
+  NotFoundError,
+  IdentityCollisionError,
+  NameCollisionError,
+  IncompleteCredentialError,
+} from "./errors";
+
+describe("FileCredentialsService", () => {
+  let tempDir: string;
+  let credentialsPath: string;
+  let service: FileCredentialsService;
+
+  beforeEach(async () => {
+    // Create a temporary directory for test credentials
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "credentials-test-"));
+    credentialsPath = path.join(tempDir, ".connect-credentials");
+    service = new FileCredentialsService(credentialsPath);
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe("setup", () => {
+    test("creates credentials file if it does not exist", async () => {
+      await service.setup();
+      const exists = await fs
+        .access(credentialsPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+
+    test("does not overwrite existing file", async () => {
+      const content = "[credentials]\n";
+      await fs.writeFile(credentialsPath, content);
+      await service.setup();
+      const readContent = await fs.readFile(credentialsPath, "utf-8");
+      expect(readContent).toBe(content);
+    });
+  });
+
+  describe("list", () => {
+    test("returns empty array when no credentials exist", async () => {
+      const credentials = await service.list();
+      expect(credentials).toEqual([]);
+    });
+
+    test("returns all credentials", async () => {
+      // Create two credentials
+      await service.set({
+        name: "cred1",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+      await service.set({
+        name: "cred2",
+        url: "https://connect2.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(2);
+      expect(credentials.map((c) => c.name).sort()).toEqual(["cred1", "cred2"]);
+    });
+  });
+
+  describe("set", () => {
+    test("creates a Connect credential with API key", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "abc123",
+      });
+
+      expect(cred.name).toBe("my-server");
+      expect(cred.url).toBe("https://connect.example.com/");
+      expect(cred.serverType).toBe(ServerType.CONNECT);
+      expect(cred.apiKey).toBe("abc123");
+      expect(cred.guid).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test("creates a Connect credential with token auth", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        token: "token123",
+        privateKey: "privatekey123",
+      });
+
+      expect(cred.name).toBe("my-server");
+      expect(cred.token).toBe("token123");
+      expect(cred.privateKey).toBe("privatekey123");
+    });
+
+    test("creates a Snowflake credential", async () => {
+      const cred = await service.set({
+        name: "my-snowflake",
+        url: "https://app.snowflakecomputing.app",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "connection-string",
+      });
+
+      expect(cred.serverType).toBe(ServerType.SNOWFLAKE);
+      expect(cred.snowflakeConnection).toBe("connection-string");
+    });
+
+    test("creates a Connect Cloud credential", async () => {
+      const cred = await service.set({
+        name: "my-cloud",
+        url: "https://connect.posit.cloud",
+        serverType: ServerType.CONNECT_CLOUD,
+        accountId: "account123",
+        accountName: "myaccount",
+        refreshToken: "refresh123",
+        accessToken: "access123",
+        cloudEnvironment: "production",
+      });
+
+      expect(cred.serverType).toBe(ServerType.CONNECT_CLOUD);
+      expect(cred.accountId).toBe("account123");
+      expect(cred.accountName).toBe("myaccount");
+    });
+
+    test("normalizes URL with trailing slash", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      expect(cred.url).toBe("https://connect.example.com/");
+    });
+
+    test("adds https scheme if missing", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      expect(cred.url).toBe("https://connect.example.com/");
+    });
+
+    test("throws NameCollisionError when name already exists", async () => {
+      await service.set({
+        name: "my-server",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+
+      await expect(
+        service.set({
+          name: "my-server",
+          url: "https://connect2.example.com",
+          serverType: ServerType.CONNECT,
+          apiKey: "key2",
+        }),
+      ).rejects.toThrow(NameCollisionError);
+    });
+
+    test("throws IdentityCollisionError when URL already exists", async () => {
+      await service.set({
+        name: "server1",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+
+      await expect(
+        service.set({
+          name: "server2",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          apiKey: "key2",
+        }),
+      ).rejects.toThrow(IdentityCollisionError);
+    });
+
+    test("throws IncompleteCredentialError when missing required fields", async () => {
+      await expect(
+        service.set({
+          name: "",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          apiKey: "key",
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+
+      await expect(
+        service.set({
+          name: "server",
+          url: "",
+          serverType: ServerType.CONNECT,
+          apiKey: "key",
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+
+      await expect(
+        service.set({
+          name: "server",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          // Missing apiKey and token auth
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+    });
+
+    test("preserves provided GUID", async () => {
+      const customGuid = "11111111-1111-1111-1111-111111111111";
+      const cred = await service.set({
+        guid: customGuid,
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      expect(cred.guid).toBe(customGuid);
+    });
+  });
+
+  describe("forceSet", () => {
+    test("allows updating existing credential", async () => {
+      await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+
+      // ForceSet should not throw despite name collision
+      const updated = await service.forceSet({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      expect(updated.apiKey).toBe("key2");
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(1);
+    });
+  });
+
+  describe("get", () => {
+    test("returns credential by GUID", async () => {
+      const created = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      const retrieved = await service.get(created.guid);
+      expect(retrieved.name).toBe("my-server");
+      expect(retrieved.guid).toBe(created.guid);
+    });
+
+    test("throws NotFoundError when GUID does not exist", async () => {
+      await expect(service.get("nonexistent-guid")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+
+  describe("delete", () => {
+    test("removes credential by GUID", async () => {
+      const created = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      await service.delete(created.guid);
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(0);
+    });
+
+    test("throws NotFoundError when GUID does not exist", async () => {
+      await expect(service.delete("nonexistent-guid")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+
+  describe("reset", () => {
+    test("clears all credentials and returns backup path", async () => {
+      await service.set({
+        name: "server1",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+      await service.set({
+        name: "server2",
+        url: "https://connect2.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      const backupPath = await service.reset();
+
+      // Verify backup file was created
+      const backupExists = await fs
+        .access(backupPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(true);
+
+      // Verify credentials are cleared
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(0);
+    });
+  });
+
+  describe("TOML file format", () => {
+    test("persists credentials in correct TOML format", async () => {
+      await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "myapikey",
+      });
+
+      const content = await fs.readFile(credentialsPath, "utf-8");
+
+      // Should have credentials section with name as key
+      expect(content).toContain("[credentials.my-server]");
+      expect(content).toContain('api_key = "myapikey"');
+      expect(content).toContain('url = "https://connect.example.com/"');
+      expect(content).toContain('server_type = "connect"');
+    });
+
+    test("reads existing TOML file", async () => {
+      const tomlContent = `[credentials.existing-server]
+guid = "12345678-1234-1234-1234-123456789012"
+version = 3
+url = "https://existing.example.com/"
+server_type = "connect"
+api_key = "existingkey"
+`;
+      await fs.writeFile(credentialsPath, tomlContent);
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(1);
+      expect(credentials[0]?.name).toBe("existing-server");
+      expect(credentials[0]?.apiKey).toBe("existingkey");
+    });
+  });
+
+  describe("concurrent access", () => {
+    test("handles concurrent reads safely", async () => {
+      await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      // Run multiple concurrent reads
+      const results = await Promise.all([
+        service.list(),
+        service.list(),
+        service.list(),
+      ]);
+
+      // All should return the same data
+      for (const creds of results) {
+        expect(creds).toHaveLength(1);
+        expect(creds[0]?.name).toBe("my-server");
+      }
+    });
+  });
+});

--- a/extensions/vscode/src/services/credentials/fileCredentials.ts
+++ b/extensions/vscode/src/services/credentials/fileCredentials.ts
@@ -1,0 +1,404 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { Mutex } from "async-mutex";
+import * as TOML from "smol-toml";
+
+import { CredentialsService } from "./credentialsService";
+import {
+  Credential,
+  CreateCredentialDetails,
+  FileCredential,
+  FileCredentials,
+  fileCredentialToCredential,
+  credentialToFileCredential,
+} from "./types";
+import {
+  NotFoundError,
+  LoadError,
+  IdentityCollisionError,
+  NameCollisionError,
+  IncompleteCredentialError,
+  BackupError,
+} from "./errors";
+import { ServerType } from "../../api/types/contentRecords";
+import { normalizeURL, formatURL } from "../../utils/url";
+
+const ONDISK_FILENAME = ".connect-credentials";
+
+/**
+ * Generates a UUIDv4.
+ */
+function generateUUID(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Normalizes a server URL by ensuring it has a scheme and trailing slash.
+ */
+function normalizeServerURL(url: string): string {
+  return normalizeURL(formatURL(url));
+}
+
+/**
+ * Infers server type from URL.
+ */
+function serverTypeFromURL(urlStr: string): ServerType {
+  try {
+    const url = new URL(formatURL(urlStr));
+    const host = url.hostname;
+
+    if (host.endsWith("connect.posit.cloud")) {
+      return ServerType.CONNECT_CLOUD;
+    } else if (
+      host.endsWith(".snowflakecomputing.app") ||
+      host.endsWith(".privatelink.snowflake.app")
+    ) {
+      return ServerType.SNOWFLAKE;
+    }
+    return ServerType.CONNECT;
+  } catch {
+    return ServerType.CONNECT;
+  }
+}
+
+/**
+ * Checks if a server type is Connect Cloud.
+ */
+function isCloud(serverType: ServerType): boolean {
+  return serverType === ServerType.CONNECT_CLOUD;
+}
+
+/**
+ * Checks if a server type is Connect-like (Connect or Snowflake).
+ */
+function isConnectLike(serverType: ServerType): boolean {
+  return (
+    serverType === ServerType.CONNECT || serverType === ServerType.SNOWFLAKE
+  );
+}
+
+/**
+ * File-based credentials service.
+ * Stores credentials in ~/.connect-credentials as TOML.
+ */
+export class FileCredentialsService implements CredentialsService {
+  private mutex = new Mutex();
+  private credsFilepath: string;
+
+  constructor(credentialsPath?: string) {
+    this.credsFilepath =
+      credentialsPath ?? path.join(os.homedir(), ONDISK_FILENAME);
+  }
+
+  /**
+   * Gets the credentials file path. Useful for testing.
+   */
+  getFilePath(): string {
+    return this.credsFilepath;
+  }
+
+  /**
+   * Ensures the credentials file exists.
+   */
+  async setup(): Promise<void> {
+    try {
+      await fs.access(this.credsFilepath);
+    } catch {
+      // File doesn't exist, create it
+      await fs.writeFile(this.credsFilepath, "", { mode: 0o644 });
+    }
+  }
+
+  async delete(guid: string): Promise<void> {
+    const release = await this.mutex.acquire();
+    try {
+      const creds = await this.load();
+      const credential = this.findCredentialByGuid(creds, guid);
+      if (!credential) {
+        throw new NotFoundError(guid);
+      }
+
+      delete creds.credentials[credential.name];
+      await this.saveFile(creds);
+    } finally {
+      release();
+    }
+  }
+
+  async get(guid: string): Promise<Credential> {
+    const release = await this.mutex.acquire();
+    try {
+      const creds = await this.load();
+      const credential = this.findCredentialByGuid(creds, guid);
+      if (!credential) {
+        throw new NotFoundError(guid);
+      }
+      return credential;
+    } finally {
+      release();
+    }
+  }
+
+  async list(): Promise<Credential[]> {
+    const release = await this.mutex.acquire();
+    try {
+      const creds = await this.load();
+      return this.credentialsList(creds);
+    } finally {
+      release();
+    }
+  }
+
+  set(details: CreateCredentialDetails): Promise<Credential> {
+    return this.setInternal(details, true);
+  }
+
+  forceSet(details: CreateCredentialDetails): Promise<Credential> {
+    return this.setInternal(details, false);
+  }
+
+  async reset(): Promise<string> {
+    const release = await this.mutex.acquire();
+    try {
+      const backupPath = await this.backupFile();
+      const newData: FileCredentials = { credentials: {} };
+      await this.saveFile(newData);
+      return backupPath;
+    } finally {
+      release();
+    }
+  }
+
+  private async setInternal(
+    details: CreateCredentialDetails,
+    checkConflict: boolean,
+  ): Promise<Credential> {
+    const release = await this.mutex.acquire();
+    try {
+      const creds = await this.load();
+      const credential = this.detailsToCredential(details);
+
+      if (checkConflict) {
+        this.checkForConflicts(creds, credential);
+      }
+
+      creds.credentials[details.name] = credentialToFileCredential(credential);
+      await this.saveFile(creds);
+      return credential;
+    } finally {
+      release();
+    }
+  }
+
+  private detailsToCredential(details: CreateCredentialDetails): Credential {
+    // Validate required fields
+    const connectPresent = !!details.apiKey;
+    const snowflakePresent = !!details.snowflakeConnection;
+    const connectCloudPresent =
+      !!details.accountId &&
+      !!details.accountName &&
+      !!details.refreshToken &&
+      !!details.accessToken;
+    const tokenAuthPresent = !!details.token && !!details.privateKey;
+
+    switch (details.serverType) {
+      case ServerType.CONNECT:
+        // Connect can use either API key or token auth, but not both
+        if (
+          (connectPresent && tokenAuthPresent) ||
+          (!connectPresent && !tokenAuthPresent) ||
+          snowflakePresent ||
+          connectCloudPresent
+        ) {
+          throw new IncompleteCredentialError();
+        }
+        break;
+      case ServerType.SNOWFLAKE:
+        if (
+          !snowflakePresent ||
+          connectPresent ||
+          connectCloudPresent ||
+          tokenAuthPresent
+        ) {
+          throw new IncompleteCredentialError();
+        }
+        break;
+      case ServerType.CONNECT_CLOUD:
+        if (
+          !connectCloudPresent ||
+          connectPresent ||
+          snowflakePresent ||
+          tokenAuthPresent
+        ) {
+          throw new IncompleteCredentialError();
+        }
+        break;
+      default:
+        throw new IncompleteCredentialError();
+    }
+
+    if (!details.name || !details.url) {
+      throw new IncompleteCredentialError();
+    }
+
+    const normalizedUrl = normalizeServerURL(details.url);
+    const guid = details.guid || generateUUID();
+
+    return {
+      guid,
+      name: details.name,
+      serverType: details.serverType,
+      url: normalizedUrl,
+      apiKey: details.apiKey ?? "",
+      snowflakeConnection: details.snowflakeConnection ?? "",
+      accountId: details.accountId ?? "",
+      accountName: details.accountName ?? "",
+      refreshToken: details.refreshToken ?? "",
+      accessToken: details.accessToken ?? "",
+      cloudEnvironment: details.cloudEnvironment ?? "",
+      token: details.token ?? "",
+      privateKey: details.privateKey ?? "",
+    };
+  }
+
+  private checkForConflicts(creds: FileCredentials, newCred: Credential): void {
+    const credsList = this.credentialsList(creds);
+
+    for (const cred of credsList) {
+      // Check for identity collision
+      if (isCloud(newCred.serverType)) {
+        // Connect Cloud credentials must have unique AccountID and CloudEnvironment combinations
+        if (
+          isCloud(cred.serverType) &&
+          cred.accountId === newCred.accountId &&
+          cred.cloudEnvironment === newCred.cloudEnvironment
+        ) {
+          throw new IdentityCollisionError(
+            cred.name,
+            cred.url,
+            cred.accountName,
+          );
+        }
+      } else {
+        // Connect/Snowflake credentials have unique URLs
+        if (isConnectLike(cred.serverType) && cred.url === newCred.url) {
+          throw new IdentityCollisionError(
+            cred.name,
+            cred.url,
+            cred.accountName,
+          );
+        }
+      }
+
+      // Check for name collision
+      if (newCred.name === cred.name) {
+        throw new NameCollisionError(cred.name, cred.url);
+      }
+    }
+  }
+
+  private async load(): Promise<FileCredentials> {
+    try {
+      await this.setup();
+      const content = await fs.readFile(this.credsFilepath, "utf-8");
+
+      if (!content.trim()) {
+        return { credentials: {} };
+      }
+
+      const parsed = TOML.parse(content) as unknown as FileCredentials;
+
+      // Ensure credentials object exists
+      if (!parsed.credentials) {
+        return { credentials: {} };
+      }
+
+      // Normalize URLs for all credentials
+      this.normalizeAll(parsed);
+
+      return parsed;
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("ENOENT")) {
+        return { credentials: {} };
+      }
+      throw new LoadError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  private async saveFile(credsData: FileCredentials): Promise<void> {
+    const content = TOML.stringify(credsData);
+    await fs.writeFile(this.credsFilepath, content, { mode: 0o644 });
+  }
+
+  private async backupFile(): Promise<string> {
+    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+    const backupPath = path.join(
+      path.dirname(this.credsFilepath),
+      `${ONDISK_FILENAME}-${today}`,
+    );
+
+    try {
+      const content = await fs.readFile(this.credsFilepath, "utf-8");
+      await fs.writeFile(backupPath, content, { mode: 0o644 });
+      return backupPath;
+    } catch (err) {
+      throw new BackupError(
+        backupPath,
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    }
+  }
+
+  private normalizeAll(creds: FileCredentials): void {
+    for (const [name, fileCred] of Object.entries(creds.credentials)) {
+      if (fileCred.url) {
+        try {
+          fileCred.url = normalizeServerURL(fileCred.url);
+          creds.credentials[name] = fileCred;
+        } catch {
+          // Ignore normalization errors
+        }
+      }
+    }
+  }
+
+  private credentialsList(creds: FileCredentials): Credential[] {
+    const list: Credential[] = [];
+    for (const [name, fileCred] of Object.entries(creds.credentials)) {
+      // Infer server type from URL if not present
+      const serverType =
+        fileCred.server_type || serverTypeFromURL(fileCred.url);
+      const credWithServerType: FileCredential = {
+        ...fileCred,
+        server_type: serverType,
+      };
+      list.push(fileCredentialToCredential(name, credWithServerType));
+    }
+    return list;
+  }
+
+  private findCredentialByGuid(
+    creds: FileCredentials,
+    guid: string,
+  ): Credential | null {
+    for (const [name, fileCred] of Object.entries(creds.credentials)) {
+      if (fileCred.guid === guid) {
+        const serverType =
+          fileCred.server_type || serverTypeFromURL(fileCred.url);
+        const credWithServerType: FileCredential = {
+          ...fileCred,
+          server_type: serverType,
+        };
+        return fileCredentialToCredential(name, credWithServerType);
+      }
+    }
+    return null;
+  }
+}

--- a/extensions/vscode/src/services/credentials/index.ts
+++ b/extensions/vscode/src/services/credentials/index.ts
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { SecretStorage } from "vscode";
+
+import { CredentialsService } from "./credentialsService";
+import { FileCredentialsService } from "./fileCredentials";
+
+// Re-export types and interfaces
+export type { CredentialsService } from "./credentialsService";
+export { FileCredentialsService } from "./fileCredentials";
+export { SecretStorageCredentialsService } from "./secretStorageCredentials";
+export type {
+  Credential,
+  CreateCredentialDetails,
+  CredentialRecord,
+  FileCredential,
+  FileCredentials,
+} from "./types";
+export { CURRENT_VERSION, SERVICE_NAME } from "./types";
+export {
+  NotFoundError,
+  LoadError,
+  CorruptedError,
+  VersionError,
+  IdentityCollisionError,
+  NameCollisionError,
+  IncompleteCredentialError,
+  BackupError,
+  isNotFoundError,
+  isLoadError,
+  isCorruptedError,
+  isVersionError,
+  isIdentityCollisionError,
+  isNameCollisionError,
+  isIncompleteCredentialError,
+  isBackupError,
+} from "./errors";
+
+/**
+ * Creates a credentials service based on the configuration.
+ *
+ * NOTE: Currently always uses file-based storage (~/.connect-credentials) because:
+ * - The Go backend stores credentials in the system keyring (via go-keyring)
+ * - VS Code's SecretStorage is a separate storage mechanism
+ * - File-based storage is the only format shared between Go and TypeScript
+ *
+ * Future work: Migrate credentials from system keyring to VS Code SecretStorage,
+ * then update both Go and TypeScript to use the new storage.
+ *
+ * @param _secrets - VS Code's SecretStorage API (currently unused)
+ * @param _useSecretStorage - Whether to prefer SecretStorage (currently unused)
+ * @returns A CredentialsService instance
+ */
+export async function createCredentialsService(
+  _secrets: SecretStorage | undefined,
+  _useSecretStorage: boolean,
+): Promise<CredentialsService> {
+  // Always use file-based storage for now since it's shared with Go backend
+  // The Go backend uses system keyring (go-keyring) which is different from
+  // VS Code's SecretStorage, so we can't read those credentials directly.
+  const fileService = new FileCredentialsService();
+  await fileService.setup();
+  return fileService;
+}

--- a/extensions/vscode/src/services/credentials/secretStorageCredentials.test.ts
+++ b/extensions/vscode/src/services/credentials/secretStorageCredentials.test.ts
@@ -1,0 +1,482 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import type { SecretStorage, Event } from "vscode";
+
+import { SecretStorageCredentialsService } from "./secretStorageCredentials";
+import { ServerType } from "../../api/types/contentRecords";
+import {
+  NotFoundError,
+  IdentityCollisionError,
+  NameCollisionError,
+  IncompleteCredentialError,
+} from "./errors";
+import { CREDENTIAL_GUIDS_KEY, CREDENTIAL_KEY_PREFIX } from "./types";
+
+/**
+ * Creates a mock SecretStorage for testing.
+ */
+function createMockSecretStorage(): SecretStorage {
+  const storage = new Map<string, string>();
+
+  return {
+    get: vi.fn((key: string) => Promise.resolve(storage.get(key))),
+    store: vi.fn((key: string, value: string) => {
+      storage.set(key, value);
+      return Promise.resolve();
+    }),
+    delete: vi.fn((key: string) => {
+      storage.delete(key);
+      return Promise.resolve();
+    }),
+    keys: vi.fn(() => Promise.resolve([...storage.keys()])),
+    onDidChange: vi.fn(() => ({ dispose: vi.fn() })) as unknown as Event<{
+      key: string;
+    }>,
+  };
+}
+
+describe("SecretStorageCredentialsService", () => {
+  let mockSecrets: SecretStorage;
+  let service: SecretStorageCredentialsService;
+
+  beforeEach(() => {
+    mockSecrets = createMockSecretStorage();
+    service = new SecretStorageCredentialsService(mockSecrets);
+  });
+
+  describe("isSupported", () => {
+    test("returns true when storage is accessible", async () => {
+      const supported = await service.isSupported();
+      expect(supported).toBe(true);
+    });
+
+    test("returns false when storage throws", async () => {
+      const failingSecrets: SecretStorage = {
+        get: vi.fn(() => Promise.reject(new Error("Storage unavailable"))),
+        store: vi.fn(),
+        delete: vi.fn(),
+        keys: vi.fn(() => Promise.resolve([])),
+        onDidChange: vi.fn(() => ({ dispose: vi.fn() })) as unknown as Event<{
+          key: string;
+        }>,
+      };
+      const failingService = new SecretStorageCredentialsService(
+        failingSecrets,
+      );
+
+      const supported = await failingService.isSupported();
+      expect(supported).toBe(false);
+    });
+  });
+
+  describe("list", () => {
+    test("returns empty array when no credentials exist", async () => {
+      const credentials = await service.list();
+      expect(credentials).toEqual([]);
+    });
+
+    test("returns all credentials", async () => {
+      // Create two credentials
+      await service.set({
+        name: "cred1",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+      await service.set({
+        name: "cred2",
+        url: "https://connect2.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(2);
+      expect(credentials.map((c) => c.name).sort()).toEqual(["cred1", "cred2"]);
+    });
+  });
+
+  describe("set", () => {
+    test("creates a Connect credential with API key", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "abc123",
+      });
+
+      expect(cred.name).toBe("my-server");
+      expect(cred.url).toBe("https://connect.example.com/");
+      expect(cred.serverType).toBe(ServerType.CONNECT);
+      expect(cred.apiKey).toBe("abc123");
+      expect(cred.guid).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test("creates a Connect credential with token auth", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        token: "token123",
+        privateKey: "privatekey123",
+      });
+
+      expect(cred.name).toBe("my-server");
+      expect(cred.token).toBe("token123");
+      expect(cred.privateKey).toBe("privatekey123");
+    });
+
+    test("creates a Snowflake credential", async () => {
+      const cred = await service.set({
+        name: "my-snowflake",
+        url: "https://app.snowflakecomputing.app",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "connection-string",
+      });
+
+      expect(cred.serverType).toBe(ServerType.SNOWFLAKE);
+      expect(cred.snowflakeConnection).toBe("connection-string");
+    });
+
+    test("creates a Connect Cloud credential", async () => {
+      const cred = await service.set({
+        name: "my-cloud",
+        url: "https://connect.posit.cloud",
+        serverType: ServerType.CONNECT_CLOUD,
+        accountId: "account123",
+        accountName: "myaccount",
+        refreshToken: "refresh123",
+        accessToken: "access123",
+        cloudEnvironment: "production",
+      });
+
+      expect(cred.serverType).toBe(ServerType.CONNECT_CLOUD);
+      expect(cred.accountId).toBe("account123");
+      expect(cred.accountName).toBe("myaccount");
+    });
+
+    test("normalizes URL with trailing slash", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      expect(cred.url).toBe("https://connect.example.com/");
+    });
+
+    test("adds https scheme if missing", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      expect(cred.url).toBe("https://connect.example.com/");
+    });
+
+    test("throws NameCollisionError when name already exists", async () => {
+      await service.set({
+        name: "my-server",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+
+      await expect(
+        service.set({
+          name: "my-server",
+          url: "https://connect2.example.com",
+          serverType: ServerType.CONNECT,
+          apiKey: "key2",
+        }),
+      ).rejects.toThrow(NameCollisionError);
+    });
+
+    test("throws IdentityCollisionError when URL already exists", async () => {
+      await service.set({
+        name: "server1",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+
+      await expect(
+        service.set({
+          name: "server2",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          apiKey: "key2",
+        }),
+      ).rejects.toThrow(IdentityCollisionError);
+    });
+
+    test("throws IncompleteCredentialError when missing required fields", async () => {
+      await expect(
+        service.set({
+          name: "",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          apiKey: "key",
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+
+      await expect(
+        service.set({
+          name: "server",
+          url: "",
+          serverType: ServerType.CONNECT,
+          apiKey: "key",
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+
+      await expect(
+        service.set({
+          name: "server",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          // Missing apiKey and token auth
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+    });
+
+    test("preserves provided GUID", async () => {
+      const customGuid = "11111111-1111-1111-1111-111111111111";
+      const cred = await service.set({
+        guid: customGuid,
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      expect(cred.guid).toBe(customGuid);
+    });
+
+    test("stores credential in secret storage", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      // Verify store was called with the credential
+      expect(mockSecrets.store).toHaveBeenCalledWith(
+        CREDENTIAL_KEY_PREFIX + cred.guid,
+        expect.any(String),
+      );
+
+      // Verify GUID list was updated
+      expect(mockSecrets.store).toHaveBeenCalledWith(
+        CREDENTIAL_GUIDS_KEY,
+        expect.any(String),
+      );
+    });
+  });
+
+  describe("forceSet", () => {
+    test("allows updating existing credential by name", async () => {
+      const original = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+
+      // ForceSet should update the existing credential
+      const updated = await service.forceSet({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      // Should use the same GUID as the original
+      expect(updated.guid).toBe(original.guid);
+      expect(updated.apiKey).toBe("key2");
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(1);
+    });
+  });
+
+  describe("get", () => {
+    test("returns credential by GUID", async () => {
+      const created = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      const retrieved = await service.get(created.guid);
+      expect(retrieved.name).toBe("my-server");
+      expect(retrieved.guid).toBe(created.guid);
+    });
+
+    test("throws NotFoundError when GUID does not exist", async () => {
+      await expect(service.get("nonexistent-guid")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+
+  describe("delete", () => {
+    test("removes credential by GUID", async () => {
+      const created = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      await service.delete(created.guid);
+
+      // Verify delete was called on storage
+      expect(mockSecrets.delete).toHaveBeenCalledWith(
+        CREDENTIAL_KEY_PREFIX + created.guid,
+      );
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(0);
+    });
+
+    test("throws NotFoundError when GUID does not exist", async () => {
+      await expect(service.delete("nonexistent-guid")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+
+    test("updates GUID list after delete", async () => {
+      const cred1 = await service.set({
+        name: "server1",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+      await service.set({
+        name: "server2",
+        url: "https://connect2.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      await service.delete(cred1.guid);
+
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(1);
+      expect(credentials[0]?.name).toBe("server2");
+    });
+  });
+
+  describe("reset", () => {
+    test("clears all credentials and returns empty string", async () => {
+      await service.set({
+        name: "server1",
+        url: "https://connect1.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key1",
+      });
+      await service.set({
+        name: "server2",
+        url: "https://connect2.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key2",
+      });
+
+      const backupPath = await service.reset();
+
+      // No backup possible for encrypted storage
+      expect(backupPath).toBe("");
+
+      // Verify GUID list was deleted
+      expect(mockSecrets.delete).toHaveBeenCalledWith(CREDENTIAL_GUIDS_KEY);
+
+      // Verify credentials are cleared
+      const credentials = await service.list();
+      expect(credentials).toHaveLength(0);
+    });
+  });
+
+  describe("Connect Cloud collision detection", () => {
+    test("throws IdentityCollisionError for same accountId and cloudEnvironment", async () => {
+      await service.set({
+        name: "cloud1",
+        url: "https://connect.posit.cloud",
+        serverType: ServerType.CONNECT_CLOUD,
+        accountId: "account123",
+        accountName: "account1",
+        refreshToken: "refresh1",
+        accessToken: "access1",
+        cloudEnvironment: "production",
+      });
+
+      // Same accountId and cloudEnvironment should collide
+      await expect(
+        service.set({
+          name: "cloud2",
+          url: "https://connect.posit.cloud",
+          serverType: ServerType.CONNECT_CLOUD,
+          accountId: "account123",
+          accountName: "account2",
+          refreshToken: "refresh2",
+          accessToken: "access2",
+          cloudEnvironment: "production",
+        }),
+      ).rejects.toThrow(IdentityCollisionError);
+    });
+
+    test("allows different accountId with same cloudEnvironment", async () => {
+      await service.set({
+        name: "cloud1",
+        url: "https://connect.posit.cloud",
+        serverType: ServerType.CONNECT_CLOUD,
+        accountId: "account123",
+        accountName: "account1",
+        refreshToken: "refresh1",
+        accessToken: "access1",
+        cloudEnvironment: "production",
+      });
+
+      // Different accountId should be allowed
+      const cred = await service.set({
+        name: "cloud2",
+        url: "https://connect.posit.cloud",
+        serverType: ServerType.CONNECT_CLOUD,
+        accountId: "account456",
+        accountName: "account2",
+        refreshToken: "refresh2",
+        accessToken: "access2",
+        cloudEnvironment: "production",
+      });
+
+      expect(cred.name).toBe("cloud2");
+    });
+  });
+
+  describe("storage format", () => {
+    test("stores credentials as JSON with version", async () => {
+      const cred = await service.set({
+        name: "my-server",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        apiKey: "key",
+      });
+
+      // Get the raw stored data
+      const storedData = await mockSecrets.get(
+        CREDENTIAL_KEY_PREFIX + cred.guid,
+      );
+      expect(storedData).toBeDefined();
+
+      const parsed = JSON.parse(storedData!);
+      expect(parsed.version).toBe(3);
+      expect(parsed.guid).toBe(cred.guid);
+      expect(parsed.data.name).toBe("my-server");
+    });
+  });
+});

--- a/extensions/vscode/src/services/credentials/secretStorageCredentials.ts
+++ b/extensions/vscode/src/services/credentials/secretStorageCredentials.ts
@@ -1,0 +1,387 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { SecretStorage } from "vscode";
+
+import { CredentialsService } from "./credentialsService";
+import {
+  Credential,
+  CreateCredentialDetails,
+  CredentialRecord,
+  CredentialTable,
+  CURRENT_VERSION,
+  CREDENTIAL_KEY_PREFIX,
+  CREDENTIAL_GUIDS_KEY,
+} from "./types";
+import {
+  NotFoundError,
+  IdentityCollisionError,
+  NameCollisionError,
+  IncompleteCredentialError,
+  CorruptedError,
+} from "./errors";
+import { ServerType } from "../../api/types/contentRecords";
+import { normalizeURL, formatURL } from "../../utils/url";
+
+/**
+ * Generates a UUIDv4.
+ */
+function generateUUID(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Normalizes a server URL by ensuring it has a scheme and trailing slash.
+ */
+function normalizeServerURL(url: string): string {
+  return normalizeURL(formatURL(url));
+}
+
+/**
+ * Checks if a server type is Connect Cloud.
+ */
+function isCloud(serverType: ServerType): boolean {
+  return serverType === ServerType.CONNECT_CLOUD;
+}
+
+/**
+ * Checks if a server type is Connect-like (Connect or Snowflake).
+ */
+function isConnectLike(serverType: ServerType): boolean {
+  return (
+    serverType === ServerType.CONNECT || serverType === ServerType.SNOWFLAKE
+  );
+}
+
+/**
+ * SecretStorage-based credentials service.
+ * Uses VS Code's built-in SecretStorage API for secure credential storage.
+ *
+ * Storage format:
+ * - credential_<guid>: JSON-encoded CredentialRecord for each credential
+ * - credential_guids: JSON-encoded array of GUIDs to enumerate credentials
+ */
+export class SecretStorageCredentialsService implements CredentialsService {
+  private secrets: SecretStorage;
+  private supported: boolean | null = null;
+
+  constructor(secrets: SecretStorage) {
+    this.secrets = secrets;
+  }
+
+  /**
+   * Checks if the secret storage is available and working.
+   */
+  async isSupported(): Promise<boolean> {
+    if (this.supported !== null) {
+      return this.supported;
+    }
+
+    try {
+      // Try to access the storage
+      await this.getKnownCredentialGuids();
+      this.supported = true;
+      return true;
+    } catch {
+      this.supported = false;
+      return false;
+    }
+  }
+
+  async delete(guid: string): Promise<void> {
+    const table = await this.load();
+
+    if (!table[guid]) {
+      throw new NotFoundError(guid);
+    }
+
+    delete table[guid];
+
+    // Delete the credential from storage
+    const key = CREDENTIAL_KEY_PREFIX + guid;
+    await this.secrets.delete(key);
+
+    // Update the GUID list
+    await this.removeGuidFromList(guid);
+  }
+
+  async get(guid: string): Promise<Credential> {
+    const table = await this.load();
+
+    const record = table[guid];
+    if (!record) {
+      throw new NotFoundError(guid);
+    }
+
+    return this.recordToCredential(record);
+  }
+
+  async list(): Promise<Credential[]> {
+    const records = await this.load();
+    const creds: Credential[] = [];
+
+    for (const record of Object.values(records)) {
+      const cred = this.recordToCredential(record);
+      creds.push(cred);
+    }
+
+    return creds;
+  }
+
+  set(details: CreateCredentialDetails): Promise<Credential> {
+    return this.setInternal(details, true);
+  }
+
+  forceSet(details: CreateCredentialDetails): Promise<Credential> {
+    return this.setInternal(details, false);
+  }
+
+  async reset(): Promise<string> {
+    // Get all known GUIDs and delete each credential
+    const knownGuids = await this.getKnownCredentialGuids();
+
+    for (const guid of knownGuids) {
+      const key = CREDENTIAL_KEY_PREFIX + guid;
+      await this.secrets.delete(key);
+    }
+
+    // Delete the GUIDs list
+    await this.secrets.delete(CREDENTIAL_GUIDS_KEY);
+
+    // No backup possible for encrypted storage
+    return "";
+  }
+
+  private async setInternal(
+    details: CreateCredentialDetails,
+    checkConflict: boolean,
+  ): Promise<Credential> {
+    const table = await this.load();
+    const credential = this.detailsToCredential(details);
+
+    let guidToUpdate = credential.guid;
+
+    if (checkConflict) {
+      this.checkForConflicts(table, credential);
+    } else {
+      // Find existing credential with same name to update
+      for (const [guid, record] of Object.entries(table)) {
+        const tableCred = this.recordToCredential(record);
+        if (tableCred.name === details.name) {
+          guidToUpdate = guid;
+          break;
+        }
+      }
+    }
+
+    credential.guid = guidToUpdate;
+
+    const record: CredentialRecord = {
+      guid: guidToUpdate,
+      version: CURRENT_VERSION,
+      data: credential,
+    };
+
+    table[guidToUpdate] = record;
+
+    // Update the GUID list
+    await this.updateGuidsListFor(guidToUpdate);
+
+    // Save the credential
+    await this.save(table);
+
+    return credential;
+  }
+
+  private detailsToCredential(details: CreateCredentialDetails): Credential {
+    // Validate required fields
+    const connectPresent = !!details.apiKey;
+    const snowflakePresent = !!details.snowflakeConnection;
+    const connectCloudPresent =
+      !!details.accountId &&
+      !!details.accountName &&
+      !!details.refreshToken &&
+      !!details.accessToken;
+    const tokenAuthPresent = !!details.token && !!details.privateKey;
+
+    switch (details.serverType) {
+      case ServerType.CONNECT:
+        // Connect can use either API key or token auth, but not both
+        if (
+          (connectPresent && tokenAuthPresent) ||
+          (!connectPresent && !tokenAuthPresent) ||
+          snowflakePresent ||
+          connectCloudPresent
+        ) {
+          throw new IncompleteCredentialError();
+        }
+        break;
+      case ServerType.SNOWFLAKE:
+        if (
+          !snowflakePresent ||
+          connectPresent ||
+          connectCloudPresent ||
+          tokenAuthPresent
+        ) {
+          throw new IncompleteCredentialError();
+        }
+        break;
+      case ServerType.CONNECT_CLOUD:
+        if (
+          !connectCloudPresent ||
+          connectPresent ||
+          snowflakePresent ||
+          tokenAuthPresent
+        ) {
+          throw new IncompleteCredentialError();
+        }
+        break;
+      default:
+        throw new IncompleteCredentialError();
+    }
+
+    if (!details.name || !details.url) {
+      throw new IncompleteCredentialError();
+    }
+
+    const normalizedUrl = normalizeServerURL(details.url);
+    const guid = details.guid || generateUUID();
+
+    return {
+      guid,
+      name: details.name,
+      serverType: details.serverType,
+      url: normalizedUrl,
+      apiKey: details.apiKey ?? "",
+      snowflakeConnection: details.snowflakeConnection ?? "",
+      accountId: details.accountId ?? "",
+      accountName: details.accountName ?? "",
+      refreshToken: details.refreshToken ?? "",
+      accessToken: details.accessToken ?? "",
+      cloudEnvironment: details.cloudEnvironment ?? "",
+      token: details.token ?? "",
+      privateKey: details.privateKey ?? "",
+    };
+  }
+
+  private checkForConflicts(table: CredentialTable, newCred: Credential): void {
+    for (const [_guid, record] of Object.entries(table)) {
+      const cred = this.recordToCredential(record);
+
+      // Check for identity collision
+      if (isCloud(newCred.serverType)) {
+        // Connect Cloud credentials must have unique AccountID and CloudEnvironment combinations
+        if (
+          isCloud(cred.serverType) &&
+          cred.accountId === newCred.accountId &&
+          cred.cloudEnvironment === newCred.cloudEnvironment
+        ) {
+          throw new IdentityCollisionError(
+            cred.name,
+            cred.url,
+            cred.accountName,
+          );
+        }
+      } else {
+        // Connect/Snowflake credentials have unique URLs
+        if (isConnectLike(cred.serverType) && cred.url === newCred.url) {
+          throw new IdentityCollisionError(
+            cred.name,
+            cred.url,
+            cred.accountName,
+          );
+        }
+      }
+
+      // Check for name collision
+      if (newCred.name === cred.name) {
+        throw new NameCollisionError(cred.name, cred.url);
+      }
+    }
+  }
+
+  private recordToCredential(record: CredentialRecord): Credential {
+    // The data is already a Credential object for version 3
+    if (record.version === CURRENT_VERSION) {
+      return record.data;
+    }
+
+    // Handle version migration if needed
+    // For now, we only support current version
+    throw new CorruptedError(record.guid);
+  }
+
+  private async load(): Promise<CredentialTable> {
+    const table: CredentialTable = {};
+
+    const knownGuids = await this.getKnownCredentialGuids();
+
+    for (const guid of knownGuids) {
+      const key = CREDENTIAL_KEY_PREFIX + guid;
+      const data = await this.secrets.get(key);
+
+      if (!data) {
+        // Skip non-existent credentials
+        continue;
+      }
+
+      try {
+        const record = JSON.parse(data) as CredentialRecord;
+        table[guid] = record;
+      } catch {
+        // Skip corrupted credentials
+        continue;
+      }
+    }
+
+    return table;
+  }
+
+  private async save(table: CredentialTable): Promise<void> {
+    for (const [guid, record] of Object.entries(table)) {
+      const key = CREDENTIAL_KEY_PREFIX + guid;
+      const data = JSON.stringify(record);
+      await this.secrets.store(key, data);
+    }
+  }
+
+  private async getKnownCredentialGuids(): Promise<string[]> {
+    const data = await this.secrets.get(CREDENTIAL_GUIDS_KEY);
+
+    if (!data) {
+      return [];
+    }
+
+    try {
+      return JSON.parse(data) as string[];
+    } catch {
+      return [];
+    }
+  }
+
+  private async updateGuidsListFor(guid: string): Promise<void> {
+    const guids = await this.getKnownCredentialGuids();
+
+    // Check if already in list
+    if (guids.includes(guid)) {
+      return;
+    }
+
+    guids.push(guid);
+    await this.saveGuidList(guids);
+  }
+
+  private async removeGuidFromList(guid: string): Promise<void> {
+    const guids = await this.getKnownCredentialGuids();
+    const updatedGuids = guids.filter((g) => g !== guid);
+    await this.saveGuidList(updatedGuids);
+  }
+
+  private async saveGuidList(guids: string[]): Promise<void> {
+    const data = JSON.stringify(guids);
+    await this.secrets.store(CREDENTIAL_GUIDS_KEY, data);
+  }
+}

--- a/extensions/vscode/src/services/credentials/types.ts
+++ b/extensions/vscode/src/services/credentials/types.ts
@@ -1,0 +1,201 @@
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import { ServerType } from "../../api/types/contentRecords";
+
+// CloudAuthToken represents an OAuth access token for Connect Cloud
+export type CloudAuthToken = string;
+
+// CloudEnvironment represents the Connect Cloud environment
+export type CloudEnvironment = string;
+
+// Current version of the credential schema
+export const CURRENT_VERSION = 3;
+
+// Service name for keyring storage
+export const SERVICE_NAME = "Posit Publisher Safe Storage";
+
+// Prefix for credential keys in keyring
+export const CREDENTIAL_KEY_PREFIX = "credential_";
+
+// Key for storing list of credential GUIDs
+export const CREDENTIAL_GUIDS_KEY = "credential_guids";
+
+/**
+ * Credential represents a fully hydrated credential for accessing a server.
+ * This matches the Go Credential struct.
+ */
+export interface Credential {
+  guid: string;
+  name: string;
+  serverType: ServerType;
+  url: string;
+
+  // Connect fields
+  apiKey: string;
+
+  // Snowflake fields
+  snowflakeConnection: string;
+
+  // Connect Cloud fields
+  accountId: string;
+  accountName: string;
+  refreshToken: string;
+  accessToken: CloudAuthToken;
+  cloudEnvironment: CloudEnvironment;
+
+  // Token authentication fields
+  token: string;
+  privateKey: string;
+}
+
+/**
+ * FileCredential represents a credential as stored in the TOML file.
+ * Uses snake_case keys to match TOML file format.
+ */
+export interface FileCredential {
+  guid: string;
+  version: number;
+  server_type: ServerType;
+  url: string;
+
+  // Connect fields
+  api_key?: string;
+
+  // Snowflake fields
+  snowflake_connection?: string;
+
+  // Connect Cloud fields
+  account_id?: string;
+  account_name?: string;
+  refresh_token?: string;
+  access_token?: CloudAuthToken;
+  cloud_environment?: CloudEnvironment;
+
+  // Token authentication fields
+  token?: string;
+  private_key?: string;
+}
+
+/**
+ * FileCredentials represents the entire TOML file structure.
+ * Credentials are keyed by name.
+ */
+export interface FileCredentials {
+  credentials: Record<string, FileCredential>;
+}
+
+/**
+ * CredentialRecord represents a versioned credential stored in the keyring.
+ * The data field contains the JSON-encoded credential.
+ */
+export interface CredentialRecord {
+  guid: string;
+  version: number;
+  data: Credential;
+}
+
+/**
+ * CredentialTable is a map of credential GUIDs to CredentialRecords.
+ */
+export type CredentialTable = Record<string, CredentialRecord>;
+
+/**
+ * CreateCredentialDetails contains the information needed to create a new credential.
+ */
+export interface CreateCredentialDetails {
+  guid?: string; // Optional, used for migration to preserve original GUID
+  name: string;
+  url: string;
+  serverType: ServerType;
+
+  // Connect fields
+  apiKey?: string;
+
+  // Snowflake fields
+  snowflakeConnection?: string;
+
+  // Connect Cloud fields
+  accountId?: string;
+  accountName?: string;
+  refreshToken?: string;
+  accessToken?: CloudAuthToken;
+  cloudEnvironment?: CloudEnvironment;
+
+  // Token authentication fields
+  token?: string;
+  privateKey?: string;
+}
+
+/**
+ * Checks if a FileCredential has valid authentication fields.
+ */
+export function isFileCredentialValid(cred: FileCredential): boolean {
+  return (
+    cred.url !== "" &&
+    ((cred.api_key !== undefined && cred.api_key !== "") ||
+      (cred.snowflake_connection !== undefined &&
+        cred.snowflake_connection !== "") ||
+      (cred.account_id !== undefined &&
+        cred.account_id !== "" &&
+        cred.account_name !== undefined &&
+        cred.account_name !== "" &&
+        cred.refresh_token !== undefined &&
+        cred.refresh_token !== "" &&
+        cred.access_token !== undefined &&
+        cred.access_token !== "") ||
+      (cred.token !== undefined &&
+        cred.token !== "" &&
+        cred.private_key !== undefined &&
+        cred.private_key !== ""))
+  );
+}
+
+/**
+ * Converts a FileCredential to a Credential.
+ */
+export function fileCredentialToCredential(
+  name: string,
+  fileCred: FileCredential,
+): Credential {
+  return {
+    guid: fileCred.guid,
+    name: name,
+    serverType: fileCred.server_type,
+    url: fileCred.url,
+    apiKey: fileCred.api_key ?? "",
+    snowflakeConnection: fileCred.snowflake_connection ?? "",
+    accountId: fileCred.account_id ?? "",
+    accountName: fileCred.account_name ?? "",
+    refreshToken: fileCred.refresh_token ?? "",
+    accessToken: fileCred.access_token ?? "",
+    cloudEnvironment: fileCred.cloud_environment ?? "",
+    token: fileCred.token ?? "",
+    privateKey: fileCred.private_key ?? "",
+  };
+}
+
+/**
+ * Converts a Credential to a FileCredential.
+ */
+export function credentialToFileCredential(cred: Credential): FileCredential {
+  const fileCred: FileCredential = {
+    guid: cred.guid,
+    version: CURRENT_VERSION,
+    server_type: cred.serverType,
+    url: cred.url,
+  };
+
+  // Only include non-empty optional fields
+  if (cred.apiKey) fileCred.api_key = cred.apiKey;
+  if (cred.snowflakeConnection)
+    fileCred.snowflake_connection = cred.snowflakeConnection;
+  if (cred.accountId) fileCred.account_id = cred.accountId;
+  if (cred.accountName) fileCred.account_name = cred.accountName;
+  if (cred.refreshToken) fileCred.refresh_token = cred.refreshToken;
+  if (cred.accessToken) fileCred.access_token = cred.accessToken;
+  if (cred.cloudEnvironment) fileCred.cloud_environment = cred.cloudEnvironment;
+  if (cred.token) fileCred.token = cred.token;
+  if (cred.privateKey) fileCred.private_key = cred.privateKey;
+
+  return fileCred;
+}

--- a/extensions/vscode/src/test/unit-test-utils/factories.ts
+++ b/extensions/vscode/src/test/unit-test-utils/factories.ts
@@ -117,9 +117,13 @@ export const credentialFactory = Factory.define<Credential>(({ sequence }) => ({
   name: `Credential ${sequence}`,
   url: `https://connect.${sequence}.site.com/connect`,
   apiKey: `qwerty-${sequence}`,
+  snowflakeConnection: "",
   accountId: "",
   accountName: "",
   refreshToken: "",
   accessToken: "",
+  cloudEnvironment: "",
+  token: "",
+  privateKey: "",
   serverType: ServerType.CONNECT,
 }));


### PR DESCRIPTION
This is a draft of a TypeScript only setup for Credentials.

> [!WARNING]
> This is not ready to be merged, just sharing openly to gather feedback and discuss.
> This code has not been refined or fully reviewed.

 Couple things worth thinking about:
 - we have to pick a TypeScript `toml` parser
 - we have to decide if we want both TS and Go implementations living together / toggle a feature switch / or just port things
 - Credentials have to be ported more universally not just the create since VS Code's `SecretStorage` doesn't setup the credentials the same as we did. It still can use the keychain, but its not the same credential
 - Moving to `SecretStorage` will require re-creating Credentials. Perhaps we do a migration as part of this work, or require users make new credentials
 