### PR TITLE
fix: resolve no-useless-assignment and preserve-caught-error violations for eslint v10

### DIFF
--- a/extensions/vscode/eslint.config.mjs
+++ b/extensions/vscode/eslint.config.mjs
@@ -27,8 +27,6 @@ export default [
           ignoreRestSiblings: true,
         },
       ],
-      "no-useless-assignment": "off",
-      "preserve-caught-error": "off",
     },
   },
   eslintConfigPrettier,

--- a/extensions/vscode/src/inspect/detectors/rmarkdown.ts
+++ b/extensions/vscode/src/inspect/detectors/rmarkdown.ts
@@ -145,7 +145,6 @@ export class RMarkdownDetector implements ContentTypeDetector {
             `[rmarkdown] found site metadata in fallback file: ${siteMeta.indexFile}`,
           );
           metadata = siteMeta.metadata;
-          content = siteMeta.indexContent;
           if (siteMeta.indexFile) {
             files.push(`/${siteMeta.indexFile}`);
           }

--- a/extensions/vscode/src/multiStepInputs/common.ts
+++ b/extensions/vscode/src/multiStepInputs/common.ts
@@ -84,7 +84,7 @@ export const getPlatformList = (): QuickPickItem[] => {
 
 // Fetch the list of all available snowflake connections
 export const fetchSnowflakeConnections = async (serverUrl: string) => {
-  let connections: SnowflakeConnection[] = [];
+  let connections: SnowflakeConnection[];
   let connectionQuickPicks: QuickPickItemWithIndex[];
 
   try {

--- a/extensions/vscode/src/multiStepInputs/newConnectCloudCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCloudCredential.ts
@@ -378,7 +378,7 @@ export async function newConnectCloudCredential(
   // ***************************************************************
   function determineAccountFlow(_: MultiStepInput, state: MultiStepState) {
     const accounts = getAvailableAccounts();
-    let name: string = "";
+    let name: string;
     let stepFunc: (input: MultiStepInput) => Thenable<InputStep | void>;
     let skipStepHistory: boolean | undefined;
 

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -455,7 +455,7 @@ export async function newDeployment(
       });
     }
 
-    let selectedEntrypointFile: string | undefined = undefined;
+    let selectedEntrypointFile: string | undefined;
     do {
       const pick = await input.showQuickPick({
         title: state.title,

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -313,17 +313,19 @@ export async function connectPublish({
         if (isAxiosError(err) && err.response?.status === 404) {
           throw new Error(
             `Cannot deploy content: ID ${contentId} - Content cannot be found.`,
+            { cause: err },
           );
         }
         if (isAxiosError(err) && err.response?.status === 403) {
           throw new Error(
             `Cannot deploy content: ID ${contentId} - ` +
               `You may need to request collaborator permissions or verify the credentials in use.`,
+            { cause: err },
           );
         }
-        const errMsg = err instanceof Error ? err.message : String(err);
         throw new Error(
-          `Cannot deploy content: ID ${contentId} - Unknown error: ${errMsg}`,
+          `Cannot deploy content: ID ${contentId} - Unknown error: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
         );
       }
 


### PR DESCRIPTION
## Summary

- Removes 4 dead assignments flagged by the new `no-useless-assignment` rule introduced in `eslint:recommended` for ESLint v10
- Adds `{ cause: err }` to 3 re-throws in `connectPublish.ts` flagged by the new `preserve-caught-error` rule
- Re-enables both rules in `eslint.config.mjs` (they were temporarily disabled in #4064 to unblock the ESLint v10 upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)