### PR TITLE
fix: resolve flaky E2E test by waiting for specific deployment item

### DIFF
--- a/test/e2e/tests/error-err-config.cy.js
+++ b/test/e2e/tests/error-err-config.cy.js
@@ -40,12 +40,12 @@ describe("Detect errors in config", () => {
     cy.get(".quick-input-widget").should("be.visible");
     cy.get(".quick-input-titlebar").should("have.text", "Select Deployment");
 
-    // Wait for deployment list to populate before searching for specific item
-    cy.get(".quick-input-widget .quick-input-list-row").should("exist");
-
-    // select our error case
+    // select our error case (retry until the specific item appears)
     cy.get(".quick-input-widget")
-      .contains("Unknown Title • Error in quarto-project-8G2B")
+      .contains("Unknown Title • Error in quarto-project-8G2B", {
+        timeout: 20000,
+      })
+      .should("be.visible")
       .click();
 
     // confirm that the selector shows the error
@@ -76,12 +76,12 @@ describe("Detect errors in config", () => {
     cy.get(".quick-input-widget").should("be.visible");
     cy.get(".quick-input-titlebar").should("have.text", "Select Deployment");
 
-    // Wait for deployment list to populate before searching for specific item
-    cy.get(".quick-input-widget .quick-input-list-row").should("exist");
-
-    // select our error case
+    // select our error case (retry until the specific item appears)
     cy.get(".quick-input-widget")
-      .contains("Unknown Title Due to Missing Config fastapi-simple-DHJL")
+      .contains("Unknown Title Due to Missing Config fastapi-simple-DHJL", {
+        timeout: 20000,
+      })
+      .should("be.visible")
       .click();
 
     // confirm that the selector shows the error


### PR DESCRIPTION
Replace the two-step wait pattern (wait for any row, then find specific item) with a single retrying assertion that waits up to 20s for the specific deployment item to appear. This eliminates the race condition where "Create a New Deployment" satisfies the first assertion before error deployments finish loading.

Fixes #3805
