### PR TITLE
Guard prepare-release against accidental version downgrades

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -7,6 +7,11 @@ on:
         description: "Version to release (e.g., 1.34.0) - must be even minor"
         required: true
         type: string
+      allow_downgrade:
+        description: "Allow setting package.json to a lower version (use only for patch releases of older release lines)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   prepare:
@@ -74,9 +79,18 @@ jobs:
           node-version: "lts/*"
 
       - name: Run prepare-release script
+        env:
+          ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
         run: |
-          # Run non-interactively by providing 'y' to any prompts
-          yes | python3 ./scripts/prepare-release.py "$VERSION" || true
+          # Auto-accept the empty-Unreleased prompt with a single 'y'.
+          # Using `echo y` (not `yes`) avoids SIGPIPE-induced nonzero exits under
+          # pipefail, so a real script failure (e.g. the no-downgrade guard) fails
+          # the step instead of being swallowed.
+          ALLOW_DOWNGRADE_FLAG=""
+          if [ "$ALLOW_DOWNGRADE" = "true" ]; then
+            ALLOW_DOWNGRADE_FLAG="--allow-downgrade"
+          fi
+          echo y | python3 ./scripts/prepare-release.py "$VERSION" $ALLOW_DOWNGRADE_FLAG
 
       - name: Install dependencies and sync lockfile
         run: npm install

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -7,6 +7,7 @@ Usage: ./scripts/prepare-release.py <version>
 Example: ./scripts/prepare-release.py 1.34.0
 """
 
+import argparse
 import json
 import re
 import sys
@@ -171,17 +172,28 @@ def update_package_version(package_json: Path, version: str) -> None:
     package_json.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def main() -> None:
-    # Check arguments
-    if len(sys.argv) != 2:
-        print("Usage: prepare-release.py <version>")
-        print("Example: prepare-release.py 1.34.0")
-        sys.exit(1)
+def read_package_version(package_json: Path) -> str:
+    """Read current version from package.json."""
+    return json.loads(package_json.read_text())["version"]
 
-    version_arg = sys.argv[1]
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare a release by updating CHANGELOG files and package.json.",
+    )
+    parser.add_argument("version", help="Version to release, e.g. 1.34.0")
+    parser.add_argument(
+        "--allow-downgrade",
+        action="store_true",
+        help=(
+            "Permit setting package.json to a lower version than its current value. "
+            "Required when preparing a patch release of an older release line."
+        ),
+    )
+    args = parser.parse_args()
 
     # Parse and validate version
-    major, minor, patch = parse_version(version_arg)
+    major, minor, patch = parse_version(args.version)
     version = f"{major}.{minor}.{patch}"
 
     # Validate even minor version for production release
@@ -205,6 +217,16 @@ def main() -> None:
         error(f"VSCode CHANGELOG not found: {vscode_changelog}")
     if not package_json.exists():
         error(f"package.json not found: {package_json}")
+
+    # Guard against accidentally setting package.json to a lower version.
+    # This catches operator typos and forces explicit acknowledgment when
+    # preparing a patch release of an older release line.
+    current_version = read_package_version(package_json)
+    if parse_version(current_version) > (major, minor, patch) and not args.allow_downgrade:
+        error(
+            f"Refusing to downgrade {package_json} from {current_version} to {version}. "
+            f"Pass --allow-downgrade to confirm (e.g. when patching an older release line)."
+        )
 
     # Extract unreleased content and check if empty
     unreleased_content = extract_unreleased_content(root_changelog)

--- a/scripts/test_prepare_release.py
+++ b/scripts/test_prepare_release.py
@@ -264,6 +264,77 @@ class TestSyncVscodeChangelog(unittest.TestCase):
             self.assertEqual(content.count("# Changelog"), 1)
 
 
+class TestDowngradeGuard(unittest.TestCase):
+    """Tests for the no-downgrade guard."""
+
+    def _setup_release_dir(self, tmpdir, package_version):
+        root_changelog = Path(tmpdir) / "CHANGELOG.md"
+        vscode_dir = Path(tmpdir) / "extensions" / "vscode"
+        vscode_dir.mkdir(parents=True)
+        vscode_changelog = vscode_dir / "CHANGELOG.md"
+        package_json = vscode_dir / "package.json"
+
+        root_changelog.write_text(SAMPLE_ROOT_CHANGELOG)
+        vscode_changelog.write_text(SAMPLE_VSCODE_CHANGELOG)
+        package_json.write_text(f'{{\n  "version": "{package_version}"\n}}\n')
+        return package_json
+
+    def test_downgrade_rejected_by_default(self):
+        """Requesting a version lower than package.json should fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup_release_dir(tmpdir, "2.1.1")
+
+            result = subprocess.run(
+                ["python3", str(Path(__file__).parent / "prepare-release.py"), "2.0.2"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                input="y\n",
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("--allow-downgrade", result.stderr)
+
+    def test_downgrade_allowed_with_flag(self):
+        """--allow-downgrade should let a lower version through."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_json = self._setup_release_dir(tmpdir, "2.1.1")
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(Path(__file__).parent / "prepare-release.py"),
+                    "2.0.2",
+                    "--allow-downgrade",
+                ],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                input="y\n",
+            )
+
+            self.assertEqual(result.returncode, 0, f"Script failed: {result.stderr}")
+            pkg_data = json.loads(package_json.read_text())
+            self.assertEqual(pkg_data["version"], "2.0.2")
+
+    def test_same_version_allowed(self):
+        """Requesting the same version as package.json is not a downgrade."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_json = self._setup_release_dir(tmpdir, "2.0.0")
+
+            result = subprocess.run(
+                ["python3", str(Path(__file__).parent / "prepare-release.py"), "2.0.0"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                input="y\n",
+            )
+
+            self.assertEqual(result.returncode, 0, f"Script failed: {result.stderr}")
+            pkg_data = json.loads(package_json.read_text())
+            self.assertEqual(pkg_data["version"], "2.0.0")
+
+
 class TestFullReleasePreparation(unittest.TestCase):
     """Tests for full release preparation flow."""
 


### PR DESCRIPTION
## Summary

The prepare-release workflow rewrites `extensions/vscode/package.json` to whatever version the operator types, with no monotonic check. A typo or a patch release of an older release line cut against current `main` silently rolls `package.json` backwards. This came up while preparing #4090 (`v2.0.1` patch), where the prepare-release flow happily set `package.json` from `2.1.1` (latest pre-release) down to `2.0.1`.

This PR adds a guard:

- `scripts/prepare-release.py` errors when the requested version is lower than the current `package.json` version
- A new `--allow-downgrade` flag overrides the guard, for genuine patch releases of older release lines
- The `prepare-release.yaml` workflow exposes the override as an opt-in `allow_downgrade` boolean input

While here, the script invocation is switched from `yes | ... || true` to `echo y | ...`. The old form swallows nonzero exits (originally to absorb `yes`'s SIGPIPE under bash's `pipefail`), which would have hidden the new guard's error and produced an empty release PR. `echo y` exits cleanly on its own without SIGPIPE, so genuine script failures now fail the workflow step.

## Test plan

- [x] `python3 scripts/test_prepare_release.py` — all 18 tests pass, including 3 new `TestDowngradeGuard` cases covering: downgrade rejected by default, downgrade allowed with `--allow-downgrade`, equal version allowed (not a downgrade)
- [x] YAML validates as a workflow file
- [ ] Reviewer sanity check: open Actions → Prepare Release; confirm `version` and `allow_downgrade` inputs render

## Out of scope

Patch-release tooling that automates branching from a prior tag and cherry-picking fixes — that will be tracked separately as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)