### PR TITLE
Drop platform-specific VSIX packaging (#4025)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -174,7 +174,7 @@ jobs:
         working-directory: test/e2e
         run: |
           # Install the Publisher extension and set ownership in parallel
-          VSIX_FILENAME=$(ls -Art ../../dist | grep linux-amd64 | tail -n 1)
+          VSIX_FILENAME=$(ls -Art ../../dist/*.vsix | xargs -n1 basename | tail -n 1)
           docker compose exec code-server code-server --install-extension "/home/coder/vsix/${VSIX_FILENAME}" &
 
           # Set proper ownership for workspace files while extension installs

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -6,22 +6,6 @@ permissions:
 jobs:
   vscode:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: windows
-            arch: amd64
-          - os: windows
-            arch: arm64
     steps:
       - uses: actions/checkout@v6
         with:
@@ -33,21 +17,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - run: just vscode deps
-      - run: just vscode package ${{ matrix.os }} ${{ matrix.arch }}
-      - uses: actions/upload-artifact@v7
-        id: upload
-        with:
-          name: dist-${{ matrix.os }}-${{ matrix.arch }}
-          path: dist/**/*
-  merge-artifacts:
-    needs: vscode
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: dist-*
-          merge-multiple: true
-          path: dist
+      - run: just vscode package
       - uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,16 +21,6 @@ jobs:
     needs:
       - package
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - darwin-amd64
-          - darwin-arm64
-          - linux-amd64
-          - linux-arm64
-          - windows-amd64
-          - windows-arm64
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
@@ -45,7 +35,7 @@ jobs:
       - id: get-extension-path
         run: |
           name="$(jq -r .name extensions/vscode/package.json)"
-          echo "extension_path=dist/${name}-$(just version)-${{ matrix.target }}.vsix" >> "$GITHUB_OUTPUT"
+          echo "extension_path=dist/${name}-$(just version).vsix" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
@@ -59,16 +49,6 @@ jobs:
     needs:
       - package
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - darwin-amd64
-          - darwin-arm64
-          - linux-amd64
-          - linux-arm64
-          - windows-amd64
-          - windows-arm64
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
@@ -83,7 +63,7 @@ jobs:
       - id: get-extension-path
         run: |
           name="$(jq -r .name extensions/vscode/package.json)"
-          echo "extension_path=dist/${name}-$(just version)-${{ matrix.target }}.vsix" >> "$GITHUB_OUTPUT"
+          echo "extension_path=dist/${name}-$(just version).vsix" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v2

--- a/extensions/vscode/justfile
+++ b/extensions/vscode/justfile
@@ -11,38 +11,15 @@ _with_debug := if _debug == "true" {
         ""
     }
 
-# Private helper: print the current OS in the legacy `go env GOOS` vocabulary
-# (darwin|linux|windows). Used as the default for `os` arguments below.
-_os:
-    #!/usr/bin/env bash
-    set -eou pipefail
-    case $(uname -s) in
-        Darwin) echo darwin ;;
-        Linux) echo linux ;;
-        MINGW*|MSYS*|CYGWIN*) echo windows ;;
-        *) echo "error: unsupported os: $(uname -s)" 1>&2; exit 1 ;;
-    esac
-
-# Private helper: print the current architecture in the legacy `go env GOARCH`
-# vocabulary (amd64|arm64). Used as the default for `arch` arguments below.
-_arch:
-    #!/usr/bin/env bash
-    set -eou pipefail
-    case $(uname -m) in
-        x86_64|amd64) echo amd64 ;;
-        arm64|aarch64) echo arm64 ;;
-        *) echo "error: unsupported arch: $(uname -m)" 1>&2; exit 1 ;;
-    esac
-
 # Quick start
-default os="$(just _os)" arch="$(just _arch)":
+default:
     #!/usr/bin/env bash
     set -eou pipefail
     {{ _with_debug }}
 
     just clean
     just configure
-    just package {{ os }} {{ arch }}
+    just package
 
 assert-command-installed command:
     #!/usr/bin/env bash
@@ -98,14 +75,14 @@ configure:
     just deps
 
 # Installs the packaged extension on your configured editor using the editor's CLI. The editor CLI defaults to 'code'. Modify this value via the EDITOR environment variable.
-install os="$(just _os)" arch="$(just _arch)" editor="code":
+install editor="code":
     #!/usr/bin/env bash
     set -eou pipefail
     {{ _with_debug }}
 
     just assert-command-installed {{ editor }}
 
-    package=$(just package-name {{ os }} {{ arch }})
+    package=$(just package-name)
     package_path=$(just package-path)
 
     echo "info: installing extension using {{ editor }}..." 1>&2
@@ -120,34 +97,32 @@ lint:
     npm run lint
 
 # Packages the extension.
-package os="$(just _os)" arch="$(just _arch)":
+package:
     #!/usr/bin/env bash
     set -eou pipefail
     {{ _with_debug }}
-    echo "info: getting package target platform..." 1>&2
-    target_platform=$(just package-target-platform {{ os }} {{ arch }})
     echo "info: getting package output path..." 1>&2
     path="$(just package-path)"
     mkdir -p "$path"
     echo "info: getting output package name..." 1>&2
-    package="$path"/$(just package-name {{ os }} {{ arch }})
+    package="$path"/$(just package-name)
     echo "info: packaging..." 1>&2
     if [[ $(just ../../pre-release) == true ]]; then
         prerelease_flag="--pre-release"
     else
         prerelease_flag=""
     fi
