### PR TITLE
Auto-label issues with `community` when external users interact

### DIFF
--- a/.github/workflows/external-issue-notify.yaml
+++ b/.github/workflows/external-issue-notify.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   notify:
@@ -40,6 +41,18 @@ jobs:
             echo "is_external=true" >> "$GITHUB_OUTPUT"
             echo "$AUTHOR is external (HTTP $HTTP_STATUS)"
           fi
+
+      - name: Add community label
+        if: steps.check-team.outputs.is_external == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['community']
+            });
 
       - name: Send Slack notification
         if: steps.check-team.outputs.is_external == 'true'


### PR DESCRIPTION
## Summary

- Adds a step to the external issue notification workflow that applies the `community` label when a non-team member opens an issue or comments on an existing one
- Adds `issues: write` permission to the workflow so it can apply labels
- Created the `community` label in the repo

Closes #4071

## Test plan

- [x] Verify the `community` label exists in the repo
- [ ] Have an external user open a test issue and confirm the label is applied
- [ ] Have an external user comment on an existing issue and confirm the label is applied
- [ ] Confirm team member actions do not trigger the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)