### PR TITLE
Fix CI failure analysis permission check for bot actors

### DIFF
--- a/.github/workflows/ci-failure-analysis.yaml
+++ b/.github/workflows/ci-failure-analysis.yaml
@@ -32,6 +32,7 @@ jobs:
 
     steps:
       - name: Check actor has write permission
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Skip the collaborator permission check for `workflow_run` events, which are inherently trusted (only triggered by workflows defined in the repo)
- The check remains active for `workflow_dispatch` (manual triggers) to prevent unauthorized use

**Root cause:** `github.actor` for `workflow_run` events resolved to `posit-connect-projects[bot]`, a GitHub App that has repo access through App installation permissions rather than the collaborators API. The API returned `'none'` permission, failing the check and blocking all automated CI failure analysis.

**Failed run:** https://github.com/posit-dev/publisher/actions/runs/23258636350/job/67620677329

## Test plan
- [ ] Verify the next `workflow_run`-triggered CI failure analysis completes without permission errors
- [ ] Verify `workflow_dispatch` manual triggers still enforce the permission check

🤖 Generated with [Claude Code](https://claude.com/claude-code)