### PR TITLE
Fix race where deploy uses config without interpreter defaults

### DIFF
--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -378,6 +378,12 @@ export class PublisherState implements Disposable {
     return findConfiguration(name, projectDir, this.configurations);
   }
 
+  // WARNING: the returned config may have empty interpreter fields
+  // (r.version, python.version, etc.) if the file watcher recently
+  // re-read the TOML from disk but the async UpdateConfigWithDefaults
+  // hydration hasn't completed yet. Callers that need interpreter
+  // fields for correctness (e.g. publish) must re-apply
+  // UpdateConfigWithDefaults before using them.
   findValidConfig(name: string, projectDir: string) {
     return findConfiguration(name, projectDir, this.validConfigs);
   }

--- a/extensions/vscode/src/state.ts
+++ b/extensions/vscode/src/state.ts
@@ -378,12 +378,11 @@ export class PublisherState implements Disposable {
     return findConfiguration(name, projectDir, this.configurations);
   }
 
-  // WARNING: the returned config may have empty interpreter fields
-  // (r.version, python.version, etc.) if the file watcher recently
-  // re-read the TOML from disk but the async UpdateConfigWithDefaults
-  // hydration hasn't completed yet. Callers that need interpreter
-  // fields for correctness (e.g. publish) must re-apply
-  // UpdateConfigWithDefaults before using them.
+  // WARNING: the returned config may have stale data (empty interpreter
+  // fields, outdated files list) if the file watcher hasn't finished
+  // refreshing yet. Safe for UI display, but code that needs the
+  // current config for correctness (e.g. publish) should read fresh
+  // from disk via loadConfiguration() instead.
   findValidConfig(name: string, projectDir: string) {
     return findConfiguration(name, projectDir, this.validConfigs);
   }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -39,6 +39,7 @@ import {
   ProductName,
   ServerType,
   IntegrationRequest,
+  UpdateConfigWithDefaults,
 } from "src/api";
 import { ConnectAPI, GUID } from "@posit-dev/connect-api";
 import type { Integration } from "@posit-dev/connect-api";
@@ -68,6 +69,7 @@ import * as workspaces from "src/workspaces";
 import { getConfigurationFiles } from "src/projectFiles";
 import { EventStream } from "src/events";
 import { getPythonInterpreterPath, getRInterpreterPath } from "../utils/vscode";
+import { getInterpreterDefaults } from "src/interpreters";
 import { scanRPackages } from "src/interpreters/rPackages";
 import { scanPythonDependencies } from "src/interpreters/scanPythonDependencies";
 import { getSummaryStringFromError } from "src/utils/errors";
@@ -371,7 +373,19 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const positron = getPositronRepoSettings();
       const clientVersion =
         this.context.extension.packageJSON.version || "unknown";
+      const python = await getPythonInterpreterPath();
       const r = await getRInterpreterPath();
