### PR TITLE
Add error handling for community label workflow step

### DIFF
--- a/.github/workflows/external-issue-notify.yaml
+++ b/.github/workflows/external-issue-notify.yaml
@@ -47,12 +47,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['community']
-            });
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['community']
+              });
+            } catch (error) {
+              core.warning(`Failed to add community label: ${error.message}`);
+            }
 
       - name: Send Slack notification
         if: steps.check-team.outputs.is_external == 'true'


### PR DESCRIPTION
## Summary

- Wraps the `addLabels` API call in the external issue notification workflow with try/catch so a labeling failure (rate limiting, network issue, etc.) doesn't block the Slack notification from being sent
- Emits a workflow warning instead of failing the step, consistent with how the Slack step already handles errors gracefully

Follow-up from code review feedback on #4073.

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Confirm Slack notification still fires when labeling succeeds
- [ ] Confirm Slack notification still fires if labeling were to fail (label step emits warning instead of failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)