### PR TITLE
Fix dev version check blanking Source for CRAN-like packages

### DIFF
--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -498,30 +498,6 @@ describe("library mapper error cases", () => {
     expect(description["Version"]).not.toBe(pkg.Version);
   });
 
-  test("CRAN package newer than mirror still resolves (toManifestPackage)", () => {
-    const pkg: RenvPackage = {
-      Package: "mypkg",
-      Version: "1.2.3",
-      Source: "Repository",
-      Repository: "CRAN",
-    };
-    const available: AvailablePackage[] = [
-      {
-        name: "mypkg",
-        version: "1.0.0", // installed is newer
-        repository: "https://cran.rstudio.com",
-      },
-    ];
-    const result = toManifestPackage(
-      pkg,
-      [{ Name: "CRAN", URL: "https://cran.rstudio.com" }],
-      available,
-      [],
-    );
-    expect(result.Source).toBe("CRAN");
-    expect(result.Repository).toBe("https://cran.rstudio.com");
-  });
-
   test("missing DESCRIPTION throws with renv::restore() guidance", async () => {
     await expect(readPackageDescription("mypkg", [])).rejects.toThrow(
       "consider running renv::restore()",

--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -69,7 +69,7 @@ describe("toManifestPackage", () => {
     });
   });
 
-  test("CRAN dev version results in empty source/repo", () => {
+  test("CRAN package newer than mirror still resolves", () => {
     const pkg: RenvPackage = {
       Package: "mypkg",
       Version: "2.0.0",
@@ -84,7 +84,10 @@ describe("toManifestPackage", () => {
       },
     ];
     const result = toManifestPackage(pkg, cranRepos, available, []);
-    expect(result).toEqual({ Source: "", Repository: "" });
+    expect(result).toEqual({
+      Source: "CRAN",
+      Repository: "https://cran.rstudio.com",
+    });
   });
 
   test("RSPM package not in available packages keeps RSPM source", () => {
@@ -495,7 +498,7 @@ describe("library mapper error cases", () => {
     expect(description["Version"]).not.toBe(pkg.Version);
   });
 
-  test("dev version produces empty Source", () => {
+  test("CRAN package newer than mirror still resolves (toManifestPackage)", () => {
     const pkg: RenvPackage = {
       Package: "mypkg",
       Version: "1.2.3",
@@ -515,8 +518,8 @@ describe("library mapper error cases", () => {
       available,
       [],
     );
-    expect(result.Source).toBe("");
-    expect(result.Repository).toBe("");
+    expect(result.Source).toBe("CRAN");
+    expect(result.Repository).toBe("https://cran.rstudio.com");
   });
 
   test("missing DESCRIPTION throws with renv::restore() guidance", async () => {
@@ -598,7 +601,7 @@ describe("libraryToManifestPackages", () => {
     ).rejects.toThrow("versions in lockfile '1.2.3' and library '4.5.6'");
   });
 
-  test("throws on dev version with empty source", async () => {
+  test("CRAN package newer than mirror succeeds", async () => {
     const projectDir = path.join(testdataDir, "dev_version");
     const libPath = path.join(projectDir, "renv_library");
 
@@ -614,9 +617,15 @@ describe("libraryToManifestPackages", () => {
         ]),
     });
 
-    await expect(
-      libraryToManifestPackages(projectDir, rConfig, "/usr/bin/R", lister),
-    ).rejects.toThrow("cannot re-install packages installed from source");
+    const result = await libraryToManifestPackages(
+      projectDir,
+      rConfig,
+      "/usr/bin/R",
+      lister,
+    );
+    expect(result["mypkg"]).toBeDefined();
+    expect(result["mypkg"]!.Source).toBe("CRAN");
+    expect(result["mypkg"]!.Repository).toBe("https://cran.rstudio.com");
   });
 
   test("throws when DESCRIPTION not found in any libPath", async () => {

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -213,53 +213,6 @@ export function isCRANLike(repo: string): boolean {
   return repo === "CRAN" || repo === "RSPM" || repo === "PPM" || repo === "P3M";
 }
 
-/**
- * Parse an R version string into an array of integers for comparison.
- * R versions are sequences of non-negative integers separated by . or -.
- */
-function packageVersion(vs: string): number[] {
-  return vs
-    .split(/[^0-9]+/)
-    .filter((s) => s !== "")
-    .map(Number);
-}
-
-/**
- * Whether a package is a dev version (newer than what's available in repos).
- */
-function isDevVersion(
-  pkg: RenvPackage,
-  availablePackages: AvailablePackage[],
-): boolean {
-  const repoVersion = findAvailableVersion(pkg.Package, availablePackages);
-  if (!repoVersion) {
-    return false;
-  }
-  const installed = packageVersion(pkg.Version);
-  const available = packageVersion(repoVersion);
-  // Compare arrays lexicographically
-  const len = Math.max(installed.length, available.length);
-  for (let i = 0; i < len; i++) {
-    const a = installed[i] ?? 0;
-    const b = available[i] ?? 0;
-    if (a > b) return true;
-    if (a < b) return false;
-  }
-  return false;
-}
-
-function findAvailableVersion(
-  pkgName: string,
-  availablePackages: AvailablePackage[],
-): string {
-  for (const avail of availablePackages) {
-    if (avail.name === pkgName) {
-      return avail.version;
-    }
-  }
-  return "";
-}
-
 function findRepoUrl(
   pkgName: string,
   availablePackages: AvailablePackage[],
@@ -325,9 +278,6 @@ export function toManifestPackage(
   switch (source) {
     case "Repository": {
       if (isCRANLike(repository)) {
-        if (isDevVersion(pkg, availablePackages)) {
-          return { Source: "", Repository: "" };
-        }
         return {
           Source: repository,
           Repository: findRepoUrl(pkg.Package, availablePackages),

--- a/test/e2e/code-server-entry.sh
+++ b/test/e2e/code-server-entry.sh
@@ -13,6 +13,8 @@ cat <<EOF > /home/coder/.local/share/code-server/User/settings.json
   "remote.autoForwardPortsSource": "hybrid",
   "workbench.settings.applyToAllProfiles": [],
   "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
   "window.restoreWindows": "none",
   "files.hotExit": "off",
   "positPublisher.useKeyChainCredentialStorage": false

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -38,8 +38,23 @@ Cypress.on("uncaught:exception", (err) => {
   return true;
 });
 
-// Delete previous vscode sessions, avoid starting up tests with previous editor data.
+// Wipe VSCode's IndexedDB for a clean start, and strip the code-server
+// onboarding overlay whenever it renders. The wipe clears "user has seen
+// onboarding" state, so the overlay reappears every test load; an observer
+// avoids racing against when it's inserted.
 Cypress.on("window:before:load", (win) => {
+  const stripOnboarding = () => {
+    win.document
+      .querySelectorAll(".onboarding-a-overlay, .onboarding-backdrop")
+      .forEach((node) => node.remove());
+  };
+  const observer = new win.MutationObserver(stripOnboarding);
+  observer.observe(win.document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+  stripOnboarding();
+
   return win.indexedDB.databases().then((dbrecs) => {
     for (var i = 0; i < dbrecs.length; i++) {
       win.indexedDB.deleteDatabase(dbrecs[i].name);
@@ -48,26 +63,6 @@ Cypress.on("window:before:load", (win) => {
 });
 
 configure({ testIdAttribute: "data-automation" });
-
-// Dismiss the VSCode onboarding overlay if it appears.
-// Newer code-server versions may show a "Welcome to Visual Studio Code"
-// dialog that covers the entire UI and blocks interaction.
-Cypress.Commands.add("dismissOnboardingOverlay", () => {
-  cy.get("body", { log: false }).then(($body) => {
-    const overlay = $body.find(".onboarding-a-overlay.visible");
-    if (overlay.length > 0) {
-      cy.log("Dismissing VSCode onboarding overlay");
-      // Remove the overlay and its backdrop from the DOM entirely.
-      // Pressing Escape doesn't reliably close it, and the overlay
-      // blocks all interaction with the underlying UI.
-      overlay.remove();
-      $body.find(".onboarding-a-overlay").remove();
-      // Also remove any remaining backdrop
-      $body.find(".onboarding-backdrop").remove();
-      cy.log("Onboarding overlay removed from DOM");
-    }
-  });
-});
 
 // Global command for skipping tests in CI
 Cypress.skipCI = (fn) => (Cypress.env("CI") === "true" ? fn.skip : fn);

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -57,12 +57,14 @@ Cypress.Commands.add("dismissOnboardingOverlay", () => {
     const overlay = $body.find(".onboarding-a-overlay.visible");
     if (overlay.length > 0) {
       cy.log("Dismissing VSCode onboarding overlay");
-      // Press Escape to close the dialog
-      cy.get("body").type("{esc}");
-      // Verify it's gone
-      cy.get(".onboarding-a-overlay.visible", { timeout: 5000 }).should(
-        "not.exist",
-      );
+      // Remove the overlay and its backdrop from the DOM entirely.
+      // Pressing Escape doesn't reliably close it, and the overlay
+      // blocks all interaction with the underlying UI.
+      overlay.remove();
+      $body.find(".onboarding-a-overlay").remove();
+      // Also remove any remaining backdrop
+      $body.find(".onboarding-backdrop").remove();
+      cy.log("Onboarding overlay removed from DOM");
     }
   });
 });

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -49,6 +49,24 @@ Cypress.on("window:before:load", (win) => {
 
 configure({ testIdAttribute: "data-automation" });
 
+// Dismiss the VSCode onboarding overlay if it appears.
+// Newer code-server versions may show a "Welcome to Visual Studio Code"
+// dialog that covers the entire UI and blocks interaction.
+Cypress.Commands.add("dismissOnboardingOverlay", () => {
+  cy.get("body", { log: false }).then(($body) => {
+    const overlay = $body.find(".onboarding-a-overlay.visible");
+    if (overlay.length > 0) {
+      cy.log("Dismissing VSCode onboarding overlay");
+      // Press Escape to close the dialog
+      cy.get("body").type("{esc}");
+      // Verify it's gone
+      cy.get(".onboarding-a-overlay.visible", { timeout: 5000 }).should(
+        "not.exist",
+      );
+    }
+  });
+});
+
 // Global command for skipping tests in CI
 Cypress.skipCI = (fn) => (Cypress.env("CI") === "true" ? fn.skip : fn);
 

--- a/test/e2e/support/selectors.js
+++ b/test/e2e/support/selectors.js
@@ -160,9 +160,6 @@ Cypress.Commands.add("publisherWebviewExtreme", () => {
 // and ensure the UI is stable before clicking.
 // When to use: Before opening the Publisher webview from VS Code UI.
 Cypress.Commands.add("getPublisherSidebarIcon", () => {
-  // Dismiss any onboarding overlay that may be covering the UI
-  cy.dismissOnboardingOverlay();
-
   // Advanced Publisher icon finder that waits for extension stability
   const maxAttempts = 30;
   const stabilityChecks = 3; // Number of consecutive checks to confirm stability

--- a/test/e2e/support/selectors.js
+++ b/test/e2e/support/selectors.js
@@ -160,6 +160,9 @@ Cypress.Commands.add("publisherWebviewExtreme", () => {
 // and ensure the UI is stable before clicking.
 // When to use: Before opening the Publisher webview from VS Code UI.
 Cypress.Commands.add("getPublisherSidebarIcon", () => {
+  // Dismiss any onboarding overlay that may be covering the UI
+  cy.dismissOnboardingOverlay();
+
   // Advanced Publisher icon finder that waits for extension stability
   const maxAttempts = 30;
   const stabilityChecks = 3; // Number of consecutive checks to confirm stability


### PR DESCRIPTION
## Summary
- Removes `isDevVersion` check entirely for CRAN-like packages in `rLibraryMapper.ts`
- Also removes the now-unused `findAvailableVersion` and `packageVersion` helper functions

## Root cause
The `isDevVersion` check blanked out `Source` and `Repository` for CRAN-like packages whose installed version was newer than what the queried mirror returned. This caused `libraryToManifestPackages` to throw:

> cannot re-install packages installed from source; all packages must be installed from a reproducible location such as a repository. Package renv, Version 1.2.2

Diagnosed via #4009: in CI, `renv::init()` installs renv 1.2.2 (current CRAN release), but `listAvailablePackages` queries PPM (`https://packagemanager.posit.co/cran/latest`) which only has 1.2.1. The `isDevVersion` check treats 1.2.2 > 1.2.1 as a "dev version" and blanks the Source, which then fails validation.

## Why full removal is correct
The `isDevVersion` check only fires inside the `Source: "Repository"` + `isCRANLike(repository)` code path. Real dev versions (GitHub, GitLab, local installs) have `Source: "GitHub"` / `Source: "Local"` etc. and hit different switch branches. r-universe packages aren't CRAN-like. So this check can **only** produce false positives from mirror sync lag — never catch an actual dev version.

This was independently confirmed by the Go codebase: the same bug hit Windows ARM runners (where binary repos had newer versions than `available.packages(type="source")` returned), and the fix on branch `fix-windows-arm-renv-dev-version` was identical — remove `isDevVersion` entirely. That Go fix hasn't merged yet, but the TypeScript port copied the code before it landed.

## Test plan
- [x] Updated unit tests: dev version scenarios now expect successful resolution with CRAN source
- [x] Updated `libraryToManifestPackages` test: dev version now succeeds instead of throwing
- [ ] CI interpreter-integration tests should pass for all R configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)