### PR TITLE
Migrate schemas to extensions/vscode, restore draft schemas and examples

### DIFF
--- a/.github/workflows/schema-upload.yaml
+++ b/.github/workflows/schema-upload.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "internal/schema/schemas/*.json"
+      - "extensions/vscode/src/toml/schemas/*.json"
   workflow_dispatch:
 
 permissions:
@@ -25,7 +25,8 @@ jobs:
 
       - name: Upload schemas to S3
         run: |
-          aws s3 sync internal/schema/schemas/ s3://posit-publisher/publisher/schemas/ \
+          SCHEMA_DIR=extensions/vscode/src/toml/schemas
+          aws s3 sync ${SCHEMA_DIR}/ s3://posit-publisher/publisher/schemas/ \
             --exclude "*" \
             --include "posit-publishing-*.json"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ When adding entries to CHANGELOG.md:
 
 # Schema Updates
 
-Schemas exist in both `extensions/vscode/src/toml/schemas/` (used by TypeScript) and `internal/schema/schemas/` (used by Go):
+Schemas are in `extensions/vscode/src/toml/schemas/` (canonical location, uploaded to CDN by CI):
 
 - `posit-publishing-schema-v3.json` - Configuration schema
 - `posit-publishing-record-schema-v3.json` - Deployment record schema

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,14 +261,14 @@ See [the Contribution Guide for the VSCode Extension](./extensions/vscode/CONTRI
 
 ## Schema Updates
 
-Schemas can be found in the `internal/schema/schemas` directory.
+Schemas can be found in the `extensions/vscode/src/toml/schemas` directory.
 
 Non-breaking or additive changes to the schema do not require a version bump. Breaking changes to the schema require a version bump.
 
 To update the schema:
 
 - Update the jsonschema file (`posit-publishing-schema-v3.json` or `posit-publishing-record-schema-v3.json` for the Configuration or Deployment schemas, respectively)
-- Update the corresponding example file (`config.toml` or `record.toml`).
+- Update the corresponding example file (`example-config.toml` or `example-record.toml`).
 - If you're using VSCode with the Even Better TOML extension, you can use the in-editor validation by putting the full local path to your updated schema in the `$schema` field in your TOML files.
 - Verify that the unit tests pass. They load the example files and validate them against the schemas.
 - The `draft` folder contains schemas that are a superset of the main schemas, and have ideas for the other settings we have considered adding. Usually we have added any new fields to those schemas and example files as well.

--- a/extensions/vscode/src/toml/schema.test.ts
+++ b/extensions/vscode/src/toml/schema.test.ts
@@ -1,9 +1,17 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
+import fs from "fs";
+import path from "path";
+
 import { describe, expect, it } from "vitest";
 import Ajv2020 from "ajv/dist/2020";
 import addFormats from "ajv-formats";
+import { parse as parseTOML } from "smol-toml";
+
 import schema from "./schemas/posit-publishing-schema-v3.json";
+import recordSchema from "./schemas/posit-publishing-record-schema-v3.json";
+import draftSchema from "./schemas/draft/posit-publishing-schema-v3.json";
+import draftRecordSchema from "./schemas/draft/posit-publishing-record-schema-v3.json";
 
 const ajv = new Ajv2020({ strict: false, allErrors: true });
 addFormats(ajv);
@@ -250,4 +258,66 @@ describe("schema rejects disallowed properties for Connect Cloud", () => {
     data.connect = { kubernetes: {} };
     expectInvalid(data);
   });
+});
+
+describe("example TOML files validate against their schemas", () => {
+  const schemasDir = path.resolve(__dirname, "schemas");
+
+  function loadTOML(relativePath: string): Record<string, unknown> {
+    const content = fs.readFileSync(
+      path.join(schemasDir, relativePath),
+      "utf-8",
+    );
+    return parseTOML(content) as Record<string, unknown>;
+  }
+
+  function compileWithRef(
+    mainSchema: Record<string, unknown>,
+    refSchema: Record<string, unknown>,
+  ) {
+    const localAjv = new Ajv2020({ strict: false, allErrors: true });
+    addFormats(localAjv);
+    localAjv.addSchema(refSchema);
+    return localAjv.compile(mainSchema);
+  }
+
+  // Release config schema
+  const validateConfig = validate;
+  // Release record schema (references config schema via $ref)
+  const validateRecord = compileWithRef(recordSchema, schema);
+  // Draft config schema
+  const validateDraftConfig = (() => {
+    const draftAjv = new Ajv2020({ strict: false, allErrors: true });
+    addFormats(draftAjv);
+    return draftAjv.compile(draftSchema);
+  })();
+  // Draft record schema (references draft config schema via $ref)
+  const validateDraftRecord = compileWithRef(draftRecordSchema, draftSchema);
+
+  const cases: { file: string; validator: ReturnType<typeof ajv.compile> }[] = [
+    { file: "example-config.toml", validator: validateConfig },
+    { file: "example-config-cloud.toml", validator: validateConfig },
+    { file: "example-record.toml", validator: validateRecord },
+    { file: "example-record-cloud.toml", validator: validateRecord },
+    {
+      file: "draft/example-config.toml",
+      validator: validateDraftConfig,
+    },
+    {
+      file: "draft/example-config-cloud.toml",
+      validator: validateDraftConfig,
+    },
+    { file: "draft/example-record.toml", validator: validateDraftRecord },
+  ];
+
+  for (const { file, validator } of cases) {
+    it(file, () => {
+      const data = loadTOML(file);
+      const valid = validator(data);
+      expect(
+        valid,
+        `${file} failed validation: ${JSON.stringify(validator.errors, null, 2)}`,
+      ).toBe(true);
+    });
+  }
 });

