### PR TITLE
fix: resolve content URLs from Connect API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname. This scenario can happen when publishing from Workbench to Connect within the Posit Team Native App in Snowpark Container Services. (#3698)
+
 ## [2.2.0]
 
 ### Fixed
 
 - Fixed Connect Cloud redeploy wiping previously set secrets. (#4082)
-- Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname. This scenario can happen when publishing from Workbench to Connect within the Posit Team Native App in Snowpark Container Services. (#3698)
 
 ## [2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Connect Cloud redeploy wiping previously set secrets. (#4082)
+- Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname, such as when publishing from inside Snowflake Native App. (#3698)
 
 ## [2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Connect Cloud redeploy wiping previously set secrets. (#4082)
-- Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname, such as when publishing from inside Snowflake Native App. (#3698)
+- Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname. This scenario can happen when publishing from Workbench to Connect within the Posit Team Native App in Snowpark Container Services. (#3698)
 
 ## [2.0.0]
 

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -186,8 +186,8 @@ const TEST_CONTENT: ContentDetailsDTO = {
   run_as: null,
   run_as_current_user: false,
   owner_guid: "user-guid",
-  content_url: "https://connect.example.com/content/content-guid-123/",
-  dashboard_url: "https://connect.example.com/connect/#/apps/content-guid-123",
+  content_url: "https://external.example.com/content/content-guid-123/",
+  dashboard_url: "https://external.example.com/connect/#/apps/content-guid-123",
   locked: false,
   app_role: "owner",
   id: "12345",
@@ -367,10 +367,10 @@ describe("connectPublish", () => {
     expect(result.contentId).toBe("content-guid-123");
     expect(result.bundleId).toBe("bundle-42");
     expect(result.dashboardUrl).toBe(
-      "https://connect.example.com/connect/#/apps/content-guid-123",
+      "https://external.example.com/connect/#/apps/content-guid-123",
     );
     expect(result.directUrl).toBe(
-      "https://connect.example.com/content/content-guid-123/",
+      "https://external.example.com/content/content-guid-123/",
     );
 
     // Verify API call sequence
@@ -395,6 +395,11 @@ describe("connectPublish", () => {
     const result = await connectPublish(opts);
 
     expect(result.contentId).toBe("existing-id");
+
+    // URLs come from the API response, not local construction from serverUrl
+    expect(result.dashboardUrl).toBe(TEST_CONTENT.dashboard_url);
+    expect(result.directUrl).toBe(TEST_CONTENT.content_url);
+    expect(result.logsUrl).toBe(TEST_CONTENT.dashboard_url + "/logs");
 
     // Should NOT create a new deployment
     expect(opts.api.createDeployment).not.toHaveBeenCalled();

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -38,7 +38,6 @@ import {
 } from "./publishShared";
 
 import { forceProductTypeCompliance } from "../toml/configCompliance";
-import { getDashboardUrl, getDirectUrl, getLogsUrl } from "../toml/urlHelpers";
 import { DEFAULT_PYTHON_PACKAGE_FILE } from "../constants";
 import { fileExistsAt } from "../interpreters/fsUtils";
 import { generateRequirements } from "../interpreters/pythonDependencySources";
@@ -129,16 +128,18 @@ export async function connectPublish({
   };
 
   let contentId = existingContentId;
+  // Assigned from the API response in both the redeploy (contentDetails)
+  // and first-deploy (createDeployment) branches before any later reads.
+  let contentUrls!: {
+    dashboardUrl: string;
+    directUrl: string;
+    logsUrl: string;
+  };
 
-  // If redeploying, populate URLs from existing content ID
+  // If redeploying, record the content ID now; URLs will be populated
+  // from the API response during the preflight step.
   if (contentId) {
-    setRecordContentInfo(
-      record,
-      contentId,
-      getDashboardUrl(serverUrl, contentId),
-      getDirectUrl(serverUrl, contentId),
-      getLogsUrl(serverUrl, contentId),
-    );
+    record.id = contentId;
   }
 
   // Write initial deployment record
@@ -326,6 +327,21 @@ export async function connectPublish({
         );
       }
 
+      // Update record URLs from API-provided values (resolves correctly
+      // when the configured serverUrl is an internal hostname).
+      contentUrls = {
+        dashboardUrl: existing.dashboard_url,
+        directUrl: existing.content_url,
+        logsUrl: logsUrlFrom(existing.dashboard_url),
+      };
+      setRecordContentInfo(
+        record,
+        contentId,
+        contentUrls.dashboardUrl,
+        contentUrls.directUrl,
+        contentUrls.logsUrl,
+      );
+
       onProgress({
         step: "preflight",
         status: "log",
@@ -385,12 +401,17 @@ export async function connectPublish({
         signal,
       );
       contentId = created.guid;
+      contentUrls = {
+        dashboardUrl: created.dashboard_url,
+        directUrl: created.content_url,
+        logsUrl: logsUrlFrom(created.dashboard_url),
+      };
       setRecordContentInfo(
         record,
         contentId,
-        getDashboardUrl(serverUrl, contentId),
-        getDirectUrl(serverUrl, contentId),
-        getLogsUrl(serverUrl, contentId),
+        contentUrls.dashboardUrl,
+        contentUrls.directUrl,
+        contentUrls.logsUrl,
       );
       onProgress({
         step: "createNewDeployment",
@@ -635,7 +656,7 @@ export async function connectPublish({
       onProgress({
         step: "validateDeployment",
         status: "start",
-        data: { url: getDirectUrl(serverUrl, contentId) },
+        data: { url: contentUrls.directUrl },
       });
       // Log events are emitted before the HTTP call so the logger writes
       // "Testing URL…" before the request is made.
@@ -666,9 +687,9 @@ export async function connectPublish({
 
     return {
       contentId,
-      dashboardUrl: record.dashboardUrl!,
-      directUrl: record.directUrl!,
-      logsUrl: record.logsUrl!,
+      dashboardUrl: contentUrls.dashboardUrl,
+      directUrl: contentUrls.directUrl,
+      logsUrl: contentUrls.logsUrl,
       bundleId: bundleDTO.id,
     };
   } catch (err) {
@@ -1081,6 +1102,10 @@ function checkMinMax(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function logsUrlFrom(dashboardUrl: string): string {
+  return dashboardUrl.replace(/\/+$/, "") + "/logs";
+}
 
 function getBundleUrl(
   serverUrl: string,


### PR DESCRIPTION
## Intent

Fix content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname, such as when publishing from inside Snowflake Native App.

Fixes #3698 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Instead of constructing URLs ourself from the credential's server URL and the content ID, use the URLs supplied by Connect API responses.

Connect Cloud deploys are unchanged.

## User Impact

Users publishing to an internal/private Connect URL (as with Snowflake Native Apps) will be able to click "View Content" and other clickable links and see their content or logs in the browser.

## Automated Tests

Updated existing tests with new expectations.

## Manual Tests

Confirmed that new deploys, redeploys, and redeploys after a failing initial deploy, all result in correct content URLs when publishing to Connect.

Also smoke tested Cloud deploys although they use a different code path that did not change.

Can't test easily in Snowflake, although I will see about uploading a VSIX to test with once it is built.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
