### PR TITLE
fix: update positron-server binary path for new Workbench image

### DIFF
--- a/test/scripts/install-positron-extension.sh
+++ b/test/scripts/install-positron-extension.sh
@@ -51,7 +51,7 @@ INSTALL_LOG="./logs/workbench-extension/workbench-extension-installation.log"
 
 # Run installation command as the rstudio user to ensure proper permissions
 echo "Running installation command..." | tee "$INSTALL_LOG"
-docker exec -u rstudio publisher-e2e.workbench-$SERVICE bash -c "cd /usr/lib/rstudio-server/bin/positron-server && ./bin/positron-server --install-extension /vsix-tmp/$VSIX_FILENAME --force" | tee -a "$INSTALL_LOG" || {
+docker exec -u rstudio publisher-e2e.workbench-$SERVICE bash -c "cd /usr/lib/rstudio-server/bin/positron-server && ./bundled/bin/positron-server --install-extension /vsix-tmp/$VSIX_FILENAME --force" | tee -a "$INSTALL_LOG" || {
     echo "Installation command failed" | tee -a "$INSTALL_LOG"
     exit 2
 }


### PR DESCRIPTION
## Summary

- Fix e2e test failures caused by the Workbench Docker image (`rstudio/rstudio-workbench:ubuntu2204`) moving the `positron-server` binary from `bin/positron-server` to `bundled/bin/positron-server`
- Updates the hardcoded path in `install-positron-extension.sh` to match the new image layout
- Confirmed the same path change applies to both the release and preview Workbench images

## Context

All four e2e test jobs (preview, 2023.03.0, 2025.03.0, release) started failing with:

```
bash: line 1: ./bin/positron-server: No such file or directory
```

This is an upstream change in the Workbench Docker image — the failing commit only modified an unrelated notification workflow.

## Test plan

- [ ] E2e tests pass in CI with the updated path

🤖 Generated with [Claude Code](https://claude.com/claude-code)