### PR TITLE
Add resolveRPackages orchestration for TS publish flow

### DIFF
--- a/extensions/vscode/src/publish/dependencies.test.ts
+++ b/extensions/vscode/src/publish/dependencies.test.ts
@@ -1,8 +1,9 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { readPythonRequirements } from "./dependencies";
+import { readPythonRequirements, resolveRPackages } from "./dependencies";
 
 const mockFiles: Record<string, string> = {};
 
@@ -12,6 +13,12 @@ vi.mock("../interpreters/fsUtils", () => ({
     return Promise.resolve(content ?? null);
   }),
 }));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+const mockReadFile = vi.mocked(readFile);
 
 function setFile(dir: string, filename: string, content: string) {
   mockFiles[path.join(dir, filename)] = content;
@@ -73,5 +80,97 @@ describe("readPythonRequirements", () => {
       packageFile: "",
     });
     expect(result).toEqual(["flask"]);
+  });
+});
+
+// ---- resolveRPackages ----
+
+const MINIMAL_LOCKFILE = JSON.stringify({
+  R: {
+    Version: "4.3.3",
+    Repositories: [{ Name: "CRAN", URL: "https://cloud.r-project.org" }],
+  },
+  Packages: {
+    rlang: {
+      Package: "rlang",
+      Version: "1.1.1",
+      Source: "Repository",
+      Repository: "CRAN",
+      Hash: "a85c767b55f0bf9b7ad16c6d7baee5bb",
+      Requirements: ["R"],
+    },
+  },
+});
+
+describe("resolveRPackages", () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+  });
+
+  test("returns undefined when no R config", async () => {
+    const result = await resolveRPackages(projectDir, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test("reads default renv.lock and returns manifest packages", async () => {
+    mockReadFile.mockResolvedValueOnce(MINIMAL_LOCKFILE as never);
+
+    const result = await resolveRPackages(projectDir, { packageFile: "" });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      path.join(projectDir, "renv.lock"),
+      "utf-8",
+    );
+    expect(result).toBeDefined();
+    const rlang = result!.packages["rlang"];
+    expect(rlang).toBeDefined();
+    expect(rlang!.Source).toBe("CRAN");
+    expect(result!.lockfilePath).toBe(path.join(projectDir, "renv.lock"));
+    expect(result!.lockfile.R.Version).toBe("4.3.3");
+  });
+
+  test("reads configured package file", async () => {
+    mockReadFile.mockResolvedValueOnce(MINIMAL_LOCKFILE as never);
+
+    const result = await resolveRPackages(projectDir, {
+      packageFile: "custom/renv.lock",
+    });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      path.join(projectDir, "custom/renv.lock"),
+      "utf-8",
+    );
+    expect(result).toBeDefined();
+    expect(result!.packages["rlang"]).toBeDefined();
+  });
+
+  test("throws on lockfile without Repositories", async () => {
+    const badLockfile = JSON.stringify({
+      R: { Version: "4.3.3", Repositories: [] },
+      Packages: {},
+    });
+    mockReadFile.mockResolvedValueOnce(badLockfile as never);
+
+    await expect(
+      resolveRPackages(projectDir, { packageFile: "" }),
+    ).rejects.toThrow("missing Repositories section");
+  });
+
+  test("throws on invalid JSON", async () => {
+    mockReadFile.mockResolvedValueOnce("not json" as never);
+
+    await expect(
+      resolveRPackages(projectDir, { packageFile: "" }),
+    ).rejects.toThrow();
+  });
+
+  test("throws when lockfile does not exist", async () => {
+    mockReadFile.mockRejectedValueOnce(
+      new Error("ENOENT: no such file or directory"),
+    );
+
+    await expect(
+      resolveRPackages(projectDir, { packageFile: "" }),
+    ).rejects.toThrow("ENOENT");
   });
 });

--- a/extensions/vscode/src/publish/dependencies.ts
+++ b/extensions/vscode/src/publish/dependencies.ts
@@ -1,7 +1,17 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { ManifestPackage } from "../bundler/types";
 import { DEFAULT_PYTHON_PACKAGE_FILE } from "../constants";
 import { getPythonPackages } from "../interpreters/pythonPackages";
+import {
+  lockfileToManifestPackages,
+  type RenvLockfile,
+} from "./rPackageDescriptions";
+
+const DEFAULT_R_PACKAGE_FILE = "renv.lock";
 
 /**
  * Read Python requirements from the configured package file.
@@ -18,4 +28,43 @@ export async function readPythonRequirements(
   }
   const packageFile = pythonConfig.packageFile || DEFAULT_PYTHON_PACKAGE_FILE;
   return await getPythonPackages(projectDir, packageFile);
+}
+
+export type ResolvedRPackages = {
+  packages: Record<string, ManifestPackage>;
+  lockfilePath: string;
+  lockfile: RenvLockfile;
+};
+
+/**
+ * Read an renv.lock file, validate it, and convert to manifest packages.
+ *
+ * This is the main entry point for R package resolution during publish.
+ * It reads the lockfile from disk, enforces the modern format requirement
+ * (renv >= 1.1.0 with Repositories), and converts each package entry
+ * into the manifest format needed by the deployment bundle.
+ */
+export async function resolveRPackages(
+  projectDir: string,
+  rConfig: { packageFile: string } | undefined,
+): Promise<ResolvedRPackages | undefined> {
+  if (!rConfig) {
+    return undefined;
+  }
+
+  const packageFile = rConfig.packageFile || DEFAULT_R_PACKAGE_FILE;
+  const lockfilePath = path.join(projectDir, packageFile);
+
+  const content = await readFile(lockfilePath, "utf-8");
+  const lockfile: RenvLockfile = JSON.parse(content);
+
+  if (!lockfile.R?.Repositories?.length) {
+    throw new Error(
+      "renv.lock is not compatible: missing Repositories section. " +
+        "Regenerate the lockfile with renv >= 1.1.0",
+    );
+  }
+
+  const packages = lockfileToManifestPackages(lockfile);
+  return { packages, lockfilePath, lockfile };
 }


### PR DESCRIPTION
## Summary

- Add `resolveRPackages()` that reads an renv.lock, validates the modern format (renv >= 1.1.0 with Repositories), and converts to manifest packages via `lockfileToManifestPackages`
- Returns `{ packages, lockfilePath, lockfile }` for use by the publish orchestrator
- Export `ResolvedRPackages` type for downstream consumers

Stacked on #3812. Part of #3792.

## Test plan

- [x] Returns undefined when no R config
- [x] Reads default renv.lock and returns manifest packages
- [x] Reads configured package file path
- [x] Throws on lockfile without Repositories section
- [x] Throws on invalid JSON
- [x] Throws when lockfile does not exist
- [x] All 862 vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)