### PR TITLE
Fix Claude action to post comments by enabling track_progress

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -69,6 +69,7 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           allowed_bots: "posit-connect-projects[bot]"
+          track_progress: true
           prompt: |
             You are a helpful AI assistant for code reviews and issue triage.
             Respond to comments and issues that mention you with relevant code suggestions or triage actions.


### PR DESCRIPTION
## Summary
- Adds `track_progress: true` to the Claude Code Action workflow to force "tag" mode

## Context

The `prompt` input causes the action to auto-detect "agent" mode, which by design:
- Does **not** include the user's `@claude` comment in the prompt
- Does **not** post responses as PR/issue comments
- Only outputs to the GitHub Actions step summary

Setting `track_progress: true` forces "tag" mode, which:
- Creates a tracking comment on the PR/issue
- Fetches full conversation context (PR diff, issue body, comment history)
- Posts Claude's response as a comment

## Test plan
- [ ] Merge to main
- [ ] Comment `@claude` on a PR and verify Claude responds with a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)