### PR TITLE
Fix missing @posit-dev/connect-api mock in contract test

### DIFF
--- a/test/extension-contract-tests/src/contracts/connect-filesystem.test.ts
+++ b/test/extension-contract-tests/src/contracts/connect-filesystem.test.ts
@@ -46,6 +46,12 @@ vi.mock("axios", () => ({
   isAxiosError: vi.fn(() => false),
 }));
 
+vi.mock("@posit-dev/connect-api", () => ({
+  ConnectAPI: vi.fn(),
+  ContentID: vi.fn((id: string) => id),
+  BundleID: vi.fn((id: string) => id),
+}));
+
 const {
   registerConnectContentFileSystem,
   ConnectContentFileSystemProvider,


### PR DESCRIPTION
## Summary
- The connect-filesystem contract test was failing on CI because `connect_content_fs.ts` imports from `@posit-dev/connect-api`, a local `file:` dependency that isn't resolvable from the contract test project's context.
- Adds a `vi.mock` for `@posit-dev/connect-api` alongside the existing `tar-stream` and `axios` mocks.

## Test plan
- [x] Verified all 73 contract tests pass locally (12 test files, 0 failures)
- [ ] CI should pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)