### PR TITLE
Implement R library mapper in TypeScript

### DIFF
--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -14,6 +14,7 @@ import {
   parseAvailablePackagesOutput,
   parseBioconductorReposOutput,
   buildAvailablePackagesCode,
+  escapeForRString,
   type AvailablePackage,
   type PackageLister,
 } from "./rLibraryMapper";
@@ -95,6 +96,7 @@ describe("toManifestPackage", () => {
     };
     const result = toManifestPackage(pkg, cranRepos, [], []);
     expect(result.Source).toBe("RSPM");
+    expect(result.Repository).toBe("");
   });
 
   test("Bioconductor package found in bioc packages", () => {
@@ -851,6 +853,30 @@ describe("parseBioconductorReposOutput", () => {
   });
 });
 
+describe("escapeForRString", () => {
+  test("escapes backslashes", () => {
+    expect(escapeForRString("C:\\Users\\test")).toBe("C:\\\\Users\\\\test");
+  });
+
+  test("escapes double quotes", () => {
+    expect(escapeForRString('hello "world"')).toBe('hello \\"world\\"');
+  });
+
+  test("escapes both backslashes and double quotes", () => {
+    expect(escapeForRString('C:\\path\\"injected')).toBe(
+      'C:\\\\path\\\\\\"injected',
+    );
+  });
+
+  test("leaves safe strings unchanged", () => {
+    expect(escapeForRString("/home/user/project")).toBe("/home/user/project");
+  });
+
+  test("handles empty string", () => {
+    expect(escapeForRString("")).toBe("");
+  });
+});
+
 describe("buildAvailablePackagesCode", () => {
   test("strips trailing slashes from repo URLs", () => {
     const code = buildAvailablePackagesCode([
@@ -865,6 +891,15 @@ describe("buildAvailablePackagesCode", () => {
       { Name: "", URL: "https://example.com" },
     ]);
     expect(code).toContain('"repo_0"');
+  });
+
+  test("escapes double quotes in repo names and URLs", () => {
+    const code = buildAvailablePackagesCode([
+      { Name: 'evil")); system("pwned', URL: 'https://evil.com/"); cat("' },
+    ]);
+    // The double quotes should be escaped so they don't break out of R strings
+    expect(code).not.toContain('system("pwned');
+    expect(code).toContain('\\"');
   });
 
   test("includes multiple repos", () => {

--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -10,6 +10,10 @@ import {
   toManifestPackage,
   readPackageDescription,
   libraryToManifestPackages,
+  parseLibPathsOutput,
+  parseAvailablePackagesOutput,
+  parseBioconductorReposOutput,
+  buildAvailablePackagesCode,
   type AvailablePackage,
   type PackageLister,
 } from "./rLibraryMapper";
@@ -137,6 +141,145 @@ describe("toManifestPackage", () => {
     };
     const result = toManifestPackage(pkg, cranRepos, [], []);
     expect(result).toEqual({ Source: "", Repository: "" });
+  });
+
+  test("GitLab package", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "GitLab",
+      RemoteType: "gitlab",
+      RemoteUsername: "user",
+      RemoteRepo: "mypkg",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({
+      Source: "gitlab",
+      Repository: "https://gitlab.com/user/mypkg",
+    });
+  });
+
+  test("Bitbucket package", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "Bitbucket",
+      RemoteType: "bitbucket",
+      RemotePkgRef: "org/mypkg",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({
+      Source: "bitbucket",
+      Repository: "https://bitbucket.org/org/mypkg",
+    });
+  });
+
+  test("GitHub package with RemotePkgRef takes precedence over derived", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "GitHub",
+      RemoteType: "github",
+      RemotePkgRef: "custom-org/custom-repo",
+      RemoteUsername: "user",
+      RemoteRepo: "mypkg",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({
+      Source: "github",
+      Repository: "https://github.com/custom-org/custom-repo",
+    });
+  });
+
+  test("GitHub package with no remote ref or username/repo returns empty Repository", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "GitHub",
+      RemoteType: "github",
+      // No RemotePkgRef, RemoteUsername, or RemoteRepo — ref is empty
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({
+      Source: "github",
+      Repository: "",
+    });
+  });
+
+  test("unknown source results in empty source/repo", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "unknown",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({ Source: "", Repository: "" });
+  });
+
+  test("non-CRAN repository resolves from available packages", () => {
+    const customRepos = [
+      { Name: "CRAN", URL: "https://cran.rstudio.com" },
+      { Name: "MyRepo", URL: "https://my-repo.example.com" },
+    ];
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "Repository",
+      Repository: "MyRepo",
+    };
+    const available: AvailablePackage[] = [
+      {
+        name: "mypkg",
+        version: "1.0.0",
+        repository: "https://my-repo.example.com",
+      },
+    ];
+    const result = toManifestPackage(pkg, customRepos, available, []);
+    expect(result).toEqual({
+      Source: "MyRepo",
+      Repository: "https://my-repo.example.com",
+    });
+  });
+
+  test("Bioconductor found in availablePackages before biocPackages", () => {
+    const pkg: RenvPackage = {
+      Package: "Biobase",
+      Version: "2.62.0",
+      Source: "Bioconductor",
+    };
+    const available: AvailablePackage[] = [
+      {
+        name: "Biobase",
+        version: "2.62.0",
+        repository: "https://bioconductor.org/packages/3.18/bioc",
+      },
+    ];
+    const biocPackages: AvailablePackage[] = [
+      {
+        name: "Biobase",
+        version: "2.62.0",
+        repository: "https://bioconductor.org/packages/3.18/OTHER",
+      },
+    ];
+    const result = toManifestPackage(pkg, cranRepos, available, biocPackages);
+    // Should use availablePackages URL, not biocPackages
+    expect(result.Repository).toBe(
+      "https://bioconductor.org/packages/3.18/bioc",
+    );
+  });
+
+  test("default case passes through unknown Source string", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "CustomSource",
+      Repository: "https://custom.example.com",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({
+      Source: "CustomSource",
+      Repository: "https://custom.example.com",
+    });
   });
 
   test("Bioconductor workaround for missing repository with bioconductor RemoteRepos", () => {
@@ -489,5 +632,249 @@ describe("libraryToManifestPackages", () => {
     await expect(
       libraryToManifestPackages(projectDir, rConfig, "/usr/bin/R", lister),
     ).rejects.toThrow("consider running renv::restore()");
+  });
+
+  test("throws when lockfile is missing Repositories section", async () => {
+    const projectDir = path.join(testdataDir, "cran_project");
+
+    // The cran_project has Repositories, but we'll use a custom packageFile
+    // that doesn't exist. Instead, we create a minimal lockfile in-memory
+    // by writing to a temp file. Simpler: just test with an rConfig pointing
+    // to a file we know has repos. For missing repos, we need a fixture.
+    // Let's just test the error message directly by checking the code path.
+    const lister = makeLister();
+
+    // Create a lockfile without Repositories by using a non-existent packageFile
+    await expect(
+      libraryToManifestPackages(
+        projectDir,
+        { ...rConfig, packageFile: "nonexistent.lock" },
+        "/usr/bin/R",
+        lister,
+      ),
+    ).rejects.toThrow(); // ENOENT for missing file
+  });
+
+  test("exercises Bioconductor path when lister returns bioc repos", async () => {
+    const projectDir = path.join(testdataDir, "bioc_project");
+    const libPath = path.join(testdataDir, "bioc_project", "renv_library");
+
+    const listCalls: string[] = [];
+    const lister = makeLister({
+      getLibPaths: () => Promise.resolve([libPath]),
+      listAvailablePackages: (_rPath, _projectDir, repos) => {
+        // Track which repos were queried
+        const repoNames = repos.map((r) => r.Name).join(",");
+        listCalls.push(repoNames);
+        if (repoNames.includes("BioCsoft")) {
+          return Promise.resolve([
+            {
+              name: "Biobase",
+              version: "2.62.0",
+              repository: "https://bioconductor.org/packages/3.18/bioc",
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+      getBioconductorRepos: () =>
+        Promise.resolve([
+          {
+            Name: "BioCsoft",
+            URL: "https://bioconductor.org/packages/3.18/bioc",
+          },
+        ]),
+    });
+
+    const result = await libraryToManifestPackages(
+      projectDir,
+      rConfig,
+      "/usr/bin/R",
+      lister,
+    );
+
+    // Should have called listAvailablePackages twice: once for lockfile repos, once for bioc
+    expect(listCalls).toHaveLength(2);
+    expect(listCalls[1]).toContain("BioCsoft");
+    expect(result["Biobase"]).toBeDefined();
+    expect(result["Biobase"]!.Source).toBe("Bioconductor");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output parsing integration tests
+// ---------------------------------------------------------------------------
+
+describe("parseLibPathsOutput", () => {
+  test("parses typical R .libPaths() output", () => {
+    const output = [
+      "/home/user/R/x86_64-pc-linux-gnu-library/4.3",
+      "/usr/local/lib/R/site-library",
+      "/usr/lib/R/library",
+      "",
+    ].join("\n");
+    expect(parseLibPathsOutput(output)).toEqual([
+      "/home/user/R/x86_64-pc-linux-gnu-library/4.3",
+      "/usr/local/lib/R/site-library",
+      "/usr/lib/R/library",
+    ]);
+  });
+
+  test("filters empty lines and lines starting with dash", () => {
+    const output = "/home/user/R/lib\n\n-some-noise\n/usr/lib/R\n";
+    expect(parseLibPathsOutput(output)).toEqual([
+      "/home/user/R/lib",
+      "/usr/lib/R",
+    ]);
+  });
+
+  test("trims whitespace from paths", () => {
+    const output = "  /home/user/R/lib  \n  /usr/lib/R  \n";
+    expect(parseLibPathsOutput(output)).toEqual([
+      "/home/user/R/lib",
+      "/usr/lib/R",
+    ]);
+  });
+
+  test("returns empty array for empty output", () => {
+    expect(parseLibPathsOutput("")).toEqual([]);
+    expect(parseLibPathsOutput("\n")).toEqual([]);
+  });
+});
+
+describe("parseAvailablePackagesOutput", () => {
+  test("parses typical available.packages() output", () => {
+    const output = [
+      "rlang 1.1.1 https://cran.rstudio.com/src/contrib",
+      "dplyr 1.1.3 https://cran.rstudio.com/src/contrib",
+      "ggplot2 3.4.4 https://cloud.r-project.org/src/contrib",
+      "",
+    ].join("\n");
+    const result = parseAvailablePackagesOutput(output);
+    expect(result).toEqual([
+      {
+        name: "rlang",
+        version: "1.1.1",
+        repository: "https://cran.rstudio.com",
+      },
+      {
+        name: "dplyr",
+        version: "1.1.3",
+        repository: "https://cran.rstudio.com",
+      },
+      {
+        name: "ggplot2",
+        version: "3.4.4",
+        repository: "https://cloud.r-project.org",
+      },
+    ]);
+  });
+
+  test("strips /src/contrib suffix from repository URLs", () => {
+    const output = "pkg 1.0.0 https://repo.example.com/src/contrib\n";
+    const result = parseAvailablePackagesOutput(output);
+    expect(result[0]!.repository).toBe("https://repo.example.com");
+  });
+
+  test("preserves repository URL without /src/contrib suffix", () => {
+    const output = "pkg 1.0.0 https://repo.example.com\n";
+    const result = parseAvailablePackagesOutput(output);
+    expect(result[0]!.repository).toBe("https://repo.example.com");
+  });
+
+  test("skips lines with wrong number of parts", () => {
+    const output = [
+      "good 1.0.0 https://cran.rstudio.com",
+      "only-two-parts 1.0.0",
+      "",
+      "too many parts here right https://example.com",
+      "also-good 2.0.0 https://other.example.com",
+    ].join("\n");
+    const result = parseAvailablePackagesOutput(output);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.name).toBe("good");
+    expect(result[1]!.name).toBe("also-good");
+  });
+
+  test("returns empty array for empty output", () => {
+    expect(parseAvailablePackagesOutput("")).toEqual([]);
+    expect(parseAvailablePackagesOutput("\n")).toEqual([]);
+  });
+});
+
+describe("parseBioconductorReposOutput", () => {
+  test("parses typical Bioconductor repos output", () => {
+    const output = [
+      "BioCsoft https://bioconductor.org/packages/3.18/bioc",
+      "BioCann https://bioconductor.org/packages/3.18/data/annotation",
+      "BioCexp https://bioconductor.org/packages/3.18/data/experiment",
+      "",
+    ].join("\n");
+    const result = parseBioconductorReposOutput(output);
+    expect(result).toEqual([
+      { Name: "BioCsoft", URL: "https://bioconductor.org/packages/3.18/bioc" },
+      {
+        Name: "BioCann",
+        URL: "https://bioconductor.org/packages/3.18/data/annotation",
+      },
+      {
+        Name: "BioCexp",
+        URL: "https://bioconductor.org/packages/3.18/data/experiment",
+      },
+    ]);
+  });
+
+  test("skips empty lines and lines starting with dash", () => {
+    const output = [
+      "BioCsoft https://bioconductor.org/packages/3.18/bioc",
+      "",
+      "- some R warning output",
+      "BioCann https://bioconductor.org/packages/3.18/data/annotation",
+    ].join("\n");
+    const result = parseBioconductorReposOutput(output);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.Name).toBe("BioCsoft");
+    expect(result[1]!.Name).toBe("BioCann");
+  });
+
+  test("skips lines with no space (no URL)", () => {
+    const output =
+      "BioCsoft https://bioconductor.org/packages/3.18/bioc\nmalformed\n";
+    const result = parseBioconductorReposOutput(output);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.Name).toBe("BioCsoft");
+  });
+
+  test("returns empty array for empty output", () => {
+    expect(parseBioconductorReposOutput("")).toEqual([]);
+    expect(parseBioconductorReposOutput("\n")).toEqual([]);
+  });
+});
+
+describe("buildAvailablePackagesCode", () => {
+  test("strips trailing slashes from repo URLs", () => {
+    const code = buildAvailablePackagesCode([
+      { Name: "CRAN", URL: "https://cran.rstudio.com/" },
+    ]);
+    expect(code).toContain('"https://cran.rstudio.com"');
+    expect(code).not.toContain('rstudio.com/"');
+  });
+
+  test("uses fallback name when repo Name is empty", () => {
+    const code = buildAvailablePackagesCode([
+      { Name: "", URL: "https://example.com" },
+    ]);
+    expect(code).toContain('"repo_0"');
+  });
+
+  test("includes multiple repos", () => {
+    const code = buildAvailablePackagesCode([
+      { Name: "CRAN", URL: "https://cran.rstudio.com" },
+      { Name: "BioCsoft", URL: "https://bioconductor.org/packages/3.18/bioc" },
+    ]);
+    expect(code).toContain('"CRAN"');
+    expect(code).toContain('"BioCsoft"');
+    expect(code).toContain('"https://cran.rstudio.com"');
+    expect(code).toContain('"https://bioconductor.org/packages/3.18/bioc"');
   });
 });

--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -902,9 +902,10 @@ describe("buildAvailablePackagesCode", () => {
     const code = buildAvailablePackagesCode([
       { Name: 'evil")); system("pwned', URL: 'https://evil.com/"); cat("' },
     ]);
-    // The double quotes should be escaped so they don't break out of R strings
-    expect(code).not.toContain('system("pwned');
-    expect(code).toContain('\\"');
+    // Verify the escaped form of the malicious strings appears in the output,
+    // confirming quotes are neutralised rather than merely absent.
+    expect(code).toContain('evil\\")); system(\\"pwned');
+    expect(code).toContain('https://evil.com/\\"); cat(\\"');
   });
 
   test("includes multiple repos", () => {

--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -1,0 +1,493 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+import type { RenvPackage } from "./rPackageDescriptions";
+import {
+  isCRANLike,
+  toManifestPackage,
+  readPackageDescription,
+  libraryToManifestPackages,
+  type AvailablePackage,
+  type PackageLister,
+} from "./rLibraryMapper";
+
+const testdataDir = path.resolve(__dirname, "testdata");
+
+// ---------------------------------------------------------------------------
+// isCRANLike
+// ---------------------------------------------------------------------------
+
+describe("isCRANLike", () => {
+  test("CRAN and Posit Package Manager variants are CRAN-like", () => {
+    expect(isCRANLike("CRAN")).toBe(true);
+    expect(isCRANLike("RSPM")).toBe(true);
+    expect(isCRANLike("PPM")).toBe(true);
+    expect(isCRANLike("P3M")).toBe(true);
+  });
+
+  test("other repositories are not CRAN-like", () => {
+    expect(isCRANLike("Bioconductor")).toBe(false);
+    expect(isCRANLike("GitHub")).toBe(false);
+    expect(isCRANLike("custom-repo")).toBe(false);
+    expect(isCRANLike("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toManifestPackage
+// ---------------------------------------------------------------------------
+
+describe("toManifestPackage", () => {
+  const cranRepos = [{ Name: "CRAN", URL: "https://cran.rstudio.com" }];
+
+  test("CRAN package found in available packages", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.2.3",
+      Source: "Repository",
+      Repository: "CRAN",
+    };
+    const available: AvailablePackage[] = [
+      {
+        name: "mypkg",
+        version: "1.2.3",
+        repository: "https://cran.rstudio.com",
+      },
+    ];
+    const result = toManifestPackage(pkg, cranRepos, available, []);
+    expect(result).toEqual({
+      Source: "CRAN",
+      Repository: "https://cran.rstudio.com",
+    });
+  });
+
+  test("CRAN dev version results in empty source/repo", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "2.0.0",
+      Source: "Repository",
+      Repository: "CRAN",
+    };
+    const available: AvailablePackage[] = [
+      {
+        name: "mypkg",
+        version: "1.0.0",
+        repository: "https://cran.rstudio.com",
+      },
+    ];
+    const result = toManifestPackage(pkg, cranRepos, available, []);
+    expect(result).toEqual({ Source: "", Repository: "" });
+  });
+
+  test("RSPM package not in available packages keeps RSPM source", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.2.3",
+      Source: "Repository",
+      Repository: "RSPM",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result.Source).toBe("RSPM");
+  });
+
+  test("Bioconductor package found in bioc packages", () => {
+    const pkg: RenvPackage = {
+      Package: "Biobase",
+      Version: "2.62.0",
+      Source: "Bioconductor",
+    };
+    const biocPackages: AvailablePackage[] = [
+      {
+        name: "Biobase",
+        version: "2.62.0",
+        repository: "https://bioconductor.org/packages/3.18/bioc",
+      },
+    ];
+    const result = toManifestPackage(pkg, cranRepos, [], biocPackages);
+    expect(result).toEqual({
+      Source: "Bioconductor",
+      Repository: "https://bioconductor.org/packages/3.18/bioc",
+    });
+  });
+
+  test("GitHub package", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "GitHub",
+      RemoteType: "github",
+      RemoteUsername: "user",
+      RemoteRepo: "mypkg",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({
+      Source: "github",
+      Repository: "https://github.com/user/mypkg",
+    });
+  });
+
+  test("Local package results in empty source/repo", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.0.0",
+      Source: "Local",
+    };
+    const result = toManifestPackage(pkg, cranRepos, [], []);
+    expect(result).toEqual({ Source: "", Repository: "" });
+  });
+
+  test("Bioconductor workaround for missing repository with bioconductor RemoteRepos", () => {
+    const pkg: RenvPackage = {
+      Package: "Biobase",
+      Version: "2.62.0",
+      Source: "Repository",
+      RemoteRepos: "https://bioconductor.org/packages/3.18/bioc",
+    };
+    const biocPackages: AvailablePackage[] = [
+      {
+        name: "Biobase",
+        version: "2.62.0",
+        repository: "https://bioconductor.org/packages/3.18/bioc",
+      },
+    ];
+    const result = toManifestPackage(pkg, cranRepos, [], biocPackages);
+    expect(result).toEqual({
+      Source: "Bioconductor",
+      Repository: "https://bioconductor.org/packages/3.18/bioc",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readPackageDescription
+// ---------------------------------------------------------------------------
+
+describe("readPackageDescription", () => {
+  test("reads DESCRIPTION from second libPath when first is nonexistent", async () => {
+    const libPath = path.join(testdataDir, "cran_project", "renv_library");
+    const desc = await readPackageDescription("mypkg", [
+      "/nonexistent",
+      libPath,
+    ]);
+    expect(desc["Package"]).toBe("mypkg");
+    expect(desc["Version"]).toBe("1.2.3");
+    expect(desc["Title"]).toBe("A Sample Package");
+  });
+
+  test("throws when package is not found in any libPath", async () => {
+    await expect(
+      readPackageDescription("nonexistent", ["/nonexistent"]),
+    ).rejects.toThrow("package not found in current libPaths");
+  });
+
+  test("reads Biobase DESCRIPTION with keepWhiteFields", async () => {
+    const libPath = path.join(testdataDir, "bioc_project", "renv_library");
+    const desc = await readPackageDescription("Biobase", [libPath]);
+    expect(desc["Package"]).toBe("Biobase");
+    expect(desc["Version"]).toBe("2.62.0");
+    // Verify continuation lines are preserved for Description field
+    expect(desc["Description"]).toContain("\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden file tests: CRAN project
+// ---------------------------------------------------------------------------
+
+describe("library mapper golden files", () => {
+  test("CRAN project matches expected.json", async () => {
+    const projectDir = path.join(testdataDir, "cran_project");
+    const expectedPath = path.join(projectDir, "expected-library.json");
+    const expectedJSON = await readFile(expectedPath, "utf-8");
+    const expected = JSON.parse(expectedJSON);
+
+    // Simulate what libraryToManifestPackages does without R subprocess:
+    // Read lockfile
+    const lockfileContent = await readFile(
+      path.join(projectDir, "renv.lock"),
+      "utf-8",
+    );
+    const lockfile = JSON.parse(lockfileContent);
+
+    const repos = lockfile.R.Repositories;
+    const availablePackages: AvailablePackage[] = [
+      {
+        name: "random_package",
+        version: "4.5.6",
+        repository: "https://cran.example.com",
+      },
+      {
+        name: "mypkg",
+        version: "1.2.3",
+        repository: "https://cran.rstudio.com",
+      },
+    ];
+    const libPath = path.join(projectDir, "renv_library");
+
+    const result: Record<
+      string,
+      {
+        Source: string;
+        Repository: string;
+        description: Record<string, string>;
+      }
+    > = {};
+    for (const pkgName of Object.keys(lockfile.Packages).sort()) {
+      const pkg = lockfile.Packages[pkgName];
+      const { Source, Repository } = toManifestPackage(
+        pkg,
+        repos,
+        availablePackages,
+        [],
+      );
+      const description = await readPackageDescription(pkgName, [
+        "/nonexistent",
+        libPath,
+      ]);
+      result[pkgName] = { Source, Repository, description };
+    }
+
+    expect(result).toEqual(expected);
+  });
+
+  test("Bioconductor project matches expected.json", async () => {
+    const projectDir = path.join(testdataDir, "bioc_project");
+    const expectedPath = path.join(projectDir, "expected-library.json");
+    const expectedJSON = await readFile(expectedPath, "utf-8");
+    const expected = JSON.parse(expectedJSON);
+
+    const lockfileContent = await readFile(
+      path.join(projectDir, "renv.lock"),
+      "utf-8",
+    );
+    const lockfile = JSON.parse(lockfileContent);
+
+    const repos = lockfile.R.Repositories;
+    const availablePackages: AvailablePackage[] = [
+      {
+        name: "random_package",
+        version: "4.5.6",
+        repository: "https://cran.example.com",
+      },
+      {
+        name: "mypkg",
+        version: "1.2.3",
+        repository: "https://cran.rstudio.com",
+      },
+    ];
+    const biocPackages: AvailablePackage[] = [
+      {
+        name: "bioassayR",
+        version: "1.40.0",
+        repository: "https://bioconductor.org/packages/3.18/bioc",
+      },
+      {
+        name: "Biobase",
+        version: "2.62.0",
+        repository: "https://bioconductor.org/packages/3.18/bioc",
+      },
+      {
+        name: "biobroom",
+        version: "1.34.0",
+        repository: "https://bioconductor.org/packages/3.18/bioc",
+      },
+    ];
+    const libPath = path.join(projectDir, "renv_library");
+
+    const result: Record<
+      string,
+      {
+        Source: string;
+        Repository: string;
+        description: Record<string, string>;
+      }
+    > = {};
+    for (const pkgName of Object.keys(lockfile.Packages).sort()) {
+      const pkg = lockfile.Packages[pkgName];
+      const { Source, Repository } = toManifestPackage(
+        pkg,
+        repos,
+        availablePackages,
+        biocPackages,
+      );
+      const description = await readPackageDescription(pkgName, [
+        "/nonexistent",
+        libPath,
+      ]);
+      result[pkgName] = { Source, Repository, description };
+    }
+
+    expect(result).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe("library mapper error cases", () => {
+  test("version mismatch throws descriptive error", async () => {
+    const projectDir = path.join(testdataDir, "version_mismatch");
+    const lockfileContent = await readFile(
+      path.join(projectDir, "renv.lock"),
+      "utf-8",
+    );
+    const lockfile = JSON.parse(lockfileContent);
+    const libPath = path.join(projectDir, "renv_library");
+
+    const pkg = lockfile.Packages["mypkg"];
+    const description = await readPackageDescription("mypkg", [libPath]);
+
+    // Lockfile says 1.2.3, DESCRIPTION says 4.5.6
+    expect(description["Version"]).toBe("4.5.6");
+    expect(pkg.Version).toBe("1.2.3");
+    expect(description["Version"]).not.toBe(pkg.Version);
+  });
+
+  test("dev version produces empty Source", () => {
+    const pkg: RenvPackage = {
+      Package: "mypkg",
+      Version: "1.2.3",
+      Source: "Repository",
+      Repository: "CRAN",
+    };
+    const available: AvailablePackage[] = [
+      {
+        name: "mypkg",
+        version: "1.0.0", // installed is newer
+        repository: "https://cran.rstudio.com",
+      },
+    ];
+    const result = toManifestPackage(
+      pkg,
+      [{ Name: "CRAN", URL: "https://cran.rstudio.com" }],
+      available,
+      [],
+    );
+    expect(result.Source).toBe("");
+    expect(result.Repository).toBe("");
+  });
+
+  test("missing DESCRIPTION throws with renv::restore() guidance", async () => {
+    await expect(readPackageDescription("mypkg", [])).rejects.toThrow(
+      "consider running renv::restore()",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// libraryToManifestPackages (with mocked R subprocess)
+// ---------------------------------------------------------------------------
+
+describe("libraryToManifestPackages", () => {
+  const rConfig = {
+    version: "4.3.0",
+    packageFile: "renv.lock",
+    packageManager: "renv",
+    packagesFromLibrary: true,
+  };
+
+  function makeLister(overrides: Partial<PackageLister> = {}): PackageLister {
+    return {
+      getLibPaths: () => Promise.resolve([]),
+      listAvailablePackages: () => Promise.resolve([]),
+      getBioconductorRepos: () => Promise.resolve([]),
+      ...overrides,
+    };
+  }
+
+  test("integrates lockfile reading, package resolution, and DESCRIPTION parsing", async () => {
+    const projectDir = path.join(testdataDir, "cran_project");
+    const libPath = path.join(projectDir, "renv_library");
+
+    const lister = makeLister({
+      getLibPaths: () => Promise.resolve(["/nonexistent", libPath]),
+      listAvailablePackages: () =>
+        Promise.resolve([
+          {
+            name: "mypkg",
+            version: "1.2.3",
+            repository: "https://cran.rstudio.com",
+          },
+        ]),
+    });
+
+    const result = await libraryToManifestPackages(
+      projectDir,
+      rConfig,
+      "/usr/bin/R",
+      lister,
+    );
+
+    expect(result["mypkg"]).toBeDefined();
+    expect(result["mypkg"]!.Source).toBe("CRAN");
+    expect(result["mypkg"]!.Repository).toBe("https://cran.rstudio.com");
+    expect(result["mypkg"]!.description["Package"]).toBe("mypkg");
+    expect(result["mypkg"]!.description["Version"]).toBe("1.2.3");
+  });
+
+  test("throws on version mismatch between lockfile and library", async () => {
+    const projectDir = path.join(testdataDir, "version_mismatch");
+    const libPath = path.join(projectDir, "renv_library");
+
+    const lister = makeLister({
+      getLibPaths: () => Promise.resolve([libPath]),
+      listAvailablePackages: () =>
+        Promise.resolve([
+          {
+            name: "mypkg",
+            version: "1.2.3",
+            repository: "https://cran.rstudio.com",
+          },
+        ]),
+    });
+
+    await expect(
+      libraryToManifestPackages(projectDir, rConfig, "/usr/bin/R", lister),
+    ).rejects.toThrow("versions in lockfile '1.2.3' and library '4.5.6'");
+  });
+
+  test("throws on dev version with empty source", async () => {
+    const projectDir = path.join(testdataDir, "dev_version");
+    const libPath = path.join(projectDir, "renv_library");
+
+    const lister = makeLister({
+      getLibPaths: () => Promise.resolve([libPath]),
+      listAvailablePackages: () =>
+        Promise.resolve([
+          {
+            name: "mypkg",
+            version: "1.0.0", // installed version (1.2.3) is newer
+            repository: "https://cran.rstudio.com",
+          },
+        ]),
+    });
+
+    await expect(
+      libraryToManifestPackages(projectDir, rConfig, "/usr/bin/R", lister),
+    ).rejects.toThrow("cannot re-install packages installed from source");
+  });
+
+  test("throws when DESCRIPTION not found in any libPath", async () => {
+    const projectDir = path.join(testdataDir, "cran_project");
+
+    const lister = makeLister({
+      getLibPaths: () => Promise.resolve([]), // No lib paths — package won't be found
+      listAvailablePackages: () =>
+        Promise.resolve([
+          {
+            name: "mypkg",
+            version: "1.2.3",
+            repository: "https://cran.rstudio.com",
+          },
+        ]),
+    });
+
+    await expect(
+      libraryToManifestPackages(projectDir, rConfig, "/usr/bin/R", lister),
+    ).rejects.toThrow("consider running renv::restore()");
+  });
+});

--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -199,7 +199,10 @@ describe("toManifestPackage", () => {
       Version: "1.0.0",
       Source: "GitHub",
       RemoteType: "github",
-      // No RemotePkgRef, RemoteUsername, or RemoteRepo — ref is empty
+      // No RemotePkgRef, RemoteUsername, or RemoteRepo.
+      // remotePkgRefOrDerived() returns "" because both RemotePkgRef and
+      // the derived username/repo are missing. The falsy `ref` causes
+      // the ternary in the GitHub case to short-circuit to "".
     };
     const result = toManifestPackage(pkg, cranRepos, [], []);
     expect(result).toEqual({
@@ -637,16 +640,18 @@ describe("libraryToManifestPackages", () => {
   });
 
   test("throws when lockfile is missing Repositories section", async () => {
-    const projectDir = path.join(testdataDir, "cran_project");
-
-    // The cran_project has Repositories, but we'll use a custom packageFile
-    // that doesn't exist. Instead, we create a minimal lockfile in-memory
-    // by writing to a temp file. Simpler: just test with an rConfig pointing
-    // to a file we know has repos. For missing repos, we need a fixture.
-    // Let's just test the error message directly by checking the code path.
+    const projectDir = path.join(testdataDir, "no_repos_project");
     const lister = makeLister();
 
-    // Create a lockfile without Repositories by using a non-existent packageFile
+    await expect(
+      libraryToManifestPackages(projectDir, rConfig, "/usr/bin/R", lister),
+    ).rejects.toThrow("missing Repositories section");
+  });
+
+  test("throws when packageFile does not exist", async () => {
+    const projectDir = path.join(testdataDir, "cran_project");
+    const lister = makeLister();
+
     await expect(
       libraryToManifestPackages(
         projectDir,
@@ -654,7 +659,7 @@ describe("libraryToManifestPackages", () => {
         "/usr/bin/R",
         lister,
       ),
-    ).rejects.toThrow(); // ENOENT for missing file
+    ).rejects.toThrow();
   });
 
   test("exercises Bioconductor path when lister returns bioc repos", async () => {
@@ -911,5 +916,16 @@ describe("buildAvailablePackagesCode", () => {
     expect(code).toContain('"BioCsoft"');
     expect(code).toContain('"https://cran.rstudio.com"');
     expect(code).toContain('"https://bioconductor.org/packages/3.18/bioc"');
+  });
+
+  test("does not place semicolons inside function-call parentheses", () => {
+    const code = buildAvailablePackagesCode([
+      { Name: "CRAN", URL: "https://cran.rstudio.com" },
+      { Name: "BioCsoft", URL: "https://bioconductor.org/packages/3.18/bioc" },
+    ]);
+    // Semicolons should only appear between top-level statements, never
+    // inside function-call parens (e.g. "(;" or ",;").
+    expect(code).not.toMatch(/\(;/);
+    expect(code).not.toMatch(/,;/);
   });
 });

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -105,12 +105,16 @@ export function buildAvailablePackagesCode(repos: Repository[]): string {
 
   // R script: query CRAN-style repos for available source packages,
   // then print each as "name version repoURL" on one line.
-  return [
+  const availablePackagesCall = [
     `pkgs <- available.packages(`,
     `  repos = setNames(c(${urls}), c(${names})),`,
     `  type = "source",`,
     `  filters = c(getOption("rsconnect.available_packages_filters", default = c()), "duplicates")`,
     `)`,
+  ].join("\n");
+
+  return [
+    availablePackagesCall,
     `info <- pkgs[, c("Package", "Version", "Repository")]`,
     `apply(info, 1, function(x) cat(x, sep = " ", collapse = "\\n"))`,
     `invisible()`,

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -456,7 +456,12 @@ export async function libraryToManifestPackages(
   const lockfilePath = path.join(projectDir, packageFile);
 
   const content = await readFile(lockfilePath, "utf-8");
-  const lockfile: RenvLockfile = JSON.parse(content);
+  let lockfile: RenvLockfile;
+  try {
+    lockfile = JSON.parse(content);
+  } catch (err) {
+    throw new Error(`Failed to parse ${lockfilePath}: invalid JSON`);
+  }
 
   if (!lockfile.R?.Repositories?.length) {
     throw new Error(

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -28,6 +28,14 @@ type Repository = { Name: string; URL: string };
 const R_SUBPROCESS_TIMEOUT = 300_000; // 5 minutes
 
 /**
+ * Escape a string for safe interpolation inside an R double-quoted string literal.
+ * Prevents code injection via crafted directory paths or repository names/URLs.
+ */
+export function escapeForRString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
  * Run an R expression and return stdout.
  * Mirrors the runRScript pattern from rPackages.ts.
  */
@@ -88,8 +96,12 @@ export async function getLibPaths(
  * Mirrors Go's ListAvailablePackages().
  */
 export function buildAvailablePackagesCode(repos: Repository[]): string {
-  const urls = repos.map((r) => `"${r.URL.replace(/\/+$/, "")}"`).join(", ");
-  const names = repos.map((r, i) => `"${r.Name || `repo_${i}`}"`).join(", ");
+  const urls = repos
+    .map((r) => `"${escapeForRString(r.URL.replace(/\/+$/, ""))}"`)
+    .join(", ");
+  const names = repos
+    .map((r, i) => `"${escapeForRString(r.Name || `repo_${i}`)}"`)
+    .join(", ");
 
   // R script: query CRAN-style repos for available source packages,
   // then print each as "name version repoURL" on one line.
@@ -147,7 +159,7 @@ export async function getBioconductorRepos(
   rPath: string,
   projectDir: string,
 ): Promise<Repository[]> {
-  const escapedDir = projectDir.replace(/\\/g, "\\\\");
+  const escapedDir = escapeForRString(projectDir);
 
   // R script: discover Bioconductor repo URLs via BiocManager or renv,
   // then print each as "name url" on one line.

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -1,0 +1,474 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { ManifestPackage } from "../bundler/types";
+import type { RConfig } from "../api/types/configurations";
+import { parseDcf, type DcfRecord } from "./dcfParser";
+import type { RenvLockfile, RenvPackage } from "./rPackageDescriptions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AvailablePackage = {
+  name: string;
+  version: string;
+  repository: string;
+};
+
+type Repository = { Name: string; URL: string };
+
+// ---------------------------------------------------------------------------
+// R subprocess helpers
+// ---------------------------------------------------------------------------
+
+const R_SUBPROCESS_TIMEOUT = 300_000; // 5 minutes
+
+/**
+ * Run an R expression and return stdout.
+ * Mirrors the runRScript pattern from rPackages.ts.
+ */
+function runRExpression(
+  rPath: string,
+  expression: string,
+  cwd: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      rPath,
+      ["-s", "-e", expression],
+      {
+        cwd,
+        timeout: R_SUBPROCESS_TIMEOUT,
+        env: { ...process.env, RENV_CONFIG_AUTOLOADER_ENABLED: "FALSE" },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const msg = stderr
+            ? `R subprocess failed: ${stderr}`
+            : `R subprocess failed: ${error.message}`;
+          reject(new Error(msg));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * Get the library paths where R packages are installed.
+ * Mirrors Go's GetLibPaths().
+ */
+export async function getLibPaths(
+  rPath: string,
+  projectDir: string,
+): Promise<string[]> {
+  const output = await runRExpression(
+    rPath,
+    'cat(.libPaths(), sep="\\n")',
+    projectDir,
+  );
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("-"));
+}
+
+/**
+ * Build the R code for listing available packages from given repositories.
+ * Mirrors Go's ListAvailablePackages().
+ */
+function buildAvailablePackagesCode(repos: Repository[]): string {
+  const urls = repos.map((r) => `"${r.URL.replace(/\/+$/, "")}"`).join(", ");
+  const names = repos.map((r, i) => `"${r.Name || `repo_${i}`}"`).join(", ");
+
+  return `(function() { pkgs <- available.packages( repos = setNames(c(${urls}), c(${names})), type = "source", filters = c(getOption("rsconnect.available_packages_filters", default = c()), "duplicates"));info <- pkgs[,c("Package", "Version", "Repository")];apply(info, 1, function(x) { cat(x, sep=" ", collapse="\\n") } );invisible()})()`;
+}
+
+/**
+ * List packages available in the given repositories.
+ * Mirrors Go's ListAvailablePackages().
+ */
+export async function listAvailablePackages(
+  rPath: string,
+  projectDir: string,
+  repos: Repository[],
+): Promise<AvailablePackage[]> {
+  const code = buildAvailablePackagesCode(repos);
+  const output = await runRExpression(rPath, code, projectDir);
+
+  const available: AvailablePackage[] = [];
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    const parts = trimmed.split(" ");
+    if (parts.length !== 3) {
+      continue;
+    }
+    available.push({
+      name: parts[0]!,
+      version: parts[1]!,
+      repository: parts[2]!.replace(/\/src\/contrib$/, ""),
+    });
+  }
+  return available;
+}
+
+/**
+ * Discover Bioconductor repository URLs via R.
+ * Mirrors Go's GetBioconductorRepos().
+ */
+export async function getBioconductorRepos(
+  rPath: string,
+  projectDir: string,
+): Promise<Repository[]> {
+  const escapedDir = projectDir.replace(/\\/g, "\\\\");
+  const code = `(function() { if (requireNamespace("BiocManager", quietly = TRUE) || requireNamespace("BiocInstaller", quietly = TRUE)) {repos <- getFromNamespace("renv_bioconductor_repos", "renv")("${escapedDir}"); repos <- repos[setdiff(names(repos), "CRAN")]; cat(repos, labels=names(repos), fill=1); invisible()}})()`;
+
+  const output = await runRExpression(rPath, code, projectDir);
+
+  const repos: Repository[] = [];
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("-")) {
+      continue;
+    }
+    const spaceIdx = trimmed.indexOf(" ");
+    if (spaceIdx === -1) {
+      continue;
+    }
+    repos.push({
+      Name: trimmed.slice(0, spaceIdx),
+      URL: trimmed.slice(spaceIdx + 1),
+    });
+  }
+  return repos;
+}
+
+// ---------------------------------------------------------------------------
+// Package resolution helpers (ported from Go's manifest_packages.go)
+// ---------------------------------------------------------------------------
+
+/** Fields whose continuation lines preserve original indentation. */
+const KEEP_WHITE_FIELDS = [
+  "Description",
+  "Authors@R",
+  "Author",
+  "Built",
+  "Packaged",
+];
+
+/**
+ * Whether a repository name is CRAN or a Posit Package Manager variant.
+ * These are all CRAN mirrors and should be treated equivalently.
+ */
+export function isCRANLike(repo: string): boolean {
+  return repo === "CRAN" || repo === "RSPM" || repo === "PPM" || repo === "P3M";
+}
+
+/**
+ * Parse an R version string into an array of integers for comparison.
+ * R versions are sequences of non-negative integers separated by . or -.
+ */
+function packageVersion(vs: string): number[] {
+  return vs
+    .split(/[^0-9]+/)
+    .filter((s) => s !== "")
+    .map(Number);
+}
+
+/**
+ * Whether a package is a dev version (newer than what's available in repos).
+ */
+function isDevVersion(
+  pkg: RenvPackage,
+  availablePackages: AvailablePackage[],
+): boolean {
+  const repoVersion = findAvailableVersion(pkg.Package, availablePackages);
+  if (!repoVersion) {
+    return false;
+  }
+  const installed = packageVersion(pkg.Version);
+  const available = packageVersion(repoVersion);
+  // Compare arrays lexicographically
+  const len = Math.max(installed.length, available.length);
+  for (let i = 0; i < len; i++) {
+    const a = installed[i] ?? 0;
+    const b = available[i] ?? 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return false;
+}
+
+function findAvailableVersion(
+  pkgName: string,
+  availablePackages: AvailablePackage[],
+): string {
+  for (const avail of availablePackages) {
+    if (avail.name === pkgName) {
+      return avail.version;
+    }
+  }
+  return "";
+}
+
+function findRepoUrl(
+  pkgName: string,
+  availablePackages: AvailablePackage[],
+): string {
+  for (const avail of availablePackages) {
+    if (avail.name === pkgName) {
+      return avail.repository;
+    }
+  }
+  return "";
+}
+
+function findRepoNameByURL(repoUrl: string, repos: Repository[]): string {
+  for (const repo of repos) {
+    if (repo.URL === repoUrl) {
+      return repo.Name;
+    }
+  }
+  return "";
+}
+
+function remotePkgRefOrDerived(pkg: RenvPackage): string {
+  return (
+    pkg.RemotePkgRef ||
+    (pkg.RemoteUsername && pkg.RemoteRepo
+      ? `${pkg.RemoteUsername}/${pkg.RemoteRepo}`
+      : "")
+  );
+}
+
+function remoteRepoURL(remoteType: string, pkgRef: string): string {
+  if (!pkgRef) return "";
+  switch (remoteType) {
+    case "github":
+      return `https://github.com/${pkgRef}`;
+    case "gitlab":
+      return `https://gitlab.com/${pkgRef}`;
+    case "bitbucket":
+      return `https://bitbucket.org/${pkgRef}`;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Determine the Source and Repository for a manifest package entry.
+ * Mirrors Go's toManifestPackage().
+ */
+export function toManifestPackage(
+  pkg: RenvPackage,
+  repos: Repository[],
+  availablePackages: AvailablePackage[],
+  biocPackages: AvailablePackage[],
+): { Source: string; Repository: string } {
+  let source = pkg.Source;
+  const repository = pkg.Repository ?? "";
+
+  if (!repository && pkg.RemoteRepos?.includes("bioconductor.org")) {
+    // Workaround for https://github.com/rstudio/renv/issues/1202
+    source = "Bioconductor";
+  }
+
+  switch (source) {
+    case "Repository": {
+      if (isCRANLike(repository)) {
+        if (isDevVersion(pkg, availablePackages)) {
+          return { Source: "", Repository: "" };
+        }
+        return {
+          Source: repository,
+          Repository: findRepoUrl(pkg.Package, availablePackages),
+        };
+      }
+      // Non-CRAN repository — look up from available packages
+      const repoUrl = findRepoUrl(pkg.Package, availablePackages);
+      return {
+        Source: findRepoNameByURL(repoUrl, repos),
+        Repository: repoUrl,
+      };
+    }
+
+    case "Bioconductor": {
+      let repoUrl = findRepoUrl(pkg.Package, availablePackages);
+      if (!repoUrl) {
+        repoUrl = findRepoUrl(pkg.Package, biocPackages);
+      }
+      return { Source: "Bioconductor", Repository: repoUrl };
+    }
+
+    case "Bitbucket":
+    case "GitHub":
+    case "GitLab": {
+      const lowerSource = source.toLowerCase();
+      const ref = remotePkgRefOrDerived(pkg);
+      const url = ref
+        ? remoteRepoURL(lowerSource, ref) || pkg.RemoteUrl || ""
+        : "";
+      return { Source: lowerSource, Repository: url };
+    }
+
+    case "Local":
+    case "unknown":
+      return { Source: "", Repository: "" };
+
+    default:
+      return { Source: pkg.Source, Repository: repository };
+  }
+}
+
+/**
+ * Read a package's DESCRIPTION file from the first matching library path.
+ * Mirrors Go's readPackageDescription().
+ */
+export async function readPackageDescription(
+  pkgName: string,
+  libPaths: string[],
+): Promise<DcfRecord> {
+  for (const libPath of libPaths) {
+    const descPath = path.join(libPath, pkgName, "DESCRIPTION");
+    try {
+      const text = await readFile(descPath, "utf-8");
+      const records = parseDcf(text, KEEP_WHITE_FIELDS);
+      if (records.length === 0) {
+        throw new Error(`${descPath}: invalid DESCRIPTION file`);
+      }
+      return records[0]!;
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        // Try next libPath
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error(
+    `${pkgName}: package not found in current libPaths; consider running renv::restore() to populate the renv library`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main library mapper
+// ---------------------------------------------------------------------------
+
+/** Interface for R subprocess operations, injectable for testing. */
+export type PackageLister = {
+  getLibPaths(rPath: string, projectDir: string): Promise<string[]>;
+  listAvailablePackages(
+    rPath: string,
+    projectDir: string,
+    repos: Repository[],
+  ): Promise<AvailablePackage[]>;
+  getBioconductorRepos(
+    rPath: string,
+    projectDir: string,
+  ): Promise<Repository[]>;
+};
+
+const defaultLister: PackageLister = {
+  getLibPaths,
+  listAvailablePackages,
+  getBioconductorRepos,
+};
+
+/**
+ * Read an renv.lock and build manifest packages using the local R library.
+ *
+ * This is the library-based package mapper (used when `packages_from_library = true`).
+ * Unlike the lockfile-only mapper, it reads each package's DESCRIPTION file
+ * from the local R library and queries R for available packages to produce
+ * richer manifest entries.
+ *
+ * Mirrors Go's defaultPackageMapper.GetManifestPackages().
+ */
+export async function libraryToManifestPackages(
+  projectDir: string,
+  rConfig: RConfig,
+  rPath: string,
+  lister: PackageLister = defaultLister,
+): Promise<Record<string, ManifestPackage>> {
+  const packageFile = rConfig.packageFile || "renv.lock";
+  const lockfilePath = path.join(projectDir, packageFile);
+
+  const content = await readFile(lockfilePath, "utf-8");
+  const lockfile: RenvLockfile = JSON.parse(content);
+
+  if (!lockfile.R?.Repositories?.length) {
+    throw new Error(
+      "renv.lock is not compatible: missing Repositories section. " +
+        "Regenerate the lockfile with renv >= 1.1.0",
+    );
+  }
+
+  // Get library paths and available packages
+  const libPaths = await lister.getLibPaths(rPath, projectDir);
+  const repos = lockfile.R.Repositories;
+  const availablePackages = await lister.listAvailablePackages(
+    rPath,
+    projectDir,
+    repos,
+  );
+
+  // Discover Bioconductor repos and their packages
+  const biocRepos = await lister.getBioconductorRepos(rPath, projectDir);
+  let biocPackages: AvailablePackage[] = [];
+  if (biocRepos.length > 0) {
+    biocPackages = await lister.listAvailablePackages(
+      rPath,
+      projectDir,
+      biocRepos,
+    );
+  }
+
+  // Process each package, sorted by name for deterministic output
+  const manifestPackages: Record<string, ManifestPackage> = {};
+  const pkgNames = Object.keys(lockfile.Packages).sort();
+
+  for (const pkgName of pkgNames) {
+    const pkg = lockfile.Packages[pkgName]!;
+
+    const { Source, Repository } = toManifestPackage(
+      pkg,
+      repos,
+      availablePackages,
+      biocPackages,
+    );
+
+    const description = await readPackageDescription(pkgName, libPaths);
+
+    // Validate version consistency between lockfile and library
+    if (description["Version"] !== pkg.Version) {
+      throw new Error(
+        `package ${pkgName}: versions in lockfile '${pkg.Version}' and library '${description["Version"]}' are out of sync. Use renv::restore() or renv::snapshot() to synchronize`,
+      );
+    }
+
+    // Validate that Source is non-empty
+    if (!Source) {
+      throw new Error(
+        `cannot re-install packages installed from source; all packages must be installed from a reproducible location such as a repository. Package ${pkgName}, Version ${pkg.Version}`,
+      );
+    }
+
+    manifestPackages[pkgName] = {
+      Source,
+      Repository,
+      description,
+    };
+  }
+
+  return manifestPackages;
+}

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -87,7 +87,18 @@ function buildAvailablePackagesCode(repos: Repository[]): string {
   const urls = repos.map((r) => `"${r.URL.replace(/\/+$/, "")}"`).join(", ");
   const names = repos.map((r, i) => `"${r.Name || `repo_${i}`}"`).join(", ");
 
-  return `(function() { pkgs <- available.packages( repos = setNames(c(${urls}), c(${names})), type = "source", filters = c(getOption("rsconnect.available_packages_filters", default = c()), "duplicates"));info <- pkgs[,c("Package", "Version", "Repository")];apply(info, 1, function(x) { cat(x, sep=" ", collapse="\\n") } );invisible()})()`;
+  // R script: query CRAN-style repos for available source packages,
+  // then print each as "name version repoURL" on one line.
+  return [
+    `pkgs <- available.packages(`,
+    `  repos = setNames(c(${urls}), c(${names})),`,
+    `  type = "source",`,
+    `  filters = c(getOption("rsconnect.available_packages_filters", default = c()), "duplicates")`,
+    `)`,
+    `info <- pkgs[, c("Package", "Version", "Repository")]`,
+    `apply(info, 1, function(x) cat(x, sep = " ", collapse = "\\n"))`,
+    `invisible()`,
+  ].join("; ");
 }
 
 /**
@@ -127,7 +138,18 @@ export async function getBioconductorRepos(
   projectDir: string,
 ): Promise<Repository[]> {
   const escapedDir = projectDir.replace(/\\/g, "\\\\");
-  const code = `(function() { if (requireNamespace("BiocManager", quietly = TRUE) || requireNamespace("BiocInstaller", quietly = TRUE)) {repos <- getFromNamespace("renv_bioconductor_repos", "renv")("${escapedDir}"); repos <- repos[setdiff(names(repos), "CRAN")]; cat(repos, labels=names(repos), fill=1); invisible()}})()`;
+
+  // R script: discover Bioconductor repo URLs via BiocManager or renv,
+  // then print each as "name url" on one line.
+  const code = [
+    `if (requireNamespace("BiocManager", quietly = TRUE)`,
+    `    || requireNamespace("BiocInstaller", quietly = TRUE)) {`,
+    `  repos <- getFromNamespace("renv_bioconductor_repos", "renv")("${escapedDir}")`,
+    `  ; repos <- repos[setdiff(names(repos), "CRAN")]`,
+    `  ; cat(repos, labels = names(repos), fill = 1)`,
+    `  ; invisible()`,
+    `}`,
+  ].join("\n");
 
   const output = await runRExpression(rPath, code, projectDir);
 

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -59,6 +59,14 @@ function runRExpression(
   });
 }
 
+/** Parse the output of `cat(.libPaths(), sep="\n")`. */
+export function parseLibPathsOutput(output: string): string[] {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("-"));
+}
+
 /**
  * Get the library paths where R packages are installed.
  * Mirrors Go's GetLibPaths().
@@ -72,18 +80,14 @@ export async function getLibPaths(
     'cat(.libPaths(), sep="\\n")',
     projectDir,
   );
-
-  return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line !== "" && !line.startsWith("-"));
+  return parseLibPathsOutput(output);
 }
 
 /**
  * Build the R code for listing available packages from given repositories.
  * Mirrors Go's ListAvailablePackages().
  */
-function buildAvailablePackagesCode(repos: Repository[]): string {
+export function buildAvailablePackagesCode(repos: Repository[]): string {
   const urls = repos.map((r) => `"${r.URL.replace(/\/+$/, "")}"`).join(", ");
   const names = repos.map((r, i) => `"${r.Name || `repo_${i}`}"`).join(", ");
 
@@ -101,18 +105,10 @@ function buildAvailablePackagesCode(repos: Repository[]): string {
   ].join("; ");
 }
 
-/**
- * List packages available in the given repositories.
- * Mirrors Go's ListAvailablePackages().
- */
-export async function listAvailablePackages(
-  rPath: string,
-  projectDir: string,
-  repos: Repository[],
-): Promise<AvailablePackage[]> {
-  const code = buildAvailablePackagesCode(repos);
-  const output = await runRExpression(rPath, code, projectDir);
-
+/** Parse the output of `available.packages()` — each line is "name version repoURL". */
+export function parseAvailablePackagesOutput(
+  output: string,
+): AvailablePackage[] {
   const available: AvailablePackage[] = [];
   for (const line of output.split("\n")) {
     const trimmed = line.trim();
@@ -127,6 +123,20 @@ export async function listAvailablePackages(
     });
   }
   return available;
+}
+
+/**
+ * List packages available in the given repositories.
+ * Mirrors Go's ListAvailablePackages().
+ */
+export async function listAvailablePackages(
+  rPath: string,
+  projectDir: string,
+  repos: Repository[],
+): Promise<AvailablePackage[]> {
+  const code = buildAvailablePackagesCode(repos);
+  const output = await runRExpression(rPath, code, projectDir);
+  return parseAvailablePackagesOutput(output);
 }
 
 /**
@@ -152,7 +162,11 @@ export async function getBioconductorRepos(
   ].join("\n");
 
   const output = await runRExpression(rPath, code, projectDir);
+  return parseBioconductorReposOutput(output);
+}
 
+/** Parse the output of the Bioconductor repos discovery script — each line is "name url". */
+export function parseBioconductorReposOutput(output: string): Repository[] {
   const repos: Repository[] = [];
   for (const line of output.split("\n")) {
     const trimmed = line.trim();

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -459,7 +459,7 @@ export async function libraryToManifestPackages(
   let lockfile: RenvLockfile;
   try {
     lockfile = JSON.parse(content);
-  } catch (err) {
+  } catch {
     throw new Error(`Failed to parse ${lockfilePath}: invalid JSON`);
   }
 

--- a/extensions/vscode/src/publish/testdata/cran_project/expected-library.json
+++ b/extensions/vscode/src/publish/testdata/cran_project/expected-library.json
@@ -1,0 +1,13 @@
+{
+  "mypkg": {
+    "Source": "CRAN",
+    "Repository": "https://cran.rstudio.com",
+    "description": {
+      "Package": "mypkg",
+      "Title": "A Sample Package",
+      "Version": "1.2.3",
+      "Depends": "R (>= 4.0)",
+      "Suggests": "testthat"
+    }
+  }
+}

--- a/extensions/vscode/src/publish/testdata/cran_project/renv_library/mypkg/DESCRIPTION
+++ b/extensions/vscode/src/publish/testdata/cran_project/renv_library/mypkg/DESCRIPTION
@@ -1,0 +1,5 @@
+Package: mypkg
+Title: A Sample Package
+Version: 1.2.3
+Depends: R (>= 4.0)
+Suggests: testthat

--- a/extensions/vscode/src/publish/testdata/dev_version/renv.lock
+++ b/extensions/vscode/src/publish/testdata/dev_version/renv.lock
@@ -1,0 +1,23 @@
+{
+	"R": {
+		"Version": "4.3.0",
+		"Repositories": [
+			{
+				"Name": "CRAN",
+				"URL": "https://cran.rstudio.com"
+			}
+		]
+	},
+	"Packages": {
+		"mypkg": {
+			"Package": "mypkg",
+			"Version": "1.2.3",
+			"Source": "Repository",
+			"Repository": "CRAN",
+			"Requirements": [
+			"R"
+			],
+			"Hash": "470851b6d5d0ac559e9d01bb352b4021"
+		}
+	}
+}

--- a/extensions/vscode/src/publish/testdata/dev_version/renv_library/mypkg/DESCRIPTION
+++ b/extensions/vscode/src/publish/testdata/dev_version/renv_library/mypkg/DESCRIPTION
@@ -1,0 +1,5 @@
+Package: mypkg
+Title: A Sample Package
+Version: 1.2.3
+Depends: R (>= 4.0)
+Suggests: testthat

--- a/extensions/vscode/src/publish/testdata/no_repos_project/renv.lock
+++ b/extensions/vscode/src/publish/testdata/no_repos_project/renv.lock
@@ -1,0 +1,13 @@
+{
+	"R": {
+		"Version": "4.3.0"
+	},
+	"Packages": {
+		"mypkg": {
+			"Package": "mypkg",
+			"Version": "1.2.3",
+			"Source": "Repository",
+			"Repository": "CRAN"
+		}
+	}
+}

--- a/extensions/vscode/src/publish/testdata/version_mismatch/renv.lock
+++ b/extensions/vscode/src/publish/testdata/version_mismatch/renv.lock
@@ -1,0 +1,23 @@
+{
+	"R": {
+		"Version": "4.3.0",
+		"Repositories": [
+			{
+				"Name": "CRAN",
+				"URL": "https://cran.rstudio.com"
+			}
+		]
+	},
+	"Packages": {
+		"mypkg": {
+			"Package": "mypkg",
+			"Version": "1.2.3",
+			"Source": "Repository",
+			"Repository": "CRAN",
+			"Requirements": [
+			"R"
+			],
+			"Hash": "470851b6d5d0ac559e9d01bb352b4021"
+		}
+	}
+}

--- a/extensions/vscode/src/publish/testdata/version_mismatch/renv_library/mypkg/DESCRIPTION
+++ b/extensions/vscode/src/publish/testdata/version_mismatch/renv_library/mypkg/DESCRIPTION
@@ -1,0 +1,5 @@
+Package: mypkg
+Title: A Sample Package
+Version: 4.5.6
+Depends: R (>= 4.0)
+Suggests: testthat


### PR DESCRIPTION
## Summary
- Ports Go's `defaultPackageMapper` to TypeScript (`rLibraryMapper.ts`)
- Includes R subprocess helpers (`getLibPaths`, `listAvailablePackages`, `getBioconductorRepos`) and package resolution logic (`toManifestPackage`, `readPackageDescription`)
- Uses `PackageLister` dependency injection for testability (no real R needed in tests)
- Golden file tests validate output matches Go's expected.json for CRAN and Bioconductor scenarios

Part 2 of 3 for #3815. Stacked on #3978.

## Test plan
- [x] Library mapper unit tests pass (20 tests: isCRANLike, toManifestPackage, readPackageDescription, golden files, error cases, integration with mocked lister)
- [x] `npm run test-unit` — all 1503 tests pass
- [x] `just lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)