### PR TITLE
feat: generate Python requirements from pylock.toml, uv.lock, or pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for deploying projects with dependencies recorded in pylock.toml (PEP 751), uv.lock, or pyproject.toml files. When requirements.txt is not present, these files are automatically detected and used in that priority order. (#2824)
 - Directory checkboxes in Project Files now show an indeterminate state when some, but not all, children are included in the deployment. Directories also now show as checked when all children are included. (#3472)
 
 ### Fixed

--- a/extensions/vscode/src/bundler/archive.ts
+++ b/extensions/vscode/src/bundler/archive.ts
@@ -25,6 +25,7 @@ export async function createArchive(
   files: FileEntry[],
   manifest: Manifest,
   onProgress?: BundleProgressCallback,
+  syntheticFiles?: Map<string, Buffer>,
 ): Promise<{
   bundle: Buffer;
   manifest: Manifest;
@@ -79,6 +80,28 @@ export async function createArchive(
     fileCount++;
     totalSize += entry.size;
     onProgress?.({ kind: "file", path: archiveName, size: entry.size });
+  }
+
+  // Add synthetic (in-memory) files to the bundle
+  if (syntheticFiles) {
+    for (const [name, content] of syntheticFiles) {
+      const hash = crypto.createHash("md5");
+      hash.update(content);
+      const md5 = hash.digest();
+
+      const syntheticEntry = pack.entry({
+        name,
+        size: content.length,
+        mode: 0o666,
+      });
+      syntheticEntry.end(content);
+      await finished(syntheticEntry);
+
+      addFile(updatedManifest, name, md5);
+      fileCount++;
+      totalSize += content.length;
+      onProgress?.({ kind: "file", path: name, size: content.length });
+    }
   }
 
   onProgress?.({ kind: "summary", files: fileCount, totalBytes: totalSize });

--- a/extensions/vscode/src/bundler/bundler.test.ts
+++ b/extensions/vscode/src/bundler/bundler.test.ts
@@ -355,4 +355,62 @@ describe("createBundle", () => {
     });
     expect(result.fileCount).toBe(1);
   });
+
+  it("includes synthetic files in the bundle", async () => {
+    makeFile("app.py", "import dash");
+
+    const syntheticFiles = new Map<string, Buffer>();
+    syntheticFiles.set("requirements.txt", Buffer.from("dash==2.0\n"));
+
+    const result = await createBundle({
+      projectPath: tmpDir,
+      manifest: newManifest(),
+      syntheticFiles,
+    });
+
+    // Synthetic file should be in the tar
+    const entries = await extractTarEntries(result.bundle);
+    expect(entries.has("requirements.txt")).toBe(true);
+    expect(entries.get("requirements.txt")!.data.toString()).toBe(
+      "dash==2.0\n",
+    );
+
+    // Synthetic file should be in the manifest with a valid checksum
+    expect(result.manifest.files["requirements.txt"]).toBeDefined();
+    expect(result.manifest.files["requirements.txt"]?.checksum).toMatch(
+      /^[0-9a-f]+$/,
+    );
+
+    // Counts should include the synthetic file
+    expect(result.fileCount).toBe(2); // app.py + requirements.txt
+  });
+
+  it("emits onProgress events for synthetic files", async () => {
+    makeFile("app.py", "import dash");
+
+    const syntheticFiles = new Map<string, Buffer>();
+    syntheticFiles.set("requirements.txt", Buffer.from("dash==2.0\n"));
+
+    const events: BundleProgressEvent[] = [];
+    await createBundle({
+      projectPath: tmpDir,
+      manifest: newManifest(),
+      syntheticFiles,
+      onProgress: (event) => events.push(event),
+    });
+
+    // Should have a file event for the synthetic file
+    const fileEvents = events.filter((e) => e.kind === "file");
+    const syntheticEvent = fileEvents.find(
+      (e) => e.kind === "file" && e.path === "requirements.txt",
+    );
+    expect(syntheticEvent).toBeDefined();
+
+    // Summary should include the synthetic file in its counts
+    const summary = events.find((e) => e.kind === "summary");
+    expect(summary).toBeDefined();
+    if (summary?.kind === "summary") {
+      expect(summary.files).toBe(2); // app.py + requirements.txt
+    }
+  });
 });

--- a/extensions/vscode/src/bundler/bundler.ts
+++ b/extensions/vscode/src/bundler/bundler.ts
@@ -60,5 +60,5 @@ export async function createBundle(
 
   onProgress?.({ kind: "sourceDir", sourceDir: baseDir });
 
-  return createArchive(files, manifest, onProgress);
+  return createArchive(files, manifest, onProgress, options.syntheticFiles);
 }

--- a/extensions/vscode/src/bundler/types.ts
+++ b/extensions/vscode/src/bundler/types.ts
@@ -104,6 +104,12 @@ export type BundleOptions = {
   filePatterns?: string[];
   /** Optional callback for per-file progress reporting */
   onProgress?: BundleProgressCallback;
+  /**
+   * Files to inject into the bundle that don't exist on disk.
+   * Keys are archive paths (e.g. "requirements.txt"), values are file contents.
+   * These are added to the tar and registered in the manifest like regular files.
+   */
+  syntheticFiles?: Map<string, Buffer>;
 };
 
 export type BundleResult = {

--- a/extensions/vscode/src/interpreters/pythonDependencySources.test.ts
+++ b/extensions/vscode/src/interpreters/pythonDependencySources.test.ts
@@ -218,13 +218,13 @@ source = { registry = "https://pypi.org/simple" }
     expect(result).toEqual(["flask==3.0.2"]);
   });
 
