### PR TITLE
Fix Connect Cloud redeploy wiping all secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Connect Cloud redeploy wiping previously set secrets. (#4082)
+
 ## [2.0.0]
 
 ### Added

--- a/extensions/vscode/src/publish/cloudContentRequest.test.ts
+++ b/extensions/vscode/src/publish/cloudContentRequest.test.ts
@@ -831,6 +831,26 @@ describe("buildUpdateContentRequest", () => {
     expect(request.secrets).toBeUndefined();
   });
 
+  it("omits secrets when secrets param is empty object (redeploy without new values)", () => {
+    const config: ConfigurationDetails = {
+      $schema: "https://example.com/schema",
+      productType: ProductType.CONNECT_CLOUD,
+      type: ContentType.R_SHINY,
+      entrypoint: "app.R",
+      validate: true,
+    };
+
+    const request = buildUpdateContentRequest(
+      config,
+      "my-app",
+      {},
+      ContentID("content-456"),
+      undefined,
+    );
+
+    expect(request.secrets).toBeUndefined();
+  });
+
   it("includes secrets in PATCH payload when secrets are provided", () => {
     const config: ConfigurationDetails = {
       $schema: "https://example.com/schema",

--- a/extensions/vscode/src/publish/cloudContentRequest.test.ts
+++ b/extensions/vscode/src/publish/cloudContentRequest.test.ts
@@ -736,6 +736,26 @@ describe("buildCreateContentRequest", () => {
 
     expect(request.title).toBe("my-save-name");
   });
+
+  it("omits secrets when no environment vars and no secrets provided", () => {
+    const config: ConfigurationDetails = {
+      $schema: "https://example.com/schema",
+      productType: ProductType.CONNECT_CLOUD,
+      type: ContentType.PYTHON_DASH,
+      entrypoint: "app.py",
+      validate: true,
+    };
+
+    const request = buildCreateContentRequest(
+      config,
+      "my-app",
+      undefined,
+      "account-123",
+      ContentAccess.ViewPrivateEditPrivate,
+    );
+
+    expect(request.secrets).toBeUndefined();
+  });
 });
 
 describe("buildUpdateContentRequest", () => {
@@ -789,5 +809,71 @@ describe("buildUpdateContentRequest", () => {
     );
 
     expect(request.access).toBeUndefined();
+  });
+
+  it("omits secrets from PATCH payload when no environment vars and no secrets provided", () => {
+    const config: ConfigurationDetails = {
+      $schema: "https://example.com/schema",
+      productType: ProductType.CONNECT_CLOUD,
+      type: ContentType.R_SHINY,
+      entrypoint: "app.R",
+      validate: true,
+    };
+
+    const request = buildUpdateContentRequest(
+      config,
+      "my-app",
+      undefined,
+      ContentID("content-456"),
+      undefined,
+    );
+
+    expect(request.secrets).toBeUndefined();
+  });
+
+  it("includes secrets in PATCH payload when secrets are provided", () => {
+    const config: ConfigurationDetails = {
+      $schema: "https://example.com/schema",
+      productType: ProductType.CONNECT_CLOUD,
+      type: ContentType.R_SHINY,
+      entrypoint: "app.R",
+      validate: true,
+    };
+
+    const request = buildUpdateContentRequest(
+      config,
+      "my-app",
+      { MY_SECRET: "value" },
+      ContentID("content-456"),
+      undefined,
+    );
+
+    expect(request.secrets).toHaveLength(1);
+    expect(request.secrets![0]).toEqual({ name: "MY_SECRET", value: "value" });
+  });
+
+  it("includes secrets in PATCH payload when config has environment vars", () => {
+    const config: ConfigurationDetails = {
+      $schema: "https://example.com/schema",
+      productType: ProductType.CONNECT_CLOUD,
+      type: ContentType.R_SHINY,
+      entrypoint: "app.R",
+      environment: { ENV_VAR: "env-value" },
+      validate: true,
+    };
+
+    const request = buildUpdateContentRequest(
+      config,
+      "my-app",
+      undefined,
+      ContentID("content-456"),
+      undefined,
+    );
+
+    expect(request.secrets).toHaveLength(1);
+    expect(request.secrets![0]).toEqual({
+      name: "ENV_VAR",
+      value: "env-value",
+    });
   });
 });

--- a/extensions/vscode/src/publish/cloudContentRequest.ts
+++ b/extensions/vscode/src/publish/cloudContentRequest.ts
@@ -373,7 +373,7 @@ function buildRequestRevision(
 function buildSecrets(
   environment: Record<string, string> | undefined,
   secrets: Record<string, string> | undefined,
-): Secret[] {
+): Secret[] | undefined {
   const combined: Record<string, string> = {};
   if (environment) {
     Object.assign(combined, environment);
@@ -382,7 +382,10 @@ function buildSecrets(
     Object.assign(combined, secrets);
   }
 
-  return Object.entries(combined).map(([name, value]) => ({ name, value }));
+  const entries = Object.entries(combined);
+  return entries.length > 0
+    ? entries.map(([name, value]) => ({ name, value }))
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #4082.

When redeploying content to Connect Cloud, all secrets were being deleted because the PATCH request always included `secrets: []` when no secrets were provided. Connect Cloud interprets this as "remove all secrets."

- Changed `buildSecrets` to return `undefined` instead of `[]` when neither `config.environment` nor the `secrets` parameter has any entries
- When `secrets` is `undefined`, it is omitted from the PATCH payload (JSON serialization drops `undefined` fields), preserving existing secrets on the content
- Added test coverage for the missing cases: omitting secrets on update when none provided, including secrets when provided, and including env vars from config

## Test plan

- [x] Unit tests pass (`npm run test-unit`)
- [x] Manual test: deploy content to Connect Cloud with secrets configured, redeploy without modifying secrets, verify secrets are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)