### PR TITLE
fix: resolve GHA security audit failures and improve audit output

### DIFF
--- a/.github/workflows/ci-failure-analysis.yaml
+++ b/.github/workflows/ci-failure-analysis.yaml
@@ -16,6 +16,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   analyze-failure:
     # Run when CI fails or is cancelled on main, OR when manually triggered with a run_id.

--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   auto-review:
     # Skip draft PRs, Dependabot PRs, and release PRs opened by bots

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   claude-code-action:
     # NOTE: contains() is a substring match, so '@claude' will also match

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -13,6 +13,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare release PR

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - ".github/workflows/**"
       - "scripts/audit_gha_security.py"
+  schedule:
+    - cron: "0 14 * * 1" # Every Monday at 9am ET
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,12 +1,23 @@
 name: Security Audit
+
 on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/audit_gha_security.py"
   workflow_dispatch:
+
 permissions:
   contents: read
+
 jobs:
   audit:
     name: Audit GitHub Actions Security
     runs-on: ubuntu-latest
+    outputs:
+      has_errors: ${{ steps.run-audit.outputs.has_errors }}
+      json_results: ${{ steps.run-audit.outputs.json_results }}
     steps:
       - uses: actions/checkout@v6
 
@@ -16,4 +27,95 @@ jobs:
           python-version: "3.12"
 
       - name: Run security audit
-        run: python scripts/audit_gha_security.py
+        id: run-audit
+        run: |
+          # Run audit and capture JSON output for downstream use
+          JSON_OUTPUT=$(python scripts/audit_gha_security.py --format json)
+          HAS_ERRORS=$(echo "$JSON_OUTPUT" | jq -r '.summary.has_errors')
+          echo "has_errors=$HAS_ERRORS" >> "$GITHUB_OUTPUT"
+
+          # Store JSON results (escaped for GH output)
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "json_results<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "$JSON_OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
+
+          # Run again in text mode for human-readable logs
+          python scripts/audit_gha_security.py || true
+
+          # Fail the step if there are errors
+          if [ "$HAS_ERRORS" = "true" ]; then
+            echo "::error::Security audit found errors that must be fixed"
+            exit 1
+          fi
+
+  auto-fix:
+    name: Auto-fix security issues
+    needs: audit
+    if: failure() && needs.audit.outputs.has_errors == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Check actor has write permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERMISSION=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "::error::Actor ${{ github.actor }} has '$PERMISSION' permission, requires 'write' or 'admin'"
+            exit 1
+          fi
+          echo "Actor ${{ github.actor }} authorized with '$PERMISSION' permission"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Sanitize role session name
+        id: session-name
+        env:
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          echo "value=$(echo "${TRIGGERING_ACTOR}" | sed 's/[^a-zA-Z0-9_+=,.@-]/_/g')" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.CLAUDE_CODE_AWS_ROLE_ARN }}
+          role-session-name: ${{ steps.session-name.outputs.value }}
+          aws-region: us-east-2
+
+      - name: Fix security issues with Claude
+        uses: anthropics/claude-code-action@v1.0.92
+        with:
+          use_bedrock: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch_prefix: "fix/gha-security-"
+          create_pull_request: true
+          prompt: |
+            The GitHub Actions security audit has failed on main. Your job is to fix
+            ALL errors identified by the audit. Do NOT fix warnings — only errors.
+
+            Here are the audit results in JSON:
+            ```json
+            ${{ needs.audit.outputs.json_results }}
+            ```
+
+            Instructions:
+            1. Read the audit script at scripts/audit_gha_security.py to understand what each check looks for.
+            2. Fix each error by editing the appropriate workflow file(s) in .github/workflows/.
+            3. After making fixes, run `python3 scripts/audit_gha_security.py` to verify 0 errors remain.
+            4. Only fix errors — do not refactor, add features, or address warnings.
+
+            Common fixes:
+            - "Missing top-level 'permissions:' block" → Add `permissions: contents: read` after the `on:` block
+            - "Uses untrusted input directly in run: block" → Move the expression to an `env:` variable and reference via $VAR_NAME
+            - "Uses secrets inherit pattern" → Pass individual secrets explicitly instead of inheriting all
+            - "Uses PR target event with PR checkout" → Avoid checking out PR code in privileged context
+          claude_args: |
+            --model us.anthropic.claude-sonnet-4-5-20241022-v2:0
+            --allowedTools Bash,Read,Write,Edit