-  test("returns null when no packages found", async () => {
+  test("returns null when no package section exists", async () => {
     setFile("/project", "uv.lock", "version = 1\n");
     const result = await readUvLockDependencies("/project");
     expect(result).toBeNull();
   });
 
-  test("returns null when only root project exists", async () => {
+  test("returns empty array when only root project exists", async () => {
     setFile(
       "/project",
       "uv.lock",
@@ -237,7 +237,7 @@ source = { editable = "." }
 `,
     );
     const result = await readUvLockDependencies("/project");
-    expect(result).toBeNull();
+    expect(result).toEqual([]);
   });
 
   test("returns null on invalid TOML", async () => {
@@ -294,7 +294,7 @@ version = "3.0.2"
     expect(result).toEqual(["flask==3.0.2"]);
   });
 
-  test("returns null when no packages found", async () => {
+  test("returns null when no packages section exists", async () => {
     setFile(
       "/project",
       "pylock.toml",

--- a/extensions/vscode/src/interpreters/pythonDependencySources.test.ts
+++ b/extensions/vscode/src/interpreters/pythonDependencySources.test.ts
@@ -306,6 +306,19 @@ created-by = "uv"
     expect(result).toBeNull();
   });
 
+  test("returns empty array when packages section is empty", async () => {
+    setFile(
+      "/project",
+      "pylock.toml",
+      `lock-version = "1.0"
+created-by = "uv"
+packages = []
+`,
+    );
+    const result = await readPyLockDependencies("/project");
+    expect(result).toEqual([]);
+  });
+
   test("returns null on invalid TOML", async () => {
     setFile("/project", "pylock.toml", "not valid toml {{{");
     const result = await readPyLockDependencies("/project");

--- a/extensions/vscode/src/interpreters/pythonDependencySources.test.ts
+++ b/extensions/vscode/src/interpreters/pythonDependencySources.test.ts
@@ -1,0 +1,447 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import path from "node:path";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  readPyProjectDependencies,
+  readPyLockDependencies,
+  readUvLockDependencies,
+  generateRequirements,
+} from "./pythonDependencySources";
+
+const mockFiles: Record<string, string> = {};
+
+vi.mock("./fsUtils", () => ({
+  readFileText: vi.fn((filePath: string) => {
+    const content = mockFiles[filePath];
+    if (content === undefined) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(content);
+  }),
+}));
+
+function setFile(dir: string, filename: string, content: string) {
+  mockFiles[path.join(dir, filename)] = content;
+}
+
+function clearFiles() {
+  for (const key of Object.keys(mockFiles)) {
+    delete mockFiles[key];
+  }
+}
+
+describe("readPyProjectDependencies", () => {
+  beforeEach(clearFiles);
+
+  test("returns null when pyproject.toml doesn't exist", async () => {
+    const result = await readPyProjectDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when no [project] section", async () => {
+    setFile("/project", "pyproject.toml", "[tool.ruff]\nline-length = 88\n");
+    const result = await readPyProjectDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when no dependencies key", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      '[project]\nname = "myproject"\nversion = "1.0"\n',
+    );
+    const result = await readPyProjectDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("reads direct dependencies", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = [
+  "requests>=2.20",
+  "numpy>=1.21",
+  "pandas",
+]
+`,
+    );
+    const result = await readPyProjectDependencies("/project");
+    expect(result).toEqual(["requests>=2.20", "numpy>=1.21", "pandas"]);
+  });
+
+  test("returns empty array when dependencies is empty", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      '[project]\nname = "myproject"\ndependencies = []\n',
+    );
+    const result = await readPyProjectDependencies("/project");
+    expect(result).toEqual([]);
+  });
+
+  test("includes optional dependency groups when specified", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["requests"]
+
+[project.optional-dependencies]
+dev = ["pytest", "black"]
+docs = ["sphinx"]
+`,
+    );
+    const result = await readPyProjectDependencies("/project", ["dev"]);
+    expect(result).toEqual(["requests", "pytest", "black"]);
+  });
+
+  test("includes multiple optional groups", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["requests"]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+docs = ["sphinx"]
+`,
+    );
+    const result = await readPyProjectDependencies("/project", ["dev", "docs"]);
+    expect(result).toEqual(["requests", "pytest", "sphinx"]);
+  });
+
+  test("ignores non-existent optional groups", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["requests"]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+`,
+    );
+    const result = await readPyProjectDependencies("/project", ["nonexistent"]);
+    expect(result).toEqual(["requests"]);
+  });
+
+  test("returns null on invalid TOML", async () => {
+    setFile("/project", "pyproject.toml", "this is not valid toml {{{}}}");
+    const result = await readPyProjectDependencies("/project");
+    expect(result).toBeNull();
+  });
+});
+
+describe("readUvLockDependencies", () => {
+  beforeEach(clearFiles);
+
+  test("returns null when uv.lock doesn't exist", async () => {
+    const result = await readUvLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("reads packages excluding root editable project", async () => {
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "my-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+  { name = "requests" },
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "urllib3"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+`,
+    );
+    const result = await readUvLockDependencies("/project");
+    expect(result).toEqual(["requests==2.31.0", "urllib3==2.1.0"]);
+  });
+
+  test("excludes virtual source packages", async () => {
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+
+[[package]]
+name = "my-project"
+version = "0.1.0"
+source = { virtual = "." }
+
+[[package]]
+name = "flask"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+`,
+    );
+    const result = await readUvLockDependencies("/project");
+    expect(result).toEqual(["flask==3.0.2"]);
+  });
+
+  test("skips packages without version", async () => {
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+
+[[package]]
+name = "mystery"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "flask"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+`,
+    );
+    const result = await readUvLockDependencies("/project");
+    expect(result).toEqual(["flask==3.0.2"]);
+  });
+
+  test("returns null when no packages found", async () => {
+    setFile("/project", "uv.lock", "version = 1\n");
+    const result = await readUvLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when only root project exists", async () => {
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+
+[[package]]
+name = "my-project"
+version = "0.1.0"
+source = { editable = "." }
+`,
+    );
+    const result = await readUvLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on invalid TOML", async () => {
+    setFile("/project", "uv.lock", "not valid toml {{{");
+    const result = await readUvLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+});
+
+describe("readPyLockDependencies", () => {
+  beforeEach(clearFiles);
+
+  test("returns null when pylock.toml doesn't exist", async () => {
+    const result = await readPyLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("reads packages with name and version", async () => {
+    setFile(
+      "/project",
+      "pylock.toml",
+      `lock-version = "1.0"
+created-by = "uv"
+
+[[packages]]
+name = "requests"
+version = "2.31.0"
+
+[[packages]]
+name = "urllib3"
+version = "2.1.0"
+`,
+    );
+    const result = await readPyLockDependencies("/project");
+    expect(result).toEqual(["requests==2.31.0", "urllib3==2.1.0"]);
+  });
+
+  test("skips packages without version", async () => {
+    setFile(
+      "/project",
+      "pylock.toml",
+      `lock-version = "1.0"
+created-by = "uv"
+
+[[packages]]
+name = "mystery"
+
+[[packages]]
+name = "flask"
+version = "3.0.2"
+`,
+    );
+    const result = await readPyLockDependencies("/project");
+    expect(result).toEqual(["flask==3.0.2"]);
+  });
+
+  test("returns null when no packages found", async () => {
+    setFile(
+      "/project",
+      "pylock.toml",
+      `lock-version = "1.0"
+created-by = "uv"
+`,
+    );
+    const result = await readPyLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on invalid TOML", async () => {
+    setFile("/project", "pylock.toml", "not valid toml {{{");
+    const result = await readPyLockDependencies("/project");
+    expect(result).toBeNull();
+  });
+});
+
+describe("generateRequirements", () => {
+  beforeEach(clearFiles);
+
+  test("returns null when no source file exists", async () => {
+    const result = await generateRequirements("/project");
+    expect(result).toBeNull();
+  });
+
+  test("prefers pylock.toml over uv.lock and pyproject.toml", async () => {
+    setFile(
+      "/project",
+      "pylock.toml",
+      `lock-version = "1.0"
+created-by = "uv"
+
+[[packages]]
+name = "flask"
+version = "3.0.1"
+`,
+    );
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+
+[[package]]
+name = "flask"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+`,
+    );
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["flask>=3.0"]
+`,
+    );
+    const result = await generateRequirements("/project");
+    // Should use pylock.toml (PEP 751), not uv.lock or pyproject.toml
+    expect(result).toEqual(["flask==3.0.1"]);
+  });
+
+  test("prefers uv.lock over pyproject.toml when no pylock.toml", async () => {
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+
+[[package]]
+name = "flask"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+`,
+    );
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["flask>=3.0"]
+`,
+    );
+    const result = await generateRequirements("/project");
+    // Should use uv.lock (pinned version), not pyproject.toml
+    expect(result).toEqual(["flask==3.0.2"]);
+  });
+
+  test("falls back to pyproject.toml when no lockfiles", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["requests>=2.20", "numpy"]
+`,
+    );
+    const result = await generateRequirements("/project");
+    expect(result).toEqual(["requests>=2.20", "numpy"]);
+  });
+
+  test("passes optional groups to pyproject.toml fallback", async () => {
+    setFile(
+      "/project",
+      "pyproject.toml",
+      `[project]
+name = "myproject"
+dependencies = ["requests"]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+`,
+    );
+    const result = await generateRequirements("/project", ["dev"]);
+    expect(result).toEqual(["requests", "pytest"]);
+  });
+
+  test("ignores optional groups when using pylock.toml", async () => {
+    setFile(
+      "/project",
+      "pylock.toml",
+      `lock-version = "1.0"
+created-by = "uv"
+
+[[packages]]
+name = "flask"
+version = "3.0.2"
+`,
+    );
+    // Even with optional groups specified, pylock.toml returns its full set
+    const result = await generateRequirements("/project", ["dev"]);
+    expect(result).toEqual(["flask==3.0.2"]);
+  });
+
+  test("ignores optional groups when using uv.lock", async () => {
+    setFile(
+      "/project",
+      "uv.lock",
+      `version = 1
+
+[[package]]
+name = "flask"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+`,
+    );
+    // Even with optional groups specified, uv.lock returns its full set
+    const result = await generateRequirements("/project", ["dev"]);
+    expect(result).toEqual(["flask==3.0.2"]);
+  });
+});

