### PR TITLE
fix: fix flaky test on windows-11-arm

### DIFF
--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -57,7 +57,10 @@ jobs:
           echo "R_PROFILE_USER=$RUNNER_TEMP/Rprofile-ci.R" >> "$GITHUB_ENV"
 
       - name: Install R packages
-        run: Rscript -e "install.packages(c('renv', 'glue', 'rmarkdown', 'knitr'))"
+        shell: Rscript {0}
+        run: |
+          type <- if (.Platform$OS.type == "windows") "binary" else getOption("pkgType", "source")
+          install.packages(c("renv", "glue", "rmarkdown", "knitr"), type = type)
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

#3885 fixed one failure on windows arm runners, but when merged to main it failed on a different test. This PR aims to fix it.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

pre-install rmarkdown and knitr in the agent CI workflow. The test needs these packages for `renv::hydrate()`, but without them pre-installed, `hydrate` falls back to installing them at test time via `renv_hydrate_resolve_missing`. renv 1.2.0 (released 2025-03-25) rewrote this code path to use a parallel socket-based installer that appears to be flaky under x64 emulation on windows-11-arm. Pre-installing the packages avoids this code path entirely.

It also appears that installing packages from source on arm windows under emulation is not reliable, so we force binaries on windows only.

## User Impact

<!-- Describe how this change will affect users. -->
<!-- Specifically changes to the flow and trade-offs we are making. -->

## Automated Tests

<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
