### PR TITLE
feat: add workflow_dispatch trigger to release workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,6 @@
 name: Publish Extension
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to both the Release and Publish Extension workflows
- This allows manual re-triggering from the GitHub Actions UI, which is needed after the id-token permission fix (#3670)

## Test plan
- [ ] Verify both workflows appear with a "Run workflow" button in the GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)