### PR TITLE
fix: sanitize LICENSES_REPO_ROOT to prevent path traversal

### DIFF
--- a/scripts/licenses.py
+++ b/scripts/licenses.py
@@ -2,10 +2,16 @@ import os
 import fnmatch
 import sys
 
-_repo_root = os.environ.get(
-    "LICENSES_REPO_ROOT",
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_repo_root = os.path.realpath(
+    os.environ.get(
+        "LICENSES_REPO_ROOT",
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
 )
+
+if not os.path.isdir(_repo_root):
+    print(f"ERROR: LICENSES_REPO_ROOT is not a valid directory: {_repo_root}", file=sys.stderr)
+    sys.exit(1)
 
 search_dirs = [
     os.path.join(_repo_root, "vendor"),


### PR DESCRIPTION
## Summary

- Wraps `_repo_root` in `os.path.realpath()` to canonicalize the path, resolving symlinks, `..`, and relative components
- Adds an `os.path.isdir()` guard that exits early with a clear error for invalid paths
- Fixes two Snyk-reported path traversal findings (CWE-22) where unsanitized input from `LICENSES_REPO_ROOT` flowed into `os.walk()` and `open()`

## Test plan

- [x] All 5 existing tests in `scripts/test_licenses.py` pass
- [ ] Verify Snyk no longer flags lines 50 and 56 of `scripts/licenses.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)