### PR TITLE
fix: increase timeout for Quarto interpreter integration tests

### DIFF
--- a/extensions/vscode/src/inspect/integration.test.ts
+++ b/extensions/vscode/src/inspect/integration.test.ts
@@ -1164,7 +1164,7 @@ describe(
 
 describe(
   "inspectProject with real interpreters (real filesystem)",
-  { timeout: 15_000 },
+  { timeout: 30_000 },
   () => {
     let python3Available = false;
     let pythonAvailable = false;


### PR DESCRIPTION
## Summary
- Increases the test timeout for the "inspectProject with real interpreters" describe block from 15s to 30s
- This block spawns sequential subprocesses (`quarto inspect` + `python`/`R` version check) that can exceed 15s on Windows CI runners, especially when the runner is under load
- The `quarto inspect` subprocess itself has a 30s timeout (`quarto.ts:99`), so the test timeout should be at least as long

## Context
The `populates Python config for Quarto Python project` test timed out at 15s on Windows in [this CI run](https://github.com/posit-dev/publisher/actions/runs/24165686718). The same test passed on the previous run of the same branch — it's a flaky timeout, not a code bug.

## Test plan
- [ ] CI passes on all platforms, especially `interpreter-integration / windows-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)