### PR TITLE
Remove useKeyChainCredentialStorage setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ test/e2e/content-workspace/.ipython/
 test/e2e/content-workspace/.local/
 test/e2e/content-workspace/.positron-server/
 test/e2e/content-workspace/.vscode-server/
-test/e2e/content-workspace/.connect-credentials
 
 # Local History for Visual Studio Code
 .history/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed the Go backend. Publisher is now a pure TypeScript extension; all functionality that previously went through the Go binary (credential CRUD, publishing, SSE streaming) runs natively in the extension. (#3818)
-- Removed the `positPublisher.useKeyChainCredentialStorage` setting. Credentials are now stored exclusively by VS Code's SecretStorage, which handles OS-level storage automatically. (#3649)
+- Removed the `positPublisher.useKeyChainCredentialStorage` setting. Credentials are now stored exclusively by Positron's and VS Code's SecretStorage, which handles OS-level storage automatically. (#3649)
 
 ## [1.36.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed the Go backend. Publisher is now a pure TypeScript extension; all functionality that previously went through the Go binary (credential CRUD, publishing, SSE streaming) runs natively in the extension. (#3818)
+- Removed the `positPublisher.useKeyChainCredentialStorage` setting. Credentials are now stored exclusively by VS Code's SecretStorage, which handles OS-level storage automatically. (#3649)
 
 ## [1.36.0]
 

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -201,7 +201,7 @@ R Packages view runs `renv::snapshot()` for you.
 This view lists the credentials you have defined.
 You need a credential for each Connect server you want to deploy to;
 each credential includes the server URL and an API key.
-Credentials are securely stored in the OS keychain.
+Credentials are securely stored by VS Code.
 
 To add a credential for a new server, click the `+` button.
 To remove a credential, right-click on it and select `Delete`.
@@ -220,11 +220,6 @@ Posit Publisher makes this easy by prompting you to **Create a new Credential**
 when the selected deployment requires a credential you don't have.
 
 ![](https://cdn.posit.co/publisher/assets/img/publisher-missing-credential.png)
-
-#### via dotfile
-
-If your OS does not have a keychain the extension will manage your credentials
-in a file in your home directory - `.connect-credentials`.
 
 ### Help and Feedback
 

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,12 +6,6 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Removed
-
-- Removed the `positPublisher.useKeyChainCredentialStorage` setting. Credentials are now stored exclusively by VS Code's SecretStorage, which handles OS-level storage automatically. (#3649)
-
 ## [1.36.0]
 
 ### Fixed

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,12 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- Removed the `positPublisher.useKeyChainCredentialStorage` setting. Credentials are now stored exclusively by VS Code's SecretStorage, which handles OS-level storage automatically. (#3649)
+
 ## [1.36.0]
 
 ### Fixed

--- a/extensions/vscode/CLAUDE.md
+++ b/extensions/vscode/CLAUDE.md
@@ -62,7 +62,7 @@ Unit tests are in `src/**/*.test.ts` (excluding `src/test/`). Integration tests 
 - **Config Files** (`src/configFiles/`) — Configuration file discovery and management.
 - **Inspect** (`src/inspect/`) — Content inspection/detection with detectors for Python, R, Quarto, HTML, notebooks, Plumber, and R Markdown.
 - **Interpreters** (`src/interpreters/`) — Detects Python/R versions via subprocess calls, scans Python packages and R package lockfiles.
-- **Credentials** (`src/credentials/`) — Manages credential storage via filesystem (`~/.connect-credentials`) or VSCode keychain.
+- **Credentials** (`src/credentials/`) — Manages credential storage via VSCode's `SecretStorage`.
 - **Publish** (`src/publish/`) — Publishing orchestration (`connectPublish.ts`) and dependency analysis for Python/R projects. Publishes to standard Connect via `@posit-dev/connect-api` and to Connect Cloud via `@posit-dev/connect-cloud-api`.
 - **Snowflake** (`src/snowflake/`) — Snowflake connection discovery, config parsing, and token providers.
 - **Project Files** (`src/projectFiles/`) — File tree building and .gitignore-aware file matching.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -50,11 +50,6 @@
             "type": "boolean",
             "default": true
           },
-          "positPublisher.useKeyChainCredentialStorage": {
-            "markdownDescription": "Controls whether Posit Publisher will use the system keychain to store credentials. When disabled, or on a system without a keychain, `~/.connect-credentials` is used. After changing this setting, you must restart VS Code for it to go into effect.",
-            "type": "boolean",
-            "default": true
-          },
           "positPublisher.defaultConnectServer": {
             "markdownDescription": "Provides the default URL for the Posit Connect server when defining new credentials.",
             "type": "string",

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -53,11 +53,6 @@ const logsCommands = {
   ToggleVisibility: "posit.publisher.logs.toggleVisibility",
 } as const;
 
-const credentialsContexts = {
-  Keychain: "posit.publisher.credentials.tree.item.keychain",
-  EnvironmentVars: "posit.publisher.credentials.tree.item.environmentVars",
-};
-
 const filesCommands = {
   Refresh: "posit.publisher.files.refresh",
   Exclude: "posit.publisher.files.exclude",
@@ -123,7 +118,6 @@ export const Commands = {
 
 export const Contexts = {
   ...baseContexts,
-  Credentials: credentialsContexts,
   HomeView: homeViewContexts,
 };
 

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -209,14 +209,6 @@ export const extensionSettings = {
       configuration.get<boolean>("verifyCertificates");
     return value !== undefined ? value : true;
   },
-  useKeyChainCredentialStorage(): boolean {
-    // get value from extension configuration - defaults to true
-    const configuration = workspace.getConfiguration("positPublisher");
-    const value: boolean | undefined = configuration.get<boolean>(
-      "useKeyChainCredentialStorage",
-    );
-    return value !== undefined ? value : true;
-  },
   async defaultConnectServer(): Promise<string> {
     const configuration = workspace.getConfiguration("positPublisher");
     let value: string | undefined = configuration.get<string>(

--- a/test/e2e/code-server-entry.sh
+++ b/test/e2e/code-server-entry.sh
@@ -16,8 +16,7 @@ cat <<EOF > /home/coder/.local/share/code-server/User/settings.json
   "workbench.welcomePage.walkthroughs.openOnInstall": false,
   "workbench.tips.enabled": false,
   "window.restoreWindows": "none",
-  "files.hotExit": "off",
-  "positPublisher.useKeyChainCredentialStorage": false
+  "files.hotExit": "off"
 }
 
 EOF

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - CONNECT_CLOUD_ENV=${CONNECT_CLOUD_ENV:-staging}
     volumes:
       - ./code-server-entry.sh:/home/coder/entrypoint.sh
-      - ./e2e-test.connect-credentials:/root/.connect-credentials
       - ./content-workspace:/home/coder/workspace
       - ../../dist:/home/coder/vsix
     ports:

--- a/test/e2e/e2e-test.connect-credentials
+++ b/test/e2e/e2e-test.connect-credentials
@@ -1,2 +1,0 @@
-# File updated and managed by e2e tests. Refrain from updating it manually.
-

--- a/test/e2e/justfile
+++ b/test/e2e/justfile
@@ -26,15 +26,6 @@ stop:
 lint:
     npm run lint
 
-clear-credentials:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    cat <<EOF > e2e-test.connect-credentials
-    # File updated and managed by e2e tests. Refrain from updating it manually.
-
-    EOF
-
 # Build publisher and run e2e tests (requires with-connect CLI and license file)
 dev:
     #!/usr/bin/env bash
@@ -63,12 +54,6 @@ e2e *cypress_args:
         exit 1
     fi
 
-    function cleanup() {
-        just clear-credentials
-    }
-    trap cleanup EXIT
-
-    just clear-credentials
     just install
     just start "code-server"
 

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -110,21 +110,10 @@ if (typeof afterEach === "function") {
 
 // resetCredentials
 // Purpose: Delete all credentials via UI by looping over each credential item.
-// Also resets the Go credential store file to ensure the Go backend is clean,
-// even if SecretStorage (IndexedDB) was already wiped by page load.
+// SecretStorage is wiped separately on page load by the IndexedDB reset in
+// support/index.js. This command exercises the UI delete path.
 // Requires UI to be loaded (page visited, sidebar open, iframe ready).
 Cypress.Commands.add("resetCredentials", () => {
-  // Reset the Go credential store file to prevent stale keyring state.
-  // IndexedDB (SecretStorage) is wiped on cy.visit("/"), so the UI may show
-  // no credentials while the Go backend still has old ones. Without this,
-  // dual-write conflicts (409) cause Go to retain expired credentials.
-  cy.exec(
-    `cat <<EOF > e2e-test.connect-credentials
-# File updated and managed by e2e tests. Refrain from updating it manually.
-
-EOF`,
-  );
-
   cy.ensureCredentialsSectionExpanded();
 
   function deleteNextCredential() {

--- a/test/e2e/support/workbench.js
+++ b/test/e2e/support/workbench.js
@@ -84,7 +84,6 @@ Cypress.Commands.add("cleanupWorkbenchData", () => {
     const cleanupPaths = [
       ".cache",
       ".config",
-      ".connect-credentials",
       ".duckdb",
       ".ipython",
       ".local",

--- a/test/extension-contract-tests/src/contracts/extension-settings.test.ts
+++ b/test/extension-contract-tests/src/contracts/extension-settings.test.ts
@@ -32,14 +32,6 @@ describe("extension-settings contract", () => {
     expect(result).toBe(true);
   });
 
-  it("reads useKeyChainCredentialStorage from positPublisher config (default true)", () => {
-    mockGet.mockReturnValue(undefined);
-    const result = extensionSettings.useKeyChainCredentialStorage();
-    expect(workspace.getConfiguration).toHaveBeenCalledWith("positPublisher");
-    expect(mockGet).toHaveBeenCalledWith("useKeyChainCredentialStorage");
-    expect(result).toBe(true);
-  });
-
   it("reads defaultConnectServer from positPublisher config (default '')", async () => {
     mockGet.mockReturnValue(undefined);
     const result = await extensionSettings.defaultConnectServer();


### PR DESCRIPTION
## Summary

Resolves #3649. With the Go backend decommissioned (#3818), the `positPublisher.useKeyChainCredentialStorage` setting no longer has any effect — the extension stores credentials exclusively via VS Code's `SecretStorage`, which handles OS-level keychain selection automatically through Electron's `safeStorage`.

This PR deletes the setting and its Go-era ancillaries:

- Setting declaration in `package.json`, its accessor in `extension.ts`, and its contract test.
- Unused `credentialsContexts` constants (`Keychain`, `EnvironmentVars`) that were load-bearing only for the old Go-backend tree view.
- e2e plumbing for the `~/.connect-credentials` dotfile fallback: Docker volume mount, `clear-credentials` justfile recipe, file-reset block in `resetCredentials`, workbench cleanup path, and the `.gitignore` entry.
- Updated extension `CLAUDE.md` and user-facing `docs/vscode.md` to stop describing the removed fallback.
- CHANGELOG entries under `[Unreleased] → Removed` in both CHANGELOGs.

No user migration needed — VS Code silently ignores unknown settings.

## Test plan

- [x] `just test-extension-contracts` passes; the `extension-settings contract` describe block has four test cases (verifyCertificates / defaultConnectServer / autoOpenLogsOnFailure / enableConnectCloud)
- [x] `just vscode lint` passes
- [x] `just vscode` packages a .vsix cleanly (confirms `package.json` contributions are valid)
- [ ] `git grep useKeyChainCredentialStorage`, `credentialsContexts`, `connect-credentials` return only historical CHANGELOG entries
- [x] Manual: a user with the removed setting defined in `settings.json` sees no errors after upgrade (VS Code ignores unknown keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)