### PR TITLE
Fix external issue notification workflow

### DIFF
--- a/.github/workflows/external-issue-notify.yaml
+++ b/.github/workflows/external-issue-notify.yaml
@@ -27,13 +27,13 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_TEAM_READ_TOKEN }}
         run: |
           # Check if the author is a member of posit-dev/publisher
-          # The API returns 200 if they are a member, 404 if not
+          # The API returns 204 if they are a member, 404 if not
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/orgs/posit-dev/teams/publisher/members/$AUTHOR")
+            "https://api.github.com/orgs/posit-dev/teams/publisher-code-owners/members/$AUTHOR")
 
-          if [ "$HTTP_STATUS" = "200" ]; then
+          if [ "$HTTP_STATUS" = "204" ]; then
             echo "is_external=false" >> "$GITHUB_OUTPUT"
             echo "$AUTHOR is a publisher team member"
           else
@@ -50,9 +50,13 @@ jobs:
           COMMENT_URL: ${{ github.event.comment.html_url }}
         run: |
           if [ "$EVENT_NAME" = "issue_comment" ]; then
-            MESSAGE=":speech_balloon: *New external comment on Publisher issue*\n\n*<${COMMENT_URL}|#${ISSUE_NUMBER}: ${ISSUE_TITLE}>*\nComment by: <https://github.com/${AUTHOR}|@${AUTHOR}>"
+            MESSAGE=$(printf ':speech_balloon: *New external comment on Publisher issue*\n\n*<%s|#%s: %s>*\nComment by: <%s|@%s>' \
+              "$COMMENT_URL" "$ISSUE_NUMBER" "$ISSUE_TITLE" \
+              "https://github.com/${AUTHOR}" "$AUTHOR")
           else
-            MESSAGE=":rotating_light: *New external issue filed on Publisher*\n\n*<${ISSUE_URL}|#${ISSUE_NUMBER}: ${ISSUE_TITLE}>*\nFiled by: <https://github.com/${AUTHOR}|@${AUTHOR}>"
+            MESSAGE=$(printf ':rotating_light: *New external issue filed on Publisher*\n\n*<%s|#%s: %s>*\nFiled by: <%s|@%s>' \
+              "$ISSUE_URL" "$ISSUE_NUMBER" "$ISSUE_TITLE" \
+              "https://github.com/${AUTHOR}" "$AUTHOR")
           fi
 
           PAYLOAD=$(jq -n \


### PR DESCRIPTION
## Summary
- **Wrong team slug**: The workflow used `publisher` as the team slug, but the actual team is `publisher-code-owners`. This caused the GitHub API to return 404 for every user, making everyone appear external.
- **Wrong status code check**: The `GET /orgs/{org}/teams/{team_slug}/members/{username}` endpoint returns `204` for members, not `200`. Even with the correct team, the check would have failed.
- **Broken Slack formatting**: Literal `\n` in bash strings weren't rendered as newlines in Slack messages. Switched to `printf` for proper formatting.

## Test plan
- [ ] Verify an internal team member commenting on an external issue does **not** trigger a Slack notification
- [ ] Verify an external user opening a new issue **does** trigger a Slack notification with correct formatting
- [ ] Verify an external user commenting on an issue **does** trigger a Slack notification with correct formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)