### PR TITLE
Allow posit-connect-projects bot to trigger Claude PR assistant

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -69,6 +69,7 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           allowed_tools: "Bash,Read,Write,Edit,WebFetch,WebSearch,mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          allowed_bots: "posit-connect-projects[bot]"
           prompt: |
             You are a helpful AI assistant for code reviews and issue triage.
             Respond to comments and issues that mention you with relevant code suggestions or triage actions.


### PR DESCRIPTION
## Intent

Add the `posit-connect-projects[bot]` to the `allowed_bots` list in the Claude PR assistant GitHub Action, so Claude can respond when triggered by comments from that bot.

## Type of Change

- - [ ] Bug Fix
- - [ ] New Feature
- - [ ] Breaking Change
- - [ ] Documentation
- - [ ] Refactor
- - [x] Tooling

## Approach

Added the `allowed_bots` input to the `anthropics/claude-code-action@v1` step in `.github/workflows/claude.yaml`. This allows the action to be triggered by comments from the `posit-connect-projects[bot]` in addition to human collaborators with write access.

## User Impact

No user-facing impact. This is a CI/tooling change only.

## Automated Tests

No automated tests needed — this is a workflow configuration change.

## Directions for Reviewers

Verify that the `allowed_bots` field is correctly placed under the `with:` block of the Claude Code Action step in `.github/workflows/claude.yaml`.

## Checklist

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
  - N/A — no user-facing changes.