### PR TITLE
docs: add pre-commit linting rule for TypeScript changes to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,10 @@ Even for "quick fixes" or "urgent hotfixes":
 
 Do NOT use `git push origin main` under any circumstances. If you find yourself about to push to main, stop and create a branch instead.
 
+# Pre-Commit Checks
+
+**Always run linting before committing or pushing TypeScript changes.** When any TypeScript files have been modified (in `extensions/vscode/` or webviews), run `just lint` from the `extensions/vscode/` directory and fix all errors before committing or pushing.
+
 # CHANGELOG Conventions
 
 When adding entries to CHANGELOG.md:


### PR DESCRIPTION
## Summary
- Adds a "Pre-Commit Checks" section to `CLAUDE.md` instructing Claude to always run TypeScript linting (`just lint` from `extensions/vscode/`) before committing or pushing TypeScript changes.

## Intent

Ensures Claude Code catches linting errors before they make it into commits, reducing CI failures and review churn on TypeScript changes.

## Type of Change

- [x] Documentation

## Approach

Added a new section between "Git Workflow" and "CHANGELOG Conventions" in the root `CLAUDE.md`, keeping it alongside the existing git workflow rules where it's most relevant.

## User Impact

No user-facing impact. This only affects Claude Code's behavior when making TypeScript changes in the repository.

## Automated Tests

N/A — documentation-only change.

## Directions for Reviewers

Verify the new "Pre-Commit Checks" section in `CLAUDE.md` is clear and placed appropriately.

## Checklist

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)