### PR TITLE
test: disable flaky open-connect-content e2e test

### DIFF
--- a/test/e2e/tests/open-connect-content.cy.js
+++ b/test/e2e/tests/open-connect-content.cy.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
 // Disabled: This test is flaky and uninformative.
+// Follow-up: https://github.com/posit-dev/publisher/issues/3688
 describe.skip("Open Connect Content", () => {
   before(() => {
     cy.initializeConnect();


### PR DESCRIPTION
## Summary

- Disables the `open-connect-content.cy.js` e2e test by changing `describe` to `describe.skip`
- This test has been flaky and uninformative, providing little signal while causing CI noise

## Test plan

- [ ] Verify e2e test suite runs successfully with this test skipped
- [ ] Revisit and re-enable or remove the test once the underlying flakiness is addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)