### PR TITLE
feat: add Slack notifications for CI recovery

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,3 +72,46 @@ jobs:
                 text:
                   type: mrkdwn
                   text: ":x: *CI Failed on ${{ github.ref_name }}*\n\n*Repository:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}`\n*Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+
+  # Slack notification when CI recovers from failure
+  slack-notification-resolved:
+    needs:
+      [agent, vscode, build, package, archive, e2e, upload, generate-licenses]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if previous run failed
+        id: check-previous
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'main.yaml',
+              branch: context.ref.replace('refs/heads/', ''),
+              per_page: 2,
+              exclude_pull_requests: true
+            });
+            // Get the previous run (skip current run)
+            const previousRuns = runs.data.workflow_runs.filter(run => run.id !== context.runId);
+            if (previousRuns.length > 0) {
+              const previousRun = previousRuns[0];
+              console.log(`Previous run conclusion: ${previousRun.conclusion}`);
+              return previousRun.conclusion === 'failure';
+            }
+            return false;
+          result-encoding: string
+      - name: Notify Slack of CI recovery
+        if: steps.check-previous.outputs.result == 'true'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":white_check_mark: CI recovered on ${{ github.ref_name }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":white_check_mark: *CI Recovered on ${{ github.ref_name }}*\n\n*Repository:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}`\n*Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,3 +45,44 @@ jobs:
                 text:
                   type: mrkdwn
                   text: ":warning: *Nightly Tests Failed*\n\n*Repository:* ${{ github.repository }}\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+
+  # Slack notification when nightly tests recover from failure
+  slack-notification-resolved:
+    needs: [agent, build, package, e2e, vscode]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if previous run failed
+        id: check-previous
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'nightly.yaml',
+              per_page: 2,
+              exclude_pull_requests: true
+            });
+            // Get the previous run (skip current run)
+            const previousRuns = runs.data.workflow_runs.filter(run => run.id !== context.runId);
+            if (previousRuns.length > 0) {
+              const previousRun = previousRuns[0];
+              console.log(`Previous run conclusion: ${previousRun.conclusion}`);
+              return previousRun.conclusion === 'failure';
+            }
+            return false;
+          result-encoding: string
+      - name: Notify Slack of nightly test recovery
+        if: steps.check-previous.outputs.result == 'true'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":white_check_mark: Nightly tests recovered"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":white_check_mark: *Nightly Tests Recovered*\n\n*Repository:* ${{ github.repository }}\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"


### PR DESCRIPTION
Add slack-notification-resolved jobs to Main and Nightly workflows that notify Slack when CI recovers from a previous failure. This helps the team know when issues have been resolved without needing to check the GitHub Actions UI.
