### PR TITLE
fix: improve error logging in getPythonInterpreterFromVSCode

### DIFF
--- a/extensions/vscode/src/utils/vscode.test.ts
+++ b/extensions/vscode/src/utils/vscode.test.ts
@@ -167,6 +167,38 @@ describe("Interpreter Detection", () => {
         expect(result).toBeUndefined();
       });
 
+      test("logs error message when python.interpreterPath command fails", async () => {
+        const consoleSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        vi.mocked(commands.executeCommand).mockRejectedValue(
+          new Error("command 'python.interpreterPath' not found"),
+        );
+
+        await getPythonInterpreterPath();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "getPythonInterpreterFromVSCode was unable to execute command. Error =",
+          "command 'python.interpreterPath' not found",
+        );
+        consoleSpy.mockRestore();
+      });
+
+      test("logs stringified error when command fails with non-Error", async () => {
+        const consoleSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        vi.mocked(commands.executeCommand).mockRejectedValue("string error");
+
+        await getPythonInterpreterPath();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "getPythonInterpreterFromVSCode was unable to execute command. Error =",
+          "string error",
+        );
+        consoleSpy.mockRestore();
+      });
+
       test("returns undefined when python.interpreterPath returns undefined", async () => {
         vi.mocked(commands.executeCommand).mockResolvedValue(undefined);
 

--- a/extensions/vscode/src/utils/vscode.ts
+++ b/extensions/vscode/src/utils/vscode.ts
@@ -85,8 +85,8 @@ async function getPythonInterpreterFromVSCode(): Promise<string | undefined> {
     );
   } catch (error: unknown) {
     console.error(
-      "getPythonInterpreterFromPath was unable to execute command. Error = ",
-      error,
+      "getPythonInterpreterFromVSCode was unable to execute command. Error =",
+      error instanceof Error ? error.message : String(error),
     );
   }
   if (configuredPython === undefined) {


### PR DESCRIPTION
## Summary

- Fix `getPythonInterpreterFromVSCode` error logging: extract the error message string instead of logging the raw Error object, which renders as an unhelpful stack trace in browser-hosted VS Code environments (e.g. Snowflake Workbench)
- Fix incorrect function name in the log line (`getPythonInterpreterFromPath` → `getPythonInterpreterFromVSCode`)
- Add tests verifying the error message format for both Error and non-Error rejection values

## Test plan

- [x] Existing unit tests pass (22/22 in `vscode.test.ts`)
- [x] Two new tests verify the corrected log output format
- [ ] Manual: confirm improved error message in browser-hosted VS Code console

🤖 Generated with [Claude Code](https://claude.com/claude-code)