### PR TITLE
fix: bare directory patterns include directory contents

### DIFF
--- a/extensions/vscode/src/bundler/collect.test.ts
+++ b/extensions/vscode/src/bundler/collect.test.ts
@@ -292,6 +292,63 @@ describe("collectFiles", () => {
     expect(files).toEqual([]);
   });
 
+  describe("bare directory patterns (no trailing slash)", () => {
+    it("includes directory contents", async () => {
+      makeFile("app.py");
+      makeFile("data/tips.csv");
+      makeFile("data/other.csv");
+
+      const files = await collectedPaths(["/app.py", "data"]);
+      expect(files).toEqual(["app.py", "data/other.csv", "data/tips.csv"]);
+    });
+
+    it("includes deeply nested contents", async () => {
+      makeFile("data/subdir/deep.csv");
+
+      const files = await collectedPaths(["data"]);
+      expect(files).toEqual(["data/subdir/deep.csv"]);
+    });
+
+    it("excludes directory contents when negated", async () => {
+      makeFile("app.py");
+      makeFile("data/tips.csv");
+
+      const files = await collectedPaths(["*", "!data"]);
+      expect(files).toEqual(["app.py"]);
+    });
+
+    it("works with rooted bare directory pattern", async () => {
+      makeFile("app.py");
+      makeFile("data/tips.csv");
+
+      const files = await collectedPaths(["/app.py", "/data"]);
+      expect(files).toEqual(["app.py", "data/tips.csv"]);
+    });
+
+    it("matches Go-generated config patterns", async () => {
+      // Go backend generates: files = ["/app.py", "/requirements.txt", "/data", "/styles.css"]
+      makeFile("app.py");
+      makeFile("requirements.txt");
+      makeFile("data/tips.csv");
+      makeFile("data/summary.csv");
+      makeFile("styles.css");
+
+      const files = await collectedPaths([
+        "/app.py",
+        "/requirements.txt",
+        "/data",
+        "/styles.css",
+      ]);
+      expect(files).toEqual([
+        "app.py",
+        "data/summary.csv",
+        "data/tips.csv",
+        "requirements.txt",
+        "styles.css",
+      ]);
+    });
+  });
+
   describe("trailing-slash directory patterns", () => {
     it("includes directory contents", async () => {
       makeFile("app.py");

--- a/extensions/vscode/src/bundler/collect.ts
+++ b/extensions/vscode/src/bundler/collect.ts
@@ -161,17 +161,21 @@ function shouldInclude(
   let lastMatch: "include" | "exclude" | null = null;
 
   for (const rule of rules) {
-    // Directory-only patterns: for files, check if the pattern matches
-    // an ancestor directory. The Go bundler treats "data/" as "include
-    // everything under data/", so we replicate that by testing ancestor
-    // paths against directory-only rules.
-    if (rule.matchesDir && !isDirectory) {
+    // For files, check if a parent directory matches the pattern.
+    // A pattern matching a directory includes its contents, whether
+    // specified as "data/" (matchesDir) or "data" (bare path).
+    // This matches the Go bundler's behavior.
+    if (!isDirectory) {
       const ancestors = getAncestorPaths(relativePath);
       for (const ancestor of ancestors) {
         if (rule.matchesPath(ancestor)) {
           lastMatch = rule.exclude ? "exclude" : "include";
         }
       }
+    }
+
+    // Directory-only patterns (trailing slash) skip direct file matching
+    if (rule.matchesDir && !isDirectory) {
       continue;
     }
 


### PR DESCRIPTION
Fixes #3862

## Summary

- Broadened the TS bundler's ancestor-path check in `shouldInclude` to run for **all** pattern rules, not just trailing-slash (`matchesDir`) patterns
- Bare directory patterns like `/data` (as generated by the Go backend) now correctly include all files within that directory
- The `matchesDir` flag is preserved to prevent trailing-slash patterns from directly matching files with the same name

## Test plan

- [x] Added 5 new tests for bare directory patterns (content inclusion, deep nesting, negation, rooted paths, Go-generated config patterns)
- [x] All 49 existing bundler collect tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)