-    npx --yes @vscode/vsce package -o "$package" -t "$target_platform" $prerelease_flag | sed 's/^/debug: /'
+    npx --yes @vscode/vsce package -o "$package" $prerelease_flag | sed 's/^/debug: /'
     echo "info: writing package to $package..." 1>&2
 
-package-name os="$(just _os)" arch="$(just _arch)":
+package-name:
     #!/usr/bin/env bash
     set -eou pipefail
     {{ _with_debug }}
 
     name="$(jq -r .name package.json)"
     version="$(just ../../version)"
-    echo "$name-$version-{{ os }}-{{ arch }}.vsix"
+    echo "$name-$version.vsix"
 
 package-path:
     #!/usr/bin/env bash
@@ -155,44 +130,6 @@ package-path:
     {{ _with_debug }}
 
     echo $(readlink -f ../../)/dist
-
-package-target-platform os="$(just _os)" arch="$(just _arch)":
-    #!/usr/bin/env bash
-    set -eou pipefail
-    {{ _with_debug }}
-
-    echo "info: finding target operating system..." 1>&2
-    case {{ os }} in
-        darwin)
-            target_os="darwin"
-            ;;
-        linux)
-            target_os="linux"
-            ;;
-        windows)
-            target_os="win32"
-            ;;
-        *)
-            echo "error: target architecture '$os' not supported." 1>&2
-            exit 1
-            ;;
-    esac
-
-    echo "info: finding target architecture..." 1>&2
-    case {{ arch }} in
-        amd64)
-            target_arch="x64"
-            ;;
-        arm64)
-            target_arch="arm64"
-            ;;
-        *)
-            echo "error: target architecture '$arch' not supported." 1>&2
-            exit 1
-            ;;
-    esac
-
-    echo "$target_os-$target_arch"
 
 # Executes commands via `npm`. Equivalent to `npm run`.
 run *args:

--- a/test/e2e/code-server-entry.sh
+++ b/test/e2e/code-server-entry.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -xeu
 
-# Get the latest linux-amd64 build
-VSIX_FILENAME=$(ls -Art /home/coder/vsix | grep linux-amd64 | tail -n 1)
+# Get the latest Publisher VSIX build
+VSIX_FILENAME=$(ls -Art /home/coder/vsix/*.vsix | xargs -n1 basename | tail -n 1)
 
 # Custom vscode User settings, avoid setup wizards
 # echo > /home/coder/.local/share/code-server/User/settings.json

--- a/test/e2e/justfile
+++ b/test/e2e/justfile
@@ -73,7 +73,7 @@ e2e *cypress_args:
     just start "code-server"
 
     # Install the Publisher extension
-    VSIX_FILENAME=$(ls -Art ../../dist | grep linux-amd64 | tail -n 1)
+    VSIX_FILENAME=$(ls -Art ../../dist/*.vsix | xargs -n1 basename | tail -n 1)
     docker compose exec code-server code-server --install-extension "/home/coder/vsix/${VSIX_FILENAME}"
 
     # Run tests with Connect managed by with-connect
@@ -99,7 +99,7 @@ e2e-open:
     just start "code-server"
 
     # Install the Publisher extension
-    VSIX_FILENAME=$(ls -Art ../../dist | grep linux-amd64 | tail -n 1)
+    VSIX_FILENAME=$(ls -Art ../../dist/*.vsix | xargs -n1 basename | tail -n 1)
     docker compose exec code-server code-server --install-extension "/home/coder/vsix/${VSIX_FILENAME}"
 
     with-connect --license "{{LICENSE}}" -- \

--- a/test/scripts/install-positron-extension.sh
+++ b/test/scripts/install-positron-extension.sh
@@ -17,10 +17,10 @@ fi
 
 # Find the VSIX file directly from the mounted volume
 echo "Looking for VSIX file in container..."
-VSIX_FILENAME=$(docker exec publisher-e2e.workbench-$SERVICE bash -c "ls -Art /vsix-tmp | grep linux-amd64 | tail -n 1")
+VSIX_FILENAME=$(docker exec publisher-e2e.workbench-$SERVICE bash -c "ls -Art /vsix-tmp/*.vsix 2>/dev/null | xargs -n1 basename | tail -n 1")
 
 if [ -z "$VSIX_FILENAME" ]; then
-    echo "ERROR: No linux-amd64 Publisher VSIX found in container."
+    echo "ERROR: No Publisher VSIX found in container."
     echo "Contents of /vsix-tmp:"
     docker exec publisher-e2e.workbench-$SERVICE bash -c "ls -la /vsix-tmp"
     exit 1


### PR DESCRIPTION
## Summary
- Ship one universal `publisher-$version.vsix` now that the extension is pure TypeScript (follow-up to #4030).
- Collapse the `(os, arch)` matrix in `package.yaml` and `publish.yaml`; drop the `merge-artifacts` job.
- Strip `grep linux-amd64` from e2e and Workbench VSIX lookups — they'd otherwise fail to find the renamed file.

Resolves #4025.

## Test plan
- [x] `just` from the repo root produces exactly one `dist/*.vsix` with no platform suffix (verified locally: `publisher-1.37.19-11-gf905712e.vsix`).
- [x] e2e helper lookup pattern resolves to that single file.
- [x] CI `package` workflow uploads a single `dist` artifact containing one VSIX.
- [x] CI e2e workflow locates and installs the VSIX.
- [ ] Next release (or `vsce publish` dry run) resolves `extension_path` to the single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)