### PR TITLE
Use client-id instead of deprecated app-id in workflows

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -35,7 +35,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: 1129585
+          client-id: 1129585
           private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
           permission-actions: read
           permission-contents: write

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -43,7 +43,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: 1129585
+          client-id: 1129585
           private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
           permission-actions: read
           permission-contents: write

--- a/.github/workflows/nightly-prerelease.yaml
+++ b/.github/workflows/nightly-prerelease.yaml
@@ -131,7 +131,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+          client-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
           private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
           # Tags are part of repository contents, so we need this permission
           permission-contents: write

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,7 +17,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+          client-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
           private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/tag-on-release-merge.yaml
+++ b/.github/workflows/tag-on-release-merge.yaml
@@ -20,7 +20,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+          client-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
           private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
           permission-contents: write
 


### PR DESCRIPTION
## Summary

- The `actions/create-github-app-token@v3` action deprecated the `app-id` input in favor of `client-id`. Running the **Prepare Release** workflow surfaced the deprecation warning: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`
- Renamed the input across all 5 workflows that use the action: `prepare-release.yaml`, `tag-on-release-merge.yaml`, `nightly-prerelease.yaml`, `claude.yaml`, `claude-auto-review.yaml`.
- No secret changes required — the action's underlying `@octokit/auth-app` library accepts the numeric App ID via either parameter, so existing secret values (`POSIT_CONNECT_PROJECTS_APP_ID`) and the literal `1129585` continue to work.

## Test plan

- [ ] Confirm the Prepare Release workflow no longer emits the `app-id` deprecation warning on the next run
- [ ] Confirm the GitHub App token is still successfully generated (PR creation succeeds, tag push succeeds, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)