--- a/extensions/vscode/src/interpreters/pythonDependencySources.ts
+++ b/extensions/vscode/src/interpreters/pythonDependencySources.ts
@@ -105,7 +105,7 @@ export async function readPyLockDependencies(
     result.push(`${pkg.name}==${pkg.version}`);
   }
 
-  return result.length > 0 ? result : null;
+  return result;
 }
 
 /** Shape of a [[package]] entry in uv.lock */
@@ -157,7 +157,7 @@ export async function readUvLockDependencies(
     result.push(`${pkg.name}==${pkg.version}`);
   }
 
-  return result.length > 0 ? result : null;
+  return result;
 }
 
 /**

--- a/extensions/vscode/src/interpreters/pythonDependencySources.ts
+++ b/extensions/vscode/src/interpreters/pythonDependencySources.ts
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import path from "node:path";
+import { parse as parseTOML } from "smol-toml";
+
+import { readFileText } from "./fsUtils";
+
+/**
+ * Read Python dependencies from pyproject.toml's [project].dependencies.
+ *
+ * Optionally includes packages from [project.optional-dependencies] for the
+ * specified groups.
+ *
+ * Returns PEP 508 dependency specifier strings (e.g. "requests>=2.20"),
+ * or null if the file doesn't exist or has no [project].dependencies.
+ */
+export async function readPyProjectDependencies(
+  projectDir: string,
+  optionalGroups?: string[],
+): Promise<string[] | null> {
+  const content = await readFileText(path.join(projectDir, "pyproject.toml"));
+  if (content === null) {
+    return null;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseTOML(content) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const project = parsed.project;
+  if (!project || typeof project !== "object") {
+    return null;
+  }
+
+  const projectTable = project as Record<string, unknown>;
+  const deps = projectTable.dependencies;
+  if (!Array.isArray(deps)) {
+    return null;
+  }
+
+  const result: string[] = deps.filter(
+    (d): d is string => typeof d === "string",
+  );
+
+  if (optionalGroups && optionalGroups.length > 0) {
+    const optDeps = projectTable["optional-dependencies"];
+    if (optDeps && typeof optDeps === "object") {
+      const optTable = optDeps as Record<string, unknown>;
+      for (const group of optionalGroups) {
+        const groupDeps = optTable[group];
+        if (Array.isArray(groupDeps)) {
+          for (const d of groupDeps) {
+            if (typeof d === "string") {
+              result.push(d);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Shape of a [[packages]] entry in pylock.toml (PEP 751) */
+interface PyLockPackage {
+  name: string;
+  version?: string;
+}
+
+/**
+ * Read all pinned dependencies from a pylock.toml file (PEP 751).
+ *
+ * Returns the full dependency set as "name==version" strings.
+ * Returns null if the file doesn't exist.
+ */
+export async function readPyLockDependencies(
+  projectDir: string,
+): Promise<string[] | null> {
+  const content = await readFileText(path.join(projectDir, "pylock.toml"));
+  if (content === null) {
+    return null;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseTOML(content) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const packages = parsed.packages;
+  if (!Array.isArray(packages)) {
+    return null;
+  }
+
+  const result: string[] = [];
+  for (const pkg of packages as PyLockPackage[]) {
+    if (!pkg.name || !pkg.version) {
+      continue;
+    }
+    result.push(`${pkg.name}==${pkg.version}`);
+  }
+
+  return result.length > 0 ? result : null;
+}
+
+/** Shape of a [[package]] entry in uv.lock */
+interface UvLockPackage {
+  name: string;
+  version?: string;
+  source?: { editable?: string; registry?: string; virtual?: string };
+}
+
+/**
+ * Read all pinned dependencies from a uv.lock file.
+ *
+ * Returns the full transitive dependency set as "name==version" strings,
+ * excluding the root project (identified by an editable or virtual source).
+ * Returns null if the file doesn't exist.
+ */
+export async function readUvLockDependencies(
+  projectDir: string,
+): Promise<string[] | null> {
+  const content = await readFileText(path.join(projectDir, "uv.lock"));
+  if (content === null) {
+    return null;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseTOML(content) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const packages = parsed.package;
+  if (!Array.isArray(packages)) {
+    return null;
+  }
+
+  const result: string[] = [];
+  for (const pkg of packages as UvLockPackage[]) {
+    // Skip the root project entry
+    if (pkg.source?.editable !== undefined) {
+      continue;
+    }
+    if (pkg.source?.virtual !== undefined) {
+      continue;
+    }
+    if (!pkg.name || !pkg.version) {
+      continue;
+    }
+    result.push(`${pkg.name}==${pkg.version}`);
+  }
+
+  return result.length > 0 ? result : null;
+}
+
+/**
+ * Try to generate Python requirements from pylock.toml, uv.lock, or pyproject.toml.
+ *
+ * Priority: pylock.toml (PEP 751, pinned) > uv.lock (pinned, full transitive set)
+ *         > pyproject.toml (declared).
+ * Returns the requirement lines, or null if no source is available.
+ *
+ * Note: readPyProjectDependencies accepts an optionalGroups parameter for including
+ * [project.optional-dependencies] groups. This will be wired through once the
+ * optional_dependency_groups config field is added to the publishing schema.
+ */
+export async function generateRequirements(
+  projectDir: string,
+  optionalGroups?: string[],
+): Promise<string[] | null> {
+  const fromPyLock = await readPyLockDependencies(projectDir);
+  if (fromPyLock !== null) {
+    return fromPyLock;
+  }
+
+  const fromUvLock = await readUvLockDependencies(projectDir);
+  if (fromUvLock !== null) {
+    return fromUvLock;
+  }
+
+  const fromPyProject = await readPyProjectDependencies(
+    projectDir,
+    optionalGroups,
+  );
+  if (fromPyProject !== null) {
+    return fromPyProject;
+  }
+
+  return null;
+}

--- a/extensions/vscode/src/interpreters/pythonPackages.test.ts
+++ b/extensions/vscode/src/interpreters/pythonPackages.test.ts
@@ -117,4 +117,13 @@ describe("getPythonPackages", () => {
     expect(result).toEqual(["numpy"]);
     expect(generateRequirements).not.toHaveBeenCalled();
   });
+
+  test("does not fall back for non-default package files", async () => {
+    // If the user explicitly configured a different package file,
+    // missing it should throw — not silently substitute generated deps.
+    await expect(
+      getPythonPackages("/project", "requirements-dev.txt"),
+    ).rejects.toThrow("Requirements file not found");
+    expect(generateRequirements).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/vscode/src/interpreters/pythonPackages.test.ts
+++ b/extensions/vscode/src/interpreters/pythonPackages.test.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { getPythonPackages, readRequirementsFile } from "./pythonPackages";
+import { generateRequirements } from "./pythonDependencySources";
 
 const mockFiles: Record<string, string> = {};
 
@@ -14,6 +15,10 @@ vi.mock("./fsUtils", () => ({
     }
     return Promise.resolve(content);
   }),
+}));
+
+vi.mock("./pythonDependencySources", () => ({
+  generateRequirements: vi.fn(() => Promise.resolve(null)),
 }));
 
 function setFile(dir: string, filename: string, content: string) {
@@ -68,6 +73,7 @@ describe("getPythonPackages", () => {
     for (const key of Object.keys(mockFiles)) {
       delete mockFiles[key];
     }
+    vi.clearAllMocks();
   });
 
   test("returns packages from a requirements file", async () => {
@@ -86,5 +92,29 @@ describe("getPythonPackages", () => {
     setFile("/project", "requirements-dev.txt", "flask\n");
     const result = await getPythonPackages("/project", "requirements-dev.txt");
     expect(result).toEqual(["flask"]);
+  });
+
+  test("falls back to generated requirements when file missing", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce([
+      "flask==3.0.2",
+      "urllib3==2.1.0",
+    ]);
+    const result = await getPythonPackages("/project", "requirements.txt");
+    expect(result).toEqual(["flask==3.0.2", "urllib3==2.1.0"]);
+  });
+
+  test("throws when file missing and no lockfile source available", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce(null);
+    await expect(
+      getPythonPackages("/project", "requirements.txt"),
+    ).rejects.toThrow("Requirements file not found");
+  });
+
+  test("prefers requirements file over generated requirements", async () => {
+    setFile("/project", "requirements.txt", "numpy\n");
+    vi.mocked(generateRequirements).mockResolvedValueOnce(["flask==3.0.2"]);
+    const result = await getPythonPackages("/project", "requirements.txt");
+    expect(result).toEqual(["numpy"]);
+    expect(generateRequirements).not.toHaveBeenCalled();
   });
 });

--- a/extensions/vscode/src/interpreters/pythonPackages.ts
+++ b/extensions/vscode/src/interpreters/pythonPackages.ts
@@ -2,6 +2,7 @@
 
 import path from "node:path";
 
+import { DEFAULT_PYTHON_PACKAGE_FILE } from "../constants";
 import { readFileText } from "./fsUtils";
 import { generateRequirements } from "./pythonDependencySources";
 
@@ -25,8 +26,10 @@ export async function readRequirementsFile(
 /**
  * Get the list of Python packages from a project's requirements file.
  *
- * If the requirements file does not exist, falls back to generating
- * requirements from pylock.toml, uv.lock, or pyproject.toml.
+ * If the default requirements file (requirements.txt) does not exist,
+ * falls back to generating requirements from pylock.toml, uv.lock, or
+ * pyproject.toml. Non-default package files are never auto-generated —
+ * if they're missing, this throws immediately.
  * Throws if no dependency source is available.
  */
 export async function getPythonPackages(
@@ -39,10 +42,14 @@ export async function getPythonPackages(
     return packages;
   }
 
-  // No requirements file on disk — try generating from pylock.toml / uv.lock / pyproject.toml
-  const generated = await generateRequirements(projectDir);
-  if (generated !== null) {
-    return generated;
+  // Only fall back to lockfile generation for the default package file.
+  // If the user explicitly configured a different file, they expect that
+  // specific file — don't silently substitute generated dependencies.
+  if (packageFile === DEFAULT_PYTHON_PACKAGE_FILE) {
+    const generated = await generateRequirements(projectDir);
+    if (generated !== null) {
+      return generated;
+    }
   }
 
   throw new Error(`Requirements file not found: ${filePath}`);

--- a/extensions/vscode/src/interpreters/pythonPackages.ts
+++ b/extensions/vscode/src/interpreters/pythonPackages.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 
 import { readFileText } from "./fsUtils";
+import { generateRequirements } from "./pythonDependencySources";
 
 /**
  * Read a Python requirements file and return its package lines,
@@ -23,7 +24,10 @@ export async function readRequirementsFile(
 
 /**
  * Get the list of Python packages from a project's requirements file.
- * Throws if the requirements file does not exist.
+ *
+ * If the requirements file does not exist, falls back to generating
+ * requirements from pylock.toml, uv.lock, or pyproject.toml.
+ * Throws if no dependency source is available.
  */
 export async function getPythonPackages(
   projectDir: string,
@@ -31,8 +35,15 @@ export async function getPythonPackages(
 ): Promise<string[]> {
   const filePath = path.join(projectDir, packageFile);
   const packages = await readRequirementsFile(filePath);
-  if (packages === null) {
-    throw new Error(`Requirements file not found: ${filePath}`);
+  if (packages !== null) {
+    return packages;
   }
-  return packages;
+
+  // No requirements file on disk — try generating from pylock.toml / uv.lock / pyproject.toml
+  const generated = await generateRequirements(projectDir);
+  if (generated !== null) {
+    return generated;
+  }
+
+  throw new Error(`Requirements file not found: ${filePath}`);
 }

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -26,6 +26,7 @@ import type {
   User,
 } from "@posit-dev/connect-api";
 import { AxiosError, AxiosHeaders } from "axios";
+import { generateRequirements } from "../interpreters/pythonDependencySources";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -102,6 +103,11 @@ vi.mock("../interpreters/rPackages", () => ({
 // Mock fsUtils — default to true so preflight requirements check passes
 vi.mock("../interpreters/fsUtils", () => ({
   fileExistsAt: vi.fn().mockResolvedValue(true),
+}));
+
+// Mock dependency source generation (pylock.toml / uv.lock / pyproject.toml fallback)
+vi.mock("../interpreters/pythonDependencySources", () => ({
+  generateRequirements: vi.fn(() => Promise.resolve(null)),
 }));
 
 // Mock TOML stringify — pass through to allow content inspection
@@ -1831,6 +1837,118 @@ describe("connectPublish — preflight validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).resolves.toBeDefined();
+  });
+});
+
+describe("connectPublish — generated requirements from lockfiles", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Default: requirements file does NOT exist on disk
+    const { fileExistsAt } = await import("../interpreters/fsUtils");
+    vi.mocked(fileExistsAt).mockResolvedValue(false);
+  });
+
+  test("succeeds when requirements file missing but lockfile generation works", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce([
+      "flask==3.0.2",
+      "urllib3==2.1.0",
+    ]);
+
+    const config = makeConfig({
+      files: ["app.py", "requirements.txt"],
+      python: {
+        version: "3.11.0",
+        packageFile: "requirements.txt",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).resolves.toBeDefined();
+  });
+
+  test("still rejects when requirements file missing and no lockfile source", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce(null);
+
+    const config = makeConfig({
+      python: {
+        version: "3.11.0",
+        packageFile: "requirements.txt",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file requirements.txt",
+    );
+  });
+
+  test("uses generated requirements for deployment record", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce([
+      "flask==3.0.2",
+      "urllib3==2.1.0",
+    ]);
+
+    const config = makeConfig({
+      files: ["app.py", "requirements.txt"],
+      python: {
+        version: "3.11.0",
+        packageFile: "requirements.txt",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await connectPublish(opts);
+
+    // Check the last writeFile call for the deployment record
+    const lastWrite = mockWriteFile.mock.calls.at(-1);
+    expect(lastWrite).toBeDefined();
+    const tomlContent = lastWrite![1] as string;
+    expect(tomlContent).toContain("flask==3.0.2");
+    expect(tomlContent).toContain("urllib3==2.1.0");
+  });
+
+  test("passes synthetic files to bundler when generating", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce(["flask==3.0.2"]);
+
+    const config = makeConfig({
+      files: ["app.py", "requirements.txt"],
+      python: {
+        version: "3.11.0",
+        packageFile: "requirements.txt",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await connectPublish(opts);
+
+    const { createBundle } = await import("../bundler/bundler");
+    const bundleCall = vi.mocked(createBundle).mock.calls[0]?.[0];
+    expect(bundleCall?.syntheticFiles).toBeDefined();
+    expect(
+      bundleCall?.syntheticFiles?.get("requirements.txt")?.toString(),
+    ).toBe("flask==3.0.2\n");
+  });
+
+  test("does not generate when requirements file exists on disk", async () => {
+    const { fileExistsAt } = await import("../interpreters/fsUtils");
+    vi.mocked(fileExistsAt).mockResolvedValue(true);
+
+    const config = makeConfig({
+      files: ["app.py", "requirements.txt"],
+      python: {
+        version: "3.11.0",
+        packageFile: "requirements.txt",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await connectPublish(opts);
+    expect(generateRequirements).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -1950,6 +1950,22 @@ describe("connectPublish — generated requirements from lockfiles", () => {
     await connectPublish(opts);
     expect(generateRequirements).not.toHaveBeenCalled();
   });
+
+  test("does not fall back for non-default package files", async () => {
+    const config = makeConfig({
+      python: {
+        version: "3.11.0",
+        packageFile: "requirements-dev.txt",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file requirements-dev.txt",
+    );
+    expect(generateRequirements).not.toHaveBeenCalled();
+  });
 });
 
 describe("connectPublish — server settings validation", () => {

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -1933,6 +1933,31 @@ describe("connectPublish — generated requirements from lockfiles", () => {
     ).toBe("flask==3.0.2\n");
   });
 
+  test("patches manifest package_file when generating from lockfiles", async () => {
+    vi.mocked(generateRequirements).mockResolvedValueOnce(["flask==3.0.2"]);
+
+    // When no requirements.txt exists, the interpreter sets packageFile to "".
+    // The manifest is built before preflight, so it initially gets package_file: "".
+    // After generation, the manifest must be patched so Connect finds the file.
+    const config = makeConfig({
+      files: ["app.py", "requirements.txt"],
+      python: {
+        version: "3.11.0",
+        packageFile: "",
+        packageManager: "pip",
+      },
+    });
+    const opts = makeOptions({ config });
+
+    await connectPublish(opts);
+
+    const { createBundle } = await import("../bundler/bundler");
+    const bundleCall = vi.mocked(createBundle).mock.calls[0]?.[0];
+    expect(bundleCall?.manifest?.python?.package_manager?.package_file).toBe(
+      "requirements.txt",
+    );
+  });
+
   test("does not generate when requirements file exists on disk", async () => {
     const { fileExistsAt } = await import("../interpreters/fsUtils");
     vi.mocked(fileExistsAt).mockResolvedValue(true);

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -41,6 +41,7 @@ import { convertKeysToSnakeCase } from "../toml/convertKeys";
 import { stripEmpty, isRecord, expandInlineArrays } from "../toml/tomlHelpers";
 import { getDashboardUrl, getDirectUrl, getLogsUrl } from "../toml/urlHelpers";
 import { fileExistsAt } from "../interpreters/fsUtils";
+import { generateRequirements } from "../interpreters/pythonDependencySources";
 import { logger } from "../logging";
 import type { ErrorCode } from "../utils/errorTypes";
 
@@ -275,33 +276,40 @@ export async function connectPublish(
       throw new Error("The description cannot be longer than 4096 characters.");
     }
 
+    let generatedRequirements: string[] | undefined;
+
     if (config.python) {
       const packageFile = config.python.packageFile || "requirements.txt";
       const packageFilePath = path.join(projectDir, packageFile);
       const packageFileExists = await fileExistsAt(packageFilePath);
 
-      // Check that the file exists on disk
-      if (!packageFileExists) {
-        throw new Error(
-          `Missing dependency file ${packageFile}. ` +
-            `This file must be included in the deployment.`,
+      if (packageFileExists) {
+        // Check that the file is included in the configured file patterns.
+        // Uses suffix matching, not glob evaluation — matches Go's
+        // checkRequirementsFile which uses strings.HasSuffix(file, packageFile).
+        // Go always requires the file in cfg.Files, even when the list is empty
+        // (the loop produces no match, so requirementsIsIncluded stays false).
+        const filePatterns = config.files ?? [];
+        const isIncluded = filePatterns.some((pattern) =>
+          pattern.endsWith(packageFile),
         );
-      }
-
-      // Check that the file is included in the configured file patterns.
-      // Uses suffix matching, not glob evaluation — matches Go's
-      // checkRequirementsFile which uses strings.HasSuffix(file, packageFile).
-      // Go always requires the file in cfg.Files, even when the list is empty
-      // (the loop produces no match, so requirementsIsIncluded stays false).
-      const filePatterns = config.files ?? [];
-      const isIncluded = filePatterns.some((pattern) =>
-        pattern.endsWith(packageFile),
-      );
-      if (!isIncluded) {
-        throw new Error(
-          `Missing dependency file ${packageFile}. ` +
-            `This file must be included in the deployment.`,
-        );
+        if (!isIncluded) {
+          throw new Error(
+            `Missing dependency file ${packageFile}. ` +
+              `This file must be included in the deployment.`,
+          );
+        }
+      } else {
+        // No requirements file on disk — try generating from lockfiles
+        const generated = await generateRequirements(projectDir);
+        if (generated !== null) {
+          generatedRequirements = generated;
+        } else {
+          throw new Error(
+            `Missing dependency file ${packageFile}. ` +
+              `This file must be included in the deployment.`,
+          );
+        }
       }
     }
 
@@ -435,6 +443,18 @@ export async function connectPublish(
       status: "log",
       message: "Preparing files",
     });
+
+    // Build synthetic files map if requirements were generated from lockfiles
+    let syntheticFiles: Map<string, Buffer> | undefined;
+    if (generatedRequirements && config.python) {
+      const packageFile = config.python.packageFile || "requirements.txt";
+      syntheticFiles = new Map<string, Buffer>();
+      syntheticFiles.set(
+        packageFile,
+        Buffer.from(generatedRequirements.join("\n") + "\n"),
+      );
+    }
+
     const { bundle, manifest: finalManifest } = await buildBundleArchive(
       projectDir,
       config,
@@ -472,13 +492,21 @@ export async function connectPublish(
             break;
         }
       },
+      syntheticFiles,
     );
     record.files = getFilenames(finalManifest);
 
     // Record dependencies in the deployment record
-    const pythonReqs = await readPythonRequirements(projectDir, config.python);
-    if (pythonReqs) {
-      record.requirements = pythonReqs;
+    if (generatedRequirements) {
+      record.requirements = generatedRequirements;
+    } else {
+      const pythonReqs = await readPythonRequirements(
+        projectDir,
+        config.python,
+      );
+      if (pythonReqs) {
+        record.requirements = pythonReqs;
+      }
     }
     if (lockfile) {
       record.renv = lockfileToDeploymentRenv(lockfile);
@@ -1192,6 +1220,7 @@ async function buildBundleArchive(
   manifest: Manifest,
   lockfilePath: string | undefined,
   onBundleProgress?: BundleProgressCallback,
+  syntheticFiles?: Map<string, Buffer>,
 ): Promise<{ bundle: Buffer; manifest: Manifest }> {
   const basePatterns = config.files?.length ? [...config.files] : ["*"];
   const extraPatterns: string[] = [];
@@ -1216,6 +1245,7 @@ async function buildBundleArchive(
       manifest,
       filePatterns,
       onProgress: onBundleProgress,
+      syntheticFiles,
     });
 
     return { bundle: result.bundle, manifest: result.manifest };

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -299,8 +299,10 @@ export async function connectPublish(
               `This file must be included in the deployment.`,
           );
         }
-      } else {
-        // No requirements file on disk — try generating from lockfiles
+      } else if (packageFile === "requirements.txt") {
+        // No default requirements file on disk — try generating from lockfiles.
+        // Only fall back for the default file name; non-default files are
+        // explicitly configured and should not be silently substituted.
         const generated = await generateRequirements(projectDir);
         if (generated !== null) {
           generatedRequirements = generated;
@@ -310,6 +312,11 @@ export async function connectPublish(
               `This file must be included in the deployment.`,
           );
         }
+      } else {
+        throw new Error(
+          `Missing dependency file ${packageFile}. ` +
+            `This file must be included in the deployment.`,
+        );
       }
     }
 

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -40,6 +40,7 @@ import { forceProductTypeCompliance } from "../toml/configCompliance";
 import { convertKeysToSnakeCase } from "../toml/convertKeys";
 import { stripEmpty, isRecord, expandInlineArrays } from "../toml/tomlHelpers";
 import { getDashboardUrl, getDirectUrl, getLogsUrl } from "../toml/urlHelpers";
+import { DEFAULT_PYTHON_PACKAGE_FILE } from "../constants";
 import { fileExistsAt } from "../interpreters/fsUtils";
 import { generateRequirements } from "../interpreters/pythonDependencySources";
 import { logger } from "../logging";
@@ -299,7 +300,7 @@ export async function connectPublish(
               `This file must be included in the deployment.`,
           );
         }
-      } else if (packageFile === "requirements.txt") {
+      } else if (packageFile === DEFAULT_PYTHON_PACKAGE_FILE) {
         // No default requirements file on disk — try generating from lockfiles.
         // Only fall back for the default file name; non-default files are
         // explicitly configured and should not be silently substituted.

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -280,7 +280,8 @@ export async function connectPublish(
     let generatedRequirements: string[] | undefined;
 
     if (config.python) {
-      const packageFile = config.python.packageFile || "requirements.txt";
+      const packageFile =
+        config.python.packageFile || DEFAULT_PYTHON_PACKAGE_FILE;
       const packageFilePath = path.join(projectDir, packageFile);
       const packageFileExists = await fileExistsAt(packageFilePath);
 
@@ -455,7 +456,8 @@ export async function connectPublish(
     // Build synthetic files map if requirements were generated from lockfiles
     let syntheticFiles: Map<string, Buffer> | undefined;
     if (generatedRequirements && config.python) {
-      const packageFile = config.python.packageFile || "requirements.txt";
+      const packageFile =
+        config.python.packageFile || DEFAULT_PYTHON_PACKAGE_FILE;
       syntheticFiles = new Map<string, Buffer>();
       syntheticFiles.set(
         packageFile,

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -308,6 +308,13 @@ export async function connectPublish(
         const generated = await generateRequirements(projectDir);
         if (generated !== null) {
           generatedRequirements = generated;
+          // The manifest was built before preflight, so its package_file
+          // reflects the config's original empty value. Patch it to match
+          // the synthetic file we'll inject into the bundle.
+          if (manifest.python?.package_manager) {
+            manifest.python.package_manager.package_file =
+              DEFAULT_PYTHON_PACKAGE_FILE;
+          }
         } else {
           throw new Error(
             `Missing dependency file ${packageFile}. ` +

--- a/extensions/vscode/src/publish/dependencies.ts
+++ b/extensions/vscode/src/publish/dependencies.ts
@@ -17,7 +17,10 @@ const DEFAULT_R_PACKAGE_FILE = "renv.lock";
  * Read Python requirements from the configured package file.
  * Returns the parsed requirement lines for the deployment record,
  * or undefined if the config has no Python section.
- * Throws if the requirements file does not exist.
+ *
+ * If the package file does not exist, falls back to generating
+ * requirements from pylock.toml, uv.lock, or pyproject.toml.
+ * Throws if no dependency source is available.
  */
 export async function readPythonRequirements(
   projectDir: string,

--- a/extensions/vscode/src/publish/dependencies.ts
+++ b/extensions/vscode/src/publish/dependencies.ts
@@ -18,9 +18,9 @@ const DEFAULT_R_PACKAGE_FILE = "renv.lock";
  * Returns the parsed requirement lines for the deployment record,
  * or undefined if the config has no Python section.
  *
- * If the package file does not exist, falls back to generating
- * requirements from pylock.toml, uv.lock, or pyproject.toml.
- * Throws if no dependency source is available.
+ * If the default package file (requirements.txt) does not exist,
+ * falls back to generating requirements from pylock.toml, uv.lock,
+ * or pyproject.toml. Throws if no dependency source is available.
  */
 export async function readPythonRequirements(
   projectDir: string,

--- a/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
@@ -20,7 +20,7 @@
             "version": {},
             "package_file": {
               "type": "string",
-              "description": "File containing package dependencies. The file must exist and be listed under 'files'. The default is 'requirements.txt'.",
+              "description": "File containing package dependencies. If the file does not exist, it will be generated from pylock.toml, uv.lock, or pyproject.toml if available. The default is 'requirements.txt'.",
               "default": "requirements.txt",
               "examples": ["requirements.txt"]
             },

--- a/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
@@ -20,7 +20,7 @@
             "version": {},
             "package_file": {
               "type": "string",
-              "description": "File containing package dependencies. If the file does not exist, it will be generated from pylock.toml, uv.lock, or pyproject.toml if available. The default is 'requirements.txt'.",
+              "description": "File containing package dependencies. When set to the default 'requirements.txt' and the file does not exist, requirements will be generated from pylock.toml, uv.lock, or pyproject.toml if available.",
               "default": "requirements.txt",
               "examples": ["requirements.txt"]
             },

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -20,7 +20,7 @@
             "version": {},
             "package_file": {
               "type": "string",
-              "description": "File containing package dependencies. The file must exist and be listed under 'files'. The default is 'requirements.txt'.",
+              "description": "File containing package dependencies. If the file does not exist, it will be generated from pylock.toml, uv.lock, or pyproject.toml if available. The default is 'requirements.txt'.",
               "default": "requirements.txt",
               "examples": ["requirements.txt"]
             },

--- a/internal/schema/schemas/posit-publishing-schema-v3.json
+++ b/internal/schema/schemas/posit-publishing-schema-v3.json
@@ -20,7 +20,7 @@
             "version": {},
             "package_file": {
               "type": "string",
-              "description": "File containing package dependencies. If the file does not exist, it will be generated from pylock.toml, uv.lock, or pyproject.toml if available. The default is 'requirements.txt'.",
+              "description": "File containing package dependencies. When set to the default 'requirements.txt' and the file does not exist, requirements will be generated from pylock.toml, uv.lock, or pyproject.toml if available.",
               "default": "requirements.txt",
               "examples": ["requirements.txt"]
             },


### PR DESCRIPTION
## Summary

Adapts the TypeScript portions of #3883 to the current main branch, dropping all Go changes since that code is being migrated away. Key decisions and differences from the original PR:

- **TS-only**: No Go parser code. The lockfile parsers (`pythonDependencySources.ts`) and all wiring live entirely in the VSCode extension TypeScript.
- **"Generate once, use twice"**: Requirements are generated during preflight and stashed as `string[]`. The same array feeds both a synthetic `requirements.txt` in the bundle archive and the deployment record — no redundant lockfile parsing.
- **Synthetic file injection**: Added `syntheticFiles` support to the bundler so generated requirements can be included in the tar archive without writing a temporary file to disk. Synthetic files participate in `onProgress` callbacks and manifest hashing.
- **Empty-is-authoritative semantics**: An empty `packages` array in a lockfile (e.g., pylock.toml with `packages = []`) returns `[]`, stopping the priority chain. A missing section returns `null`, allowing fallback to the next source. Priority: pylock.toml > uv.lock > pyproject.toml.
- **Gated fallback**: Lockfile generation only triggers for the default `requirements.txt`. If the user configured a custom `package_file`, a missing file throws immediately rather than silently substituting generated dependencies.
- **Resolved bundler conflicts**: The original PR's `syntheticFiles` parameter and main's `onProgress` callback both touched the same function signatures in `archive.ts` / `bundler.ts` — merged both additions.

Closes #2824

## Test plan

- [ ] 29 unit tests for lockfile parsers (`pythonDependencySources.test.ts`) — all formats, priority ordering, edge cases, empty-vs-missing semantics
- [ ] 12 unit tests for `pythonPackages.ts` — fallback logic, gated on default file, preference for on-disk file
- [ ] 98 unit tests for `connectPublish.ts` — including 6 new tests for generated requirements (preflight, bundler synthetic files, deployment record, no-fallback cases)
- [ ] 2 bundler tests for synthetic file injection and progress events

### Manual tests
- [x] pylock.toml is used as requirements source
- [x] uv.lock is used as requirements source
- [x] pyproject.toml is used as requirements source
- [x] pylock.toml is used when all three options are present
- [x] existing requirements.txt is preferred when present
- [x] project with no dependency source fails preflight with clear error
- [x] project with custom package file (overriding "requirements.txt") fails preflight when that file is missing (does not fall back to scanning other lock files)
- [x] project with custom package file uses that file when it is present
- [x] pylock.toml with empty packages is respected (does not fall through to uv.lock even though package list is empty)
- [x] publish log progress still works with synthetic requirements.txt
- [x] generated bundle includes valid md5 for synthetic requirements.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)