### PR TITLE
chore(deps): bump axios to ^1.15.0 in remaining packages

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -15,7 +15,7 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "async-mutex": "^0.5.0",
-        "axios": "^1.13.6",
+        "axios": "^1.15.0",
         "debounce": "^3.0.0",
         "entities": "^8.0.0",
         "eventsource": "^4.1.0",
@@ -73,7 +73,7 @@
       "name": "@posit-dev/connect-cloud-api",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.9.0"
+        "axios": "^1.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1960,14 +1960,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -5224,10 +5224,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -690,7 +690,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "async-mutex": "^0.5.0",
-    "axios": "^1.13.6",
+    "axios": "^1.15.0",
     "debounce": "^3.0.0",
     "entities": "^8.0.0",
     "eventsource": "^4.1.0",

--- a/test/connect-api-contracts/package-lock.json
+++ b/test/connect-api-contracts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "connect-api-contracts",
       "dependencies": {
         "@posit-dev/connect-api": "file:../../packages/connect-api",
-        "axios": "^1.9.0"
+        "axios": "^1.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -21,7 +21,7 @@
       "name": "@posit-dev/connect-api",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.9.0"
+        "axios": "^1.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1037,14 +1037,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1543,10 +1543,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/test/connect-api-contracts/package.json
+++ b/test/connect-api-contracts/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@posit-dev/connect-api": "file:../../packages/connect-api",
-    "axios": "^1.9.0"
+    "axios": "^1.15.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Updates `axios` from `^1.13.6` to `^1.15.0` in `extensions/vscode`
- Updates `axios` from `^1.9.0` to `^1.15.0` in `test/connect-api-contracts`
- Aligns all packages in the repo on the same axios version (`^1.15.0`)

## Test plan
- [x] ESLint passes
- [x] TypeScript type checking passes (`tsc --noEmit`)
- [x] `extensions/vscode` unit tests pass (97 files, 1528 tests)
- [x] `test/connect-api-contracts` tests pass (15 files, 68 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)