### PR TITLE
fix: detect shiny in Quarto dashboard format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Quarto dashboards with `server: shiny` being misdetected as static content, causing deployment to fail with an `output-dir` error on Connect. (#3991)
 - Fixed content URLs (View Content, dashboard, logs) being unreachable when the configured server URL differs from the external hostname. This scenario can happen when publishing from Workbench to Connect within the Posit Team Native App in Snowpark Container Services. (#3698)
 
 ## [2.2.0]

--- a/extensions/vscode/src/inspect/detectors/quarto.test.ts
+++ b/extensions/vscode/src/inspect/detectors/quarto.test.ts
@@ -236,6 +236,36 @@ describe("QuartoDetector", () => {
     expect(configs[0]?.title).toBe("posit::conf(2024)");
   });
 
+  test("detects dashboard shiny (format: dashboard)", async () => {
+    setupGlobDir(["dashboard.qmd"]);
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const qmdContent = "```{r}\nlibrary(shiny)\n```\n";
+    mockReadFile.mockResolvedValue(qmdContent);
+
+    const inspectJson = makeInspectOutput({
+      engines: ["knitr"],
+      files: { input: ["/project/dashboard.qmd"], configResources: [] },
+      formats: {
+        dashboard: {
+          metadata: {
+            title: "Diamonds Explorer",
+            format: "dashboard",
+            server: "shiny",
+          },
+          pandoc: {},
+        },
+      },
+    });
+    mockExecFile.mockResolvedValue({ stdout: inspectJson });
+
+    const configs = await detector.inferType("/project", "dashboard.qmd");
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.type).toBe(ContentType.QUARTO_SHINY);
+    expect(configs[0]?.title).toBe("Diamonds Explorer");
+    expect(configs[0]?.alternatives).toBeUndefined();
+  });
+
   test("website project with output-dir generates static alternative", async () => {
     setupGlobDir(["index.qmd"]);
     mockAccess.mockRejectedValue(new Error("ENOENT"));

--- a/extensions/vscode/src/inspect/detectors/quarto.ts
+++ b/extensions/vscode/src/inspect/detectors/quarto.ts
@@ -153,7 +153,8 @@ export class QuartoDetector implements ContentTypeDetector {
     // Determine content type: shiny or static
     if (
       isQuartoShiny(inspectOutput.htmlMetadata) ||
-      isQuartoShiny(inspectOutput.revealjsMetadata)
+      isQuartoShiny(inspectOutput.revealjsMetadata) ||
+      isQuartoShiny(inspectOutput.dashboardMetadata)
     ) {
       logger.info(`[quarto] detected Quarto Shiny content: ${relEntrypoint}`);
       cfg.type = ContentType.QUARTO_SHINY;

--- a/extensions/vscode/src/inspect/detectors/quartoInspectOutput.ts
+++ b/extensions/vscode/src/inspect/detectors/quartoInspectOutput.ts
@@ -59,6 +59,12 @@ export interface QuartoInspectData {
         "output-file"?: string;
       };
     };
+    dashboard?: {
+      metadata?: QuartoMetadata;
+      pandoc?: {
+        "output-file"?: string;
+      };
+    };
   };
   fileInformation?: Record<
     string,
@@ -98,6 +104,10 @@ export class QuartoInspectOutput {
 
   get revealjsMetadata(): QuartoMetadata {
     return this.data.formats?.revealjs?.metadata ?? {};
+  }
+
+  get dashboardMetadata(): QuartoMetadata {
+    return this.data.formats?.dashboard?.metadata ?? {};
   }
 
   outputDir(): string {
@@ -188,6 +198,10 @@ export class QuartoInspectOutput {
     const revealjsTitle = this.data.formats?.revealjs?.metadata?.title;
     if (isValidTitle(revealjsTitle)) {
       return revealjsTitle;
+    }
+    const dashboardTitle = this.data.formats?.dashboard?.metadata?.title;
+    if (isValidTitle(dashboardTitle)) {
+      return dashboardTitle;
     }
     const websiteTitle = this.data.config?.website?.title;
     if (isValidTitle(websiteTitle)) {


### PR DESCRIPTION
## Summary

- Quarto documents with `format: dashboard` and `server: shiny` were misdetected as `quarto-static` because the shiny detection only checked `formats.html` and `formats.revealjs` metadata from `quarto inspect` output.
- Added `formats.dashboard` to the shiny detection, title extraction, and inspect output types so these documents are correctly classified as `quarto-shiny`.

Closes #3991

## Test plan

- [ ] New unit test "detects dashboard shiny (format: dashboard)" passes
- [ ] Existing quarto detector and inspect output tests still pass
- [ ] Manual test: publish a Quarto dashboard with `server: shiny` (knitr engine) to Connect and verify it deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)