### PR TITLE
Add Cloud SSE log streaming client

### DIFF
--- a/packages/connect-cloud-api/package-lock.json
+++ b/packages/connect-cloud-api/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@posit-dev/connect-cloud-api",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.15.0"
+        "axios": "^1.15.0",
+        "eventsource": "^4.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -679,6 +680,27 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {

--- a/packages/connect-cloud-api/package.json
+++ b/packages/connect-cloud-api/package.json
@@ -9,11 +9,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.0",
+    "eventsource": "^4.1.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
     "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
     "vitest": "^4.0.0"
   }
 }

--- a/packages/connect-cloud-api/src/index.ts
+++ b/packages/connect-cloud-api/src/index.ts
@@ -2,6 +2,7 @@
 
 export { ConnectCloudAPI } from "./client.js";
 export { CloudAuthClient } from "./auth.js";
+export { watchCloudLogs } from "./logs.js";
 
 export {
   CloudAuthToken,
@@ -10,6 +11,7 @@ export {
   cloudEnvironmentBaseUrls,
   cloudAuthBaseUrls,
   cloudAuthClientIds,
+  cloudLogsBaseUrls,
 } from "./types.js";
 
 export { ContentAccess, ContentType, PublishResult } from "./types.js";
@@ -28,6 +30,9 @@ export type {
   ContentResponse,
   CreateContentRequest,
   DeviceAuthResponse,
+  LogLevel,
+  LogLine,
+  LogsEventData,
   RequestRevision,
   Revision,
   Secret,
@@ -37,4 +42,5 @@ export type {
   UserAccountRole,
   UserAccountRoleAccount,
   UserResponse,
+  WatchLogsOptions,
 } from "./types.js";

--- a/packages/connect-cloud-api/src/index.ts
+++ b/packages/connect-cloud-api/src/index.ts
@@ -30,6 +30,8 @@ export type {
   ContentResponse,
   CreateContentRequest,
   DeviceAuthResponse,
+  LogEntry,
+  LogEntryType,
   LogLevel,
   LogLine,
   LogsEventData,

--- a/packages/connect-cloud-api/src/logs.test.ts
+++ b/packages/connect-cloud-api/src/logs.test.ts
@@ -158,6 +158,30 @@ describe("watchCloudLogs", () => {
       );
     });
 
+    it("encodes logChannel in the URL path", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "channel/with special?chars#here",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+
+      const nowNanos = 1_700_000_000_000 * 1_000_000;
+      const lookbackNanos = 60 * 1_000_000_000;
+      const sortKeyGt = nowNanos - lookbackNanos;
+
+      expect(instance.url).toBe(
+        `https://logs.connect.posit.cloud/v1/logs/${encodeURIComponent("channel/with special?chars#here")}/stream?sort_key__gt=${sortKeyGt}`,
+      );
+    });
+
     it("includes correct 60-second lookback in sort_key__gt parameter", async () => {
       const onLog = vi.fn();
       const promise = watchCloudLogs({
@@ -497,6 +521,26 @@ describe("watchCloudLogs", () => {
   });
 
   describe("AbortSignal", () => {
+    it("resolves immediately without opening EventSource when signal is already aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const onLog = vi.fn();
+
+      await expect(
+        watchCloudLogs({
+          environment: CloudEnvironment.Production,
+          logChannel: "test-channel",
+          authToken: "test-token",
+          onLog,
+          signal: controller.signal,
+        }),
+      ).resolves.toBeUndefined();
+
+      // No EventSource should have been created
+      expect(latestMockInstance).toBeNull();
+      expect(onLog).not.toHaveBeenCalled();
+    });
+
     it("closes EventSource and resolves when signal is aborted", async () => {
       const controller = new AbortController();
       const onLog = vi.fn();

--- a/packages/connect-cloud-api/src/logs.test.ts
+++ b/packages/connect-cloud-api/src/logs.test.ts
@@ -22,7 +22,10 @@ vi.mock("eventsource", () => {
   class MockEventSource {
     static CLOSED = 2;
     readyState = 0; // CONNECTING
-    close = vi.fn();
+    close = vi.fn(() => {
+      // Match real EventSource behavior: close() sets readyState to CLOSED
+      this.readyState = MockEventSource.CLOSED;
+    });
     url: string;
     options: { fetch?: unknown } | undefined;
     private eventHandlers = new Map<

--- a/packages/connect-cloud-api/src/logs.test.ts
+++ b/packages/connect-cloud-api/src/logs.test.ts
@@ -1,0 +1,767 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudEnvironment, type LogLine, type LogsEventData } from "./types.js";
+
+// Track the latest EventSource instance for testing
+interface MockInstance {
+  url: string;
+  options: { fetch?: unknown } | undefined;
+  readyState: number;
+  close: ReturnType<typeof vi.fn>;
+  triggerEvent: (
+    event: string,
+    data?: { data?: string; message?: string },
+  ) => void;
+}
+
+let latestMockInstance: MockInstance | null = null;
+
+// Mock the eventsource module
+vi.mock("eventsource", () => {
+  class MockEventSource {
+    static CLOSED = 2;
+    readyState = 0; // CONNECTING
+    close = vi.fn();
+    url: string;
+    options: { fetch?: unknown } | undefined;
+    private eventHandlers = new Map<
+      string,
+      Array<(event: { data?: string; message?: string }) => void>
+    >();
+
+    constructor(url: string, options?: { fetch?: unknown }) {
+      this.url = url;
+      this.options = options;
+      latestMockInstance = this as unknown as MockInstance;
+    }
+
+    addEventListener(
+      event: string,
+      handler: (event: { data?: string; message?: string }) => void,
+    ) {
+      const handlers = this.eventHandlers.get(event) || [];
+      handlers.push(handler);
+      this.eventHandlers.set(event, handlers);
+    }
+
+    triggerEvent(event: string, data?: { data?: string; message?: string }) {
+      const handlers = this.eventHandlers.get(event);
+      if (handlers) {
+        for (const handler of handlers) {
+          handler(data || {});
+        }
+      }
+    }
+  }
+
+  return { EventSource: MockEventSource };
+});
+
+// Import after mocking
+import { watchCloudLogs } from "./logs.js";
+
+// Helper function to get the latest instance
+function getInstance(): MockInstance {
+  if (!latestMockInstance) {
+    throw new Error("No EventSource instance created yet");
+  }
+  return latestMockInstance;
+}
+
+describe("watchCloudLogs", () => {
+  let dateNowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Mock Date.now() for deterministic timestamps
+    dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    latestMockInstance = null;
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  describe("URL construction", () => {
+    it("constructs correct URL for development environment", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Development,
+        logChannel: "test-channel-123",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Close immediately to resolve the promise
+      instance.readyState = 2; // CLOSED
+      instance.triggerEvent("error");
+
+      await promise;
+
+      const nowNanos = 1_700_000_000_000 * 1_000_000;
+      const lookbackNanos = 60 * 1_000_000_000;
+      const sortKeyGt = nowNanos - lookbackNanos;
+
+      expect(instance.url).toBe(
+        `https://logs.dev.connect.posit.cloud/v1/logs/test-channel-123/stream?sort_key__gt=${sortKeyGt}`,
+      );
+    });
+
+    it("constructs correct URL for staging environment", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Staging,
+        logChannel: "staging-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+
+      const nowNanos = 1_700_000_000_000 * 1_000_000;
+      const lookbackNanos = 60 * 1_000_000_000;
+      const sortKeyGt = nowNanos - lookbackNanos;
+
+      expect(instance.url).toBe(
+        `https://logs.staging.connect.posit.cloud/v1/logs/staging-channel/stream?sort_key__gt=${sortKeyGt}`,
+      );
+    });
+
+    it("constructs correct URL for production environment", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "prod-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+
+      const nowNanos = 1_700_000_000_000 * 1_000_000;
+      const lookbackNanos = 60 * 1_000_000_000;
+      const sortKeyGt = nowNanos - lookbackNanos;
+
+      expect(instance.url).toBe(
+        `https://logs.connect.posit.cloud/v1/logs/prod-channel/stream?sort_key__gt=${sortKeyGt}`,
+      );
+    });
+
+    it("includes correct 60-second lookback in sort_key__gt parameter", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+
+      // Calculate expected values
+      const nowNanos = 1_700_000_000_000 * 1_000_000;
+      const lookbackNanos = 60 * 1_000_000_000; // 60 seconds
+      const expectedSortKeyGt = nowNanos - lookbackNanos;
+
+      expect(instance.url).toContain(`sort_key__gt=${expectedSortKeyGt}`);
+    });
+  });
+
+  describe("Authorization header", () => {
+    it("passes Authorization header to custom fetch", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "my-secret-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Get the options passed to EventSource
+      expect(instance.options).toBeDefined();
+      expect(instance.options?.fetch).toBeDefined();
+
+      // Call the custom fetch function to verify Authorization header is injected
+      const customFetch = instance.options?.fetch as (
+        input: string,
+        init?: { headers?: Record<string, string> },
+      ) => Promise<Response>;
+
+      const mockFetch = vi.fn().mockResolvedValue(new Response());
+      global.fetch = mockFetch;
+
+      await customFetch("https://example.com", {
+        headers: { "X-Custom": "value" },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith("https://example.com", {
+        headers: {
+          "X-Custom": "value",
+          Authorization: "Bearer my-secret-token",
+        },
+      });
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+
+    it("preserves existing headers when adding Authorization", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "token-123",
+        onLog,
+      });
+
+      const instance = getInstance();
+      const customFetch = instance.options?.fetch as (
+        input: string,
+        init?: { headers?: Record<string, string> },
+      ) => Promise<Response>;
+
+      const mockFetch = vi.fn().mockResolvedValue(new Response());
+      global.fetch = mockFetch;
+
+      await customFetch("https://example.com", {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Request-ID": "abc",
+        },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith("https://example.com", {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Request-ID": "abc",
+          Authorization: "Bearer token-123",
+        },
+      });
+
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+  });
+
+  describe("Log parsing", () => {
+    it("parses single log entry and calls onLog", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      const eventData: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000000000,
+            sort_key: 1700000000000,
+            message: "Test log message",
+            type: "build",
+            level: "info",
+          },
+        ],
+      };
+
+      instance.triggerEvent("message", { data: JSON.stringify(eventData) });
+
+      expect(onLog).toHaveBeenCalledTimes(1);
+      expect(onLog).toHaveBeenCalledWith({
+        level: "info",
+        message: "Test log message",
+      });
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+
+    it("parses multiple log entries from single event", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      const eventData: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000000000,
+            sort_key: 1700000000000,
+            message: "First message",
+            type: "build",
+            level: "info",
+          },
+          {
+            timestamp: 1700000001000,
+            sort_key: 1700000001000,
+            message: "Second message",
+            type: "runtime",
+            level: "debug",
+          },
+          {
+            timestamp: 1700000002000,
+            sort_key: 1700000002000,
+            message: "Third message",
+            type: "build",
+            level: "error",
+          },
+        ],
+      };
+
+      instance.triggerEvent("message", { data: JSON.stringify(eventData) });
+
+      expect(onLog).toHaveBeenCalledTimes(3);
+      expect(onLog).toHaveBeenNthCalledWith(1, {
+        level: "info",
+        message: "First message",
+      });
+      expect(onLog).toHaveBeenNthCalledWith(2, {
+        level: "debug",
+        message: "Second message",
+      });
+      expect(onLog).toHaveBeenNthCalledWith(3, {
+        level: "error",
+        message: "Third message",
+      });
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+
+    it("extracts only level and message from log entries", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      const eventData: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000000000,
+            sort_key: 1700000000000,
+            message: "Log with extra fields",
+            type: "runtime",
+            level: "info",
+          },
+        ],
+      };
+
+      instance.triggerEvent("message", { data: JSON.stringify(eventData) });
+
+      const expectedLogLine: LogLine = {
+        level: "info",
+        message: "Log with extra fields",
+      };
+
+      expect(onLog).toHaveBeenCalledTimes(1);
+      expect(onLog).toHaveBeenCalledWith(expectedLogLine);
+
+      // Verify no extra properties
+      const actualCall = onLog.mock.calls[0][0];
+      expect(Object.keys(actualCall)).toEqual(["level", "message"]);
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+  });
+
+  describe("Multiple events", () => {
+    it("handles multiple SSE message events", async () => {
+      const onLog = vi.fn();
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // First event
+      const event1: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000000000,
+            sort_key: 1700000000000,
+            message: "Event 1 message",
+            type: "build",
+            level: "info",
+          },
+        ],
+      };
+      instance.triggerEvent("message", { data: JSON.stringify(event1) });
+
+      // Second event
+      const event2: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000001000,
+            sort_key: 1700000001000,
+            message: "Event 2 message",
+            type: "runtime",
+            level: "debug",
+          },
+        ],
+      };
+      instance.triggerEvent("message", { data: JSON.stringify(event2) });
+
+      // Third event with multiple entries
+      const event3: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000002000,
+            sort_key: 1700000002000,
+            message: "Event 3 message 1",
+            type: "build",
+            level: "error",
+          },
+          {
+            timestamp: 1700000003000,
+            sort_key: 1700000003000,
+            message: "Event 3 message 2",
+            type: "build",
+            level: "info",
+          },
+        ],
+      };
+      instance.triggerEvent("message", { data: JSON.stringify(event3) });
+
+      expect(onLog).toHaveBeenCalledTimes(4);
+      expect(onLog).toHaveBeenNthCalledWith(1, {
+        level: "info",
+        message: "Event 1 message",
+      });
+      expect(onLog).toHaveBeenNthCalledWith(2, {
+        level: "debug",
+        message: "Event 2 message",
+      });
+      expect(onLog).toHaveBeenNthCalledWith(3, {
+        level: "error",
+        message: "Event 3 message 1",
+      });
+      expect(onLog).toHaveBeenNthCalledWith(4, {
+        level: "info",
+        message: "Event 3 message 2",
+      });
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+  });
+
+  describe("AbortSignal", () => {
+    it("closes EventSource and resolves when signal is aborted", async () => {
+      const controller = new AbortController();
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+        signal: controller.signal,
+      });
+
+      const instance = getInstance();
+
+      // Abort the signal
+      controller.abort();
+
+      // Promise should resolve (not reject)
+      await expect(promise).resolves.toBeUndefined();
+
+      // close() should have been called
+      expect(instance.close).toHaveBeenCalled();
+    });
+
+    it("continues to work without signal", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+        // No signal provided
+      });
+
+      const instance = getInstance();
+
+      // Send a log event
+      const eventData: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000000000,
+            sort_key: 1700000000000,
+            message: "No signal test",
+            type: "build",
+            level: "info",
+          },
+        ],
+      };
+      instance.triggerEvent("message", { data: JSON.stringify(eventData) });
+
+      expect(onLog).toHaveBeenCalledWith({
+        level: "info",
+        message: "No signal test",
+      });
+
+      // Close the stream normally
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+  });
+
+  describe("Server-initiated closure", () => {
+    it("resolves when server closes stream (readyState === CLOSED)", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Simulate server closing the stream
+      instance.readyState = 2; // CLOSED
+      instance.triggerEvent("error");
+
+      // Should resolve, not reject
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it("closes EventSource on server-initiated closure", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+
+      expect(instance.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("Connection error", () => {
+    it("rejects when connection error occurs (readyState !== CLOSED)", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Simulate connection error (readyState is not CLOSED)
+      instance.readyState = 0; // CONNECTING
+      instance.triggerEvent("error", { message: "Network error" });
+
+      await expect(promise).rejects.toThrow(
+        "Cloud logs stream error: Network error",
+      );
+    });
+
+    it("rejects with default message when error has no message", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      instance.readyState = 1; // OPEN
+      instance.triggerEvent("error", {});
+
+      await expect(promise).rejects.toThrow(
+        "Cloud logs stream error: unknown error",
+      );
+    });
+
+    it("closes EventSource on connection error", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      instance.readyState = 0;
+      instance.triggerEvent("error");
+
+      await expect(promise).rejects.toThrow();
+
+      expect(instance.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("Malformed JSON", () => {
+    it("skips events with invalid JSON", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Send malformed JSON
+      instance.triggerEvent("message", { data: "invalid json{" });
+
+      // onLog should not have been called
+      expect(onLog).not.toHaveBeenCalled();
+
+      // Send valid event after malformed one
+      const validEvent: LogsEventData = {
+        data: [
+          {
+            timestamp: 1700000000000,
+            sort_key: 1700000000000,
+            message: "Valid message",
+            type: "build",
+            level: "info",
+          },
+        ],
+      };
+      instance.triggerEvent("message", { data: JSON.stringify(validEvent) });
+
+      // Now onLog should have been called once
+      expect(onLog).toHaveBeenCalledTimes(1);
+      expect(onLog).toHaveBeenCalledWith({
+        level: "info",
+        message: "Valid message",
+      });
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+
+    it("does not reject promise on malformed JSON", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Send malformed JSON
+      instance.triggerEvent("message", { data: "}{invalid" });
+
+      // Close the stream normally
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      // Should resolve, not reject
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it("skips events with missing data property", async () => {
+      const onLog = vi.fn();
+
+      const promise = watchCloudLogs({
+        environment: CloudEnvironment.Production,
+        logChannel: "test-channel",
+        authToken: "test-token",
+        onLog,
+      });
+
+      const instance = getInstance();
+
+      // Send JSON without data array
+      instance.triggerEvent("message", {
+        data: JSON.stringify({ invalid: "structure" }),
+      });
+
+      // This should cause an error when iterating over data.data
+      // The try-catch should handle it silently
+      expect(onLog).not.toHaveBeenCalled();
+
+      // Close the stream
+      instance.readyState = 2;
+      instance.triggerEvent("error");
+
+      await promise;
+    });
+  });
+});

--- a/packages/connect-cloud-api/src/logs.test.ts
+++ b/packages/connect-cloud-api/src/logs.test.ts
@@ -210,6 +210,12 @@ describe("watchCloudLogs", () => {
   });
 
   describe("Authorization header", () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
     it("passes Authorization header to custom fetch", async () => {
       const onLog = vi.fn();
       const promise = watchCloudLogs({

--- a/packages/connect-cloud-api/src/logs.ts
+++ b/packages/connect-cloud-api/src/logs.ts
@@ -92,8 +92,11 @@ export async function watchCloudLogs({
     // code's WatchLogs resolves without error on stream close. Only reject
     // for genuine connection failures (readyState !== CLOSED).
     es.addEventListener("error", (err) => {
+      // Capture readyState before close() — close() sets it to CLOSED,
+      // which would mask genuine connection failures.
+      const wasCleanClose = es.readyState === EventSource.CLOSED;
       es.close();
-      if (es.readyState === EventSource.CLOSED) {
+      if (wasCleanClose) {
         resolve();
       } else {
         reject(

--- a/packages/connect-cloud-api/src/logs.ts
+++ b/packages/connect-cloud-api/src/logs.ts
@@ -29,9 +29,13 @@ import {
  * });
  * ```
  */
-export async function watchCloudLogs(options: WatchLogsOptions): Promise<void> {
-  const { environment, logChannel, authToken, onLog, signal } = options;
-
+export async function watchCloudLogs({
+  environment,
+  logChannel,
+  authToken,
+  onLog,
+  signal,
+}: WatchLogsOptions): Promise<void> {
   // Construct SSE URL with 60-second lookback (matching Go's logLookback)
   const baseUrl = cloudLogsBaseUrls[environment];
   const nowNanos = Date.now() * 1_000_000;

--- a/packages/connect-cloud-api/src/logs.ts
+++ b/packages/connect-cloud-api/src/logs.ts
@@ -36,12 +36,17 @@ export async function watchCloudLogs({
   onLog,
   signal,
 }: WatchLogsOptions): Promise<void> {
+  // Short-circuit if already aborted — avoid opening a connection at all.
+  if (signal?.aborted) {
+    return;
+  }
+
   // Construct SSE URL with 60-second lookback (matching Go's logLookback)
   const baseUrl = cloudLogsBaseUrls[environment];
   const nowNanos = Date.now() * 1_000_000;
   const lookbackNanos = 60 * 1_000_000_000; // 60 seconds in nanoseconds
   const sortKeyGt = nowNanos - lookbackNanos;
-  const url = `${baseUrl}/v1/logs/${logChannel}/stream?sort_key__gt=${sortKeyGt}`;
+  const url = `${baseUrl}/v1/logs/${encodeURIComponent(logChannel)}/stream?sort_key__gt=${sortKeyGt}`;
 
   return new Promise<void>((resolve, reject) => {
     // Create EventSource with custom fetch to inject Authorization header

--- a/packages/connect-cloud-api/src/logs.ts
+++ b/packages/connect-cloud-api/src/logs.ts
@@ -71,36 +71,28 @@ export async function watchCloudLogs(options: WatchLogsOptions): Promise<void> {
             message: entry.message,
           });
         }
-      } catch (err) {
+      } catch {
         // Skip malformed events (don't reject the promise)
         // This matches Go behavior of continuing on parse errors
       }
     });
 
-    // Handle errors (connection failures, HTTP errors)
+    // Handle errors and server-initiated closure.
+    // When the server closes the SSE stream, the EventSource fires an
+    // "error" event with readyState === CLOSED. This is normal — the Go
+    // code's WatchLogs resolves without error on stream close. Only reject
+    // for genuine connection failures (readyState !== CLOSED).
     es.addEventListener("error", (err) => {
       es.close();
-      reject(
-        new Error(`Cloud logs stream error: ${err.message || "unknown error"}`),
-      );
-    });
-
-    // Handle normal stream closure (server-initiated)
-    // Note: EventSource doesn't have a 'close' event in the spec,
-    // but if the server closes the connection cleanly, the error
-    // event will fire with readyState === CLOSED
-    const checkClosed = () => {
       if (es.readyState === EventSource.CLOSED) {
         resolve();
+      } else {
+        reject(
+          new Error(
+            `Cloud logs stream error: ${err.message || "unknown error"}`,
+          ),
+        );
       }
-    };
-
-    // Poll readyState to detect clean closure
-    const closeCheck = setInterval(checkClosed, 100);
-
-    // Cleanup interval on resolution/rejection
-    const cleanup = () => clearInterval(closeCheck);
-    signal?.addEventListener("abort", cleanup);
-    es.addEventListener("error", cleanup);
+    });
   });
 }

--- a/packages/connect-cloud-api/src/logs.ts
+++ b/packages/connect-cloud-api/src/logs.ts
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { EventSource } from "eventsource";
+import {
+  cloudLogsBaseUrls,
+  type LogsEventData,
+  type WatchLogsOptions,
+} from "./types.js";
+
+/**
+ * Watch Cloud logs via Server-Sent Events.
+ *
+ * Opens a persistent SSE connection to the Cloud logs endpoint and streams log
+ * messages in real-time. Each SSE event contains a batch of log entries that are
+ * parsed and forwarded to the `onLog` callback.
+ *
+ * @param options - Configuration for the log stream
+ * @returns Promise that resolves when the stream closes (server-initiated or via signal)
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * await watchCloudLogs({
+ *   environment: CloudEnvironment.Production,
+ *   logChannel: "abc123",
+ *   authToken: "cloud-token",
+ *   onLog: (line) => console.log(`[${line.level}] ${line.message}`),
+ *   signal: controller.signal,
+ * });
+ * ```
+ */
+export async function watchCloudLogs(options: WatchLogsOptions): Promise<void> {
+  const { environment, logChannel, authToken, onLog, signal } = options;
+
+  // Construct SSE URL with 60-second lookback (matching Go's logLookback)
+  const baseUrl = cloudLogsBaseUrls[environment];
+  const nowNanos = Date.now() * 1_000_000;
+  const lookbackNanos = 60 * 1_000_000_000; // 60 seconds in nanoseconds
+  const sortKeyGt = nowNanos - lookbackNanos;
+  const url = `${baseUrl}/v1/logs/${logChannel}/stream?sort_key__gt=${sortKeyGt}`;
+
+  return new Promise<void>((resolve, reject) => {
+    // Create EventSource with custom fetch to inject Authorization header
+    const es = new EventSource(url, {
+      fetch: (input, init) =>
+        fetch(input, {
+          ...init,
+          headers: {
+            ...init?.headers,
+            Authorization: `Bearer ${authToken}`,
+          },
+        }),
+    });
+
+    // Handle abort signal
+    if (signal) {
+      signal.addEventListener("abort", () => {
+        es.close();
+        resolve();
+      });
+    }
+
+    // Handle incoming SSE messages
+    es.addEventListener("message", (event) => {
+      try {
+        const data = JSON.parse(event.data) as LogsEventData;
+        // Each event contains an array of log messages
+        for (const entry of data.data) {
+          onLog({
+            level: entry.level,
+            message: entry.message,
+          });
+        }
+      } catch (err) {
+        // Skip malformed events (don't reject the promise)
+        // This matches Go behavior of continuing on parse errors
+      }
+    });
+
+    // Handle errors (connection failures, HTTP errors)
+    es.addEventListener("error", (err) => {
+      es.close();
+      reject(
+        new Error(`Cloud logs stream error: ${err.message || "unknown error"}`),
+      );
+    });
+
+    // Handle normal stream closure (server-initiated)
+    // Note: EventSource doesn't have a 'close' event in the spec,
+    // but if the server closes the connection cleanly, the error
+    // event will fire with readyState === CLOSED
+    const checkClosed = () => {
+      if (es.readyState === EventSource.CLOSED) {
+        resolve();
+      }
+    };
+
+    // Poll readyState to detect clean closure
+    const closeCheck = setInterval(checkClosed, 100);
+
+    // Cleanup interval on resolution/rejection
+    const cleanup = () => clearInterval(closeCheck);
+    signal?.addEventListener("abort", cleanup);
+    es.addEventListener("error", cleanup);
+  });
+}

--- a/packages/connect-cloud-api/src/types.ts
+++ b/packages/connect-cloud-api/src/types.ts
@@ -250,3 +250,46 @@ export interface AuthorizationResponse {
   authorized: boolean;
   token?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Cloud logs base URLs
+// ---------------------------------------------------------------------------
+
+export const cloudLogsBaseUrls: Record<CloudEnvironment, string> = {
+  [CloudEnvironment.Development]: "https://logs.dev.connect.posit.cloud",
+  [CloudEnvironment.Staging]: "https://logs.staging.connect.posit.cloud",
+  [CloudEnvironment.Production]: "https://logs.connect.posit.cloud",
+};
+
+// ---------------------------------------------------------------------------
+// Log streaming types (from connect_cloud_logs/types.go)
+// ---------------------------------------------------------------------------
+
+export type LogLevel = "debug" | "info" | "error";
+
+export interface LogLine {
+  level: LogLevel;
+  message: string;
+}
+
+/**
+ * Shape of each SSE event's JSON `data` field from the Cloud logs endpoint.
+ * Each event contains an array of log messages.
+ */
+export interface LogsEventData {
+  data: Array<{
+    timestamp: number;
+    sort_key: number;
+    message: string;
+    type: string; // "build" | "runtime"
+    level: LogLevel;
+  }>;
+}
+
+export interface WatchLogsOptions {
+  environment: CloudEnvironment;
+  logChannel: string;
+  authToken: string;
+  onLog: (line: LogLine) => void;
+  signal?: AbortSignal;
+}

--- a/packages/connect-cloud-api/src/types.ts
+++ b/packages/connect-cloud-api/src/types.ts
@@ -267,23 +267,24 @@ export const cloudLogsBaseUrls: Record<CloudEnvironment, string> = {
 
 export type LogLevel = "debug" | "info" | "error";
 
-export interface LogLine {
-  level: LogLevel;
+export type LogEntryType = "build" | "runtime";
+
+export interface LogEntry {
+  timestamp: number;
+  sort_key: number;
   message: string;
+  type: LogEntryType;
+  level: LogLevel;
 }
+
+export type LogLine = Pick<LogEntry, "level" | "message">;
 
 /**
  * Shape of each SSE event's JSON `data` field from the Cloud logs endpoint.
  * Each event contains an array of log messages.
  */
 export interface LogsEventData {
-  data: Array<{
-    timestamp: number;
-    sort_key: number;
-    message: string;
-    type: string; // "build" | "runtime"
-    level: LogLevel;
-  }>;
+  data: LogEntry[];
 }
 
 export interface WatchLogsOptions {


### PR DESCRIPTION
## Summary

Part of #3916 (SSE log streaming portion)

Adds a Server-Sent Events client for streaming server-side logs during Connect Cloud deployments. This is **PR 1 of 2** for the Connect Cloud TypeScript publish migration (#3795).

- Adds `watchCloudLogs()` function to `@posit-dev/connect-cloud-api` that opens an SSE connection to the Cloud logs endpoint, parses batched log entries, and streams them to a callback
- Adds log streaming types (`LogLine`, `LogsEventData`, `WatchLogsOptions`) and environment base URLs (`cloudLogsBaseUrls`) to `types.ts`
- Matches Go behavior: 60-second lookback, Bearer token auth via custom fetch, silent skip of malformed events, resolve (not reject) on server-initiated stream closure
- Uses `eventsource@4.1.0` npm package for high-level SSE client with custom fetch support
- 20 unit tests covering URL construction, auth headers, log parsing, abort signal, stream closure, connection errors, and malformed JSON

## Test plan

- [x] `npx vitest run` in `packages/connect-cloud-api/` — all 77 tests pass (20 new)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)