--- a/.github/workflows/tag-on-release-merge.yaml
+++ b/.github/workflows/tag-on-release-merge.yaml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   tag:
     name: Create release tag

--- a/scripts/audit_gha_security.py
+++ b/scripts/audit_gha_security.py
@@ -96,7 +96,8 @@ class Output:
                     location += f",line={line}"
             print(f"::error{location}::{message}")
         else:
-            print(f"{self._color(self.RED, '✗ ERROR:')} {message}")
+            location = self._format_location(file, line)
+            print(f"{self._color(self.RED, '✗ ERROR:')} {location}{message}")
 
     def warning(self, message: str, file: Optional[str] = None, line: Optional[int] = None) -> None:
         if self.github_actions:
@@ -107,7 +108,16 @@ class Output:
                     location += f",line={line}"
             print(f"::warning{location}::{message}")
         else:
-            print(f"{self._color(self.YELLOW, '⚠ WARNING:')} {message}")
+            location = self._format_location(file, line)
+            print(f"{self._color(self.YELLOW, '⚠ WARNING:')} {location}{message}")
+
+    def _format_location(self, file: Optional[str], line: Optional[int]) -> str:
+        """Format file:line prefix for local output."""
+        if not file:
+            return ""
+        if line:
+            return f"{file}:{line} — "
+        return f"{file} — "
 
     def success(self, message: str) -> None:
         if self.github_actions:
@@ -495,21 +505,62 @@ def check_dangerous_patterns(
         content = workflow.read_text()
         filename = workflow.name
 
-        # Check for direct use of untrusted input
-        match = untrusted_input_pattern.search(content)
-        if match:
-            line_num = find_line_number(content, match.group(0))
-            finding = Finding(
-                level="error",
-                check="dangerous-patterns",
-                file=filename,
-                message="Potentially uses untrusted input directly (possible injection)",
-                line=line_num,
-                suggestion="Use an intermediate environment variable to sanitize input",
-            )
-            result.errors.append(finding)
-            out.error(finding.message, file=filename, line=line_num)
-            dangerous_found = True
+        # Check for direct use of untrusted input in run: blocks (not env: assignments)
+        # Using untrusted input in env: is the SAFE pattern (intermediate variable)
+        lines = content.splitlines()
+        in_run_block = False
+        run_indent = 0
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip())
+
+            # Detect start of run: block (multiline with |)
+            if re.match(r"(-\s+)?run:\s*\|", stripped):
+                in_run_block = True
+                run_indent = indent
+                continue
+
+            # Detect inline run: (single line, e.g. `- run: echo "..."`)
+            inline_run_match = re.match(r"(-\s+)?run:\s+(?!\|)", stripped)
+            if inline_run_match:
+                match = untrusted_input_pattern.search(line)
+                if match:
+                    finding = Finding(
+                        level="error",
+                        check="dangerous-patterns",
+                        file=filename,
+                        message="Potentially uses untrusted input directly in run: block (possible injection)",
+                        line=i,
+                        suggestion="Use an intermediate environment variable to sanitize input",
+                    )
+                    result.errors.append(finding)
+                    out.error(finding.message, file=filename, line=i)
+                    dangerous_found = True
+                in_run_block = False
+                continue
+
+            # If we're in a multiline run block, check if we've exited
+            if in_run_block:
+                # Empty lines are part of the block
+                if not stripped:
+                    continue
+                # If indentation is at or below the run: key level, we've left the block
+                if indent <= run_indent:
+                    in_run_block = False
+                else:
+                    match = untrusted_input_pattern.search(line)
+                    if match:
+                        finding = Finding(
+                            level="error",
+                            check="dangerous-patterns",
+                            file=filename,
+                            message="Potentially uses untrusted input directly in run: block (possible injection)",
+                            line=i,
+                            suggestion="Use an intermediate environment variable to sanitize input",
+                        )
+                        result.errors.append(finding)
+                        out.error(finding.message, file=filename, line=i)
+                        dangerous_found = True
 
         # Check for pull_request_target with checkout of PR code
         if "pull_request_target" in content:
@@ -650,16 +701,40 @@ def main() -> int:
         return 1 if result.has_errors else 0
 
     # Summary
-    print("=" * 40)
+    print("=" * 60)
     print("Audit Summary")
-    print("=" * 40)
+    print("=" * 60)
     if use_colors:
         print(f"Errors:   {Output.RED}{result.error_count}{Output.NC}")
         print(f"Warnings: {Output.YELLOW}{result.warning_count}{Output.NC}")
+        print(f"Passed:   {Output.GREEN}{len(result.passed)}{Output.NC}")
     else:
         print(f"Errors:   {result.error_count}")
         print(f"Warnings: {result.warning_count}")
+        print(f"Passed:   {len(result.passed)}")
     print()
+
+    # Print grouped findings for actionability
+    if result.errors or result.warnings:
+        # Group findings by file
+        findings_by_file: dict[str, list[Finding]] = {}
+        for f in result.errors + result.warnings:
+            findings_by_file.setdefault(f.file, []).append(f)
+
+        print("Findings by file:")
+        print("-" * 60)
+        for fname in sorted(findings_by_file.keys()):
+            print(f"  {fname}:")
+            for f in findings_by_file[fname]:
+                level_str = (
+                    out._color(Output.RED, "ERROR") if f.level == "error"
+                    else out._color(Output.YELLOW, "WARN")
+                )
+                loc = f":{f.line}" if f.line else ""
+                print(f"    [{level_str}] {f.message} ({f.check}{loc})")
+                if f.suggestion:
+                    print(f"           Fix: {f.suggestion}")
+            print()
 
     # GitHub Actions outputs and summary
     if is_github_actions:

--- a/scripts/audit_gha_security.py
+++ b/scripts/audit_gha_security.py
@@ -82,7 +82,7 @@ class Output:
     YELLOW = "\033[1;33m"
     NC = "\033[0m"
 
-    def _color(self, color: str, text: str) -> str:
+    def color(self, color: str, text: str) -> str:
         if self.use_colors:
             return f"{color}{text}{self.NC}"
         return text
@@ -97,7 +97,7 @@ class Output:
             print(f"::error{location}::{message}")
         else:
             location = self._format_location(file, line)
-            print(f"{self._color(self.RED, '✗ ERROR:')} {location}{message}")
+            print(f"{self.color(self.RED, '✗ ERROR:')} {location}{message}")
 
     def warning(self, message: str, file: Optional[str] = None, line: Optional[int] = None) -> None:
         if self.github_actions:
@@ -109,7 +109,7 @@ class Output:
             print(f"::warning{location}::{message}")
         else:
             location = self._format_location(file, line)
-            print(f"{self._color(self.YELLOW, '⚠ WARNING:')} {location}{message}")
+            print(f"{self.color(self.YELLOW, '⚠ WARNING:')} {location}{message}")
 
     def _format_location(self, file: Optional[str], line: Optional[int]) -> str:
         """Format file:line prefix for local output."""
@@ -123,7 +123,7 @@ class Output:
         if self.github_actions:
             print(f"::notice::{message}")
         else:
-            print(f"{self._color(self.GREEN, '✓')} {message}")
+            print(f"{self.color(self.GREEN, '✓')} {message}")
 
     def info(self, message: str) -> None:
         print(f"  {message}")
