### PR TITLE
Add Claude PR assistant GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   claude-code-action:
+    # NOTE: contains() is a substring match, so '@claude' will also match
+    # usernames like '@claudesmith'. This is a known limitation of GitHub
+    # Actions expressions which do not support regex word-boundary matching.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -28,13 +31,15 @@ jobs:
       - name: Check actor has write permission
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_REPO: ${{ github.repository }}
         run: |
-          PERMISSION=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          PERMISSION=$(gh api "/repos/${GITHUB_REPO}/collaborators/${GITHUB_ACTOR}/permission" --jq '.permission')
           if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
-            echo "::error::Actor ${{ github.actor }} has '$PERMISSION' permission, requires 'write' or 'admin'"
+            echo "::error::Actor ${GITHUB_ACTOR} has '$PERMISSION' permission, requires 'write' or 'admin'"
             exit 1
           fi
-          echo "Actor ${{ github.actor }} authorized with '$PERMISSION' permission"
+          echo "Actor ${GITHUB_ACTOR} authorized with '$PERMISSION' permission"
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -43,8 +48,10 @@ jobs:
 
       - name: Sanitize role session name
         id: session-name
+        env:
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
-          echo "value=$(echo '${{ github.triggering_actor }}' | sed 's/[^a-zA-Z0-9_+=,.@-]/_/g')" >> "$GITHUB_OUTPUT"
+          echo "value=$(echo "${TRIGGERING_ACTOR}" | sed 's/[^a-zA-Z0-9_+=,.@-]/_/g')" >> "$GITHUB_OUTPUT"
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Intent

Configure Claude as a PR assistant for the repository. When collaborators mention `@claude` on issues or PRs, Claude Code will respond with code suggestions, reviews, or triage actions.

## Type of Change

- [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Adds a new `.github/workflows/claude.yml` workflow.

- **Permission gate**: Before running Claude, the workflow verifies that the `@claude` mentioner has `write` or `admin` collaborator permission on the repo. This prevents unauthorized users from triggering Claude actions.
- **AWS Bedrock via OIDC**: Uses the `CLAUDE_CODE_AWS_ROLE_ARN` repo secret for Bedrock model access.
- **Session name sanitization**: Handles bot usernames containing special characters like `[bot]`.
- **Model config**: Opus 4.6 primary, Haiku 4.5 fallback.
- **Allowed tools**: File editing, web access, and GitHub MCP tools for creating PRs, issues, and reviews.

## Setup Required

Add the following repo secret before merging:
- `CLAUDE_CODE_AWS_ROLE_ARN` — the full ARN of the IAM role for Bedrock access

## User Impact

No impact on existing functionality. Enables a new `@claude` interaction on issues and PRs for collaborators with write access.

## Automated Tests

N/A — this is a CI workflow configuration. Can be validated by mentioning `@claude` on a test issue/PR after merging.

## Directions for Reviewers

1. Review the workflow file at `.github/workflows/claude.yml`
2. Verify the permission check step (lines 28-35) matches the team-operator security pattern
3. Confirm the AWS role and allowed tools are appropriate for this repo

## Checklist

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.