### PR TITLE
ci: point npm dependabot at the workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,11 @@
 
 version: 2
 updates:
-  # npm
+  # npm — root workspace covers extensions/vscode, its homeView webview,
+  # packages/*, and test/{connect-api-contracts,extension-contract-tests}
+  # via the single root package-lock.json. test/e2e stays standalone.
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/extensions/vscode"
-      - "/extensions/vscode/webviews/homeView"
+    directory: "/"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Summary

After #4056 collapsed six sub-lockfiles into a single root `package-lock.json`, the npm Dependabot entry kept pointing at `/extensions/vscode` and `/extensions/vscode/webviews/homeView` — paths where lockfiles no longer exist. The first group PR it produced (#4047) tried to modify those deleted files and couldn't merge. A standalone per-package update (#4022) targeting `/packages/connect-api`'s old lockfile hit the same wall.

Dependabot understands npm workspaces natively: a single `directory: "/"` entry walks the root `package.json`'s `workspaces` field and updates every member (`packages/*`, `extensions/vscode`, `extensions/vscode/webviews/homeView`, `test/connect-api-contracts`, `test/extension-contract-tests`) against the one root lockfile. `test/e2e` keeps its separate entry since it's excluded from the workspace.

## Test plan

- [ ] After merge, confirm the next weekly Dependabot run produces an npm-minor-and-patch group PR that touches only the root `package-lock.json` (plus any workspace `package.json` files whose version ranges change).
- [ ] Confirm Dependabot does not open per-workspace-member PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)