### PR TITLE
Pin claude-code-action to v1.0.92

### DIFF
--- a/.github/workflows/ci-failure-analysis.yaml
+++ b/.github/workflows/ci-failure-analysis.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Analyze failure with Claude
         if: steps.get-logs.outputs.has_failures == 'true'
         id: analyze
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.92
         with:
           use_bedrock: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -66,7 +66,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.92
         env:
           # Pass git config via environment to rewrite SSH URLs to authenticated HTTPS
           # This is for installing plugins from private repos

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -72,7 +72,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Run Claude Code Action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.92
         with:
           use_bedrock: true
           github_token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Pin `anthropics/claude-code-action` from `@v1` (floating tag) to `@v1.0.92` across all three Claude workflows: `claude.yaml`, `claude-auto-review.yaml`, and `ci-failure-analysis.yaml`

## Test plan

- [ ] Verify CI passes
- [ ] Trigger a test run of each workflow to confirm they still work with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)