### PR TITLE
fix: detect Quarto engines in fallback path and normalize backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Quarto `.qmd` files being deployed with empty engines when `quarto inspect` is unavailable, causing Connect to skip `renv` restore and fail at render time due to missing packages. The fallback path now detects `knitr` and `jupyter` engines from code chunks, and `normalizeConfig()` backfills missing engines when R or Python dependencies are present. (#3993)
 - Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname. This scenario can happen when publishing from Workbench to Connect within the Posit Team Native App in Snowpark Container Services. (#3698)
 
 ## [2.2.0]

--- a/extensions/vscode/src/inspect/detectors/quarto.test.ts
+++ b/extensions/vscode/src/inspect/detectors/quarto.test.ts
@@ -713,6 +713,60 @@ describe("QuartoDetector", () => {
     expect(configs[0]?.alternatives).toBeUndefined();
   });
 
+  test("fallback detects R engine from .qmd file content", async () => {
+    setupGlobDir(["report.qmd"]);
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+    mockReadFile.mockResolvedValue(
+      '---\ntitle: "Report"\n---\n\n```{r}\nsource("script.R")\n```\n',
+    );
+
+    mockExecFile.mockRejectedValue(
+      new Error("executable file not found in $PATH"),
+    );
+
+    const configs = await detector.inferType("/project", "report.qmd");
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.type).toBe(ContentType.QUARTO_STATIC);
+    expect(configs[0]?.r).toEqual({});
+    expect(configs[0]?.quarto?.engines).toContain("knitr");
+  });
+
+  test("fallback detects Python engine from .qmd file content", async () => {
+    setupGlobDir(["analysis.qmd"]);
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+    mockReadFile.mockResolvedValue(
+      '---\ntitle: "Analysis"\n---\n\n```{python}\nimport pandas\n```\n',
+    );
+
+    mockExecFile.mockRejectedValue(
+      new Error("executable file not found in $PATH"),
+    );
+
+    const configs = await detector.inferType("/project", "analysis.qmd");
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.python).toEqual({});
+    expect(configs[0]?.quarto?.engines).toContain("jupyter");
+  });
+
+  test("fallback detects both engines from .qmd file content", async () => {
+    setupGlobDir(["mixed.qmd"]);
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+    mockReadFile.mockResolvedValue(
+      "```{r}\nlibrary(ggplot2)\n```\n\n```{python}\nimport pandas\n```\n",
+    );
+
+    mockExecFile.mockRejectedValue(
+      new Error("executable file not found in $PATH"),
+    );
+
+    const configs = await detector.inferType("/project", "mixed.qmd");
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.r).toEqual({});
+    expect(configs[0]?.python).toEqual({});
+    expect(configs[0]?.quarto?.engines).toContain("knitr");
+    expect(configs[0]?.quarto?.engines).toContain("jupyter");
+  });
+
   test("fallback detects .rmd (lowercase) as Quarto content", async () => {
     setupGlobDir(["report.rmd"]);
     mockAccess.mockRejectedValue(new Error("ENOENT"));

--- a/extensions/vscode/src/inspect/detectors/quarto.ts
+++ b/extensions/vscode/src/inspect/detectors/quarto.ts
@@ -508,7 +508,7 @@ export class QuartoDetector implements ContentTypeDetector {
     }
 
     // Include .qmd files and detect languages from their content
-    const qmdFiles = await globDir(baseDir, "*.qmd");
+    const qmdFiles = await globDir(baseDir, "*.qmd", { nocase: true });
     const engines: string[] = [];
     for (const qmdPath of qmdFiles) {
       const relPath = path.basename(qmdPath);

--- a/extensions/vscode/src/inspect/detectors/quarto.ts
+++ b/extensions/vscode/src/inspect/detectors/quarto.ts
@@ -507,11 +507,35 @@ export class QuartoDetector implements ContentTypeDetector {
       return cfg;
     }
 
-    // Include .qmd files
+    // Include .qmd files and detect languages from their content
     const qmdFiles = await globDir(baseDir, "*.qmd");
+    const engines: string[] = [];
     for (const qmdPath of qmdFiles) {
       const relPath = path.basename(qmdPath);
       files.push(`/${relPath}`);
+
+      // Read file content to detect R/Python code chunks
+      try {
+        const content = await fs.readFile(qmdPath, "utf-8");
+        const langs = detectMarkdownLanguagesInContent(content);
+        if (langs.needsR && !engines.includes("knitr")) {
+          engines.push("knitr");
+          cfg.r = {};
+        }
+        if (langs.needsPython && !engines.includes("jupyter")) {
+          engines.push("jupyter");
+          cfg.python = {};
+        }
+      } catch (err: unknown) {
+        logger.debug(
+          `[quarto] could not read file for language detection in fallback: ${qmdPath}: ${err}`,
+        );
+      }
+    }
+
+    if (engines.length > 0) {
+      engines.sort();
+      cfg.quarto = { version: defaultQuartoVersion, engines };
     }
 
     // Include special yml files

--- a/extensions/vscode/src/inspect/normalize.test.ts
+++ b/extensions/vscode/src/inspect/normalize.test.ts
@@ -322,4 +322,64 @@ describe("normalizeConfig", () => {
     );
     expect(result.entrypoint).toBe("custom-entry.py");
   });
+
+  test("backfills knitr engine when R discovered via renv.lock", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.QUARTO_STATIC,
+      entrypoint: "report.qmd",
+      quarto: { version: "1.7.34" },
+    };
+    // renv.lock exists
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await normalizeConfig(cfg, "/project", undefined, "R");
+    expect(result.r).toBeDefined();
+    expect(result.quarto?.engines).toContain("knitr");
+  });
+
+  test("backfills jupyter engine when Python discovered", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.QUARTO_STATIC,
+      entrypoint: "report.qmd",
+      quarto: { version: "1.4.0" },
+      python: {},
+    };
+    setupDefaultMocks();
+
+    const result = await normalizeConfig(cfg, "/project", "python3");
+    expect(result.python).toBeDefined();
+    expect(result.quarto?.engines).toContain("jupyter");
+  });
+
+  test("does not duplicate existing engines during backfill", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.QUARTO_STATIC,
+      entrypoint: "report.qmd",
+      quarto: { version: "1.4.0", engines: ["knitr"] },
+      r: {},
+    };
+    // renv.lock exists
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await normalizeConfig(cfg, "/project", undefined, "R");
+    expect(result.r).toBeDefined();
+    const knitrCount = result.quarto?.engines?.filter(
+      (e) => e === "knitr",
+    ).length;
+    expect(knitrCount).toBe(1);
+  });
+
+  test("does not backfill engines when no quarto config", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.R_SHINY,
+      entrypoint: "app.R",
+      r: {},
+    };
+    setupDefaultMocks();
+
+    const result = await normalizeConfig(cfg, "/project", undefined, "R");
+    expect(result.quarto).toBeUndefined();
+  });
 });

