### PR TITLE
fix: remove content_category entrypoint heuristic that breaks re-deploys

### DIFF
--- a/extensions/vscode/src/bundler/bundler.test.ts
+++ b/extensions/vscode/src/bundler/bundler.test.ts
@@ -419,7 +419,7 @@ describe("createBundle", () => {
 });
 
 describe("pre-rendered Quarto website bundle", () => {
-  it("sets content_category to 'site' in the archived manifest for HTML with subdirectory entrypoint", async () => {
+  it("does not set content_category from entrypoint path", async () => {
     // Simulate a pre-rendered Quarto website: output lives under _site/
     makeFile("_site/index.html", "<html><body>Home</body></html>");
     makeFile(
@@ -428,7 +428,6 @@ describe("pre-rendered Quarto website bundle", () => {
     );
     makeFile("_site/site_libs/revealjs/reveal.js", "/* reveal.js library */");
 
-    // Build manifest from config the same way connectPublish does
     const manifest = manifestFromConfig({
       $schema: "" as never,
       productType: ProductType.CONNECT,
@@ -444,43 +443,18 @@ describe("pre-rendered Quarto website bundle", () => {
       filePatterns: ["/_site"],
     });
 
-    // The archived manifest.json should have content_category: "site"
     const entries = await extractTarEntries(result.bundle);
     const archivedManifest = JSON.parse(
       entries.get("manifest.json")!.data.toString(),
     );
-    expect(archivedManifest.metadata.content_category).toBe("site");
+    // content_category should NOT be set from entrypoint path alone
+    expect(archivedManifest.metadata.content_category).toBeUndefined();
     expect(archivedManifest.metadata.appmode).toBe("static");
     expect(archivedManifest.metadata.primary_html).toBe("_site/index.html");
 
-    // All site files should be present in the bundle
+    // All site files should still be present in the bundle
     expect(entries.has("_site/index.html")).toBe(true);
     expect(entries.has("_site/slides.html")).toBe(true);
     expect(entries.has("_site/site_libs/revealjs/reveal.js")).toBe(true);
-  });
-
-  it("does not set content_category for single-file HTML deployment", async () => {
-    makeFile("index.html", "<html><body>Single page</body></html>");
-
-    const manifest = manifestFromConfig({
-      $schema: "" as never,
-      productType: ProductType.CONNECT,
-      type: ContentType.HTML,
-      entrypoint: "index.html",
-      validate: true,
-      files: ["/index.html"],
-    });
-
-    const result = await createBundle({
-      projectPath: tmpDir,
-      manifest,
-      filePatterns: ["/index.html"],
-    });
-
-    const entries = await extractTarEntries(result.bundle);
-    const archivedManifest = JSON.parse(
-      entries.get("manifest.json")!.data.toString(),
-    );
-    expect(archivedManifest.metadata.content_category).toBeUndefined();
   });
 });

--- a/extensions/vscode/src/bundler/manifestFromConfig.test.ts
+++ b/extensions/vscode/src/bundler/manifestFromConfig.test.ts
@@ -394,60 +394,11 @@ describe("manifestFromConfig", () => {
   });
 
   describe("content_category", () => {
-    it("sets content_category to 'site' for HTML with _site/ entrypoint", () => {
+    it("does not set content_category from entrypoint path", () => {
       const m = manifestFromConfig(
         minimalConfig({
           type: ContentType.HTML,
           entrypoint: "_site/index.html",
-        }),
-      );
-      expect(m.metadata.content_category).toBe("site");
-    });
-
-    it("sets content_category to 'site' for HTML with _book/ entrypoint", () => {
-      const m = manifestFromConfig(
-        minimalConfig({
-          type: ContentType.HTML,
-          entrypoint: "_book/index.html",
-        }),
-      );
-      expect(m.metadata.content_category).toBe("site");
-    });
-
-    it("does not set content_category for HTML with flat entrypoint", () => {
-      const m = manifestFromConfig(
-        minimalConfig({
-          type: ContentType.HTML,
-          entrypoint: "index.html",
-        }),
-      );
-      expect(m.metadata.content_category).toBeUndefined();
-    });
-
-    it("does not set content_category for HTML in an arbitrary subdirectory", () => {
-      const m = manifestFromConfig(
-        minimalConfig({
-          type: ContentType.HTML,
-          entrypoint: "subdir/single-page.html",
-        }),
-      );
-      expect(m.metadata.content_category).toBeUndefined();
-    });
-
-    it("does not set content_category for non-HTML types with _site/ entrypoint", () => {
-      const m = manifestFromConfig(
-        minimalConfig({
-          type: ContentType.QUARTO_STATIC,
-          entrypoint: "_site/index.html",
-        }),
-      );
-      expect(m.metadata.content_category).toBeUndefined();
-    });
-
-    it("does not set content_category when entrypoint is undefined", () => {
-      const m = manifestFromConfig(
-        minimalConfig({
-          type: ContentType.HTML,
         }),
       );
       expect(m.metadata.content_category).toBeUndefined();

--- a/extensions/vscode/src/bundler/manifestFromConfig.ts
+++ b/extensions/vscode/src/bundler/manifestFromConfig.ts
@@ -25,7 +25,6 @@ export function manifestFromConfig(cfg: ConfigurationDetails): Manifest {
       appmode,
       entrypoint: cfg.entrypoint,
       ...primaryField(cfg.type, cfg.entrypoint),
-      ...contentCategoryField(cfg),
       // false is omitted so it doesn't appear in manifest.json
       has_parameters: cfg.hasParameters || undefined,
     },
@@ -115,28 +114,4 @@ function primaryField(
     default:
       return undefined;
   }
-}
-
-// Known Quarto output directories that indicate a pre-rendered multi-page site.
-const quartoSiteOutputDirs = new Set(["_site", "_book"]);
-
-// Detect multi-page site content for the manifest's content_category field.
-// When an HTML deployment's entrypoint lives inside a known Quarto output
-// directory (e.g. "_site/index.html" or "_book/index.html"), the content is a
-// pre-rendered multi-page site. Connect uses content_category="site" to serve
-// all files in the bundle rather than only the entrypoint.
-//
-// Only known Quarto output directories trigger this — an arbitrary subdirectory
-// (e.g. "subdir/page.html") does not, to avoid false positives for standalone
-// HTML files that happen to be nested.
-function contentCategoryField(
-  cfg: ConfigurationDetails,
-): { content_category: string } | undefined {
-  if (cfg.type === ContentType.HTML && cfg.entrypoint) {
-    const parts = cfg.entrypoint.split("/");
-    if (parts.length > 1 && quartoSiteOutputDirs.has(parts[0]!)) {
-      return { content_category: "site" };
-    }
-  }
-  return undefined;
 }


### PR DESCRIPTION
## Summary

Fixes #4110 — Re-deploying static HTML content fails with Connect error 110: *"You cannot change the categorization of content once deployed."*

### Root cause

The `contentCategoryField` heuristic added in #4048 sets `content_category: "site"` in the deployment manifest whenever the entrypoint path starts with `_site/` or `_book/`. This causes a regression for any content originally deployed **without** `content_category` (e.g., by an older Publisher version using the Go bundler, or by the TS bundler before #4048). Connect locks `content_category` after first deploy and rejects any change with error 110.

### Investigation

We tested `content_category: "site"` against both **standard Connect** and **Connect Cloud**:

**Standard Connect** — deployed identical multi-page Quarto site bundles (including revealjs presentations) with and without `content_category: "site"`:
- Sub-page navigation: Works identically with and without `content_category`
- Revealjs rendering: Works identically with and without `content_category`
- Re-deploy with changed category: Reproduces error 110 as reported

**Connect Cloud** — deployed a multi-page Quarto site (including revealjs) without `content_category: "site"`:
- Sub-page navigation and revealjs rendering work correctly

`content_category: "site"` has no observable effect on content serving behavior for `app_mode: "static"` on either platform.

### Fix

- Removed the `contentCategoryField` entrypoint-path heuristic from `manifestFromConfig.ts`
- The `_site.yml` / `_bookdown.yml` file detection in `manifest.ts` (carried over from the original Go implementation) is **preserved** — this only triggers when those config files are actually present in the bundle

## Test plan

- [x] Unit tests updated in `manifestFromConfig.test.ts` — confirms `content_category` is not set from entrypoint path
- [x] Integration test updated in `bundler.test.ts` — confirms bundle for `_site/` entrypoint does not include `content_category`
- [x] `manifest.test.ts` unchanged — `_site.yml`/`_bookdown.yml` detection still works
- [x] All 93 bundler tests pass
- [x] Lint passes
- [x] Manual testing: deployed multi-page Quarto sites (with revealjs) to Connect and Connect Cloud without `content_category` — all pages serve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)