### PR TITLE
Remove renv issue #1202 Bioconductor workaround

### DIFF
--- a/extensions/vscode/src/publish/rLibraryMapper.test.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.test.ts
@@ -289,27 +289,6 @@ describe("toManifestPackage", () => {
       Repository: "https://custom.example.com",
     });
   });
-
-  test("Bioconductor workaround for missing repository with bioconductor RemoteRepos", () => {
-    const pkg: RenvPackage = {
-      Package: "Biobase",
-      Version: "2.62.0",
-      Source: "Repository",
-      RemoteRepos: "https://bioconductor.org/packages/3.18/bioc",
-    };
-    const biocPackages: AvailablePackage[] = [
-      {
-        name: "Biobase",
-        version: "2.62.0",
-        repository: "https://bioconductor.org/packages/3.18/bioc",
-      },
-    ];
-    const result = toManifestPackage(pkg, cranRepos, [], biocPackages);
-    expect(result).toEqual({
-      Source: "Bioconductor",
-      Repository: "https://bioconductor.org/packages/3.18/bioc",
-    });
-  });
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/vscode/src/publish/rLibraryMapper.ts
+++ b/extensions/vscode/src/publish/rLibraryMapper.ts
@@ -263,13 +263,8 @@ export function toManifestPackage(
   availablePackages: AvailablePackage[],
   biocPackages: AvailablePackage[],
 ): { Source: string; Repository: string } {
-  let source = pkg.Source;
+  const source = pkg.Source;
   const repository = pkg.Repository ?? "";
-
-  if (!repository && pkg.RemoteRepos?.includes("bioconductor.org")) {
-    // Workaround for https://github.com/rstudio/renv/issues/1202
-    source = "Bioconductor";
-  }
 
   switch (source) {
     case "Repository": {


### PR DESCRIPTION
Closes #3984

## Summary
- Remove the workaround for rstudio/renv#1202 from both TypeScript and Go code
- The upstream bug was fixed in renv v1.0.4 (Feb 2024), now over 2 years old
- Remove corresponding test case

## Test plan
- [ ] All TypeScript unit tests pass (1662 passed)
- [ ] CI passes

Generated with [Claude Code](https://claude.ai/code)