@@ -514,8 +514,8 @@ def check_dangerous_patterns(
             stripped = line.strip()
             indent = len(line) - len(line.lstrip())
 
-            # Detect start of run: block (multiline with |)
-            if re.match(r"(-\s+)?run:\s*\|", stripped):
+            # Detect start of run: block (multiline with |, |+, or |-)
+            if re.match(r"(-\s+)?run:\s*\|[-+]?", stripped):
                 in_run_block = True
                 run_indent = indent
                 continue
@@ -727,8 +727,8 @@ def main() -> int:
             print(f"  {fname}:")
             for f in findings_by_file[fname]:
                 level_str = (
-                    out._color(Output.RED, "ERROR") if f.level == "error"
-                    else out._color(Output.YELLOW, "WARN")
+                    out.color(Output.RED, "ERROR") if f.level == "error"
+                    else out.color(Output.YELLOW, "WARN")
                 )
                 loc = f":{f.line}" if f.line else ""
                 print(f"    [{level_str}] {f.message} ({f.check}{loc})")

--- a/scripts/test_audit_gha_security.py
+++ b/scripts/test_audit_gha_security.py
@@ -672,6 +672,100 @@ jobs:
 
             self.assertEqual(len(result.errors), 1)
 
+    def test_safe_env_assignment_not_flagged(self):
+        """Using untrusted input in env: (intermediate variable) is the safe pattern."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow = create_workflow(
+                Path(tmpdir),
+                "safe.yaml",
+                """name: Safe
+on:
+  issues:
+    types: [opened]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          echo "$ISSUE_TITLE"
+          echo "$ISSUE_BODY"
+""",
+            )
+            result = AuditResult()
+            out = create_silent_output()
+
+            sys.stdout = io.StringIO()
+            check_dangerous_patterns([workflow], result, out)
+            sys.stdout = sys.__stdout__
+
+            self.assertEqual(len(result.errors), 0)
+
+    def test_fails_on_untrusted_input_in_multiline_run(self):
+        """Untrusted input directly in a multiline run: | block should be flagged."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow = create_workflow(
+                Path(tmpdir),
+                "bad.yaml",
+                """name: Bad
+on:
+  issues:
+    types: [opened]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dangerous
+        run: |
+          echo "Title: ${{ github.event.issue.title }}"
+          echo "done"
+""",
+            )
+            result = AuditResult()
+            out = create_silent_output()
+
+            sys.stdout = io.StringIO()
+            check_dangerous_patterns([workflow], result, out)
+            sys.stdout = sys.__stdout__
+
+            self.assertEqual(len(result.errors), 1)
+            self.assertIn("untrusted input", result.errors[0].message)
+
+    def test_mixed_safe_env_and_unsafe_run(self):
+        """Workflow with safe env: usage in one step and unsafe run: in another."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow = create_workflow(
+                Path(tmpdir),
+                "mixed.yaml",
+                """name: Mixed
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Safe step
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+        run: echo "$COMMENT"
+      - name: Unsafe step
+        run: echo "${{ github.event.comment.body }}"
+""",
+            )
+            result = AuditResult()
+            out = create_silent_output()
+
+            sys.stdout = io.StringIO()
+            check_dangerous_patterns([workflow], result, out)
+            sys.stdout = sys.__stdout__
+
+            self.assertEqual(len(result.errors), 1)
+            self.assertIn("untrusted input", result.errors[0].message)
+
     def test_warns_on_pull_request_target(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             workflow = create_workflow(


### PR DESCRIPTION
## Summary

- Fix all 6 errors identified by the GHA security audit CI run ([job link](https://github.com/posit-dev/publisher/actions/runs/25385718435/job/74446121382))
- Improve audit script output for human readability
- Add auto-fix capability: when the audit fails on main, Claude automatically opens a PR with fixes

## Changes

### Fixes for CI errors
- Added missing top-level `permissions: contents: read` to 5 workflows: `ci-failure-analysis`, `claude-auto-review`, `claude`, `prepare-release`, `tag-on-release-merge`
- Fixed false positive in dangerous-patterns check — the script was flagging `${{ github.event.issue.title }}` in `env:` blocks, which is actually the *safe* pattern (intermediate env var). Now only flags untrusted input used directly in `run:` blocks.

### Improved audit output
- Errors and warnings now show the filename and line number in local (non-CI) output
- Added a grouped "Findings by file" summary at the end with check names and actionable fix suggestions

### Auto-fix workflow
- `security-audit.yaml` now triggers on pushes to main (when workflow files or the audit script change)
- New `auto-fix` job runs only when: the audit fails with errors AND the push was to main
- Invokes Claude Code Action to fix the errors and open a PR on a `fix/gha-security-*` branch
- Includes write-permission gate before invoking Claude (matches pattern in `claude.yaml`)

## Test plan

- [x] `python3 scripts/audit_gha_security.py` exits 0 locally
- [x] All 34 existing audit tests pass (`python3 -m pytest scripts/test_audit_gha_security.py`)
- [ ] Security audit CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)