### PR TITLE
fix: Snowflake SPCS dual authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)
+- Fixed deploying content to Connect running within the Posit Team Native App in Snowpark Container Services from Publisher running outside of SPCS. Users with existing credentials for SPCS servers must delete and recreate those credentials. Credentials now require a valid Snowflake connection and valid Connect authentication (either API key or token). (#3465)
 
 ## [2.4.0]
 

--- a/extensions/vscode/src/auth/ConnectAuthTokenActivator.test.ts
+++ b/extensions/vscode/src/auth/ConnectAuthTokenActivator.test.ts
@@ -101,12 +101,14 @@ describe("ConnectAuthTokenActivator", () => {
     expect(mockGenerateToken).toHaveBeenCalledWith(
       "https://connect.example.com",
       undefined,
+      undefined,
     );
     expect(mockOpenExternal).toHaveBeenCalled();
     expect(MockConnectAPI).toHaveBeenCalledWith({
       url: "https://connect.example.com",
       token: "test-token-123",
       privateKey: "test-private-key-123",
+      snowflakeToken: undefined,
       rejectUnauthorized: undefined,
     });
     expect(result).toEqual({
@@ -184,11 +186,13 @@ describe("ConnectAuthTokenActivator", () => {
     expect(mockGenerateToken).toHaveBeenCalledWith(
       "https://connect.example.com",
       true,
+      undefined,
     );
     expect(MockConnectAPI).toHaveBeenCalledWith({
       url: "https://connect.example.com",
       token: "test-token-123",
       privateKey: "test-private-key-123",
+      snowflakeToken: undefined,
       rejectUnauthorized: false,
     });
     expect(result.userName).toBe("testuser");
@@ -224,6 +228,48 @@ describe("ConnectAuthTokenActivator", () => {
 
     expect(hoistedMockTestAuthentication).toHaveBeenCalledTimes(3);
     expect(result.userName).toBe("testuser");
+  });
+
+  test("activateToken() passes snowflakeToken to generateToken and polling client", async () => {
+    mockGenerateToken.mockResolvedValue({
+      token: "test-token-123",
+      claimUrl: "https://connect.example.com/claim/123",
+      privateKey: "test-private-key-123",
+      serverUrl: "https://connect.example.com",
+    });
+
+    hoistedMockTestAuthentication.mockResolvedValue({
+      user: {
+        id: "guid-1",
+        username: "testuser",
+        first_name: "Test",
+        last_name: "User",
+        email: "t@t.com",
+      },
+      error: null,
+    });
+
+    const activator = new ConnectAuthTokenActivator(
+      "https://connect.example.com",
+      "test-view-id",
+      60,
+      undefined,
+      "snowflake-session-token",
+    );
+    await activator.activateToken();
+
+    expect(mockGenerateToken).toHaveBeenCalledWith(
+      "https://connect.example.com",
+      undefined,
+      "snowflake-session-token",
+    );
+    expect(MockConnectAPI).toHaveBeenCalledWith({
+      url: "https://connect.example.com",
+      token: "test-token-123",
+      privateKey: "test-private-key-123",
+      snowflakeToken: "snowflake-session-token",
+      rejectUnauthorized: undefined,
+    });
   });
 
   test("activateToken() handles token generation failure", async () => {

--- a/extensions/vscode/src/auth/ConnectAuthTokenActivator.ts
+++ b/extensions/vscode/src/auth/ConnectAuthTokenActivator.ts
@@ -24,18 +24,21 @@ export class ConnectAuthTokenActivator {
   private readonly viewId: string;
   private readonly maxAttempts: number;
   private readonly insecure?: boolean;
+  private readonly snowflakeToken?: string;
 
   constructor(
     serverUrl: string,
     viewId: string,
     maxAttempts: number = 60,
     insecure?: boolean,
+    snowflakeToken?: string,
   ) {
     this.serverUrl = serverUrl;
     this.viewId = viewId;
     // default: 60 = 30 seconds with 500ms between attempts
     this.maxAttempts = maxAttempts;
     this.insecure = insecure;
+    this.snowflakeToken = snowflakeToken;
   }
 
   async activateToken(): Promise<TokenAuthResult> {
@@ -71,7 +74,11 @@ export class ConnectAuthTokenActivator {
       "Generating authentication token",
       this.viewId,
       async () => {
-        return await generateToken(this.serverUrl, this.insecure);
+        return await generateToken(
+          this.serverUrl,
+          this.insecure,
+          this.snowflakeToken,
+        );
       },
     );
   }
@@ -98,6 +105,7 @@ export class ConnectAuthTokenActivator {
           url: serverUrl,
           token,
           privateKey,
+          snowflakeToken: this.snowflakeToken,
           rejectUnauthorized: this.insecure ? false : undefined,
         });
 

--- a/extensions/vscode/src/auth/generateToken.test.ts
+++ b/extensions/vscode/src/auth/generateToken.test.ts
@@ -147,6 +147,30 @@ describe("generateToken", () => {
     );
   });
 
+  test("passes snowflakeToken through to ConnectAPI", async () => {
+    hoistedMockRegisterToken.mockResolvedValue({
+      token_claim_url: "https://connect.example.com/connect/#/claim/abc123",
+    });
+
+    mockDiscoverServerURL.mockImplementation(async (_url, tester) => {
+      await tester("https://connect.example.com");
+      return { url: "https://connect.example.com" };
+    });
+
+    await generateToken(
+      "https://connect.example.com",
+      undefined,
+      "snowflake-session-token",
+    );
+
+    expect(MockConnectAPI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://connect.example.com",
+        snowflakeToken: "snowflake-session-token",
+      }),
+    );
+  });
+
   test("uses discovered URL (not provided URL) in the result", async () => {
     hoistedMockRegisterToken.mockResolvedValue({
       token_claim_url: "https://connect.example.com/connect/#/claim/abc123",

--- a/extensions/vscode/src/auth/generateToken.ts
+++ b/extensions/vscode/src/auth/generateToken.ts
@@ -57,6 +57,7 @@ export interface GenerateTokenResult {
 export async function generateToken(
   serverUrl: string,
   insecure?: boolean,
+  snowflakeToken?: string,
 ): Promise<GenerateTokenResult> {
   const tokenId = generateTokenId();
   const { privateKey, publicKey } = generateKeyPair();
@@ -66,6 +67,7 @@ export async function generateToken(
   const tester = async (urlToTest: string): Promise<void> => {
     const client = new ConnectAPI({
       url: urlToTest,
+      snowflakeToken,
       rejectUnauthorized: insecure ? false : undefined,
     });
 

--- a/extensions/vscode/src/credentials/service.test.ts
+++ b/extensions/vscode/src/credentials/service.test.ts
@@ -119,18 +119,67 @@ describe("CredentialsService", () => {
       expect(result.apiKey).toBe("");
     });
 
-    test("creates a Snowflake credential", async () => {
+    test("creates a Snowflake credential with API key", async () => {
       const input: CreateCredentialInput = {
         name: "My Snowflake",
         url: "https://my-org.snowflakecomputing.app",
         serverType: ServerType.SNOWFLAKE,
         snowflakeConnection: "my-connection",
+        apiKey: "connect-api-key",
       };
 
       const result = await service.create(input);
 
       expect(result.snowflakeConnection).toBe("my-connection");
+      expect(result.apiKey).toBe("connect-api-key");
       expect(result.serverType).toBe(ServerType.SNOWFLAKE);
+    });
+
+    test("creates a Snowflake credential with token auth", async () => {
+      const input: CreateCredentialInput = {
+        name: "My Snowflake Token",
+        url: "https://my-org.snowflakecomputing.app",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "my-connection",
+        token: "connect-token-id",
+        privateKey: "connect-private-key",
+      };
+
+      const result = await service.create(input);
+
+      expect(result.snowflakeConnection).toBe("my-connection");
+      expect(result.token).toBe("connect-token-id");
+      expect(result.privateKey).toBe("connect-private-key");
+      expect(result.serverType).toBe(ServerType.SNOWFLAKE);
+    });
+
+    test("throws IncompleteCredentialError when Snowflake has no Connect auth", async () => {
+      const input: CreateCredentialInput = {
+        name: "Bad Snowflake",
+        url: "https://my-org.snowflakecomputing.app",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "my-connection",
+      };
+
+      await expect(service.create(input)).rejects.toThrow(
+        IncompleteCredentialError,
+      );
+    });
+
+    test("throws IncompleteCredentialError when Snowflake has both apiKey and token", async () => {
+      const input: CreateCredentialInput = {
+        name: "Bad Snowflake",
+        url: "https://my-org.snowflakecomputing.app",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "my-connection",
+        apiKey: "key",
+        token: "tok",
+        privateKey: "pk",
+      };
+
+      await expect(service.create(input)).rejects.toThrow(
+        IncompleteCredentialError,
+      );
     });
 
     test("creates a Connect Cloud credential", async () => {
@@ -418,7 +467,42 @@ describe("connectAPIOptionsFromCredential", () => {
       });
     });
 
-    test("returns snowflakeToken options for Snowflake credentials", async () => {
+    test("returns snowflakeToken + apiKey options for Snowflake credentials with API key", async () => {
+      const result = await connectAPIOptionsFromCredential({
+        url: "https://my-org.snowflakecomputing.app",
+        apiKey: "connect-api-key",
+        token: "",
+        privateKey: "",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "default",
+      });
+
+      expect(result).toMatchObject({
+        url: "https://my-org.snowflakecomputing.app",
+        snowflakeToken: "sf-test-token-123",
+        apiKey: "connect-api-key",
+      });
+    });
+
+    test("returns snowflakeToken + token+privateKey options for Snowflake credentials with token auth", async () => {
+      const result = await connectAPIOptionsFromCredential({
+        url: "https://my-org.snowflakecomputing.app",
+        apiKey: "",
+        token: "connect-token-id",
+        privateKey: "connect-private-key",
+        serverType: ServerType.SNOWFLAKE,
+        snowflakeConnection: "default",
+      });
+
+      expect(result).toMatchObject({
+        url: "https://my-org.snowflakecomputing.app",
+        snowflakeToken: "sf-test-token-123",
+        token: "connect-token-id",
+        privateKey: "connect-private-key",
+      });
+    });
+
+    test("returns snowflakeToken-only for legacy Snowflake credentials with no Connect auth", async () => {
       const result = await connectAPIOptionsFromCredential({
         url: "https://my-org.snowflakecomputing.app",
         apiKey: "",
@@ -433,6 +517,7 @@ describe("connectAPIOptionsFromCredential", () => {
         snowflakeToken: "sf-test-token-123",
       });
       expect(result).not.toHaveProperty("apiKey");
+      expect(result).not.toHaveProperty("token");
     });
 
     test("passes extra options through for Snowflake credentials", async () => {

--- a/extensions/vscode/src/credentials/service.ts
+++ b/extensions/vscode/src/credentials/service.ts
@@ -89,7 +89,10 @@ export async function connectAPIOptionsFromCredential(
 }
 
 async function buildSnowflakeOptions(
-  credential: Pick<Credential, "url" | "snowflakeConnection">,
+  credential: Pick<
+    Credential,
+    "url" | "snowflakeConnection" | "apiKey" | "token" | "privateKey"
+  >,
   extra?: Pick<ConnectAPIOptions, "rejectUnauthorized" | "timeout">,
 ): Promise<ConnectAPIOptions> {
   const connections = listConnections();
@@ -105,6 +108,25 @@ async function buildSnowflakeOptions(
   const hostname = new URL(credential.url).hostname;
   const snowflakeToken = await tokenProvider.getToken(hostname);
 
+  if (credential.token && credential.privateKey) {
+    return {
+      url: credential.url,
+      snowflakeToken,
+      token: credential.token,
+      privateKey: credential.privateKey,
+      ...extra,
+    };
+  }
+  if (credential.apiKey) {
+    return {
+      url: credential.url,
+      snowflakeToken,
+      apiKey: credential.apiKey,
+      ...extra,
+    };
+  }
+  // Legacy credential with no Connect auth — will fail at request time
+  // but we still need to allow loading/displaying it.
   return {
     url: credential.url,
     snowflakeToken,
@@ -153,12 +175,12 @@ export class CredentialsService {
       case ServerType.SNOWFLAKE:
         if (
           !snowflakePresent ||
-          connectPresent ||
-          connectCloudPresent ||
-          tokenAuthPresent
+          (connectPresent && tokenAuthPresent) ||
+          (!connectPresent && !tokenAuthPresent) ||
+          connectCloudPresent
         ) {
           throw new IncompleteCredentialError(
-            "Snowflake credential requires a Snowflake connection string and no other auth fields",
+            "Snowflake credential requires a Snowflake connection and either an API Key or Token+PrivateKey (but not both)",
           );
         }
         break;

--- a/extensions/vscode/src/multiStepInputs/common.ts
+++ b/extensions/vscode/src/multiStepInputs/common.ts
@@ -84,7 +84,7 @@ export const getPlatformList = (): QuickPickItem[] => {
 
 // Fetch the list of all available snowflake connections
 export const fetchSnowflakeConnections = async (serverUrl: string) => {
-  let connections: SnowflakeConnection[] = [];
+  let connections: SnowflakeConnection[];
   let connectionQuickPicks: QuickPickItemWithIndex[];
 
   try {

--- a/extensions/vscode/src/multiStepInputs/common.ts
+++ b/extensions/vscode/src/multiStepInputs/common.ts
@@ -83,12 +83,15 @@ export const getPlatformList = (): QuickPickItem[] => {
 };
 
 // Fetch the list of all available snowflake connections
-export const fetchSnowflakeConnections = async (serverUrl: string) => {
-  let connections: SnowflakeConnection[];
+export const fetchSnowflakeConnections = async (
+  serverUrl: string,
+  connectAuth?: { apiKey?: string; token?: string; privateKey?: string },
+) => {
+  let connections: SnowflakeConnection[] = [];
   let connectionQuickPicks: QuickPickItemWithIndex[];
 
   try {
-    connections = await discoverSnowflakeConnections(serverUrl);
+    connections = await discoverSnowflakeConnections(serverUrl, connectAuth);
     connectionQuickPicks = connections.map((connection, i) => ({
       label: connection.name,
       index: i,

--- a/extensions/vscode/src/multiStepInputs/common.ts
+++ b/extensions/vscode/src/multiStepInputs/common.ts
@@ -83,15 +83,12 @@ export const getPlatformList = (): QuickPickItem[] => {
 };
 
 // Fetch the list of all available snowflake connections
-export const fetchSnowflakeConnections = async (
-  serverUrl: string,
-  connectAuth?: { apiKey?: string; token?: string; privateKey?: string },
-) => {
+export const fetchSnowflakeConnections = async (serverUrl: string) => {
   let connections: SnowflakeConnection[] = [];
   let connectionQuickPicks: QuickPickItemWithIndex[];
 
   try {
-    connections = await discoverSnowflakeConnections(serverUrl, connectAuth);
+    connections = await discoverSnowflakeConnections(serverUrl);
     connectionQuickPicks = connections.map((connection, i) => ({
       label: connection.name,
       index: i,

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -75,6 +75,7 @@ export async function newConnectCredential(
     INPUT_SERVER_URL = "inputServerUrl",
     INPUT_API_KEY = "inputAPIKey",
     INPUT_SNOWFLAKE_CONN = "inputSnowflakeConnection",
+    INPUT_SNOWFLAKE_AUTH_METHOD = "inputSnowflakeAuthMethod",
     INPUT_CRED_NAME = "inputCredentialName",
     INPUT_AUTH_METHOD = "inputAuthMethod",
     INPUT_TOKEN = "inputToken",
@@ -87,6 +88,7 @@ export async function newConnectCredential(
     [step.INPUT_SERVER_URL]: inputServerUrl,
     [step.INPUT_API_KEY]: inputAPIKey,
     [step.INPUT_SNOWFLAKE_CONN]: inputSnowflakeConnection,
+    [step.INPUT_SNOWFLAKE_AUTH_METHOD]: inputSnowflakeAuthMethod,
     [step.INPUT_CRED_NAME]: inputCredentialName,
     [step.INPUT_AUTH_METHOD]: inputAuthMethod,
     [step.INPUT_TOKEN]: inputToken,
@@ -120,8 +122,12 @@ export async function newConnectCredential(
   };
 
   const isValidSnowflakeAuth = () => {
-    // for Snowflake, require snowflakeConnection
-    return isSnowflake(serverType) && isString(state.data.snowflakeConnection);
+    return (
+      isSnowflake(serverType) &&
+      isString(state.data.snowflakeConnection) &&
+      (isString(state.data.apiKey) ||
+        (isString(state.data.token) && isString(state.data.privateKey)))
+    );
   };
 
   // ***************************************************************
@@ -483,7 +489,19 @@ export async function newConnectCredential(
 
     try {
       await showProgress("Reading Snowflake connections", viewId, async () => {
-        const resp = await fetchSnowflakeConnections(serverUrl);
+        const connectAuth =
+          typeof state.data.apiKey === "string" && state.data.apiKey
+            ? { apiKey: state.data.apiKey }
+            : typeof state.data.token === "string" &&
+                typeof state.data.privateKey === "string" &&
+                state.data.token &&
+                state.data.privateKey
+              ? {
+                  token: state.data.token,
+                  privateKey: state.data.privateKey,
+                }
+              : undefined;
+        const resp = await fetchSnowflakeConnections(serverUrl, connectAuth);
         connections = resp.connections;
         connectionQuickPicks = resp.connectionQuickPicks;
       });
@@ -514,9 +532,57 @@ export async function newConnectCredential(
     }
 
     return {
-      name: step.INPUT_CRED_NAME,
+      name: step.INPUT_SNOWFLAKE_AUTH_METHOD,
       step: (input: MultiStepInput) =>
-        steps[step.INPUT_CRED_NAME](input, state),
+        steps[step.INPUT_SNOWFLAKE_AUTH_METHOD](input, state),
+    };
+  }
+
+  // ***************************************************************
+  // Step: Select Connect auth method (Snowflake SPCS only)
+  // ***************************************************************
+  async function inputSnowflakeAuthMethod(
+    input: MultiStepInput,
+    state: MultiStepState,
+  ) {
+    const authMethods = [
+      {
+        label: AuthMethodName.API_KEY,
+        description: "Enter a Connect API key",
+      },
+      {
+        label: AuthMethodName.TOKEN,
+        description: "One-click token authentication",
+      },
+    ];
+
+    const pick = await input.showQuickPick({
+      title: state.title,
+      step: 0,
+      totalSteps: 0,
+      placeholder:
+        "Select how to authenticate with Posit Connect (behind Snowflake)",
+      items: authMethods,
+      activeItem: authMethods[0],
+      buttons: [],
+      shouldResume: () => Promise.resolve(false),
+      ignoreFocusOut: true,
+    });
+
+    authMethod = getAuthMethod(pick.label as AuthMethodName);
+
+    if (isApiKey(authMethod)) {
+      return {
+        name: step.INPUT_API_KEY,
+        step: (input: MultiStepInput) =>
+          steps[step.INPUT_API_KEY](input, state),
+      };
+    }
+
+    return {
+      name: step.INPUT_TOKEN,
+      step: (input: MultiStepInput) => steps[step.INPUT_TOKEN](input, state),
+      skipStepHistory: true,
     };
   }
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -572,6 +572,8 @@ export async function newConnectCredential(
     authMethod = getAuthMethod(pick.label as AuthMethodName);
 
     if (isApiKey(authMethod)) {
+      state.data.token = undefined;
+      state.data.privateKey = undefined;
       return {
         name: step.INPUT_API_KEY,
         step: (input: MultiStepInput) =>
@@ -579,6 +581,7 @@ export async function newConnectCredential(
       };
     }
 
+    state.data.apiKey = undefined;
     return {
       name: step.INPUT_TOKEN,
       step: (input: MultiStepInput) => steps[step.INPUT_TOKEN](input, state),

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -347,21 +347,21 @@ export async function newConnectCredential(
     // url should always be defined by the time we get to this step
     const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
 
-    // For Snowflake-proxied servers, generate a fresh session token so
-    // the token registration request can reach Connect through the proxy.
-    let snowflakeToken: string | undefined;
-    const connName = state.data.snowflakeConnection;
-    if (isSnowflake(serverType) && typeof connName === "string") {
-      const connections = listConnections();
-      const config = connections[connName];
-      if (config) {
-        const provider = createTokenProvider(config);
-        const hostname = new URL(serverUrl).hostname;
-        snowflakeToken = await provider.getToken(hostname);
-      }
-    }
-
     try {
+      // For Snowflake-proxied servers, generate a fresh session token so
+      // the token registration request can reach Connect through the proxy.
+      let snowflakeToken: string | undefined;
+      const connName = state.data.snowflakeConnection;
+      if (isSnowflake(serverType) && typeof connName === "string") {
+        const connections = listConnections();
+        const config = connections[connName];
+        if (config) {
+          const provider = createTokenProvider(config);
+          const hostname = new URL(serverUrl).hostname;
+          snowflakeToken = await provider.getToken(hostname);
+        }
+      }
+
       // Create the token activator
       const tokenActivator = new ConnectAuthTokenActivator(
         serverUrl,

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -509,19 +509,7 @@ export async function newConnectCredential(
 
     try {
       await showProgress("Reading Snowflake connections", viewId, async () => {
-        const connectAuth =
-          typeof state.data.apiKey === "string" && state.data.apiKey
-            ? { apiKey: state.data.apiKey }
-            : typeof state.data.token === "string" &&
-                typeof state.data.privateKey === "string" &&
-                state.data.token &&
-                state.data.privateKey
-              ? {
-                  token: state.data.token,
-                  privateKey: state.data.privateKey,
-                }
-              : undefined;
-        const resp = await fetchSnowflakeConnections(serverUrl, connectAuth);
+        const resp = await fetchSnowflakeConnections(serverUrl);
         connections = resp.connections;
         connectionQuickPicks = resp.connectionQuickPicks;
       });

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -77,7 +77,6 @@ export async function newConnectCredential(
     INPUT_SERVER_URL = "inputServerUrl",
     INPUT_API_KEY = "inputAPIKey",
     INPUT_SNOWFLAKE_CONN = "inputSnowflakeConnection",
-    INPUT_SNOWFLAKE_AUTH_METHOD = "inputSnowflakeAuthMethod",
     INPUT_CRED_NAME = "inputCredentialName",
     INPUT_AUTH_METHOD = "inputAuthMethod",
     INPUT_TOKEN = "inputToken",
@@ -90,7 +89,6 @@ export async function newConnectCredential(
     [step.INPUT_SERVER_URL]: inputServerUrl,
     [step.INPUT_API_KEY]: inputAPIKey,
     [step.INPUT_SNOWFLAKE_CONN]: inputSnowflakeConnection,
-    [step.INPUT_SNOWFLAKE_AUTH_METHOD]: inputSnowflakeAuthMethod,
     [step.INPUT_CRED_NAME]: inputCredentialName,
     [step.INPUT_AUTH_METHOD]: inputAuthMethod,
     [step.INPUT_TOKEN]: inputToken,
@@ -315,7 +313,7 @@ export async function newConnectCredential(
       title: state.title,
       step: 0,
       totalSteps: 0,
-      placeholder: "Select authentication method",
+      placeholder: "Select Posit Connect authentication method",
       items: authMethods,
       activeItem: authMethods[0], // Token authentication is default
       buttons: [],
@@ -326,6 +324,9 @@ export async function newConnectCredential(
     authMethod = getAuthMethod(pick.label as AuthMethodName);
 
     if (isApiKey(authMethod)) {
+      // clear token (in case user navigated back to change auth method)
+      state.data.token = undefined;
+      state.data.privateKey = undefined;
       return {
         name: step.INPUT_API_KEY,
         step: (input: MultiStepInput) =>
@@ -333,6 +334,8 @@ export async function newConnectCredential(
       };
     }
 
+    // clear api key (in case user navigated back to change auth method)
+    state.data.apiKey = undefined;
     return {
       name: step.INPUT_TOKEN,
       step: (input: MultiStepInput) => steps[step.INPUT_TOKEN](input, state),
@@ -549,60 +552,9 @@ export async function newConnectCredential(
     }
 
     return {
-      name: step.INPUT_SNOWFLAKE_AUTH_METHOD,
+      name: step.INPUT_AUTH_METHOD,
       step: (input: MultiStepInput) =>
-        steps[step.INPUT_SNOWFLAKE_AUTH_METHOD](input, state),
-    };
-  }
-
-  // ***************************************************************
-  // Step: Select Connect auth method (Snowflake SPCS only)
-  // ***************************************************************
-  async function inputSnowflakeAuthMethod(
-    input: MultiStepInput,
-    state: MultiStepState,
-  ) {
-    const authMethods = [
-      {
-        label: AuthMethodName.API_KEY,
-        description: "Enter a Connect API key",
-      },
-      {
-        label: AuthMethodName.TOKEN,
-        description: "One-click token authentication",
-      },
-    ];
-
-    const pick = await input.showQuickPick({
-      title: state.title,
-      step: 0,
-      totalSteps: 0,
-      placeholder:
-        "Select how to authenticate with Posit Connect (behind Snowflake)",
-      items: authMethods,
-      activeItem: authMethods[0],
-      buttons: [],
-      shouldResume: () => Promise.resolve(false),
-      ignoreFocusOut: true,
-    });
-
-    authMethod = getAuthMethod(pick.label as AuthMethodName);
-
-    if (isApiKey(authMethod)) {
-      state.data.token = undefined;
-      state.data.privateKey = undefined;
-      return {
-        name: step.INPUT_API_KEY,
-        step: (input: MultiStepInput) =>
-          steps[step.INPUT_API_KEY](input, state),
-      };
-    }
-
-    state.data.apiKey = undefined;
-    return {
-      name: step.INPUT_TOKEN,
-      step: (input: MultiStepInput) => steps[step.INPUT_TOKEN](input, state),
-      skipStepHistory: true,
+        steps[step.INPUT_AUTH_METHOD](input, state),
     };
   }
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -102,6 +102,24 @@ export async function newConnectCredential(
     return authMethod === AuthMethod.API_KEY;
   };
 
+  async function getSnowflakeToken(
+    state: MultiStepState,
+  ): Promise<string | undefined> {
+    const connName = state.data.snowflakeConnection;
+    if (!isSnowflake(serverType) || typeof connName !== "string") {
+      return undefined;
+    }
+    const connections = listConnections();
+    const config = connections[connName];
+    if (!config) {
+      return undefined;
+    }
+    const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
+    const provider = createTokenProvider(config);
+    const hostname = new URL(serverUrl).hostname;
+    return provider.getToken(hostname);
+  }
+
   const isValidTokenAuth = () => {
     // for token authentication, require token and privateKey
     return (
@@ -351,19 +369,7 @@ export async function newConnectCredential(
     const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
 
     try {
-      // For Snowflake-proxied servers, generate a fresh session token so
-      // the token registration request can reach Connect through the proxy.
-      let snowflakeToken: string | undefined;
-      const connName = state.data.snowflakeConnection;
-      if (isSnowflake(serverType) && typeof connName === "string") {
-        const connections = listConnections();
-        const config = connections[connName];
-        if (config) {
-          const provider = createTokenProvider(config);
-          const hostname = new URL(serverUrl).hostname;
-          snowflakeToken = await provider.getToken(hostname);
-        }
-      }
+      const snowflakeToken = await getSnowflakeToken(state);
 
       // Create the token activator
       const tokenActivator = new ConnectAuthTokenActivator(
@@ -457,9 +463,11 @@ export async function newConnectCredential(
         const serverUrl =
           typeof state.data.url === "string" ? state.data.url : "";
         try {
+          const snowflakeToken = await getSnowflakeToken(state);
           const testResult = await testCredentials({
             url: serverUrl,
             apiKey: input,
+            snowflakeToken,
             insecure: !extensionSettings.verifyCertificates(),
           });
           if (testResult.error) {

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -28,6 +28,8 @@ import {
 } from "src/multiStepInputs/common";
 import { CredentialsService } from "src/credentials/service";
 import { isConnect, isSnowflake } from "../utils/multiStepHelpers";
+import { listConnections } from "src/snowflake/connections";
+import { createTokenProvider } from "src/snowflake/tokenProviders";
 import { openConfigurationCommand } from "src/commands";
 import { extensionSettings } from "src/extension";
 import { formatURL } from "src/utils/url";
@@ -345,6 +347,20 @@ export async function newConnectCredential(
     // url should always be defined by the time we get to this step
     const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
 
+    // For Snowflake-proxied servers, generate a fresh session token so
+    // the token registration request can reach Connect through the proxy.
+    let snowflakeToken: string | undefined;
+    const connName = state.data.snowflakeConnection;
+    if (isSnowflake(serverType) && typeof connName === "string") {
+      const connections = listConnections();
+      const config = connections[connName];
+      if (config) {
+        const provider = createTokenProvider(config);
+        const hostname = new URL(serverUrl).hostname;
+        snowflakeToken = await provider.getToken(hostname);
+      }
+    }
+
     try {
       // Create the token activator
       const tokenActivator = new ConnectAuthTokenActivator(
@@ -352,6 +368,7 @@ export async function newConnectCredential(
         viewId,
         undefined,
         !extensionSettings.verifyCertificates(),
+        snowflakeToken,
       );
 
       const resp = await input.showInfoMessage<

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -331,7 +331,7 @@ export async function newConnectCredential(
       title: state.title,
       step: 0,
       totalSteps: 0,
-      placeholder: "Select Posit Connect authentication method",
+      placeholder: "Select authentication method",
       items: authMethods,
       activeItem: authMethods[0], // Token authentication is default
       buttons: [],

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -117,7 +117,7 @@ export async function newConnectCredential(
     const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
     const provider = createTokenProvider(config);
     const hostname = new URL(serverUrl).hostname;
-    return provider.getToken(hostname);
+    return await provider.getToken(hostname);
   }
 
   const isValidTokenAuth = () => {

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -34,7 +34,7 @@ import { openConfigurationCommand } from "src/commands";
 import { extensionSettings } from "src/extension";
 import { formatURL } from "src/utils/url";
 import { checkSyntaxApiKey } from "src/utils/apiKeys";
-import { testCredentials } from "src/utils/testCredentials";
+import { testServerURL, testAuthentication } from "src/utils/testCredentials";
 import {
   ConnectAuthTokenActivator,
   TokenAuthResult,
@@ -262,7 +262,7 @@ export async function newConnectCredential(
           });
         }
         try {
-          const testResult = await testCredentials({
+          const testResult = await testServerURL({
             url: input,
             insecure: !extensionSettings.verifyCertificates(),
           });
@@ -464,7 +464,7 @@ export async function newConnectCredential(
           typeof state.data.url === "string" ? state.data.url : "";
         try {
           const snowflakeToken = await getSnowflakeToken(state);
-          const testResult = await testCredentials({
+          const testResult = await testAuthentication({
             url: serverUrl,
             apiKey: input,
             snowflakeToken,
@@ -476,8 +476,7 @@ export async function newConnectCredential(
               severity: InputBoxValidationSeverity.Error,
             });
           }
-          // we have success, but testCredentials may have returned a different
-          // url for us to use.
+          // testAuthentication may have discovered a different URL.
           if (testResult.url) {
             state.data.url = testResult.url;
           }

--- a/extensions/vscode/src/snowflake/discovery.ts
+++ b/extensions/vscode/src/snowflake/discovery.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
-import { ConnectAPI } from "@posit-dev/connect-api";
+import { ConnectAPI, ConnectAPIError } from "@posit-dev/connect-api";
 
 import { listConnections } from "./connections";
 import { createTokenProvider } from "./tokenProviders";
@@ -10,12 +10,19 @@ import type { SnowflakeConnection } from "./types";
 
 const VALIDATION_TIMEOUT_MS = 30_000;
 
+export interface SnowflakeDiscoveryAuth {
+  apiKey?: string;
+  token?: string;
+  privateKey?: string;
+}
+
 /**
  * Discovers Snowflake connections that can successfully authenticate
  * to the Connect server at the given URL.
  */
 export async function discoverSnowflakeConnections(
   serverUrl: string,
+  connectAuth?: SnowflakeDiscoveryAuth,
 ): Promise<SnowflakeConnection[]> {
   const urlCandidates = getListOfPossibleURLs(serverUrl);
   const connections = listConnections();
@@ -35,13 +42,33 @@ export async function discoverSnowflakeConnections(
         const hostname = new URL(candidateUrl).hostname;
         const token = await tokenProvider.getToken(hostname);
 
-        const api = new ConnectAPI({
+        const baseOpts = {
           url: candidateUrl,
           snowflakeToken: token,
           timeout: VALIDATION_TIMEOUT_MS,
+        };
+
+        const connectOpts =
+          connectAuth?.token && connectAuth?.privateKey
+            ? { token: connectAuth.token, privateKey: connectAuth.privateKey }
+            : connectAuth?.apiKey
+              ? { apiKey: connectAuth.apiKey }
+              : {};
+
+        const api = new ConnectAPI({
+          ...baseOpts,
+          ...connectOpts,
         });
 
-        await api.testAuthentication();
+        try {
+          await api.testAuthentication();
+        } catch (e) {
+          // 401 means we got through the Snowflake proxy (good!) but
+          // Connect rejected us (expected when no Connect auth yet).
+          if (!(e instanceof ConnectAPIError && e.httpStatus === 401)) {
+            throw e;
+          }
+        }
 
         results.push({ name, serverUrl: candidateUrl });
         // Stop trying other URLs for this connection

--- a/extensions/vscode/src/snowflake/discovery.ts
+++ b/extensions/vscode/src/snowflake/discovery.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
-import { ConnectAPI, ConnectAPIError } from "@posit-dev/connect-api";
+import { ConnectAPI } from "@posit-dev/connect-api";
 
 import { listConnections } from "./connections";
 import { createTokenProvider } from "./tokenProviders";
@@ -22,7 +22,6 @@ export interface SnowflakeDiscoveryAuth {
  */
 export async function discoverSnowflakeConnections(
   serverUrl: string,
-  connectAuth?: SnowflakeDiscoveryAuth,
 ): Promise<SnowflakeConnection[]> {
   const urlCandidates = getListOfPossibleURLs(serverUrl);
   const connections = listConnections();
@@ -42,33 +41,13 @@ export async function discoverSnowflakeConnections(
         const hostname = new URL(candidateUrl).hostname;
         const token = await tokenProvider.getToken(hostname);
 
-        const baseOpts = {
+        const api = new ConnectAPI({
           url: candidateUrl,
           snowflakeToken: token,
           timeout: VALIDATION_TIMEOUT_MS,
-        };
-
-        const connectOpts =
-          connectAuth?.token && connectAuth?.privateKey
-            ? { token: connectAuth.token, privateKey: connectAuth.privateKey }
-            : connectAuth?.apiKey
-              ? { apiKey: connectAuth.apiKey }
-              : {};
-
-        const api = new ConnectAPI({
-          ...baseOpts,
-          ...connectOpts,
         });
 
-        try {
-          await api.testAuthentication();
-        } catch (e) {
-          // 401 means we got through the Snowflake proxy (good!) but
-          // Connect rejected us (expected when no Connect auth yet).
-          if (!(e instanceof ConnectAPIError && e.httpStatus === 401)) {
-            throw e;
-          }
-        }
+        await api.testAuthentication();
 
         results.push({ name, serverUrl: candidateUrl });
         // Stop trying other URLs for this connection

--- a/extensions/vscode/src/snowflake/discovery.ts
+++ b/extensions/vscode/src/snowflake/discovery.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
-import { ConnectAPI } from "@posit-dev/connect-api";
+import { ConnectAPI, ConnectAPIError } from "@posit-dev/connect-api";
 
 import { listConnections } from "./connections";
 import { createTokenProvider } from "./tokenProviders";
@@ -41,7 +41,15 @@ export async function discoverSnowflakeConnections(
           timeout: VALIDATION_TIMEOUT_MS,
         });
 
-        await api.testAuthentication();
+        try {
+          await api.testAuthentication();
+        } catch (e) {
+          // 401 means we got through the Snowflake proxy (good!) but
+          // Connect rejected us (expected when no Connect auth yet).
+          if (!(e instanceof ConnectAPIError && e.httpStatus === 401)) {
+            throw e;
+          }
+        }
 
         results.push({ name, serverUrl: candidateUrl });
         // Stop trying other URLs for this connection

--- a/extensions/vscode/src/snowflake/discovery.ts
+++ b/extensions/vscode/src/snowflake/discovery.ts
@@ -10,12 +10,6 @@ import type { SnowflakeConnection } from "./types";
 
 const VALIDATION_TIMEOUT_MS = 30_000;
 
-export interface SnowflakeDiscoveryAuth {
-  apiKey?: string;
-  token?: string;
-  privateKey?: string;
-}
-
 /**
  * Discovers Snowflake connections that can successfully authenticate
  * to the Connect server at the given URL.

--- a/extensions/vscode/src/utils/testCredentials.test.ts
+++ b/extensions/vscode/src/utils/testCredentials.test.ts
@@ -274,4 +274,31 @@ describe("testCredentials", () => {
     expect(result.error).toBeNull();
     expect(mockTestAuthentication).not.toHaveBeenCalled();
   });
+
+  test("Snowflake URL with apiKey and snowflakeToken — tests auth through proxy", async () => {
+    mockTestAuthentication.mockResolvedValue({
+      user: mockUser,
+      error: null,
+    });
+
+    const result = await testCredentials({
+      url: "https://example.snowflakecomputing.app",
+      apiKey: "0123456789abcdef0123456789abcdef",
+      snowflakeToken: "snowflake-session-token",
+      insecure: false,
+    });
+
+    expect(result.user).toEqual(mockUser);
+    expect(result.serverType).toBe(ServerType.SNOWFLAKE);
+    expect(result.error).toBeNull();
+
+    const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    expect(constructorCalls[0]![0].snowflakeToken).toBe(
+      "snowflake-session-token",
+    );
+    expect(constructorCalls[0]![0].apiKey).toBe(
+      "0123456789abcdef0123456789abcdef",
+    );
+  });
 });

--- a/extensions/vscode/src/utils/testCredentials.test.ts
+++ b/extensions/vscode/src/utils/testCredentials.test.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
 import { describe, expect, test, vi, beforeEach } from "vitest";
-import { testCredentials } from "./testCredentials";
+import { testServerURL, testAuthentication } from "./testCredentials";
 import { ServerType } from "src/api/types/contentRecords";
 import { ConnectAPIError } from "@posit-dev/connect-api";
 
@@ -39,111 +39,99 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests
+// testServerURL
 // ---------------------------------------------------------------------------
 
-describe("testCredentials", () => {
-  test("successful auth — returns user, discovered URL, serverType, no error", async () => {
-    mockTestAuthentication.mockResolvedValue({
-      user: mockUser,
-      error: null,
-    });
-
-    const result = await testCredentials({
-      url: "https://connect.example.com",
-      apiKey: "0123456789abcdef0123456789abcdef",
-      insecure: false,
-    });
-
-    expect(result.user).toEqual(mockUser);
-    expect(result.url).toBe("https://connect.example.com");
-    expect(result.serverType).toBe(ServerType.CONNECT);
-    expect(result.error).toBeNull();
-  });
-
-  test("URL discovery with Connect copied URL — extra path/fragment trimmed", async () => {
-    // URL produces: base, /rsc, /rsc/dev-password, /rsc/dev-password/connect
-    // Walking backwards: /rsc/dev-password/connect fails, /rsc/dev-password succeeds
-    mockTestAuthentication
-      .mockRejectedValueOnce(new Error("nope1"))
-      .mockResolvedValueOnce({ user: mockUser, error: null });
-
-    const result = await testCredentials({
-      url: "https://connect.localtest.me/rsc/dev-password/connect/#/apps/guid/access",
-      apiKey: "0123456789abcdef0123456789abcdef",
-      insecure: false,
-    });
-
-    expect(result.user).toEqual(mockUser);
-    expect(result.url).toBe("https://connect.localtest.me/rsc/dev-password");
-    expect(result.error).toBeNull();
-  });
-
-  test("URL discovery with extra paths — multiple failures before success", async () => {
-    // fail /pass/fail/fail, fail /pass/fail, succeed /pass
-    mockTestAuthentication
-      .mockRejectedValueOnce(new Error("nope1"))
-      .mockRejectedValueOnce(new Error("nope2"))
-      .mockResolvedValueOnce({ user: mockUser, error: null });
-
-    const result = await testCredentials({
-      url: "https://connect.example.com/pass/fail/fail",
-      apiKey: "0123456789abcdef0123456789abcdef",
-      insecure: false,
-    });
-
-    expect(result.user).toEqual(mockUser);
-    expect(result.url).toBe("https://connect.example.com/pass");
-    expect(result.error).toBeNull();
-
-    // ConnectAPI should have been constructed 3 times with the right URLs
-    const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
-      .mock.calls;
-    expect(constructorCalls[0]![0].url).toBe(
-      "https://connect.example.com/pass/fail/fail",
-    );
-    expect(constructorCalls[1]![0].url).toBe(
-      "https://connect.example.com/pass/fail",
-    );
-    expect(constructorCalls[2]![0].url).toBe(
-      "https://connect.example.com/pass",
-    );
-  });
-
-  test("no API key — 401 treated as success (URL reachable), no user", async () => {
-    // Without credentials, Connect returns 401. The tester should treat this
-    // as success (server is reachable).
+describe("testServerURL", () => {
+  test("reachable server — returns serverType, discovered URL, no error", async () => {
     mockTestAuthentication.mockRejectedValue(
       new ConnectAPIError("HTTP 401", 401),
     );
 
-    const result = await testCredentials({
+    const result = await testServerURL({
       url: "https://connect.example.com",
       insecure: false,
     });
 
     expect(result.user).toBeNull();
+    expect(result.url).toBe("https://connect.example.com");
     expect(result.serverType).toBe(ServerType.CONNECT);
     expect(result.error).toBeNull();
   });
 
-  test("bad API key — returns error with normalized message", async () => {
+  test("URL discovery — extra path/fragment trimmed", async () => {
+    mockTestAuthentication
+      .mockRejectedValueOnce(new Error("nope1"))
+      .mockRejectedValueOnce(new ConnectAPIError("HTTP 401", 401));
+
+    const result = await testServerURL({
+      url: "https://connect.localtest.me/rsc/dev-password/connect/#/apps/guid/access",
+      insecure: false,
+    });
+
+    expect(result.url).toBe("https://connect.localtest.me/rsc/dev-password");
+    expect(result.error).toBeNull();
+  });
+
+  test("Snowflake URL — skips Connect API probe, returns serverType", async () => {
+    const result = await testServerURL({
+      url: "https://example.snowflakecomputing.app",
+      insecure: false,
+    });
+
+    expect(result.serverType).toBe(ServerType.SNOWFLAKE);
+    expect(result.user).toBeNull();
+    expect(result.url).toBe("https://example.snowflakecomputing.app");
+    expect(result.error).toBeNull();
+    expect(mockTestAuthentication).not.toHaveBeenCalled();
+  });
+
+  test("Snowflake privatelink URL — skips Connect API probe", async () => {
+    const result = await testServerURL({
+      url: "https://example.privatelink.snowflake.app",
+      insecure: false,
+    });
+
+    expect(result.serverType).toBe(ServerType.SNOWFLAKE);
+    expect(result.error).toBeNull();
+    expect(mockTestAuthentication).not.toHaveBeenCalled();
+  });
+
+  test("Connect Cloud URL — detects server type", async () => {
     mockTestAuthentication.mockRejectedValue(
-      new Error("test error from TestAuthentication"),
+      new ConnectAPIError("HTTP 401", 401),
     );
 
-    const result = await testCredentials({
-      url: "https://connect.example.com",
-      apiKey: "invalid",
+    const result = await testServerURL({
+      url: "https://connect.posit.cloud",
+      insecure: false,
+    });
+
+    expect(result.serverType).toBe(ServerType.CONNECT_CLOUD);
+  });
+
+  test("invalid URL — returns error, null serverType", async () => {
+    const result = await testServerURL({
+      url: ":bad",
       insecure: false,
     });
 
     expect(result.user).toBeNull();
+    expect(result.url).toBeNull();
+    expect(result.serverType).toBeNull();
     expect(result.error).not.toBeNull();
-    expect(result.error!.msg).toBe("Test error from TestAuthentication.");
-    expect(result.error!.code).toBe("unknown");
-    expect(result.url).toBe("https://connect.example.com");
-    expect(result.serverType).toBe(ServerType.CONNECT);
+  });
+
+  test("unreachable server — returns error", async () => {
+    mockTestAuthentication.mockRejectedValue(new Error("connection refused"));
+
+    const result = await testServerURL({
+      url: "https://connect.example.com",
+      insecure: false,
+    });
+
+    expect(result.error).not.toBeNull();
+    expect(result.error!.msg).toBe("Connection refused.");
   });
 
   test.each([
@@ -158,30 +146,25 @@ describe("testCredentials", () => {
     async (pattern) => {
       mockTestAuthentication.mockRejectedValue(new Error(pattern));
 
-      const result = await testCredentials({
+      const result = await testServerURL({
         url: "https://connect.example.com",
-        apiKey: "somekey",
         insecure: false,
       });
 
-      expect(result.user).toBeNull();
       expect(result.error).not.toBeNull();
       expect(result.error!.code).toBe("errorCertificateVerification");
     },
   );
 
-  test("network error — returns error with 'Unable to reach' message", async () => {
-    // ConnectAPIError with no httpStatus indicates a network-level failure
-    // (VPN disconnected, DNS failure, ECONNREFUSED, etc.)
+  test("network error — returns error with connectionFailed code", async () => {
     mockTestAuthentication.mockRejectedValue(
       new ConnectAPIError(
         "Unable to reach the server. Check your network connection, VPN, and server URL.",
       ),
     );
 
-    const result = await testCredentials({
+    const result = await testServerURL({
       url: "https://connect.example.com",
-      apiKey: "somekey",
       insecure: false,
     });
 
@@ -191,27 +174,13 @@ describe("testCredentials", () => {
     expect(result.error!.code).toBe("connectionFailed");
   });
 
-  test("invalid URL — returns error, null serverType", async () => {
-    const result = await testCredentials({
-      url: ":bad",
-      insecure: false,
-    });
-
-    expect(result.user).toBeNull();
-    expect(result.url).toBeNull();
-    expect(result.serverType).toBeNull();
-    expect(result.error).not.toBeNull();
-  });
-
   test("passes rejectUnauthorized and timeout to ConnectAPI", async () => {
-    mockTestAuthentication.mockResolvedValue({
-      user: mockUser,
-      error: null,
-    });
+    mockTestAuthentication.mockRejectedValue(
+      new ConnectAPIError("HTTP 401", 401),
+    );
 
-    await testCredentials({
+    await testServerURL({
       url: "https://connect.example.com",
-      apiKey: "key",
       insecure: true,
       timeout: 60,
     });
@@ -221,67 +190,84 @@ describe("testCredentials", () => {
     expect(constructorCalls[0]![0].rejectUnauthorized).toBe(false);
     expect(constructorCalls[0]![0].timeout).toBe(60000);
   });
+});
 
-  test("detects Connect Cloud server type", async () => {
+// ---------------------------------------------------------------------------
+// testAuthentication
+// ---------------------------------------------------------------------------
+
+describe("testAuthentication", () => {
+  test("successful auth — returns user, discovered URL, serverType", async () => {
     mockTestAuthentication.mockResolvedValue({
       user: mockUser,
       error: null,
     });
 
-    const result = await testCredentials({
-      url: "https://connect.posit.cloud",
-      apiKey: "key",
-      insecure: false,
-    });
-
-    expect(result.serverType).toBe(ServerType.CONNECT_CLOUD);
-  });
-
-  test("error message already ending with period is not double-punctuated", async () => {
-    mockTestAuthentication.mockRejectedValue(new Error("Something failed."));
-
-    const result = await testCredentials({
+    const result = await testAuthentication({
       url: "https://connect.example.com",
-      apiKey: "key",
+      apiKey: "0123456789abcdef0123456789abcdef",
       insecure: false,
     });
 
-    expect(result.error).not.toBeNull();
-    expect(result.error!.msg).toBe("Something failed.");
+    expect(result.user).toEqual(mockUser);
+    expect(result.url).toBe("https://connect.example.com");
+    expect(result.serverType).toBe(ServerType.CONNECT);
+    expect(result.error).toBeNull();
   });
 
-  test("Snowflake URL — skips Connect API probe, returns serverType", async () => {
-    const result = await testCredentials({
-      url: "https://example.snowflakecomputing.app",
+  test("URL discovery — tries multiple paths", async () => {
+    mockTestAuthentication
+      .mockRejectedValueOnce(new Error("nope1"))
+      .mockRejectedValueOnce(new Error("nope2"))
+      .mockResolvedValueOnce({ user: mockUser, error: null });
+
+    const result = await testAuthentication({
+      url: "https://connect.example.com/pass/fail/fail",
+      apiKey: "0123456789abcdef0123456789abcdef",
       insecure: false,
     });
 
-    expect(result.serverType).toBe(ServerType.SNOWFLAKE);
+    expect(result.user).toEqual(mockUser);
+    expect(result.url).toBe("https://connect.example.com/pass");
+    expect(result.error).toBeNull();
+
+    const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    expect(constructorCalls[0]![0].url).toBe(
+      "https://connect.example.com/pass/fail/fail",
+    );
+    expect(constructorCalls[1]![0].url).toBe(
+      "https://connect.example.com/pass/fail",
+    );
+    expect(constructorCalls[2]![0].url).toBe(
+      "https://connect.example.com/pass",
+    );
+  });
+
+  test("bad API key — returns error with normalized message", async () => {
+    mockTestAuthentication.mockRejectedValue(
+      new Error("test error from TestAuthentication"),
+    );
+
+    const result = await testAuthentication({
+      url: "https://connect.example.com",
+      apiKey: "invalid",
+      insecure: false,
+    });
+
     expect(result.user).toBeNull();
-    expect(result.url).toBe("https://example.snowflakecomputing.app");
-    expect(result.error).toBeNull();
-    // testAuthentication should NOT have been called for Snowflake URLs
-    expect(mockTestAuthentication).not.toHaveBeenCalled();
+    expect(result.error).not.toBeNull();
+    expect(result.error!.msg).toBe("Test error from TestAuthentication.");
+    expect(result.error!.code).toBe("unknown");
   });
 
-  test("Snowflake privatelink URL — skips Connect API probe", async () => {
-    const result = await testCredentials({
-      url: "https://example.privatelink.snowflake.app",
-      insecure: false,
-    });
-
-    expect(result.serverType).toBe(ServerType.SNOWFLAKE);
-    expect(result.error).toBeNull();
-    expect(mockTestAuthentication).not.toHaveBeenCalled();
-  });
-
-  test("Snowflake URL with apiKey and snowflakeToken — tests auth through proxy", async () => {
+  test("Snowflake + apiKey + snowflakeToken — tests auth through proxy", async () => {
     mockTestAuthentication.mockResolvedValue({
       user: mockUser,
       error: null,
     });
 
-    const result = await testCredentials({
+    const result = await testAuthentication({
       url: "https://example.snowflakecomputing.app",
       apiKey: "0123456789abcdef0123456789abcdef",
       snowflakeToken: "snowflake-session-token",
@@ -300,5 +286,50 @@ describe("testCredentials", () => {
     expect(constructorCalls[0]![0].apiKey).toBe(
       "0123456789abcdef0123456789abcdef",
     );
+  });
+
+  test("passes rejectUnauthorized and timeout to ConnectAPI", async () => {
+    mockTestAuthentication.mockResolvedValue({
+      user: mockUser,
+      error: null,
+    });
+
+    await testAuthentication({
+      url: "https://connect.example.com",
+      apiKey: "key",
+      insecure: true,
+      timeout: 60,
+    });
+
+    const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    expect(constructorCalls[0]![0].rejectUnauthorized).toBe(false);
+    expect(constructorCalls[0]![0].timeout).toBe(60000);
+  });
+
+  test("invalid URL — returns error, null serverType", async () => {
+    const result = await testAuthentication({
+      url: ":bad",
+      apiKey: "key",
+      insecure: false,
+    });
+
+    expect(result.user).toBeNull();
+    expect(result.url).toBeNull();
+    expect(result.serverType).toBeNull();
+    expect(result.error).not.toBeNull();
+  });
+
+  test("error message already ending with period is not double-punctuated", async () => {
+    mockTestAuthentication.mockRejectedValue(new Error("Something failed."));
+
+    const result = await testAuthentication({
+      url: "https://connect.example.com",
+      apiKey: "key",
+      insecure: false,
+    });
+
+    expect(result.error).not.toBeNull();
+    expect(result.error!.msg).toBe("Something failed.");
   });
 });

--- a/extensions/vscode/src/utils/testCredentials.test.ts
+++ b/extensions/vscode/src/utils/testCredentials.test.ts
@@ -174,7 +174,7 @@ describe("testServerURL", () => {
     expect(result.error!.code).toBe("connectionFailed");
   });
 
-  test("passes rejectUnauthorized and timeout to ConnectAPI", async () => {
+  test("passes rejectUnauthorized to ConnectAPI", async () => {
     mockTestAuthentication.mockRejectedValue(
       new ConnectAPIError("HTTP 401", 401),
     );
@@ -182,13 +182,11 @@ describe("testServerURL", () => {
     await testServerURL({
       url: "https://connect.example.com",
       insecure: true,
-      timeout: 60,
     });
 
     const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
       .mock.calls;
     expect(constructorCalls[0]![0].rejectUnauthorized).toBe(false);
-    expect(constructorCalls[0]![0].timeout).toBe(60000);
   });
 });
 
@@ -288,7 +286,7 @@ describe("testAuthentication", () => {
     );
   });
 
-  test("passes rejectUnauthorized and timeout to ConnectAPI", async () => {
+  test("passes rejectUnauthorized to ConnectAPI", async () => {
     mockTestAuthentication.mockResolvedValue({
       user: mockUser,
       error: null,
@@ -298,13 +296,11 @@ describe("testAuthentication", () => {
       url: "https://connect.example.com",
       apiKey: "key",
       insecure: true,
-      timeout: 60,
     });
 
     const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
       .mock.calls;
     expect(constructorCalls[0]![0].rejectUnauthorized).toBe(false);
-    expect(constructorCalls[0]![0].timeout).toBe(60000);
   });
 
   test("invalid URL — returns error, null serverType", async () => {

--- a/extensions/vscode/src/utils/testCredentials.test.ts
+++ b/extensions/vscode/src/utils/testCredentials.test.ts
@@ -250,48 +250,6 @@ describe("testCredentials", () => {
     expect(result.error!.msg).toBe("Something failed.");
   });
 
-  test("token auth — passes token and privateKey to ConnectAPI", async () => {
-    mockTestAuthentication.mockResolvedValue({
-      user: mockUser,
-      error: null,
-    });
-
-    const result = await testCredentials({
-      url: "https://connect.example.com",
-      token: "my-token-id",
-      privateKey: "my-private-key",
-      insecure: false,
-    });
-
-    expect(result.user).toEqual(mockUser);
-    expect(result.serverType).toBe(ServerType.CONNECT);
-    expect(result.error).toBeNull();
-
-    const constructorCalls = (ConnectAPI as unknown as ReturnType<typeof vi.fn>)
-      .mock.calls;
-    expect(constructorCalls[0]![0].token).toBe("my-token-id");
-    expect(constructorCalls[0]![0].privateKey).toBe("my-private-key");
-    expect(constructorCalls[0]![0].apiKey).toBeUndefined();
-  });
-
-  test("token auth — failure returns error", async () => {
-    mockTestAuthentication.mockRejectedValue(
-      new Error("authentication failed"),
-    );
-
-    const result = await testCredentials({
-      url: "https://connect.example.com",
-      token: "bad-token",
-      privateKey: "bad-key",
-      insecure: false,
-    });
-
-    expect(result.user).toBeNull();
-    expect(result.error).not.toBeNull();
-    expect(result.error!.msg).toBe("Authentication failed.");
-    expect(result.serverType).toBe(ServerType.CONNECT);
-  });
-
   test("Snowflake URL — skips Connect API probe, returns serverType", async () => {
     const result = await testCredentials({
       url: "https://example.snowflakecomputing.app",

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -12,6 +12,7 @@ import { serverTypeFromURL, discoverServerURL } from "src/utils/url";
 export interface TestCredentialsParams {
   url: string;
   apiKey?: string;
+  snowflakeToken?: string;
   insecure: boolean;
   timeout?: number; // seconds — minimum 30
 }
@@ -103,11 +104,15 @@ export async function testCredentials(
       rejectUnauthorized: !params.insecure,
       timeout: timeoutMs,
     };
-    const authOptions = params.apiKey ? { apiKey: params.apiKey } : {};
+    const auth = params.snowflakeToken
+      ? { snowflakeToken: params.snowflakeToken, apiKey: params.apiKey! }
+      : params.apiKey
+        ? { apiKey: params.apiKey }
+        : {};
     const client = new ConnectAPI({
       url: urlToTest,
+      ...auth,
       ...baseOptions,
-      ...authOptions,
     });
 
     try {

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -12,8 +12,6 @@ import { serverTypeFromURL, discoverServerURL } from "src/utils/url";
 export interface TestCredentialsParams {
   url: string;
   apiKey?: string;
-  token?: string;
-  privateKey?: string;
   insecure: boolean;
   timeout?: number; // seconds — minimum 30
 }
@@ -101,20 +99,14 @@ export async function testCredentials(
 
   const timeoutMs = Math.max(params.timeout ?? 30, 30) * 1000;
 
-  const hasCredentials =
-    !!params.apiKey || (!!params.token && !!params.privateKey);
+  const hasCredentials = !!params.apiKey;
 
   const tester = async (urlToTest: string): Promise<void> => {
     const baseOptions = {
       rejectUnauthorized: !params.insecure,
       timeout: timeoutMs,
     };
-    const authOptions =
-      params.token && params.privateKey
-        ? { token: params.token, privateKey: params.privateKey }
-        : params.apiKey
-          ? { apiKey: params.apiKey }
-          : {};
+    const authOptions = params.apiKey ? { apiKey: params.apiKey } : {};
     const client = new ConnectAPI({
       url: urlToTest,
       ...baseOptions,

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -9,10 +9,6 @@ import { TestResult } from "src/api/types/credentials";
 import type { ErrorCode } from "src/utils/errorTypes";
 import { serverTypeFromURL, discoverServerURL } from "src/utils/url";
 
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
 const CERTIFICATE_ERROR_PATTERNS = [
   "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
   "DEPTH_ZERO_SELF_SIGNED_CERT",
@@ -60,16 +56,16 @@ function toAgentError(err: unknown): AgentError {
   };
 }
 
-// ---------------------------------------------------------------------------
-// testServerURL — validate reachability and detect server type (no auth)
-// ---------------------------------------------------------------------------
-
 export interface TestServerURLParams {
   url: string;
   insecure: boolean;
   timeout?: number;
 }
 
+/**
+ * testServerURL validates reachability and detects server type but does not
+ * perform authentication.
+ */
 export async function testServerURL(
   params: TestServerURLParams,
 ): Promise<TestResult> {
@@ -134,10 +130,6 @@ export async function testServerURL(
   };
 }
 
-// ---------------------------------------------------------------------------
-// testAuthentication — verify credentials authenticate successfully
-// ---------------------------------------------------------------------------
-
 export interface TestAuthenticationParams {
   url: string;
   apiKey: string;
@@ -146,6 +138,11 @@ export interface TestAuthenticationParams {
   timeout?: number;
 }
 
+/**
+ * testAuthentication validates credentials by attempting to authenticate and returns
+ * the authenticated user on success. It also finds the correct URL to authenticate
+ * against (which may be a shortened version of the provided URL).
+ */
 export async function testAuthentication(
   params: TestAuthenticationParams,
 ): Promise<TestResult> {

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -56,10 +56,11 @@ function toAgentError(err: unknown): AgentError {
   };
 }
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 export interface TestServerURLParams {
   url: string;
   insecure: boolean;
-  timeout?: number;
 }
 
 /**
@@ -91,13 +92,11 @@ export async function testServerURL(
     };
   }
 
-  const timeoutMs = Math.max(params.timeout ?? 30, 30) * 1000;
-
   const tester = async (urlToTest: string): Promise<void> => {
     const client = new ConnectAPI({
       url: urlToTest,
       rejectUnauthorized: !params.insecure,
-      timeout: timeoutMs,
+      timeout: DEFAULT_TIMEOUT_MS,
     });
 
     try {
@@ -135,7 +134,6 @@ export interface TestAuthenticationParams {
   apiKey: string;
   snowflakeToken?: string;
   insecure: boolean;
-  timeout?: number;
 }
 
 /**
@@ -159,7 +157,6 @@ export async function testAuthentication(
   }
 
   let lastUser: User | null = null;
-  const timeoutMs = Math.max(params.timeout ?? 30, 30) * 1000;
 
   const tester = async (urlToTest: string): Promise<void> => {
     const auth = params.snowflakeToken
@@ -169,7 +166,7 @@ export async function testAuthentication(
       url: urlToTest,
       ...auth,
       rejectUnauthorized: !params.insecure,
-      timeout: timeoutMs,
+      timeout: DEFAULT_TIMEOUT_MS,
     });
 
     const result = await client.testAuthentication();

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -68,7 +68,6 @@ function toAgentError(err: unknown): AgentError {
 export async function testCredentials(
   params: TestCredentialsParams,
 ): Promise<TestResult> {
-  // 1. Detect server type
   let st: ServerType;
   try {
     st = serverTypeFromURL(params.url);
@@ -81,11 +80,11 @@ export async function testCredentials(
     };
   }
 
-  // 2. Snowflake URLs don't expose the Connect API, so skip the
-  //    authentication / reachability probe. The extension does not attempt
-  //    to call /__api__/v1/user on Snowflake servers — it only
-  //    validates the URL format and credential structure.
-  if (st === ServerType.SNOWFLAKE) {
+  const hasCredentials = !!params.apiKey;
+
+  // For Snowflake, we initially skip auth testing and just detect the server type.
+  // Later in the flow when we have an API token, we will do the full test.
+  if (st === ServerType.SNOWFLAKE && !hasCredentials) {
     return {
       user: null,
       url: params.url,
@@ -98,8 +97,6 @@ export async function testCredentials(
   let lastUser: User | null = null;
 
   const timeoutMs = Math.max(params.timeout ?? 30, 30) * 1000;
-
-  const hasCredentials = !!params.apiKey;
 
   const tester = async (urlToTest: string): Promise<void> => {
     const baseOptions = {

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -9,13 +9,9 @@ import { TestResult } from "src/api/types/credentials";
 import type { ErrorCode } from "src/utils/errorTypes";
 import { serverTypeFromURL, discoverServerURL } from "src/utils/url";
 
-export interface TestCredentialsParams {
-  url: string;
-  apiKey?: string;
-  snowflakeToken?: string;
-  insecure: boolean;
-  timeout?: number; // seconds — minimum 30
-}
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
 
 const CERTIFICATE_ERROR_PATTERNS = [
   "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
@@ -35,10 +31,8 @@ function normalizeErrorMessage(msg: string): string {
   const trimmed = msg.trim();
   if (trimmed.length === 0) return trimmed;
 
-  // Capitalize first letter
   const capitalized = trimmed[0]!.toUpperCase() + trimmed.slice(1);
 
-  // Add terminal period if not ending with special punctuation
   const lastChar = capitalized[capitalized.length - 1]!;
   if (["?", "!", ")", "."].includes(lastChar)) {
     return capitalized;
@@ -66,8 +60,18 @@ function toAgentError(err: unknown): AgentError {
   };
 }
 
-export async function testCredentials(
-  params: TestCredentialsParams,
+// ---------------------------------------------------------------------------
+// testServerURL — validate reachability and detect server type (no auth)
+// ---------------------------------------------------------------------------
+
+export interface TestServerURLParams {
+  url: string;
+  insecure: boolean;
+  timeout?: number;
+}
+
+export async function testServerURL(
+  params: TestServerURLParams,
 ): Promise<TestResult> {
   let st: ServerType;
   try {
@@ -81,11 +85,8 @@ export async function testCredentials(
     };
   }
 
-  const hasCredentials = !!params.apiKey;
-
-  // For Snowflake, we initially skip auth testing and just detect the server type.
-  // Later in the flow when we have an API token, we will do the full test.
-  if (st === ServerType.SNOWFLAKE && !hasCredentials) {
+  // Snowflake URLs don't expose the Connect API directly — skip the probe.
+  if (st === ServerType.SNOWFLAKE) {
     return {
       user: null,
       url: params.url,
@@ -94,45 +95,90 @@ export async function testCredentials(
     };
   }
 
-  // 3. Build a tester function
-  let lastUser: User | null = null;
-
   const timeoutMs = Math.max(params.timeout ?? 30, 30) * 1000;
 
   const tester = async (urlToTest: string): Promise<void> => {
-    const baseOptions = {
-      rejectUnauthorized: !params.insecure,
-      timeout: timeoutMs,
-    };
-    const auth = params.snowflakeToken
-      ? { snowflakeToken: params.snowflakeToken, apiKey: params.apiKey! }
-      : params.apiKey
-        ? { apiKey: params.apiKey }
-        : {};
     const client = new ConnectAPI({
       url: urlToTest,
-      ...auth,
-      ...baseOptions,
+      rejectUnauthorized: !params.insecure,
+      timeout: timeoutMs,
     });
 
     try {
-      const result = await client.testAuthentication();
-      lastUser = result.user;
+      await client.testAuthentication();
     } catch (err) {
-      // When no credentials are provided, treat HTTP 401 as success:
-      // the server is reachable but requires auth.
-      if (
-        !hasCredentials &&
-        err instanceof ConnectAPIError &&
-        err.httpStatus === 401
-      ) {
+      // 401 means the server is reachable but requires auth — that's success.
+      if (err instanceof ConnectAPIError && err.httpStatus === 401) {
         return;
       }
       throw err;
     }
   };
 
-  // 4. Discover server URL
+  const discovery = await discoverServerURL(params.url, tester);
+
+  if (discovery.error === undefined) {
+    return {
+      user: null,
+      url: discovery.url,
+      serverType: st,
+      error: null,
+    };
+  }
+
+  return {
+    user: null,
+    url: params.url,
+    serverType: st,
+    error: toAgentError(discovery.error),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// testAuthentication — verify credentials authenticate successfully
+// ---------------------------------------------------------------------------
+
+export interface TestAuthenticationParams {
+  url: string;
+  apiKey: string;
+  snowflakeToken?: string;
+  insecure: boolean;
+  timeout?: number;
+}
+
+export async function testAuthentication(
+  params: TestAuthenticationParams,
+): Promise<TestResult> {
+  let st: ServerType;
+  try {
+    st = serverTypeFromURL(params.url);
+  } catch (err) {
+    return {
+      user: null,
+      url: null,
+      serverType: null,
+      error: toAgentError(err),
+    };
+  }
+
+  let lastUser: User | null = null;
+  const timeoutMs = Math.max(params.timeout ?? 30, 30) * 1000;
+
+  const tester = async (urlToTest: string): Promise<void> => {
+    const auth = params.snowflakeToken
+      ? { snowflakeToken: params.snowflakeToken, apiKey: params.apiKey }
+      : { apiKey: params.apiKey };
+    const client = new ConnectAPI({
+      url: urlToTest,
+      ...auth,
+      rejectUnauthorized: !params.insecure,
+      timeout: timeoutMs,
+    });
+
+    const result = await client.testAuthentication();
+    lastUser = result.user;
+  };
+
   const discovery = await discoverServerURL(params.url, tester);
 
   if (discovery.error === undefined) {

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -1430,11 +1430,12 @@ describe("Token authentication", () => {
 // Snowflake authentication
 // ---------------------------------------------------------------------------
 
-describe("Snowflake authentication", () => {
-  it("sets Snowflake authorization header", () => {
+describe("Snowflake + API key authentication", () => {
+  it("sets both Snowflake Authorization and X-RSC-Authorization headers", () => {
     new ConnectAPI({
       url: BASE_URL,
       snowflakeToken: "sf-session-token-abc",
+      apiKey: "connect-api-key-123",
     });
 
     expect(axios.create).toHaveBeenCalledWith(
@@ -1442,6 +1443,7 @@ describe("Snowflake authentication", () => {
         baseURL: BASE_URL,
         headers: expect.objectContaining({
           Authorization: 'Snowflake Token="sf-session-token-abc"',
+          "X-RSC-Authorization": "Key connect-api-key-123",
         }),
       }),
     );
@@ -1453,11 +1455,57 @@ describe("Snowflake authentication", () => {
     const client = new ConnectAPI({
       url: BASE_URL,
       snowflakeToken: "sf-session-token-abc",
+      apiKey: "connect-api-key-123",
     });
     await client.getCurrentUser();
 
     const config = mockRequest.mock.calls[0][0] as Record<string, unknown>;
     expect(config._signedHeaders).toBeUndefined();
+  });
+});
+
+describe("Snowflake + token authentication", () => {
+  const SF_TOKEN = "sf-session-token-abc";
+  const { privateKeyBase64: SF_PRIVATE_KEY } = generateTestKeyPair();
+  const SF_CONNECT_TOKEN = "Tconnect-token-456";
+
+  it("sets Snowflake Authorization as static header", () => {
+    new ConnectAPI({
+      url: BASE_URL,
+      snowflakeToken: SF_TOKEN,
+      token: SF_CONNECT_TOKEN,
+      privateKey: SF_PRIVATE_KEY,
+    });
+
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: BASE_URL,
+        headers: expect.objectContaining({
+          Authorization: `Snowflake Token="${SF_TOKEN}"`,
+        }),
+      }),
+    );
+  });
+
+  it("adds signing interceptor for Connect token auth", async () => {
+    mockRequest.mockResolvedValue(jsonResponse(validUserDTO()));
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      snowflakeToken: SF_TOKEN,
+      token: SF_CONNECT_TOKEN,
+      privateKey: SF_PRIVATE_KEY,
+    });
+    await client.getCurrentUser();
+
+    const config = mockRequest.mock.calls[0][0] as Record<string, unknown>;
+    const signedHeaders = config._signedHeaders as Record<string, string>;
+
+    expect(signedHeaders).toBeDefined();
+    expect(signedHeaders["X-Auth-Token"]).toBe(SF_CONNECT_TOKEN);
+    expect(signedHeaders["X-Auth-Signature"]).toBeDefined();
+    expect(signedHeaders["X-Content-Checksum"]).toBeDefined();
+    expect(signedHeaders["Date"]).toBeDefined();
   });
 });
 
@@ -1512,9 +1560,33 @@ describe("Constructor validation", () => {
     ).not.toThrow();
   });
 
-  it("accepts snowflakeToken auth", () => {
+  it("accepts snowflakeToken + apiKey auth", () => {
     expect(
-      () => new ConnectAPI({ url: BASE_URL, snowflakeToken: "sf-token" }),
+      () =>
+        new ConnectAPI({
+          url: BASE_URL,
+          snowflakeToken: "sf-token",
+          apiKey: "connect-key",
+        }),
+    ).not.toThrow();
+  });
+
+  it("accepts snowflakeToken + token+privateKey auth", () => {
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privateKeyBase64 = Buffer.from(
+      privateKey.export({ format: "der", type: "pkcs1" }),
+    ).toString("base64");
+
+    expect(
+      () =>
+        new ConnectAPI({
+          url: BASE_URL,
+          snowflakeToken: "sf-token",
+          token: "Ttoken123",
+          privateKey: privateKeyBase64,
+        }),
     ).not.toThrow();
   });
 });

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -77,6 +77,7 @@ export class ConnectAPI {
   constructor(options: ConnectAPIOptions) {
     const hasApiKey = !!options.apiKey;
     const hasToken = !!options.token && !!options.privateKey;
+    const hasSnowflake = !!options.snowflakeToken;
 
     // Allow no credentials (for URL reachability checks), but reject
     // partial token auth (token without privateKey or vice versa).
@@ -90,15 +91,16 @@ export class ConnectAPI {
       baseURL: options.url,
     };
 
-    if (hasApiKey) {
-      config.headers = {
-        Authorization: `Key ${options.apiKey}`,
-      };
-    }
-
-    if (options.snowflakeToken) {
+    if (hasSnowflake) {
       config.headers = {
         Authorization: `Snowflake Token="${options.snowflakeToken}"`,
+      };
+      if (hasApiKey) {
+        config.headers["X-RSC-Authorization"] = `Key ${options.apiKey}`;
+      }
+    } else if (hasApiKey) {
+      config.headers = {
+        Authorization: `Key ${options.apiKey}`,
       };
     }
 

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -44,22 +44,39 @@ interface TokenAuth extends ConnectAPIBaseOptions {
   snowflakeToken?: never;
 }
 
-interface SnowflakeAuth extends ConnectAPIBaseOptions {
-  apiKey?: never;
-  token?: never;
-  privateKey?: never;
+interface SnowflakeApiKeyAuth extends ConnectAPIBaseOptions {
   /** Pre-computed Snowflake session token for Snowflake-proxied Connect servers. */
   snowflakeToken: string;
+  /** Connect API key, sent via X-RSC-Authorization header. */
+  apiKey: string;
+  token?: never;
+  privateKey?: never;
+}
+
+interface SnowflakeTokenAuth extends ConnectAPIBaseOptions {
+  /** Pre-computed Snowflake session token for Snowflake-proxied Connect servers. */
+  snowflakeToken: string;
+  apiKey?: never;
+  /** Token ID for Connect token-based authentication (RSA key-pair signing). */
+  token: string;
+  /** Base64-encoded DER PKCS#1 RSA private key for Connect token-based authentication. */
+  privateKey: string;
 }
 
 interface NoAuth extends ConnectAPIBaseOptions {
   apiKey?: never;
   token?: never;
   privateKey?: never;
-  snowflakeToken?: never;
+  /** Optional Snowflake token for legacy credentials without Connect auth. */
+  snowflakeToken?: string;
 }
 
-export type ConnectAPIOptions = ApiKeyAuth | TokenAuth | SnowflakeAuth | NoAuth;
+export type ConnectAPIOptions =
+  | ApiKeyAuth
+  | TokenAuth
+  | SnowflakeApiKeyAuth
+  | SnowflakeTokenAuth
+  | NoAuth;
 
 // ---------------------------------------------------------------------------
 // User types

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -67,7 +67,10 @@ interface NoAuth extends ConnectAPIBaseOptions {
   apiKey?: never;
   token?: never;
   privateKey?: never;
-  /** Optional Snowflake token for legacy credentials without Connect auth. */
+  /** Optional Snowflake token for legacy credentials without Connect auth.
+   *  These will not work, but still need to be loadable for users to transition
+   *  to new credentials with Connect auth.
+   */
   snowflakeToken?: string;
 }
 


### PR DESCRIPTION
## Summary

Fix publishing to Connect in SPCS _from Publisher outside of SPCS_

- Adds dual-header authentication for Snowflake SPCS: `Authorization: Snowflake Token="..."` for the ingress proxy plus `X-RSC-Authorization: Key <apiKey>` or token-signing headers for Connect
- Updates the credential wizard to collect Snowflake connection first (needed to reach Connect through the proxy), then prompt for Connect auth method (API key or token)
- Legacy snowflake-only credentials remain loadable for display/deletion but will fail auth at request time 
 
Closes #3465

## Approach

Users publishing to Connect in SPCS from a Publisher outside of SPCS need to provide two forms of authentication: Snowflake and Connect. So, which should come first in the new credentials wizard? I opted to put Snowflake first to enable support for Connect token auth, which requires being able to get through the Snowflake ingress in order to reach Connect and set up the token.

- user enters a Snowflake server URL
- Publisher reads Snowflake connections.toml and narrows down the list of options by trying to connect to each one: if we get a 401, we assume the connection worked and Connect then rejected it for being unauthorized. This weeds out some forms of bad Snowflake config, and in any case I expect most users will only have one connection set up anyway, so I'm not too worried about bad connection configs getting through.
- User selects which Snowflake connection they want to use and then picks API Key or Token Auth. Credential setup proceeds as normal, except when we make requests to Connect we include a Snowflake token.

## Related

This PR also fixes a bug in wizard navigation: if for some reason a user completes token auth setup, but then navigates back and enters an API Key instead, this would previously have failed (tried to create a credential with both token and API key auth). Now we reset state so this failure doesn't happen.

Previously we were using `testCredential` in two places:
- server URL validation (expects authentication failure)
- auth validation

This seemed confusing to me, especially with the changes I had to make for snowflake, so I split this into two separate functions, one for each purpose.

## Test plan

- [x] Unit tests pass (1677 passed)
- [x] Manual: create new Snowflake credential with API key on dogfood SPCS instance
- [x] Manual: create new Snowflake credential with token auth on dogfood SPCS instance
- [x] Manual: verify legacy snowflake-only credential loads without crashing
- [x] Manual: verify Snowflake discovery works without Connect auth (401-as-success)
- [x] Manual: verify wizard back-navigation clears stale auth fields

