### PR TITLE
Exclude CLAUDE.md files from packaged extension

### DIFF
--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -9,6 +9,7 @@ scripts/
 \*\*/_.ts
 CONTRIBUTING.md
 vsc-extension-quickstart.md
+**/CLAUDE.md
 
 # Exclude icons as they are bundled into a font
 assets/icons/**


### PR DESCRIPTION
## Summary
- `CLAUDE.md` and `webviews/homeView/CLAUDE.md` were being bundled into the shipped `.vsix`
- Added `**/CLAUDE.md` to `extensions/vscode/.vscodeignore` to exclude them
- These are internal developer guidance files for Claude Code and shouldn't ship to end users

## Verification
Before:
```
$ npx @vscode/vsce ls | grep -i claude
CLAUDE.md
webviews/homeView/CLAUDE.md
```

After:
```
$ npx @vscode/vsce ls | grep -i claude
(no matches)
```

## Test plan
- [x] Run `just package` from `extensions/vscode/` and confirm no `CLAUDE.md` files are in the resulting `.vsix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)