### PR TITLE
fix: add id-token permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
       - "v*.*.*"
 permissions:
   contents: write # Required to create GitHub releases
+  id-token: write # Required for AWS OIDC authentication in upload workflow
 jobs:
   # Security: Verify the tag points to a commit on main branch
   verify-tag:


### PR DESCRIPTION
Fixes an issue with the `release.yaml` workflow. See a failing run here: https://github.com/posit-dev/publisher/actions/runs/22865814699