### PR TITLE
ci: add slack failure/recovery message to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,15 +62,7 @@ jobs:
             dist/**/*
   # Slack notification on failure
   slack-notification:
-    needs:
-      [
-        verify-tag,
-        build,
-        package,
-        archive,
-        upload,
-        release,
-      ]
+    needs: [verify-tag, build, package, archive, upload, release]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -89,15 +81,7 @@ jobs:
 
   # Slack notification when Release recovers from failure
   slack-notification-resolved:
-    needs:
-      [
-        verify-tag,
-        build,
-        package,
-        archive,
-        upload,
-        release,
-      ]
+    needs: [verify-tag, build, package, archive, upload, release]
     if: success()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds Slack messaging jobs to our `release.yaml` workflow to notify us if the Release workflow failed or recovered.

This is very similar to what we are doing in the `main.yaml` and `nightly.yaml` workflows.