--- a/extensions/vscode/src/toml/schemas/draft/example-config-cloud.toml
+++ b/extensions/vscode/src/toml/schemas/draft/example-config-cloud.toml
@@ -1,0 +1,41 @@
+# Example schema file
+"$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+product_type = "connect_cloud"
+type = "quarto-static"
+entrypoint = "report.qmd"
+title = "Regional Quarterly Sales Report"
+description = "This is the quarterly sales report, broken down by region."
+validate = true
+
+files = [
+    "*.py",
+    "*.qmd",
+    "requirements.txt",
+]
+secrets = ["API_KEY", "DATABASE_PASSWORD"]
+
+[python]
+version = "3.11.3"
+
+[r]
+version = "4.3.1"
+
+[environment]
+API_URL = "https://example.com/api"
+
+[connect_cloud]
+vanity_name = "sales-report"
+
+[connect_cloud.access_control]
+public_access = true
+organization_access = "viewer"
+
+[connect.runtime]
+connection_timeout = 5
+read_timeout = 30
+init_timeout = 60
+idle_timeout = 120
+max_processes = 5
+min_processes = 1
+max_conns_per_process = 50
+load_factor = 0.5

--- a/extensions/vscode/src/toml/schemas/draft/example-config.toml
+++ b/extensions/vscode/src/toml/schemas/draft/example-config.toml
@@ -1,0 +1,77 @@
+# Example schema file for the full draft schema
+"$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+type = "quarto-static"
+product_type = "connect"
+entrypoint = "report.qmd"
+title = "Regional Quarterly Sales Report"
+description = "This is the quarterly sales report, broken down by region."
+thumbnail = "images/thumbnail.jpg"
+validate = true
+
+files = [
+    "*.py",
+    "*.qmd",
+    "requirements.txt",
+]
+
+tags = [ "sales", "quarterly", "regional" ]
+
+secrets = ["API_KEY"]
+
+[python]
+version = "3.11.3"
+package_file = "requirements.txt"
+package_manager = "pip"
+
+[r]
+version = "4.3.1"
+package_file = "renv.lock"
+package_manager = "renv"
+
+[quarto]
+version = "1.4"
+
+[environment]
+API_URL = "https://example.com/api"
+
+[[schedules]]
+start = "2023-10-25T08:00:00Z"
+recurrence = "FREQ=MONTHLY;INTERVAL=3"
+
+[[connect.access_control.users]]
+id = "jqpublic"
+guid = "536b456e-0311-4f92-ba10-dbf1db8a468e"
+name = "John Q. Public"
+permissions = "editor"
+
+[[connect.access_control.groups]]
+id = "Data Science Team"
+guid = "8b4fde3e-f995-4894-bc02-ae47538262ff"
+name = "Data Science Team"
+permissions = "editor"
+
+[connect.access]
+run_as = "rstudio-connect"
+run_as_current_user = false
+
+[connect.runtime]
+connection_timeout = 5
+read_timeout = 30
+init_timeout = 60
+idle_timeout = 120
+max_processes = 5
+min_processes = 1
+max_conns_per_process = 50
+load_factor = 0.5
+
+[connect.kubernetes]
+amd_gpu_limit = 0
+cpu_limit = 1.5
+cpu_request = 0.5
+default_image_name = "posit/connect-runtime-python3.11-r4.3"
+memory_limit = 100000000
+memory_request = 20000000
+nvidia_gpu_limit = 0
+service_account_name = "posit-connect-content"
+default_r_environment_management = true
+default_py_environment_management = true

--- a/extensions/vscode/src/toml/schemas/draft/example-record.toml
+++ b/extensions/vscode/src/toml/schemas/draft/example-record.toml
@@ -1,0 +1,87 @@
+"$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-record-schema-v3.json"
+server_url = "https://connect.example.com"
+id = "de2e7bdb-b085-401e-a65c-443e40009749"
+client_version = '1.0.1'
+type = 'python-shiny'
+created_at = '2024-01-19T09:33:33.131481-05:00'
+configuration_name = "production"
+deployed_at = '2024-01-19T09:33:33.131481-05:00'
+bundle_id = '123'
+bundle_url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
+dashboard_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/'
+direct_url = 'https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/'
+logs_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs'
+
+[configuration]
+"$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+type = "quarto-static"
+entrypoint = "report.qmd"
+title = "Regional Quarterly Sales Report"
+description = "This is the quarterly sales report, broken down by region."
+validate = true
+files = [
+    "*.py",
+    "*.qmd",
+    "requirements.txt",
+]
+thumbnail = "images/thumbnail.jpg"
+tags = [ "sales", "quarterly", "regional" ]
+secrets = ["API_KEY"]
+
+[configuration.python]
+version = "3.11.3"
+package_file = "requirements.txt"
+package_manager = "pip"
+
+[configuration.r]
+version = "4.3.1"
+package_file = "renv.lock"
+package_manager = "renv"
+
+[configuration.quarto]
+version = "1.4"
+
+[configuration.environment]
+API_URL = "https://example.com/api"
+
+[[configuration.schedules]]
+start = "2023-10-25T08:00:00Z"
+recurrence = "FREQ=MONTHLY;INTERVAL=3"
+
+[[configuration.connect.access_control.users]]
+id = "jqpublic"
+guid = "536b456e-0311-4f92-ba10-dbf1db8a468e"
+name = "John Q. Public"
+permissions = "editor"
+
+[[configuration.connect.access_control.groups]]
+id = "Data Science Team"
+guid = "8b4fde3e-f995-4894-bc02-ae47538262ff"
+name = "Data Science Team"
+permissions = "editor"
+
+[configuration.connect.access]
+run_as = "rstudio-connect"
+run_as_current_user = false
+
+[configuration.connect.runtime]
+connection_timeout = 5
+read_timeout = 30
+init_timeout = 60
+idle_timeout = 120
+max_processes = 5
+min_processes = 1
+max_conns_per_process = 50
+load_factor = 0.5
+
+[configuration.connect.kubernetes]
+amd_gpu_limit = 0
+cpu_limit = 1
+cpu_request = 0.5
+default_image_name = "posit/connect-runtime-python3.11-r4.3"
+memory_limit = 100000000
+memory_request = 20000000
+nvidia_gpu_limit = 0
+service_account_name = "posit-connect-content"
+default_r_environment_management = true
+default_py_environment_management = true

