### PR TITLE
Add reopened trigger to auto-review workflow

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   auto-review:


### PR DESCRIPTION
## Summary
- Add `reopened` to the `pull_request` event types in `claude-auto-review.yaml` so the workflow also triggers when a PR is closed and reopened, not just on initial open or draft-to-ready transitions

## Test plan
- [ ] Close and reopen a PR to verify the auto-review triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)