--- a/extensions/vscode/src/inspect/normalize.ts
+++ b/extensions/vscode/src/inspect/normalize.ts
@@ -126,6 +126,27 @@ export async function normalizeConfig(
     }
   }
 
+  // Ensure quarto engines reflect discovered R/Python needs.
+  // Detectors may miss engines (e.g., fallback path when quarto binary is
+  // unavailable), but normalize can discover R/Python via renv.lock or rpy2.
+  let quartoConfig = cfg.quarto;
+  if (quartoConfig) {
+    const engines = [...(quartoConfig.engines ?? [])];
+    let changed = false;
+    if (rConfig && !engines.includes("knitr")) {
+      engines.push("knitr");
+      changed = true;
+    }
+    if (pythonConfig && !engines.includes("jupyter")) {
+      engines.push("jupyter");
+      changed = true;
+    }
+    if (changed) {
+      engines.sort();
+      quartoConfig = { ...quartoConfig, engines };
+    }
+  }
+
   const comments = initialComment.split("\n");
 
   return {
@@ -138,7 +159,7 @@ export async function normalizeConfig(
     files,
     python: pythonConfig,
     r: rConfig,
-    quarto: cfg.quarto,
+    quarto: quartoConfig,
     comments,
     // Pass alternatives through without normalization. The detector already
     // sets the fields the UI needs (type, entrypoint, source, title, files).


### PR DESCRIPTION
## Summary

Fixes #3993

- **Fallback engine detection for `.qmd` files**: When `quarto inspect` is unavailable (quarto not installed or not in PATH), the fallback path now reads `.qmd` file content and scans for `{r}` and `{python}` code chunks, setting the appropriate engines (`knitr`/`jupyter`) and language configs. Previously, `.qmd` files in the fallback path got no engines at all, while `.ipynb` and `.Rmd` already had correct handling.
- **Normalize engine backfill**: `normalizeConfig()` now ensures `quarto.engines` includes `knitr`/`jupyter` when it independently discovers R/Python needs (e.g., via `renv.lock` or `rpy2`). This is a defensive fix — if the detector missed engines for any reason, normalize catches it before the config is written to TOML.

Without these fixes, Connect receives `engines: []` in the manifest, which causes it to skip `renv` restore entirely, leading to missing packages at render time.

## Test plan

- [x] New unit tests for fallback R, Python, and mixed engine detection in `quarto.test.ts`
- [x] New unit tests for engine backfill (knitr via renv.lock, jupyter, dedup, no-op without quarto) in `normalize.test.ts`
- [x] All 1676 existing unit tests pass
- [x] Lint passes
- [ ] Manual test: publish a `.qmd` with `{r}` chunks and `renv.lock` from Positron, verify manifest has `engines: ["knitr"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)