### PR TITLE
feat: add onOutput callback to ConnectAPI.waitForTask (#3825)

### DIFF
--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -687,6 +687,120 @@ describe("waitForTask", () => {
     expect(call2.url).toBe(`/__api__/v1/tasks/${taskId}`);
     expect(call2.params).toEqual({ first: 3 });
   });
+
+  it("calls onOutput with each batch of log lines", async () => {
+    mockRequest
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: taskId,
+          output: ["Building..."],
+          result: null,
+          finished: false,
+          code: 0,
+          error: "",
+          last: 1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: taskId,
+          output: ["Installing packages...", "Launching content..."],
+          result: null,
+          finished: true,
+          code: 0,
+          error: "",
+          last: 3,
+        }),
+      );
+
+    const batches: string[][] = [];
+    const onOutput = (lines: string[]) => batches.push(lines);
+
+    const client = createClient();
+    await client.waitForTask(taskId, 0, onOutput);
+
+    expect(batches).toEqual([
+      ["Building..."],
+      ["Installing packages...", "Launching content..."],
+    ]);
+  });
+
+  it("does not call onOutput when output is empty", async () => {
+    mockRequest
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: taskId,
+          output: [],
+          result: null,
+          finished: false,
+          code: 0,
+          error: "",
+          last: 0,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: taskId,
+          output: ["done"],
+          result: null,
+          finished: true,
+          code: 0,
+          error: "",
+          last: 1,
+        }),
+      );
+
+    const batches: string[][] = [];
+    const onOutput = (lines: string[]) => batches.push(lines);
+
+    const client = createClient();
+    await client.waitForTask(taskId, 0, onOutput);
+
+    expect(batches).toEqual([["done"]]);
+  });
+
+  it("calls onOutput before throwing on task error", async () => {
+    mockRequest.mockResolvedValueOnce(
+      jsonResponse({
+        id: taskId,
+        output: ["error output"],
+        result: null,
+        finished: true,
+        code: 1,
+        error: "deployment failed",
+        last: 1,
+      }),
+    );
+
+    const batches: string[][] = [];
+    const onOutput = (lines: string[]) => batches.push(lines);
+
+    const client = createClient();
+    await expect(client.waitForTask(taskId, 0, onOutput)).rejects.toThrow(
+      "deployment failed",
+    );
+
+    expect(batches).toEqual([["error output"]]);
+  });
+
+  it("works without onOutput (backward compatible)", async () => {
+    mockRequest.mockResolvedValue(
+      jsonResponse({
+        id: taskId,
+        output: ["line 1"],
+        result: null,
+        finished: true,
+        code: 0,
+        error: "",
+        last: 1,
+      }),
+    );
+
+    const client = createClient();
+    const result = await client.waitForTask(taskId, 0);
+
+    expect(result.output).toEqual(["line 1"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -181,8 +181,13 @@ export class ConnectAPI {
   /**
    * Polls for task completion.
    * @param pollIntervalMs - milliseconds between polls (default 500, pass 0 for tests)
+   * @param onOutput - optional callback invoked with each batch of new log lines as they arrive
    */
-  async waitForTask(taskId: TaskID, pollIntervalMs = 500): Promise<TaskDTO> {
+  async waitForTask(
+    taskId: TaskID,
+    pollIntervalMs = 500,
+    onOutput?: (lines: string[]) => void,
+  ): Promise<TaskDTO> {
     let firstLine = 0;
 
     while (true) {
@@ -190,6 +195,10 @@ export class ConnectAPI {
         `/__api__/v1/tasks/${taskId}`,
         { params: { first: firstLine } },
       );
+
+      if (onOutput && task.output.length > 0) {
+        onOutput(task.output);
+      }
 
       if (task.finished) {
         if (task.error) {


### PR DESCRIPTION
Add an optional onOutput callback parameter that receives task log lines as they arrive during polling, enabling granular server-side progress reporting during the deploy-and-wait phase.