--- a/extensions/vscode/src/toml/schemas/draft/posit-publishing-record-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/draft/posit-publishing-record-schema-v3.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-record-schema-v3.json",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Posit Publishing Record",
+  "required": ["$schema", "server_url", "id", "configuration_name"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "url",
+      "description": "URL of the json-schema definition for this file. Must be 'https://cdn.posit.co/publisher/schemas/draft/posit-publishing-record-schema-v3.json'.",
+      "enum": [
+        "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-record-schema-v3.json"
+      ],
+      "examples": [
+        "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-record-schema-v3.json"
+      ]
+    },
+    "server_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the server where this content was deployed.",
+      "examples": ["https://connect.example.com"]
+    },
+    "server_type": {
+      "type": "string",
+      "description": "Type of server",
+      "enum": ["connect", "snowflake", "connect_cloud"],
+      "examples": ["connect"]
+    },
+    "account_name": {
+      "type": ["string"],
+      "description": "Name of the account on the server where this content was deployed.",
+      "examples": ["my-account"]
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique ID of this deployment.",
+      "examples": ["de2e7bdb-b085-401e-a65c-443e40009749"]
+    },
+    "client_version": {
+      "type": "string",
+      "description": "Version of the publisher that deployed the content."
+    },
+    "type": {
+      "type": "string",
+      "description": "Indicates the type of content. Valid values are: html, jupyter-notebook, jupyter-voila, python-bokeh, python-dash, python-fastapi, python-flask, python-shiny, python-streamlit, quarto-shiny, quarto-static, r-plumber, r-shiny, rmd-shiny, rmd",
+      "enum": [
+        "",
+        "html",
+        "jupyter-notebook",
+        "jupyter-voila",
+        "python-bokeh",
+        "python-dash",
+        "python-fastapi",
+        "python-flask",
+        "python-shiny",
+        "python-streamlit",
+        "quarto-shiny",
+        "quarto",
+        "quarto-static",
+        "r-plumber",
+        "r-shiny",
+        "rmd-shiny",
+        "rmd",
+        "unknown"
+      ],
+      "examples": ["quarto-static"]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time the deployment was created.",
+      "examples": ["2024-01-19T09:33:33.131481-05:00"]
+    },
+    "dismissed_at": {
+      "description": "Date and time that the deployment process was dismissed. Will be empty if the deployment process was not dismissed.",
+      "examples": ["2024-01-19T09:33:33.131481-05:00"],
+      "anyOf": [
+        {
+          "type": "string",
+          "maxLength": 0
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
+    },
+    "deployed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time of the last deployment to the server.",
+      "examples": ["2024-01-19T09:33:33.131481-05:00"]
+    },
+    "configuration_name": {
+      "type": "string",
+      "description": "Name of the configuration that was used during deployment.",
+      "examples": ["production"]
+    },
+    "bundle_id": {
+      "type": "string",
+      "description": "ID of the uploaded file bundle.",
+      "examples": ["123"]
+    },
+    "bundle_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to download the bundle for this deployment.",
+      "examples": [
+        "https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download"
+      ]
+    },
+    "dashboard_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of this deployment in the Connect dashboard.",
+      "examples": [
+        "https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/"
+      ]
+    },
+    "direct_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Direct URL for this deployment. This is the link to use when accessing a deployed API.",
+      "examples": [
+        "https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/"
+      ]
+    },
+    "logs_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to the logs for this deployment in the Connect dashboard.",
+      "examples": [
+        "https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs"
+      ]
+    },
+    "deployment_error": {
+      "type": "object",
+      "description": "Error from the deployment operation. Will be omitted if no error occurred.",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Error message"
+        },
+        "code": {
+          "type": "string",
+          "description": "Error code"
+        },
+        "data": {
+          "type": "object",
+          "description": "Additional error-specific data",
+          "additionalProperties": true
+        }
+      }
+    },
+    "configuration": {
+      "$ref": "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+    },
+    "requirements": {
+      "type": "array",
+      "items": {
+        "type": ["string"]
+      },
+      "description": "List of package requirements deployed with the content.",
+      "examples": ["numpy==1.23.4", "click=8.0.0"]
+    },
+    "renv": {
+      "type": "object",
+      "description": "Contents of renv.lock deployed with the content.",
+      "additionalProperties": false,
+      "properties": {
+        "r": {
+          "type": "object",
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "R version"
+            },
+            "repositories": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the repository"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of the repository"
+                  }
+                }
+              },
+              "description": "List of R repositories"
+            }
+          }
+        },
+        "packages": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "package": {
+                "type": "string",
+                "description": "Name of the R package"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version of the R package"
+              },
+              "source": {
+                "type": "string",
+                "description": "Source of the R package"
+              },
+              "repository": {
+                "type": "string",
+                "description": "Repository where the R package originated"
+              }
+            }
+          },
+          "description": "Detailed list of R packages"
+        }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": ["string"]
+      },
+      "description": "Project-relative paths of the files that were included in the deployment.",
+      "examples": ["app.py", "model/weights.csv"]
+    }
+  }
+}

