### PR TITLE
Remove show_full_output debugging from Claude action

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -64,7 +64,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: true
-          show_full_output: true
           github_token: ${{ steps.generate-token.outputs.token }}
           branch_prefix: "claude-"
           additional_permissions: "actions: read"


### PR DESCRIPTION
## Summary
- Removes `show_full_output: true` from the Claude Code Action workflow, which was added temporarily for debugging

## Test plan
- [ ] Verify Claude still responds to `@claude` comments after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)