### PR TITLE
Update dev-setup skill and adjacent docs for pure-TypeScript project

### DIFF
--- a/.claude/skills/dev-setup/SKILL.md
+++ b/.claude/skills/dev-setup/SKILL.md
@@ -35,33 +35,27 @@ Work through these steps in order.
 - **Act:** If missing, suggest installing Homebrew (https://brew.sh). Many later steps use brew for installing tools. On Linux, the system package manager is fine.
 - **Verify:** `brew --version` succeeds.
 
-### Step 2: Go
-
-- **Check:** `go version` — compare against the minimum version in `go.mod`.
-- **Act:** If missing or too old, point to https://go.dev/dl/ for installation.
-- **Verify:** `go version` shows a version >= the `go.mod` requirement.
-
-### Step 3: Node.js
+### Step 2: Node.js
 
 - **Check:** `node --version` and `npm --version`. The project needs a current LTS version.
 - **Act:** If missing, recommend nvm (https://github.com/nvm-sh/nvm) as the version manager. **Important: Do NOT install nvm via Homebrew — it is not compatible.** Follow the install script from the nvm README. Then: `nvm install --lts`.
 - **Verify:** `node --version` shows an LTS version and `npm --version` succeeds.
 
-### Step 4: Just
+### Step 3: Just
 
 - **Check:** `just --version`
 - **Act:** If missing: `brew install just` (macOS) or see https://github.com/casey/just for other platforms.
 - **Verify:** `just --version` succeeds.
 
-### Step 5: R and renv
+### Step 4: R and renv
 
 - **Check:** `R --version` to confirm R is installed. Then check renv: `R -e 'if (!requireNamespace("renv", quietly = TRUE)) quit(status = 1)' 2>/dev/null`
 - **Act:** If R is missing, suggest rig (https://github.com/r-lib/rig) as a convenient installer. If renv is missing: `R -e 'install.packages("renv")'`.
 - **Verify:** Both checks pass.
 
-**Why this matters:** Several Go tests in `internal/inspect/dependencies/renv/` require R with renv. Without them, `just test` will fail on those tests. Everything else passes without R.
+**Why this matters:** Some R-related extension tests invoke `R` directly and may fail if R is unavailable. R is also required to inspect and deploy R projects locally.
 
-### Step 6: VS Code Extensions
+### Step 5: VS Code Extensions
 
 - **Check:** Run `code --list-extensions` and look for:
   - `connor4312.esbuild-problem-matchers` — **Required** for debug launch configs
@@ -72,38 +66,37 @@ Work through these steps in order.
 
 **Why `esbuild-problem-matchers` is critical:** Without it, the "Run Extension" debug launch configuration fails. This is the single most commonly missed setup step. These extensions are listed in `extensions/vscode/.vscode/extensions.json` and VS Code should prompt to install them when the workspace is opened, but the prompt is easily dismissed.
 
-### Step 7: Install Dependencies
+### Step 6: Install Dependencies
 
 - **Check:** Check if `node_modules/` exists at the repo root and looks populated.
 - **Act:** Run `npm install` at the repo root. This installs Prettier, Husky (git hooks), and lint-staged. Also run `npm install --prefix="test/e2e"` so that git hooks work correctly when committing changes to E2E test files.
 - **Verify:** `node_modules/.package-lock.json` exists and `npx husky --version` works (git hooks are configured).
 
-### Step 8: Full Build
+### Step 7: Full Build
 
-- **Check:** Check if the Go binary exists at the expected location under `bin/`.
-- **Act:** Run `just` from the repo root. This builds the Go binary, installs extension + webview npm dependencies, and packages the VS Code extension (.vsix).
+- **Check:** Check if `dist/` contains a `.vsix` from a previous build.
+- **Act:** Run `just` from the repo root. This installs npm dependencies (extension + webview) and packages the VS Code extension (.vsix).
 - **Verify:** The build completes without errors and a `.vsix` file exists in `dist/`.
 
-### Step 9: Verify Tests
+### Step 8: Verify Tests
 
-Run all three test suites and check for failures:
+Run both test suites and check for failures:
 
-1. **Go tests:** `just test`
-   - **Check/Verify:** All tests pass. If tests fail only in `internal/inspect/dependencies/renv/`, that's the R/renv prerequisite — guide the developer back to Step 5.
+1. **Extension tests:** `cd extensions/vscode && just test`
+   - **Check/Verify:** Mocha integration tests pass (opens a VS Code window briefly) and all Vitest unit tests pass. If R-related suites fail, guide the developer back to Step 4 (R and renv).
 
-2. **Extension tests:** `cd extensions/vscode && just test`
-   - **Check/Verify:** Mocha integration tests pass (opens a VS Code window briefly) and all Vitest unit tests pass.
-
-3. **Webview tests:** `cd extensions/vscode/webviews/homeView && npm test`
+2. **Webview tests:** `cd extensions/vscode/webviews/homeView && npm test`
    - **Check/Verify:** All Vitest tests pass.
 
 ### Core Setup Complete
 
 Tell the developer their core environment is ready. Summarize what's set up and what they can do:
 
-- `just` — full rebuild
-- `just test` — Go tests
-- `just build` — Go binary only
+- `just` — full rebuild and package (.vsix)
+- `just vscode test` — extension tests (Mocha integration + Vitest unit)
+- `just format` / `just check-format` — formatting
+- `just test-extension-contracts` — extension contract tests
+- `just test-connect-contracts` — Connect API contract tests
 - F5 in VS Code (with `extensions/vscode/` open) — run the extension in debug mode
 - Point them to `CONTRIBUTING.md` and `extensions/vscode/CONTRIBUTING.md` for workflow details
 

--- a/.claude/skills/dev-setup/SKILL.md
+++ b/.claude/skills/dev-setup/SKILL.md
@@ -106,7 +106,7 @@ Then ask: **"Would you like to set up E2E testing too? This requires Docker and 
 
 Only proceed if the developer wants this. E2E tests run the extension in a real VS Code environment (code-server in Docker) against a real Posit Connect server.
 
-### Step 10: Docker Desktop
+### Step 9: Docker Desktop
 
 - **Check:** `docker --version` and `docker info` (confirms the daemon is running).
 - **Act:** If missing, point to https://www.docker.com/products/docker-desktop/.
@@ -119,13 +119,13 @@ On Apple Silicon (`uname -m` shows `arm64`), the developer needs to configure Do
 
 Ask the developer to confirm these are set.
 
-### Step 11: uv and with-connect
+### Step 10: uv and with-connect
 
 - **Check:** `uv --version` and `which with-connect`
 - **Act:** If uv is missing: `brew install uv`. If with-connect is missing: `uv tool install git+https://github.com/posit-dev/with-connect.git`
 - **Verify:** `with-connect --help` produces usage output.
 
-### Step 12: Connect License
+### Step 11: Connect License
 
 The developer needs a Posit Connect license file to run E2E tests locally. This is not something that can be automated.
 
@@ -133,7 +133,7 @@ The developer needs a Posit Connect license file to run E2E tests locally. This 
 - **Act:** If they don't have one, let them know they can rely on GitHub CI for E2E tests, or ask a team member for help getting a license.
 - **Verify:** The file they specified exists on disk.
 
-### Step 13: Environment Variables
+### Step 12: Environment Variables
 
 The E2E tests need `CONNECT_LICENSE_FILE` and (on macOS) `DOCKER_HOST` set.
 
@@ -146,19 +146,17 @@ The E2E tests need `CONNECT_LICENSE_FILE` and (on macOS) `DOCKER_HOST` set.
   Then `direnv allow test/e2e/`. If the developer doesn't want direnv, they can export these manually before running E2E tests.
 - **Verify:** `direnv exec test/e2e env | grep CONNECT_LICENSE_FILE` shows the expected value, or the developer confirms they'll set the variables manually.
 
-### Step 14: Build for E2E
+### Step 13: Build for E2E
 
-E2E tests run in a Linux/amd64 Docker container, so the publisher binary needs to be cross-compiled.
-
-- **Check:** Check if a linux/amd64 binary and .vsix exist from a previous build.
-- **Act:** Run `USE_PLATFORM="linux/amd64" just` from the repo root. Then from `test/e2e/`, build Docker images:
+- **Check:** Check if a `.vsix` exists in `dist/` from a previous build and if Docker images exist: `docker images | grep publisher-e2e`
+- **Act:** Run `just` from the repo root to build the `.vsix`. Then from `test/e2e/`, build Docker images:
   ```bash
   just build-base
   just build-image code-server
   ```
-- **Verify:** Docker images exist: `docker images | grep publisher-e2e`
+- **Verify:** A `.vsix` exists in `dist/` and Docker images exist: `docker images | grep publisher-e2e`
 
-### Step 15: Install E2E Dependencies
+### Step 14: Install E2E Dependencies
 
 - **Check:** Check if `test/e2e/node_modules/` exists.
 - **Act:** From `test/e2e/`:
@@ -168,7 +166,7 @@ E2E tests run in a Linux/amd64 Docker container, so the publisher binary needs t
   ```
 - **Verify:** `npx cypress --version` succeeds from the `test/e2e/` directory.
 
-### Step 16: Verify E2E (skipping Connect Cloud tests)
+### Step 15: Verify E2E (skipping Connect Cloud tests)
 
 Run a quick smoke test excluding Connect Cloud tests (which need 1Password):
 
@@ -186,7 +184,7 @@ Then retry.
 
 After tests complete, clean up: `just stop`
 
-### Step 17: 1Password CLI (Optional, Connect Cloud only)
+### Step 16: 1Password CLI (Optional, Connect Cloud only)
 
 For Connect Cloud tests (tagged `@pcc`), credentials are fetched from 1Password.
 
@@ -210,10 +208,9 @@ Summarize what's available:
 
 If the developer hits issues at any point, here are common problems:
 
-| Symptom                           | Cause                                     | Fix                                                      |
-| --------------------------------- | ----------------------------------------- | -------------------------------------------------------- |
-| `just test` fails in `renv` tests | R or renv not installed                   | Install R (rig) + `R -e 'install.packages("renv")'`      |
-| "Run Extension" launch fails      | Missing esbuild-problem-matchers          | Install `connor4312.esbuild-problem-matchers` extension  |
-| Port 3939 already allocated       | Stale with-connect container              | `docker rm -f $(docker ps -aq --filter publish=3939)`    |
-| `op: command not found`           | 1Password CLI not installed system-wide   | `brew install 1password-cli`                             |
-| E2E container fails to start      | Docker Desktop not configured for Rosetta | Enable Apple Virtualization + Rosetta in Docker settings |
+| Symptom                      | Cause                                     | Fix                                                      |
+| ---------------------------- | ----------------------------------------- | -------------------------------------------------------- |
+| "Run Extension" launch fails | Missing esbuild-problem-matchers          | Install `connor4312.esbuild-problem-matchers` extension  |
+| Port 3939 already allocated  | Stale with-connect container              | `docker rm -f $(docker ps -aq --filter publish=3939)`    |
+| `op: command not found`      | 1Password CLI not installed system-wide   | `brew install 1password-cli`                             |
+| E2E container fails to start | Docker Desktop not configured for Rosetta | Enable Apple Virtualization + Rosetta in Docker settings |

--- a/test/connect-api-contracts/README.md
+++ b/test/connect-api-contracts/README.md
@@ -1,19 +1,20 @@
 # Connect API Contract Tests
 
-Contract tests that validate the HTTP requests Publisher sends **to Posit Connect** and how it parses Connect's responses. These ensure a future TypeScript ConnectClient produces identical behavior to the Go implementation.
+Contract tests that validate the HTTP requests Publisher sends **to Posit Connect** and how it parses Connect's responses. Tests run against a Node.js mock Connect server and exercise the shared `@posit-dev/connect-api` client (the same client the extension uses in production).
 
 ## Architecture
 
 ```
-Test code  →  Go harness (POST /call)  →  Mock Connect server (Node.js)
-               { method: "CreateDeployment",    POST /__api__/v1/content
-                 body: {...} }                   (canned Connect response)
+Test code  →  TypeScriptDirectClient  →  @posit-dev/connect-api  →  Mock Connect server (Node.js)
+                                                                      POST /__api__/v1/content
+                                                                      (canned Connect response)
 ```
 
-Two servers are involved:
+One server is involved:
 
-1. **Mock Connect server** — A Node.js HTTP server that simulates Connect's API endpoints with canned JSON responses and captures all incoming requests for assertion.
-2. **Go harness** — A thin HTTP server with a single `POST /call` endpoint that dispatches to `APIClient` methods by name. Each request creates a fresh `ConnectClient` pointed at the mock, calls the target method, and returns the result plus captured requests as JSON.
+- **Mock Connect server** — A Node.js HTTP server (`src/mock-connect-server.ts`) that simulates Connect's API endpoints with canned JSON responses and captures all incoming requests for assertion.
+
+Tests construct a `TypeScriptDirectClient` pointed at the mock. The client dispatches `call(method, params)` to the corresponding method on the shared `@posit-dev/connect-api` client, which issues real HTTP requests to the mock. Captured requests and responses flow back to the test for assertion.
 
 The mock exposes control endpoints for tests:
 
@@ -24,7 +25,7 @@ The mock exposes control endpoints for tests:
 
 ## What's tested
 
-All 15 methods on the Go `APIClient` interface have corresponding test files, mock routes, and fixtures.
+All 15 entries in the `Method` constant have corresponding test files, mock routes, and fixtures.
 
 | Method               | Connect Path                                        |
 | -------------------- | --------------------------------------------------- |
@@ -51,28 +52,18 @@ Each test validates both:
 - **Request correctness** — method, path, `Authorization: Key <apiKey>` header
 - **Response parsing** — Publisher correctly transforms Connect's DTO into its internal types
 
-## Client implementations
+## Client
 
-| Client                   | Description                                                              |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `GoPublisherClient`      | Calls the Go harness `POST /call`, which internally calls mock Connect   |
-| `TypeScriptDirectClient` | Stub for future TS ConnectClient (`call()` throws "Not implemented yet") |
-
-Both implement a single `call(method, params?)` interface. The `connectUrl` and `apiKey` are injected at construction time, so tests only pass method-specific params. Method names are typed via the `Method` constant and `MethodName` type exported from `src/client.ts` (e.g. `Method.CreateDeployment` instead of a raw string).
-
-Set `API_BACKEND=typescript` to run against the TS client once implemented.
+`TypeScriptDirectClient` (`src/clients/ts-direct-client.ts`) implements the `ConnectContractClient` interface. It wraps the shared `@posit-dev/connect-api` package and dispatches `call(method, params?)` to the corresponding SDK method. The `connectUrl` and `apiKey` are injected at construction time, so tests only pass method-specific params. Method names are typed via the `Method` constant and `MethodName` type exported from `src/client.ts` (e.g. `Method.CreateDeployment` instead of a raw string).
 
 ## Running
 
 ```bash
-# Run Connect contract tests (harness is built automatically)
+# Run Connect contract tests
 just test-connect-contracts
 
 # Or directly
 cd test/connect-api-contracts && npm test
-
-# Build the harness binary manually
-just build-connect-harness
 
 # Update snapshots (currently only one inline snapshot in authentication.test.ts)
 cd test/connect-api-contracts && npm run test:update
@@ -97,7 +88,7 @@ Fixture-to-endpoint mappings are defined in `src/validation/fixture-map.ts`. Whe
 
 ## Adding tests
 
-1. Add a case to the `dispatch()` switch in the Go harness (`harness/main.go`)
+1. Add a new entry to the `Method` constant in `src/client.ts` and dispatch it inside the `dispatch()` switch in `TypeScriptDirectClient` (`src/clients/ts-direct-client.ts`)
 2. Add a route handler in `src/mock-connect-server.ts` with a canned response fixture
 3. Create a test file in `src/endpoints/` using `setupContractTest()`:
 
@@ -121,17 +112,10 @@ describe("NewMethod", () => {
 ## Project structure
 
 - `src/client.ts` — `Method` constants, `MethodName` type, and `ConnectContractClient` interface
+- `src/clients/ts-direct-client.ts` — `TypeScriptDirectClient` implementation wrapping `@posit-dev/connect-api`
 - `src/mock-connect-server.ts` — `MockConnectServer` class with route-based dispatch and test control endpoints
 - `src/helpers.ts` — `setupContractTest()` helper for test setup/teardown
-- `src/endpoints/` — One test file per `APIClient` method
+- `src/endpoints/` — One test file per `Method` entry
 - `src/fixtures/connect-responses/` — Canned JSON responses for Connect API endpoints
 - `src/fixtures/workspace/` — Minimal project files (used by GetSettings for config)
 - `src/validation/` — Swagger spec validation for fixtures
-- `harness/main.go` — Go test harness binary
-
-## Future expansion
-
-When the TS ConnectClient is built:
-
-1. Implement the `call()` dispatcher in `ts-direct-client.ts` to route methods to the TS client
-2. Both Go and TS paths validate against the same snapshots and request expectations

--- a/test/e2e/CONTRIBUTING.md
+++ b/test/e2e/CONTRIBUTING.md
@@ -63,7 +63,7 @@ npx playwright install chromium
 **2. Build the Publisher extension** (from repo root):
 
 ```bash
-USE_PLATFORM="linux/amd64" just
+just
 ```
 
 **3. Build Docker images:**

--- a/test/e2e/justfile
+++ b/test/e2e/justfile
@@ -98,7 +98,7 @@ build-images:
     just pull-workbench "release"
 
 build-publisher:
-    USE_PLATFORM="linux/amd64" just ../../
+    just ../../
 
 
 


### PR DESCRIPTION
## Summary

- Rewrites `.claude/skills/dev-setup/SKILL.md` to reflect today's pure-TypeScript Publisher: deletes the Go step, renumbers the rest, fixes the build/verify-tests guidance, updates the post-setup command reference, and drops the cross-compile/`USE_PLATFORM` premise from E2E setup.
- Removes the dead `USE_PLATFORM="linux/amd64"` env var from `test/e2e/CONTRIBUTING.md` and `test/e2e/justfile` (nothing reads it after the Go binary removal).
- Rewrites `test/connect-api-contracts/README.md` to describe today's TypeScript-direct architecture (Vitest → `TypeScriptDirectClient` → `@posit-dev/connect-api` → mock Connect server). The Go harness at `harness/main.go` is gone.

Scope was intentionally expanded beyond issue #4026 to include the two adjacent docs (`test/e2e/*` and `test/connect-api-contracts/README.md`) that shared the same stale Go-era premise as the skill, so we do not re-discover the same staleness next week. The historical note at `extensions/vscode/CLAUDE.md:70` about the `src/api/` directory name was considered and deliberately left as-is — it is useful signal for readers.

No CHANGELOG entry: this is internal docs and one dead-code Justfile cleanup, no user-facing change.

Closes #4026

## Test plan

- [ ] `just --list` at repo root still works
- [ ] `just -f test/e2e/justfile --list` still works and `build-publisher` recipe is present
- [ ] Grep sweep across the four changed files returns no residual Go-era references (`Go binary`, `go test`, `internal/`, `USE_PLATFORM`, `Go harness`, `GoPublisherClient`)
- [ ] Read the rewritten `SKILL.md` top-to-bottom and confirm step numbering is contiguous (1–8 for Phase 1, 9–16 for Phase 2)