### PR TITLE
Skip Slack release announcement for pre-releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,8 @@ jobs:
     needs:
       - archive
       - package
+    outputs:
+      prerelease: ${{ steps.get-prerelease.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -124,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release
-    if: success()
+    if: success() && needs.release.outputs.prerelease != 'true'
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
## Summary
- Expose the `prerelease` output from the `release` job in `release.yaml`
- Add condition to `notify-slack` job to skip Slack announcements when the release is a pre-release (odd-minor versions like v1.37.0)

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm next stable release (even-minor) still sends Slack notification
- [ ] Confirm next pre-release (odd-minor) skips Slack notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)