### PR TITLE
fix: derive expected extension version from VSIX filename instead of git tags

### DIFF
--- a/test/scripts/install-positron-extension.sh
+++ b/test/scripts/install-positron-extension.sh
@@ -6,29 +6,6 @@ set -euo pipefail
 
 SERVICE="${1:-release}"
 
-# Determine the expected installed version
-# The build process (set-version.py) only updates package.json for exact semver versions (X.Y.Z).
-# For non-release versions (e.g., 1.31.7-7-gabcdef), it leaves package.json at 99.0.0.
-# We need to match this logic to know what version the extension will actually install as.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$SCRIPT_DIR/../.."
-
-# Get the git-derived version (same as build process)
-GIT_VERSION=$(cd "$REPO_ROOT" && git describe --tags 2>/dev/null | sed 's/^v//')
-
-if [ -z "$GIT_VERSION" ]; then
-    echo "Warning: Could not determine version from git tags, falling back to 99.0.0"
-    EXPECTED_VERSION="99.0.0"
-elif [[ "$GIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    # Exact semver version (e.g., 1.32.0) - set-version.py will update package.json
-    EXPECTED_VERSION="$GIT_VERSION"
-else
-    # Non-release version (e.g., 1.31.7-7-gabcdef) - set-version.py skips, stays at 99.0.0
-    EXPECTED_VERSION="99.0.0"
-fi
-
-echo "Git version: $GIT_VERSION, Expected installed version: $EXPECTED_VERSION"
-
 echo "Installing Publisher extension in Workbench $SERVICE container..."
 
 # Check if container is running
@@ -50,6 +27,24 @@ if [ -z "$VSIX_FILENAME" ]; then
 fi
 
 echo "Using VSIX: $VSIX_FILENAME"
+
+# Determine the expected installed version from the VSIX filename.
+# The build process (set-version.py) only updates package.json for exact semver versions (X.Y.Z).
+# For non-release versions (e.g., 1.31.7-7-gabcdef), it leaves package.json at 99.0.0.
+# We derive the version from the VSIX filename (which reflects the actual build) rather than
+# git describe (which can race with tag creation from other workflows).
+# VSIX filename format: publisher-<VERSION>-linux-amd64.vsix
+VSIX_VERSION=$(echo "$VSIX_FILENAME" | sed 's/^publisher-//' | sed 's/-linux-amd64\.vsix$//')
+
+if [[ "$VSIX_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # Exact semver version (e.g., 1.32.0) - set-version.py will have updated package.json
+    EXPECTED_VERSION="$VSIX_VERSION"
+else
+    # Non-release version (e.g., 1.31.7-7-gabcdef) - set-version.py skips, stays at 99.0.0
+    EXPECTED_VERSION="99.0.0"
+fi
+
+echo "VSIX version: $VSIX_VERSION, Expected installed version: $EXPECTED_VERSION"
 
 # Set proper ownership for the VSIX directory and files
 docker exec publisher-e2e.workbench-$SERVICE bash -c "chown -R rstudio:rstudio /vsix-tmp" || {


### PR DESCRIPTION
## Summary

- Fixes a race condition causing E2E CI failures on main when a release PR merges
- The install-positron-extension script was using `git describe --tags` to determine the expected installed version, but this races with the `tag-on-release-merge` workflow that creates the version tag concurrently
- Now derives the expected version from the actual VSIX filename, which always reflects what `set-version.py` produced during the build

## Root cause

When a release PR merges to main, two workflows trigger simultaneously:
1. `main.yaml` — builds the VSIX (before the tag exists, so version is e.g. `1.35.6-4-g16bde683`, and `set-version.py` leaves package.json at `99.0.0`)
2. `tag-on-release-merge.yaml` — creates the `v1.35.7` tag

By the time the E2E install script runs (with `fetch-depth: 0`), it picks up the newly-created tag and expects version `1.35.7`, but the extension was installed as `99.0.0`.

## Test plan

- [ ] Verify the E2E `install-positron-extension` step passes on this PR's CI run
- [ ] Confirm no regression on non-release builds (version should resolve to `99.0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)