--- a/extensions/vscode/src/toml/schemas/draft/posit-publishing-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/draft/posit-publishing-schema-v3.json
@@ -1,0 +1,711 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json",
+  "type": "object",
+  "description": "Posit Publishing Configuration",
+  "$defs": {
+    "config_connect": {
+      "description": "Extensions to the base schema for Posit Connect deployments.",
+      "properties": {
+        "has_parameters": {
+          "type": "boolean",
+          "description": "True if this is a report that accepts parameters.",
+          "default": false
+        },
+        "python": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Python language and dependencies.",
+          "properties": {
+            "version": {},
+            "package_file": {
+              "type": "string",
+              "description": "File containing package dependencies. The file must exist and be listed under 'files'. The default is 'requirements.txt'.",
+              "default": "requirements.txt",
+              "examples": ["requirements.txt"]
+            },
+            "package_manager": {
+              "type": "string",
+              "default": "pip",
+              "description": "Package manager that will install the dependencies. If package-manager is none, dependencies are assumed to be pre-installed on the server. The default is 'pip'.",
+              "examples": ["pip", "conda", "pipenv", "poetry", "none"]
+            },
+            "requires_python": {
+              "type": "string",
+              "default": "",
+              "description": "Python interpreter version, in PEP 440 format, required to run the content. If not specified it will be detected from the one in use.",
+              "examples": [">3.8", "<3.9", "==3.5"]
+            }
+          }
+        },
+        "r": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "R language and dependencies.",
+          "properties": {
+            "version": {},
+            "package_file": {
+              "type": "string",
+              "default": "renv.lock",
+              "description": "File containing package dependencies. The file must exist and be listed under 'files'.",
+              "examples": ["renv.lock"]
+            },
+            "package_manager": {
+              "type": "string",
+              "default": "renv",
+              "description": "Package manager that will install the dependencies. If package-manager is none, dependencies will be assumed to be pre-installed on the server.",
+              "examples": ["renv", "none"]
+            },
+            "requires_r": {
+              "type": "string",
+              "default": "",
+              "description": "R interpreter version, required to run the content. If not specified it will be detected from the one in use.",
+              "examples": [">3.8", "<4.3", ">=3.5.0"]
+            },
+            "packages_from_library": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, generate manifest packages from the local renv library (legacy behavior). When false (default), read packages from renv.lock."
+            }
+          }
+        },
+        "jupyter": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Additional rendering options for Jupyter Notebooks.",
+          "properties": {
+            "hide_all_input": {
+              "type": "boolean",
+              "description": "Hide all input cells when rendering output."
+            },
+            "hide_tagged_input": {
+              "type": "boolean",
+              "description": "Hide input code cells with the 'hide_input' tag when rendering output."
+            }
+          }
+        },
+        "quarto": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Quarto version required to run the content.",
+          "required": ["version"],
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "Quarto version. The server must have a similar Quarto version in order to run the content.",
+              "examples": ["1.4"]
+            },
+            "engines": {
+              "type": "array",
+              "description": "List of Quarto engines required for this content.",
+              "items": {
+                "type": "string",
+                "enum": ["knitr", "jupyter", "markdown"],
+                "examples": ["knitr", "jupyter", "markdown"]
+              }
+            }
+          }
+        },
+        "connect": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Setting specific to Posit Connect deployments.",
+          "properties": {
+            "runtime": {},
+            "kubernetes": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Settings used with Posit Connect's off-host execution feature, where content is run in Kubernetes.",
+              "properties": {
+                "amd_gpu_limit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "The number of AMD GPUs that will be allocated by Kubernetes to run this content.",
+                  "examples": [0]
+                },
+                "cpu_limit": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "The maximum amount of compute power this content will be allowed to consume when executing or rendering, expressed in CPU Units, where 1.0 unit is equivalent to 1 physical or virtual core. Fractional values are allowed. If the process tries to use more CPU than allowed, it will be throttled.",
+                  "examples": [1]
+                },
+                "cpu_request": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "The minimum amount of compute power this content needs when executing virtual core. Fractional values are allowed.",
+                  "examples": [0.5]
+                },
+                "default_image_name": {
+                  "type": "string",
+                  "pattern": "^[^\t\n\b\f\r ]*$",
+                  "description": "Name of the target container image.",
+                  "examples": ["posit/connect-runtime-python3.11-r4.3"]
+                },
+                "memory_limit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "The maximum amount of RAM this content will be allowed to consume when executing or rendering, expressed in bytes. If the process tries to use more memory than allowed, it will be terminated",
+                  "examples": ["100000000"]
+                },
+                "memory_request": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "The minimum amount of RAM this content needs when executing or rendering, expressed in bytes.",
+                  "examples": ["20000000"]
+                },
+                "nvidia_gpu_limit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "The number of NVIDIA GPUs that will be allocated by Kubernetes to run this content.",
+                  "examples": [0]
+                },
+                "service_account_name": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "description": "The name of the Kubernetes service account that is used to run this content. It must adhere to Kubernetes service account naming rules. You must be an administrator to set this value.",
+                  "examples": ["posit-connect-content"]
+                },
+                "default_r_environment_management": {
+                  "type": "boolean",
+                  "description": "Enables or disables R environment management. When false, Posit Connect will not install R packages and instead assume that all required packages are present in the container image.",
+                  "examples": [true]
+                },
+                "default_py_environment_management": {
+                  "type": "boolean",
+                  "description": "Enables or disables Python environment management. When false, Posit Connect will not install Python packages and instead assume that all required packages are present in the container image.",
+                  "examples": [true]
+                }
+              }
+            },
+            "access_control": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Access control settings.",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "default": "acl",
+                  "description": "Type of access control. 'public' make the deployment public (no login required), with no login required. 'all-users' allows all logged-in users to access the content. 'acl' (the default) allows only specific users and groups to access the content.",
+                  "enum": ["public", "all-users", "acl"],
+                  "examples": ["all-users"]
+                },
+                "users": {
+                  "type": "array",
+                  "description": "List of users who have access to this content.",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "anyOf": [{ "required": ["id"] }, { "required": ["guid"] }],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Unique ID from the authentication provider that identifies this user. This may be a username, LDAP CN/DN, email address, etc. depending on the provider.",
+                        "examples": ["jqpublic"]
+                      },
+                      "guid": {
+                        "type": "string",
+                        "description": "Unique identifier assigned by Connect. When deploying to the same server, this will determine the user who is granted access. When deploying to a different server, the provider-id will be used to look up the user.",
+                        "examples": ["cd2e7cef-a195-512e-b76d-554f4f5a239c"]
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "User's name. This field is informational only.",
+                        "examples": ["John Q. Public"]
+                      },
+                      "permissions": {
+                        "type": "string",
+                        "description": "Permission level assigned to this user.",
+                        "enum": ["viewer", "editor", "owner"],
+                        "examples": ["viewer"]
+                      }
+                    }
+                  }
+                },
+                "groups": {
+                  "type": "array",
+                  "description": "List of groups who have access to this content.",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "anyOf": [{ "required": ["id"] }, { "required": ["guid"] }],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Unique ID from the authentication provider that identifies this group. For groups created by Connect, this will be the group name. This may be a group name, LDAP CN/DN, etc. depending on the provider.",
+                        "examples": ["Data Science Team"]
+                      },
+                      "guid": {
+                        "type": "string",
+                        "description": "Unique identifier assigned by Connect. When deploying to the same server, this will determine the user who is granted access. When deploying to a different server, the provider-id will be used to look up the user.",
+                        "examples": ["8b4fde3e-f995-4894-bc02-ae47538262ff"]
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Group name. This field is informational only.",
+                        "examples": ["Data Science Team"]
+                      },
+                      "permissions": {
+                        "type": "string",
+                        "default": "viewer",
+                        "description": "Permission level assigned to this group.",
+                        "enum": ["viewer", "editor", "owner"],
+                        "examples": ["editor"]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "access": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "run_as": {
+                  "type": "string",
+                  "description": "The system username under which the content should be run. Must be an existing user in the allowed group. You must be an administrator to set this value.",
+                  "examples": ["rstudio-connect"]
+                },
+                "run_as_current_user": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "For application content types, run a separate process under the user account of each visiting user under that user's server account. Requires PAM authentication on the Posit Connect server. You must be an administrator to set this value."
+                }
+              }
+            }
+          }
+        },
+        "schedules": {
+          "type": "array",
+          "description": "Schedules for recurring execution of this content. Only applies to reports, such as Quarto, R Markdown, and Jupyter Notebooks.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["start", "recurrence"],
+            "properties": {
+              "start": {
+                "type": "string",
+                "description": "Time for the first run of the content.",
+                "examples": ["2023-10-25T08:00:00Z"]
+              },
+              "recurrence": {
+                "type": "string",
+                "description": "Recurrence scheme for the content, in cron or iCalendar RRULE format.",
+                "examples": ["FREQ=MONTHLY;INTERVAL=3", "0 2 * * *"]
+              }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["quarto-shiny", "quarto", "quarto-static"]
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["quarto"]
+          }
+        }
+      ]
+    },
+    "config_connect_cloud": {
+      "description": "Extensions to the base schema for Posit Connect Cloud deployments.",
+      "properties": {
+        "product_type": {
+          "type": "string",
+          "description": "Product type indicating this is a Posit Connect Cloud configuration.",
+          "enum": ["connect_cloud"]
+        },
+        "python": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Python language and dependencies.",
+          "properties": {
+            "version": {}
+          }
+        },
+        "r": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "R language and dependencies.",
+          "properties": {
+            "version": {}
+          }
+        }
+      },
+      "connect_cloud": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Setting specific to Posit Connect Cloud deployments.",
+        "properties": {
+          "python": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Python language and dependencies.",
+            "properties": {
+              "version": {}
+            }
+          },
+          "r": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "R language and dependencies.",
+            "properties": {
+              "version": {}
+            }
+          },
+          "vanity_name": {
+            "type": "string",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])$",
+            "description": "The custom component of the vanity URL. If your account name is 'my-account' and this value is 'vanity', the vanity URL will be https://my-account-vanity.share.connect.posit.cloud.",
+            "examples": ["sales-report"]
+          },
+          "access_control": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "public_access": {
+                "type": "boolean",
+                "description": "Whether or not the content is publicly accessible."
+              },
+              "organization_access": {
+                "type": "string",
+                "enum": ["disabled", "viewer", "editor"],
+                "default": "disabled",
+                "description": "The default level of access for account members within an organizational account."
+              }
+            }
+          }
+        }
+      },
+      "connect": {
+        "additionalProperties": false,
+        "properties": {
+          "runtime": {}
+        }
+      }
+    }
+  },
+  "properties": {
+    "product_type": {
+      "type": "string",
+      "description": "The product type that this content will be deployed to (Connect or Connect Cloud).",
+      "enum": ["connect", "connect_cloud"],
+      "default": "connect"
+    },
+    "comments": {
+      "type": "array",
+      "items": {
+        "type": ["string"]
+      },
+      "description": "Comments are allowed at the top of the configuration file, with a leading '#' character."
+    },
+    "$schema": {
+      "type": "string",
+      "format": "url",
+      "description": "URL of the json-schema definition for this file. Must be 'https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json'.",
+      "examples": [
+        "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "description": "Indicates the type of content being deployed. Valid values are: html, jupyter-notebook, jupyter-voila, python-bokeh, python-dash, python-fastapi, python-flask, python-gradio, python-panel, python-shiny, python-streamlit, quarto-shiny, quarto-static, r-plumber, r-shiny, rmd-shiny, rmd",
+      "enum": [
+        "html",
+        "jupyter-notebook",
+        "jupyter-voila",
+        "python-bokeh",
+        "python-dash",
+        "python-fastapi",
+        "python-flask",
+        "python-gradio",
+        "python-panel",
+        "python-shiny",
+        "python-streamlit",
+        "quarto-shiny",
+        "quarto",
+        "quarto-static",
+        "r-plumber",
+        "r-shiny",
+        "rmd-shiny",
+        "rmd",
+        "unknown"
+      ],
+      "examples": ["quarto-static"]
+    },
+    "entrypoint": {
+      "type": "string",
+      "description": "Name of the primary file containing the content. For Python flask, dash, fastapi, and python-shiny projects, this specifies the object within the file in module:object format. See the documentation at https://docs.posit.co/connect/user/publishing-cli-apps/#publishing-rsconnect-python-entrypoint.",
+      "examples": ["app.py", "report.qmd"]
+    },
+    "source": {
+      "type": "string",
+      "description": "Name of the primary file that acts as the source for content that can be rendered on demand. Only useful when deploying static content which has been rendered from Quarto, Rmarkdown or Jupyter Notebooks",
+      "examples": ["report.qmd", "_quarto.yml"]
+    },
+    "title": {
+      "type": "string",
+      "pattern": "^[^\t\n\f\r]{3,1000}$|",
+      "description": "Title for this content. If specified, it must be a single line containing between 3 and 1000 characters.",
+      "examples": ["Quarterly Sales Report"]
+    },
+    "description": {
+      "type": "string",
+      "pattern": "^[^\t\f\r]*$",
+      "description": "Description for this content. It may span multiple lines and be up to 4000 characters.",
+      "examples": ["This is the quarterly sales report, broken down by region."]
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "Path to thumbnail preview image for this content.",
+      "examples": ["images/thumbnail.jpg"]
+    },
+    "validate": {
+      "type": "boolean",
+      "description": "Access the content after deploying, to validate that it is live. Defaults to true.",
+      "default": true
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": ["string"]
+      },
+      "description": "Project-relative paths of the files to be included in the deployment. Wildcards are accepted, using .gitignore syntax.",
+      "examples": ["app.py", "model/*.csv", "!model/excludeme.csv"]
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags to apply to this deployment. When publishing to Connect, tags must be pre-defined by an administrator.",
+      "items": {
+        "type": "string",
+        "examples": ["sales", "quarterly", "regional"]
+      }
+    },
+    "python": {
+      "$comment": "Note: this object is extended by the other config definitions. Extensions should use additionalProperties: false to prevent unexpected properties.",
+      "type": "object",
+      "description": "Python language and dependencies.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Python version. The server must have a matching Python major/minor version in order to run the content.",
+          "examples": ["3.11.3", "3.11"]
+        }
+      }
+    },
+    "r": {
+      "$comment": "Note: this object is extended by the other config definitions. Extensions should use additionalProperties: false to prevent unexpected properties.",
+      "type": "object",
+      "description": "R language and dependencies.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "R version. The server will use the nearest R version to run the content.",
+          "examples": ["4.3.1"]
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string"]
+      },
+      "description": "Environment variable/value map. All values must be strings. Secrets such as API keys or tokens should not be stored here.",
+      "examples": [
+        {
+          "API_URL": "https://example.com/api"
+        }
+      ]
+    },
+    "secrets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Names of secrets required by the application. Injected as environment variables.",
+      "examples": ["API_KEY", "DATABASE_PASSWORD"]
+    },
+    "integration_requests": {
+      "type": "array",
+      "description": "Integration requests associated with this configuration",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "guid": {
+            "type": "string",
+            "description": "Unique identifier for the integration request"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the integration request"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the integration request"
+          },
+          "auth_type": {
+            "type": "string",
+            "description": "Authentication type for the integration request"
+          },
+          "type": {
+            "type": "string",
+            "description": "Integration type"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Configuration for the integration request"
+          }
+        }
+      }
+    },
+    "connect": {
+      "type": "object",
+      "description": "Settings for Posit Connect applications.",
+      "properties": {
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Runtime settings for application content types.",
+          "properties": {
+            "connection_timeout": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2592000,
+              "description": "Maximum number of seconds allowed without data sent or received across a client connection. A value of `0` means connections will never time-out (not recommended).",
+              "examples": [5]
+            },
+            "read_timeout": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2592000,
+              "description": "Maximum number of seconds allowed without data received from a client connection. A value of `0` means a lack of client (browser) interaction never causes the connection to close.",
+              "examples": [30]
+            },
+            "init_timeout": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2592000,
+              "description": "The maximum number of seconds allowed for an interactive application to start. Posit Connect must be able to connect to a newly launched application before this threshold has elapsed.",
+              "examples": [60]
+            },
+            "idle_timeout": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2592000,
+              "description": "The maximum number of seconds a worker process for an interactive application to remain alive after it goes idle (no active connections).",
+              "examples": [120]
+            },
+            "max_processes": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Specifies the total number of concurrent processes allowed for a single interactive application.",
+              "examples": [5]
+            },
+            "min_processes": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Specifies the minimum number of concurrent processes allowed for a single interactive application.",
+              "examples": [1]
+            },
+            "max_conns_per_process": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Specifies the maximum number of client connections allowed to an individual process. Incoming connections which will exceed this limit are routed to a new process or rejected.",
+              "examples": [50]
+            },
+            "load_factor": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Controls how aggressively new processes are spawned. The valid range is between 0.0 and 1.0.",
+              "examples": [0.5]
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["$schema", "type", "entrypoint"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "enum": [
+              "jupyter-notebook",
+              "jupyter-voila",
+              "python-bokeh",
+              "python-dash",
+              "python-fastapi",
+              "python-flask",
+              "python-gradio",
+              "python-panel",
+              "python-shiny",
+              "python-streamlit"
+            ]
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "required": ["python"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "enum": ["r-plumber", "r-shiny", "rmd-shiny", "rmd"]
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "required": ["r"]
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "$comment": "Default to connect if product_type is not specified.",
+            "properties": {
+              "product_type": false
+            }
+          },
+          {
+            "required": ["product_type"],
+            "properties": {
+              "product_type": {
+                "const": "connect"
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/config_connect"
+      }
+    },
+    {
+      "if": {
+        "required": ["product_type"],
+        "properties": {
+          "product_type": {
+            "const": "connect_cloud"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/config_connect_cloud"
+      }
+    }
+  ]
+}

--- a/extensions/vscode/src/toml/schemas/example-config-cloud.toml
+++ b/extensions/vscode/src/toml/schemas/example-config-cloud.toml
@@ -1,0 +1,41 @@
+# Example schema file
+"$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+product_type = "connect_cloud"
+type = "quarto-static"
+entrypoint = "report.qmd"
+title = "Regional Quarterly Sales Report"
+description = "This is the quarterly sales report, broken down by region."
+validate = true
+
+files = [
+    "*.py",
+    "*.qmd",
+    "requirements.txt",
+]
+secrets = ["API_KEY", "DATABASE_PASSWORD"]
+
+[python]
+version = "3.11.3"
+
+[r]
+version = "4.3.1"
+
+[environment]
+API_URL = "https://example.com/api"
+
+[connect_cloud]
+vanity_name = "sales-report"
+
+[connect_cloud.access_control]
+public_access = true
+organization_access = "viewer"
+
+[connect.runtime]
+connection_timeout = 5
+read_timeout = 30
+init_timeout = 60
+idle_timeout = 120
+max_processes = 5
+min_processes = 1
+max_conns_per_process = 50
+load_factor = 0.5

--- a/extensions/vscode/src/toml/schemas/example-config-cloud.toml
+++ b/extensions/vscode/src/toml/schemas/example-config-cloud.toml
@@ -1,5 +1,5 @@
 # Example schema file
-"$schema" = "https://cdn.posit.co/publisher/schemas/draft/posit-publishing-schema-v3.json"
+"$schema" = "https://cdn.posit.co/publisher/schemas/posit-publishing-schema-v3.json"
 product_type = "connect_cloud"
 type = "quarto-static"
 entrypoint = "report.qmd"

--- a/extensions/vscode/src/toml/schemas/example-record-cloud.toml
+++ b/extensions/vscode/src/toml/schemas/example-record-cloud.toml
@@ -1,0 +1,41 @@
+"$schema" = "https://cdn.posit.co/publisher/schemas/posit-publishing-record-schema-v3.json"
+server_type = "connect_cloud"
+server_url = "https://connect.example.com"
+id = "de2e7bdb-b085-401e-a65c-443e40009749"
+client_version = '1.0.1'
+type = 'python-shiny'
+created_at = '2024-01-19T09:33:33.131481-05:00'
+configuration_name = "production"
+deployed_at = '2024-01-19T09:33:33.131481-05:00'
+bundle_id = '123'
+bundle_url = 'https://connect.posit.cloud/bundle'
+dashboard_url = 'https://connect.posit.cloud/dashboard'
+direct_url = 'https://connect.posit.cloud/direct'
+logs_url = 'https://connect.posit.cloud/logs'
+
+[configuration]
+"$schema" = "https://cdn.posit.co/publisher/schemas/posit-publishing-schema-v3.json"
+type = "quarto-static"
+product_type = "connect_cloud"
+entrypoint = "report.qmd"
+validate = true
+files = [
+    "*.py",
+    "*.qmd",
+    "requirements.txt",
+]
+secrets = ["API_KEY", "DATABASE_PASSWORD"]
+title = "Regional Quarterly Sales Report"
+description = "This is the quarterly sales report, broken down by region."
+
+[configuration.python]
+version = "3.11.3"
+
+[configuration.r]
+version = "4.3.1"
+
+[configuration.environment]
+API_URL = "https://example.com/api"
+
+[connect_cloud]
+account_name = 'my-account'

--- a/extensions/vscode/src/toml/schemas/example-record.toml
+++ b/extensions/vscode/src/toml/schemas/example-record.toml
@@ -1,0 +1,72 @@
+"$schema" = "https://cdn.posit.co/publisher/schemas/posit-publishing-record-schema-v3.json"
+server_type = "connect"
+server_url = "https://connect.example.com"
+id = "de2e7bdb-b085-401e-a65c-443e40009749"
+client_version = '1.0.1'
+type = 'python-shiny'
+created_at = '2024-01-19T09:33:33.131481-05:00'
+configuration_name = "production"
+deployed_at = '2024-01-19T09:33:33.131481-05:00'
+bundle_id = '123'
+bundle_url = 'https://connect.example.com/__api__/v1/content/de2e7bdb-b085-401e-a65c-443e40009749/bundles/123/download'
+dashboard_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749'
+direct_url = 'https://connect.example.com/content/de2e7bdb-b085-401e-a65c-443e40009749/'
+logs_url = 'https://connect.example.com/connect/#/apps/de2e7bdb-b085-401e-a65c-443e40009749/logs'
+
+[configuration]
+"$schema" = "https://cdn.posit.co/publisher/schemas/posit-publishing-schema-v3.json"
+type = "quarto-static"
+entrypoint = "report.qmd"
+validate = true
+files = [
+    "*.py",
+    "*.qmd",
+    "requirements.txt",
+]
+secrets = ["API_KEY", "DATABASE_PASSWORD"]
+title = "Regional Quarterly Sales Report"
+description = "This is the quarterly sales report, broken down by region."
+
+[configuration.python]
+version = "3.11.3"
+package_file = "requirements.txt"
+package_manager = "pip"
+requires_python = "<3.12"
+
+[configuration.r]
+version = "4.3.1"
+package_file = "renv.lock"
+package_manager = "renv"
+requires_r = ">=4.3.0"
+
+[configuration.quarto]
+version = "1.4"
+
+[configuration.environment]
+API_URL = "https://example.com/api"
+
+[configuration.connect.access]
+run_as = "rstudio-connect"
+run_as_current_user = false
+
+[configuration.connect.runtime]
+connection_timeout = 5
+read_timeout = 30
+init_timeout = 60
+idle_timeout = 120
+max_processes = 5
+min_processes = 1
+max_conns_per_process = 50
+load_factor = 0.5
+
+[configuration.connect.kubernetes]
+amd_gpu_limit = 0
+cpu_limit = 1.5
+cpu_request = 0.5
+default_image_name = "posit/connect-runtime-python3.11-r4.3"
+memory_limit = 100000000
+memory_request = 20000000
+nvidia_gpu_limit = 0
+service_account_name = "posit-connect-content"
+default_r_environment_management = true
+default_py_environment_management = true


### PR DESCRIPTION
## Summary

- **Restores draft JSON schemas and example TOML files** that were accidentally deleted in #4012 (66fcd8e9), which broke the `schema-upload` CI workflow
- **Updates `schema-upload.yaml`** to source schemas from `extensions/vscode/src/toml/schemas/` instead of the deleted `internal/schema/schemas/`
- **Adds TOML-against-schema validation tests** mirroring the old Go `schema_test.go` — each example TOML is validated against its corresponding JSON schema (release + draft)
- **Updates `CLAUDE.md` and `CONTRIBUTING.md`** to reference the new canonical schema location

## Details

The release JSON schemas (`posit-publishing-schema-v3.json` and `posit-publishing-record-schema-v3.json`) were already copied to the extensions location before the deletion and are identical. The draft schemas and all example TOML files were not copied and have been restored from git history.

## Test plan

- [x] All 1695 vitest tests pass, including 7 new TOML-against-schema validation tests
- [x] tsc and eslint pass clean
- [ ] Verify `schema-upload` workflow succeeds after merge (or trigger via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)