+
+      // The cached config from findValidConfig() may not have interpreter
+      // defaults populated yet if the file watcher recently re-read the
+      // config from disk. Re-apply defaults to guarantee fields like
+      // r.version are set before the publish orchestrator uses them.
+      const defaults = await getInterpreterDefaults(
+        absProjectDir,
+        python?.pythonPath,
+        r?.rPath,
+      );
+      UpdateConfigWithDefaults(config, defaults);
 
       const progressOptions = {
         onComplete: () => this.refreshContentRecords(),

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -58,6 +58,8 @@ import {
 import {
   loadAllConfigurations,
   loadAllDeployments,
+  loadConfiguration,
+  ConfigurationLoadError,
   patchDeploymentRecord,
 } from "src/toml";
 import {
@@ -312,6 +314,51 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     return await setSelectionIsPreContentRecord(match);
   }
 
+  // Read a config fresh from disk and apply interpreter defaults.
+  // Returns undefined (with an error message shown) if the config
+  // cannot be loaded.
+  private async loadFreshConfig(
+    configurationName: string,
+    projectDir: string,
+    rootDir: string,
+    absProjectDir: string,
+    pythonPath?: string,
+    rPath?: string,
+  ): Promise<Configuration | undefined> {
+    try {
+      const loaded = await loadConfiguration(
+        configurationName,
+        projectDir,
+        rootDir,
+      );
+      const defaults = await getInterpreterDefaults(
+        absProjectDir,
+        pythonPath,
+        rPath,
+      );
+      UpdateConfigWithDefaults(loaded, defaults);
+      return loaded;
+    } catch (error: unknown) {
+      if (error instanceof ConfigurationLoadError) {
+        window.showErrorMessage(
+          `Invalid configuration ${configurationName}: ${error.configurationError.error.msg}`,
+        );
+        return undefined;
+      }
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        window.showErrorMessage(
+          `Configuration not found: ${configurationName}`,
+        );
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
   private async initiateDeployment(
     deploymentName: string,
     credentialName: string,
@@ -321,26 +368,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
   ) {
     try {
       const credential = this.state.findCredential(credentialName);
-      const config = this.state.findValidConfig(configurationName, projectDir);
 
       if (!credential) {
         window.showErrorMessage(`Credential not found: ${credentialName}`);
-        return;
-      }
-      if (!config) {
-        const errConfig = this.state.findConfigInError(
-          configurationName,
-          projectDir,
-        );
-        if (errConfig) {
-          window.showErrorMessage(
-            `Invalid configuration ${configurationName}: ${errConfig.error.msg}`,
-          );
-        } else {
-          window.showErrorMessage(
-            `Configuration not found: ${configurationName}`,
-          );
-        }
         return;
       }
 
@@ -363,6 +393,27 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
         return;
       }
 
+      const python = await getPythonInterpreterPath();
+      const r = await getRInterpreterPath();
+
+      // Always read the config fresh from disk rather than using the
+      // in-memory cache. After a new deployment is created, the cached
+      // config may be stale — missing TOML files in the files list and
+      // missing interpreter defaults like r.version. The file watcher
+      // will eventually refresh the cache, but the user can click Deploy
+      // before that completes.
+      const config = await this.loadFreshConfig(
+        configurationName,
+        projectDir,
+        root,
+        absProjectDir,
+        python?.pythonPath,
+        r?.rPath,
+      );
+      if (!config) {
+        return;
+      }
+
       const contentRecord = this.state.findContentRecord(
         deploymentName,
         projectDir,
@@ -373,19 +424,6 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       const positron = getPositronRepoSettings();
       const clientVersion =
         this.context.extension.packageJSON.version || "unknown";
-      const python = await getPythonInterpreterPath();
-      const r = await getRInterpreterPath();
-
-      // The cached config from findValidConfig() may not have interpreter
-      // defaults populated yet if the file watcher recently re-read the
-      // config from disk. Re-apply defaults to guarantee fields like
-      // r.version are set before the publish orchestrator uses them.
-      const defaults = await getInterpreterDefaults(
-        absProjectDir,
-        python?.pythonPath,
-        r?.rPath,
-      );
-      UpdateConfigWithDefaults(config, defaults);
 
       const progressOptions = {
         onComplete: () => this.refreshContentRecords(),


### PR DESCRIPTION
## Summary

Fixes first deploy after creating a new deployment failing with "Invalid manifest.json" (missing R version in manifest, missing TOML files from bundle).

**Root cause:** `newDeployment()` writes the config TOML to disk, then calls `updateFileList()` twice to add the config and deployment TOML paths to the `files` list. But `updateFileList()` re-reads from disk, modifies, and writes back — it does not update the in-memory `Configuration` object that `newDeployment()` already captured. That stale object (missing both TOML file paths, missing interpreter defaults like `r.version`) gets pushed directly into the state cache by `showNewDeploymentMultiStep()`. The file watcher will eventually refresh the cache from disk, but if the user clicks Deploy before that completes, `initiateDeployment()` gets the stale config via `findValidConfig()`.

**Fix:** `initiateDeployment()` now reads the config fresh from disk via `loadConfiguration()` and applies interpreter defaults, instead of using the in-memory cache. This guarantees the config reflects the current TOML state regardless of file watcher timing. The stale cache push in `showNewDeploymentMultiStep()` is kept for UI responsiveness — the watcher replaces it shortly after.

- New `loadFreshConfig()` private method on `HomeViewProvider` handles disk read + interpreter hydration + error handling
- `findValidConfig()` warning comment updated to note the broader staleness risk and recommend `loadConfiguration()` for correctness-sensitive paths

## Test plan

- [x] Create a new R Shiny deployment and click "Deploy your project" immediately — should succeed with correct `r.version` in manifest and both TOML files in bundle
- [x] Create a new Python deployment and deploy immediately — should succeed with correct `python.version`
- [x] Deploy an existing deployment (not newly created) — should continue working as before
- [x] Edit a config TOML and deploy before the loading spinner finishes — should use the saved config from disk, not stale cache
- [x] Deploy with a missing or invalid config file — should show appropriate error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)