### PR TITLE
Notify on external issue comments in addition to new issues

### DIFF
--- a/.github/workflows/external-issue-notify.yaml
+++ b/.github/workflows/external-issue-notify.yaml
@@ -3,15 +3,21 @@ name: External Issue Notification
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 jobs:
   notify:
+    # Skip comments on pull requests (issue_comment fires for both issues and PRs)
+    if: >-
+      github.event_name == 'issues' ||
+      (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
     runs-on: ubuntu-latest
     env:
-      AUTHOR: ${{ github.event.issue.user.login }}
+      AUTHOR: ${{ github.event_name == 'issue_comment' && github.event.comment.user.login || github.event.issue.user.login }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       ISSUE_URL: ${{ github.event.issue.html_url }}
     steps:
@@ -20,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ORG_TEAM_READ_TOKEN }}
         run: |
-          # Check if the issue author is a member of posit-dev/publisher
+          # Check if the author is a member of posit-dev/publisher
           # The API returns 200 if they are a member, 404 if not
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer $GH_TOKEN" \
@@ -40,19 +46,24 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_ISSUE_SLACK_WEBHOOK_URL }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
         run: |
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            MESSAGE=":speech_balloon: *New external comment on Publisher issue*\n\n*<${COMMENT_URL}|#${ISSUE_NUMBER}: ${ISSUE_TITLE}>*\nComment by: <https://github.com/${AUTHOR}|@${AUTHOR}>"
+          else
+            MESSAGE=":rotating_light: *New external issue filed on Publisher*\n\n*<${ISSUE_URL}|#${ISSUE_NUMBER}: ${ISSUE_TITLE}>*\nFiled by: <https://github.com/${AUTHOR}|@${AUTHOR}>"
+          fi
+
           PAYLOAD=$(jq -n \
-            --arg title "$ISSUE_TITLE" \
-            --arg url "$ISSUE_URL" \
-            --arg number "$ISSUE_NUMBER" \
-            --arg author "$AUTHOR" \
+            --arg text "$MESSAGE" \
             '{
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":rotating_light: *New external issue filed on Publisher*\n\n*<\($url)|#\($number): \($title)>*\nFiled by: <https://github.com/\($author)|@\($author)>"
+                    "text": $text
                   }
                 }
               ]


### PR DESCRIPTION
## Summary

- Adds an `issue_comment` trigger (on `created`) to the external issue notification workflow, so the team gets a Slack alert when someone outside the `posit-dev/publisher` group comments on an issue
- Filters out comments on pull requests (since `issue_comment` fires for both issues and PRs)
- Uses a distinct Slack message format for comments (links to the comment, not the issue) to differentiate from new-issue notifications

## Test plan

- [ ] Verify the workflow triggers on a new issue from an external user (existing behavior, unchanged)
- [ ] Verify the workflow triggers on a comment from an external user on an issue
- [ ] Verify the workflow does **not** trigger on a comment from an external user on a pull request
- [ ] Verify the workflow does **not** trigger on a comment from a publisher team member
- [ ] Confirm Slack messages use the correct format for each event type

🤖 Generated with [Claude Code](https://claude.com/claude-code)