### PR TITLE
docs: add cross-platform path handling guidance to CLAUDE.md

### DIFF
--- a/extensions/vscode/CLAUDE.md
+++ b/extensions/vscode/CLAUDE.md
@@ -161,12 +161,13 @@ This extension runs on macOS, Linux, and Windows. Never construct file-system pa
 - Build paths with `path.join()` and assert against `path.join()` results — never hardcode `"/project/foo"` literals as file-system paths
 - For tests that touch the real filesystem, use `os.tmpdir()` + `fs.mkdtempSync()` for setup (see `bundler.test.ts`, `configWriter.test.ts` for good examples)
 - TOML config patterns like `"/app.py"` are data values, not file-system paths — those are fine as string literals
-**In tests:**
+  **In tests:**
 
 - Build paths with `path.join()` and assert against `path.join()` results — never hardcode `"/project/foo"` literals as file-system paths
 - For tests that touch the real filesystem, use `os.tmpdir()` + `fs.mkdtempSync()` for setup (see `bundler.test.ts`, `configWriter.test.ts` for good examples)
 - TOML config patterns like `"/app.py"` are data values, not file-system paths — those are fine as string literals
 - Whenever possible, test paths with spaces (other relevant non-ascii characters) to ensure that our path operations are compatible across shells and systems.
+
 ## Avoid Type Assertions
 
 Do not use TypeScript [type assertions](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) (`as Type`) unless there is no alternative. Type assertions bypass the compiler's type checking and can hide bugs. Instead, prefer:


### PR DESCRIPTION
## Summary
- Adds a **Cross-Platform Path Handling** section to the VSCode extension's `CLAUDE.md` under TypeScript Conventions
- Documents rules for using `path.join()`, `path.resolve()`, and `Uri.joinPath()` instead of hardcoded forward-slash paths
- Covers both production code and test patterns, with pointers to good examples in the codebase

Motivated by recurring Windows CI failures (e.g., #3923) caused by hardcoded `/` path separators in test assertions.