### PR TITLE
Skip Claude review on release PRs opened by bots (#4079)

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -6,8 +6,12 @@ on:
 
 jobs:
   auto-review:
-    # Skip draft PRs and Dependabot PRs
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    # Skip draft PRs, Dependabot PRs, and release PRs opened by bots
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'posit-connect-projects[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Intent

Release PRs opened by `posit-connect-projects[bot]` were failing the Claude auto-review workflow because the collaborator permission check rejects bot-authored PRs.

Resolves #4079

## Type of Change

- [x] Tooling

## Approach

Added two conditions to the `claude-auto-review.yaml` workflow's job-level `if` guard:

1. **Skip the specific bot actor** — `github.actor != 'posit-connect-projects[bot]'`
2. **Skip any release branch** — `!startsWith(github.event.pull_request.head.ref, 'release/')`

This provides defense-in-depth: even if the bot name changes or someone manually opens a release PR, the branch pattern check still skips the review.

## User Impact

None. Release PRs will no longer trigger (and fail) the Claude auto-review workflow.

## Automated Tests

No automated tests — this is a CI workflow condition change. Verified by inspecting the GitHub Actions expression logic.

## Directions for Reviewers

1. Review the `if` condition in `.github/workflows/claude-auto-review.yaml`
2. Confirm both conditions correctly match release PR characteristics (bot actor name and `release/*` branch pattern)