### PR TITLE
feat: add Claude hooks for pre-commit quality gates

### DIFF
--- a/.claude/hooks/pre-commit-checks.sh
+++ b/.claude/hooks/pre-commit-checks.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Claude hook: PreToolUse gate for git commit commands.
+# Inspects staged files and runs appropriate quality checks before allowing commits.
+# Exit 0 = allow, Exit 2 = block with error message.
+
+set -euo pipefail
+
+# Read tool input JSON from stdin
+INPUT=$(cat)
+
+# Extract the bash command being run
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate git commit commands — let everything else through immediately
+if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+# Resolve project root (CLAUDE_PROJECT_DIR or fall back to git toplevel)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+VSCODE_DIR="$PROJECT_DIR/extensions/vscode"
+WEBVIEW_DIR="$VSCODE_DIR/webviews/homeView"
+
+# Get staged files
+STAGED_FILES=$(git diff --cached --name-only 2>/dev/null || true)
+
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+# Determine which check groups are needed
+RUN_ESBUILD=false
+RUN_LINT=false
+RUN_TEST_UNIT=false
+RUN_WEBVIEW_BUILD=false
+
+while IFS= read -r file; do
+  case "$file" in
+    extensions/vscode/src/*|extensions/vscode/test/*)
+      RUN_ESBUILD=true
+      RUN_TEST_UNIT=true
+      ;;
+  esac
+  case "$file" in
+    extensions/vscode/*.ts|extensions/vscode/*.vue| \
+    extensions/vscode/**/*.ts|extensions/vscode/**/*.vue)
+      RUN_LINT=true
+      ;;
+  esac
+  case "$file" in
+    extensions/vscode/webviews/homeView/src/*)
+      RUN_WEBVIEW_BUILD=true
+      ;;
+  esac
+done <<< "$STAGED_FILES"
+
+# Also match with grep for patterns that case statements handle poorly with deep paths
+if echo "$STAGED_FILES" | grep -qE '^extensions/vscode/.*\.(ts|vue)$'; then
+  RUN_LINT=true
+fi
+if echo "$STAGED_FILES" | grep -qE '^extensions/vscode/(src|test)/'; then
+  RUN_ESBUILD=true
+  RUN_TEST_UNIT=true
+fi
+if echo "$STAGED_FILES" | grep -qE '^extensions/vscode/webviews/homeView/src/'; then
+  RUN_WEBVIEW_BUILD=true
+fi
+
+# Nothing to check
+if ! $RUN_ESBUILD && ! $RUN_LINT && ! $RUN_TEST_UNIT && ! $RUN_WEBVIEW_BUILD; then
+  exit 0
+fi
+
+# Check that dependencies are installed where needed
+if ($RUN_ESBUILD || $RUN_LINT || $RUN_TEST_UNIT) && [ ! -d "$VSCODE_DIR/node_modules" ]; then
+  echo "Dependencies not installed. Run 'npm install' in extensions/vscode/ first." >&2
+  exit 2
+fi
+if $RUN_WEBVIEW_BUILD && [ ! -d "$WEBVIEW_DIR/node_modules" ]; then
+  echo "Dependencies not installed. Run 'npm install' in extensions/vscode/webviews/homeView/ first." >&2
+  exit 2
+fi
+
+FAILED=false
+
+run_check() {
+  local label="$1"
+  local dir="$2"
+  shift 2
+  echo "Running $label..." >&2
+  if ! (cd "$dir" && "$@") 2>&1; then
+    echo "FAILED: $label" >&2
+    FAILED=true
+  fi
+}
+
+if $RUN_ESBUILD; then
+  run_check "esbuild-base (tsc + esbuild)" "$VSCODE_DIR" npm run esbuild-base
+fi
+
+if $RUN_LINT; then
+  run_check "lint (eslint)" "$VSCODE_DIR" npm run lint
+fi
+
+if $RUN_TEST_UNIT; then
+  run_check "test-unit (vitest)" "$VSCODE_DIR" npm run test-unit
+fi
+
+if $RUN_WEBVIEW_BUILD; then
+  run_check "webview build (vue-tsc + vite)" "$WEBVIEW_DIR" npm run build
+fi
+
+if $FAILED; then
+  echo "" >&2
+  echo "Pre-commit checks failed. Fix the errors above before committing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | xargs npx prettier --write --ignore-unknown"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-checks.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,10 +148,6 @@ Even for "quick fixes" or "urgent hotfixes":
 
 Do NOT use `git push origin main` under any circumstances. If you find yourself about to push to main, stop and create a branch instead.
 
-# Pre-Commit Checks
-
-**Always run linting before committing or pushing TypeScript changes.** When any TypeScript files have been modified (in `extensions/vscode/` or webviews), run `just lint` from the `extensions/vscode/` directory and fix all errors before committing or pushing.
-
 # CHANGELOG Conventions
 
 When adding entries to CHANGELOG.md:


### PR DESCRIPTION
## Summary

- Adds two Claude hooks (`.claude/settings.json`) to automate quality checks that were previously manual:
  - **PostToolUse hook**: Runs `prettier --write` on every file after `Edit` or `Write` operations
  - **PreToolUse hook**: Gates `git commit` commands by inspecting staged files and conditionally running esbuild, eslint, vitest, and webview build checks
- Adds `.claude/hooks/pre-commit-checks.sh` implementing the commit gate logic with dependency guards and staged-file detection
- Removes the manual "Pre-Commit Checks" section from `CLAUDE.md` since hooks now enforce this automatically

## Test plan

Locally tested the different flows:
- verified commands that were not `git commit` passed through immediately with no extra prompting
- verified `git commit` skipped checks if it was Go code only
- verified that the filtering on the changed files worked
  - `extensions/vscode/src/` triggers esbuild, lint, and unit tests
  - Vue files in webviews triggers webview build and lint
- if `node_modules` weren't installed which is common when using a worktree the message is clear and actionable for Claude to continue
- `prettier` gets run on all file edits using `--ignore-unknown` to avoid files Prettier doesn't support just like we do in the `package.json` npm script