### PR TITLE
feat(detector): add NodejsAppDetector for Node.js project detection

### DIFF
--- a/extensions/vscode/src/inspect/detectorRunner.ts
+++ b/extensions/vscode/src/inspect/detectorRunner.ts
@@ -17,6 +17,7 @@ import {
   newStreamlitDetector,
   newBokehDetector,
 } from "./detectors/pythonApp";
+import { NodejsAppDetector } from "./detectors/nodejs";
 import { StaticHTMLDetector } from "./detectors/html";
 import { PlumberDetector } from "./detectors/plumber";
 import { RMarkdownDetector } from "./detectors/rmarkdown";
@@ -40,6 +41,7 @@ function createDetectors(): ContentTypeDetector[] {
     newPanelDetector(),
     newStreamlitDetector(),
     newBokehDetector(),
+    new NodejsAppDetector(),
     new StaticHTMLDetector(),
   ];
 }

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -72,6 +72,16 @@ describe("NodejsAppDetector", () => {
         ]);
       }
     });
+
+    test("caller-provided entrypoint wins when package.json main points elsewhere", async () => {
+      writePackageJson({ main: "other.js" });
+      writeFile("other.js", "");
+      writeFile("server.js", "");
+      const configs = await detector.inferType(baseDir, "server.js");
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "server.js" },
+      ]);
+    });
   });
 
   describe("package.json main field", () => {
@@ -209,6 +219,30 @@ describe("NodejsAppDetector", () => {
         { type: ContentType.NODEJS, entrypoint: "server.js" },
       ]);
     });
+
+    test("falls through from missing main to scripts.start", async () => {
+      writePackageJson({
+        main: "missing.js",
+        scripts: { start: "node app.js" },
+      });
+      writeFile("app.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "app.js" },
+      ]);
+    });
+
+    test("matches node within ts-node (mirrors Connect parity)", async () => {
+      writePackageJson({ scripts: { start: "ts-node app.ts" } });
+      writeFile("app.ts", "");
+      const configs = await detector.inferType(baseDir);
+      // The \bnode\s+ regex finds the boundary between '-' and 'n', so this
+      // emits app.ts. Mirrors run_app.js exactly. If Connect's behavior changes,
+      // this test should fail loudly so the detector can be re-aligned.
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "app.ts" },
+      ]);
+    });
   });
 
   describe("conventional file fallback", () => {
@@ -286,6 +320,15 @@ describe("NodejsAppDetector", () => {
       const configs = await detector.inferType(baseDir);
       expect(configs).toEqual([
         { type: ContentType.NODEJS, entrypoint: "index.js" },
+      ]);
+    });
+
+    test("falls through from non-node scripts.start to conventional fallback", async () => {
+      writePackageJson({ scripts: { start: "nodemon app.js" } });
+      writeFile("server.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "server.js" },
       ]);
     });
   });

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { NodejsAppDetector } from "./nodejs";
+
+const detector = new NodejsAppDetector();
+
+let baseDir: string;
+
+beforeEach(() => {
+  baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "nodejs-detector-"));
+});
+
+afterEach(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+function writeFile(rel: string, contents = ""): void {
+  const abs = path.join(baseDir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+function writePackageJson(json: unknown): void {
+  writeFile("package.json", JSON.stringify(json));
+}
+
+describe("NodejsAppDetector", () => {
+  test("returns [] when there is no package.json and no caller entrypoint", async () => {
+    const configs = await detector.inferType(baseDir);
+    expect(configs).toEqual([]);
+  });
+});

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ContentType } from "src/api/types/configurations";
 import { NodejsAppDetector } from "./nodejs";
 
 const detector = new NodejsAppDetector();
@@ -32,5 +33,44 @@ describe("NodejsAppDetector", () => {
   test("returns [] when there is no package.json and no caller entrypoint", async () => {
     const configs = await detector.inferType(baseDir);
     expect(configs).toEqual([]);
+  });
+
+  describe("caller-provided entrypoint", () => {
+    test("emits config when file exists and extension is valid", async () => {
+      writeFile("server.js", "");
+      const configs = await detector.inferType(baseDir, "server.js");
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "server.js" },
+      ]);
+    });
+
+    test("normalizes ./prefix and subdir paths to forward slashes", async () => {
+      writeFile("src/app.ts", "");
+      const configs = await detector.inferType(baseDir, "./src/app.ts");
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "src/app.ts" },
+      ]);
+    });
+
+    test("returns [] when extension is not a valid Node.js extension", async () => {
+      writeFile("app.py", "");
+      const configs = await detector.inferType(baseDir, "app.py");
+      expect(configs).toEqual([]);
+    });
+
+    test("returns [] when file does not exist", async () => {
+      const configs = await detector.inferType(baseDir, "missing.js");
+      expect(configs).toEqual([]);
+    });
+
+    test("accepts every valid extension", async () => {
+      for (const ext of [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"]) {
+        writeFile(`entry${ext}`, "");
+        const configs = await detector.inferType(baseDir, `entry${ext}`);
+        expect(configs).toEqual([
+          { type: ContentType.NODEJS, entrypoint: `entry${ext}` },
+        ]);
+      }
+    });
   });
 });

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -164,16 +164,16 @@ describe("NodejsAppDetector", () => {
 
     test("falls through when start command uses nodemon", async () => {
       writePackageJson({ scripts: { start: "nodemon app.js" } });
-      writeFile("app.js", "");
+      // No fallback files present — should return [] because nodemon isn't
+      // a literal `node` invocation and there is nothing for the fallback to find.
       const configs = await detector.inferType(baseDir);
-      // No fallback files, no main — should return [] because nodemon isn't
-      // a literal `node` invocation.
       expect(configs).toEqual([]);
     });
 
     test("falls through when start command uses npx tsx", async () => {
       writePackageJson({ scripts: { start: "npx tsx app.ts" } });
-      writeFile("app.ts", "");
+      // No fallback files present — should return [] because npx tsx isn't
+      // a literal `node` invocation and there is nothing for the fallback to find.
       const configs = await detector.inferType(baseDir);
       expect(configs).toEqual([]);
     });
@@ -207,6 +207,85 @@ describe("NodejsAppDetector", () => {
       const configs = await detector.inferType(baseDir);
       expect(configs).toEqual([
         { type: ContentType.NODEJS, entrypoint: "server.js" },
+      ]);
+    });
+  });
+
+  describe("conventional file fallback", () => {
+    test("emits server.js when no main or scripts.start", async () => {
+      writePackageJson({});
+      writeFile("server.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "server.js" },
+      ]);
+    });
+
+    test("prefers server.js over app.js", async () => {
+      writePackageJson({});
+      writeFile("server.js", "");
+      writeFile("app.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs[0]?.entrypoint).toBe("server.js");
+    });
+
+    test("prefers app.js over index.js", async () => {
+      writePackageJson({});
+      writeFile("app.js", "");
+      writeFile("index.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs[0]?.entrypoint).toBe("app.js");
+    });
+
+    test("prefers index.js over .ts variants", async () => {
+      writePackageJson({});
+      writeFile("index.js", "");
+      writeFile("server.ts", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs[0]?.entrypoint).toBe("index.js");
+    });
+
+    test("prefers server.ts over app.ts", async () => {
+      writePackageJson({});
+      writeFile("server.ts", "");
+      writeFile("app.ts", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs[0]?.entrypoint).toBe("server.ts");
+    });
+
+    test("prefers app.ts over index.ts", async () => {
+      writePackageJson({});
+      writeFile("app.ts", "");
+      writeFile("index.ts", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs[0]?.entrypoint).toBe("app.ts");
+    });
+
+    test("emits index.ts when it is the only fallback present", async () => {
+      writePackageJson({});
+      writeFile("index.ts", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "index.ts" },
+      ]);
+    });
+
+    test("returns [] when package.json exists but no conventional file is present", async () => {
+      writePackageJson({});
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("works when baseDir contains spaces", async () => {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+      baseDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nodejs detector with spaces "),
+      );
+      writePackageJson({});
+      writeFile("index.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "index.js" },
       ]);
     });
   });

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -129,4 +129,85 @@ describe("NodejsAppDetector", () => {
       expect(configs).toEqual([]);
     });
   });
+
+  describe("package.json scripts.start", () => {
+    test("emits config for simple node <file> command", async () => {
+      writePackageJson({ scripts: { start: "node app.js" } });
+      writeFile("app.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "app.js" },
+      ]);
+    });
+
+    test("ignores flags between node and the file", async () => {
+      writePackageJson({
+        scripts: { start: "node --inspect=9229 -r dotenv/config app.js" },
+      });
+      writeFile("app.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "app.js" },
+      ]);
+    });
+
+    test("matches node even when env vars are prepended", async () => {
+      writePackageJson({
+        scripts: { start: "NODE_ENV=production node app.js" },
+      });
+      writeFile("app.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "app.js" },
+      ]);
+    });
+
+    test("falls through when start command uses nodemon", async () => {
+      writePackageJson({ scripts: { start: "nodemon app.js" } });
+      writeFile("app.js", "");
+      const configs = await detector.inferType(baseDir);
+      // No fallback files, no main — should return [] because nodemon isn't
+      // a literal `node` invocation.
+      expect(configs).toEqual([]);
+    });
+
+    test("falls through when start command uses npx tsx", async () => {
+      writePackageJson({ scripts: { start: "npx tsx app.ts" } });
+      writeFile("app.ts", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("falls through when start is just `node` with no file", async () => {
+      writePackageJson({ scripts: { start: "node" } });
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("falls through when first arg has unsupported extension", async () => {
+      writePackageJson({ scripts: { start: "node app.txt" } });
+      writeFile("app.txt", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("ignores scripts.start when referenced file does not exist", async () => {
+      writePackageJson({ scripts: { start: "node missing.js" } });
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("prefers main over scripts.start when both resolve", async () => {
+      writePackageJson({
+        main: "server.js",
+        scripts: { start: "node other.js" },
+      });
+      writeFile("server.js", "");
+      writeFile("other.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "server.js" },
+      ]);
+    });
+  });
 });

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -120,4 +120,13 @@ describe("NodejsAppDetector", () => {
       expect(configs).toEqual([]);
     });
   });
+
+  describe("malformed package.json", () => {
+    test("returns [] silently and does NOT fall through to conventional files", async () => {
+      writeFile("package.json", "{ this is not json");
+      writeFile("server.js", ""); // present but should NOT be picked up.
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+  });
 });

--- a/extensions/vscode/src/inspect/detectors/nodejs.test.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.test.ts
@@ -73,4 +73,51 @@ describe("NodejsAppDetector", () => {
       }
     });
   });
+
+  describe("package.json main field", () => {
+    test("emits config when main resolves to an existing file", async () => {
+      writePackageJson({ main: "server.js" });
+      writeFile("server.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "server.js" },
+      ]);
+    });
+
+    test("preserves subdir paths from main", async () => {
+      writePackageJson({ main: "src/index.js" });
+      writeFile("src/index.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "src/index.js" },
+      ]);
+    });
+
+    test("normalizes ./ prefix in main", async () => {
+      writePackageJson({ main: "./dist/server.js" });
+      writeFile("dist/server.js", "");
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([
+        { type: ContentType.NODEJS, entrypoint: "dist/server.js" },
+      ]);
+    });
+
+    test("ignores main when the referenced file does not exist", async () => {
+      writePackageJson({ main: "missing.js" });
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("ignores empty main string", async () => {
+      writePackageJson({ main: "" });
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+
+    test("ignores non-string main", async () => {
+      writePackageJson({ main: 42 });
+      const configs = await detector.inferType(baseDir);
+      expect(configs).toEqual([]);
+    });
+  });
 });

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -2,7 +2,7 @@
 
 import * as path from "path";
 import { ContentType } from "src/api/types/configurations";
-import { fileExistsAt } from "src/interpreters/fsUtils";
+import { fileExistsAt, readFileText } from "src/interpreters/fsUtils";
 import { ContentTypeDetector, PartialConfig } from "../types";
 
 const VALID_EXTENSIONS: ReadonlySet<string> = new Set([
@@ -29,6 +29,35 @@ function makeConfig(baseDir: string, abs: string): PartialConfig {
   };
 }
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function readMain(pkg: unknown): string | undefined {
+  if (!isRecord(pkg)) return undefined;
+  const main = pkg.main;
+  if (typeof main !== "string" || main.length === 0) return undefined;
+  return main;
+}
+
+async function readPackageJson(baseDir: string): Promise<unknown | undefined> {
+  const text = await readFileText(path.join(baseDir, "package.json"));
+  if (text === null) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveCandidate(
+  baseDir: string,
+  candidate: string,
+): Promise<string | undefined> {
+  const abs = path.resolve(baseDir, candidate);
+  return (await fileExistsAt(abs)) ? abs : undefined;
+}
+
 export class NodejsAppDetector implements ContentTypeDetector {
   async inferType(
     baseDir: string,
@@ -43,6 +72,19 @@ export class NodejsAppDetector implements ContentTypeDetector {
         return [];
       }
       return [makeConfig(baseDir, resolved)];
+    }
+
+    const pkg = await readPackageJson(baseDir);
+    if (pkg === undefined) {
+      return [];
+    }
+
+    const main = readMain(pkg);
+    if (main !== undefined) {
+      const resolved = await resolveCandidate(baseDir, main);
+      if (resolved !== undefined) {
+        return [makeConfig(baseDir, resolved)];
+      }
     }
 
     return [];

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -23,14 +23,21 @@ const FALLBACK_FILES: readonly string[] = [
   "index.ts",
 ];
 
+/** True if `filePath` ends with a Node.js source extension we can detect. */
 function hasValidExtension(filePath: string): boolean {
   return VALID_EXTENSIONS.has(path.extname(filePath));
 }
 
+/**
+ * Convert an absolute path to a baseDir-relative path with forward slashes,
+ * regardless of host platform — entrypoints are persisted in TOML and must be
+ * portable across macOS, Linux, and Windows.
+ */
 function toRelForwardSlash(baseDir: string, abs: string): string {
   return path.relative(baseDir, abs).split(path.sep).join("/");
 }
 
+/** Build the detector's output for a resolved Node.js entrypoint. */
 function makeConfig(baseDir: string, abs: string): PartialConfig {
   return {
     type: ContentType.NODEJS,
@@ -38,10 +45,15 @@ function makeConfig(baseDir: string, abs: string): PartialConfig {
   };
 }
 
+/** Type guard narrowing parsed JSON to a plain object before field access. */
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
 }
 
+/**
+ * Read a non-empty string `main` field from a parsed package.json, or
+ * `undefined` if absent or not a usable string.
+ */
 function readMain(pkg: unknown): string | undefined {
   if (!isRecord(pkg)) return undefined;
   const main = pkg.main;
@@ -49,6 +61,10 @@ function readMain(pkg: unknown): string | undefined {
   return main;
 }
 
+/**
+ * Read a non-empty `scripts.start` string from a parsed package.json, or
+ * `undefined` if absent or not a usable string.
+ */
 function readStart(pkg: unknown): string | undefined {
   if (!isRecord(pkg)) return undefined;
   const scripts = pkg.scripts;
@@ -58,6 +74,12 @@ function readStart(pkg: unknown): string | undefined {
   return start;
 }
 
+/**
+ * Find the script file in a `scripts.start` command. Locates `node` (with a
+ * word boundary so `ts-node` also matches — Connect parity, see test) and
+ * returns the first following non-flag argument with a valid extension.
+ * Returns `undefined` if no matching argument is found.
+ */
 function parseStartScript(start: string): string | undefined {
   const match = start.match(/\bnode\s+(.+)/);
   const rest = match?.[1];
@@ -66,6 +88,12 @@ function parseStartScript(start: string): string | undefined {
   return args.find((a) => !a.startsWith("-") && hasValidExtension(a));
 }
 
+/**
+ * Read and parse `<baseDir>/package.json`. Returns `undefined` when the file
+ * is missing or unparseable so the caller treats both as "no package.json
+ * signal" — Connect's runtime warns and falls through, but in detection we
+ * prefer Unknown over guessing.
+ */
 async function readPackageJson(baseDir: string): Promise<unknown> {
   const text = await readFileText(path.join(baseDir, "package.json"));
   if (text === null) return undefined;
@@ -76,6 +104,10 @@ async function readPackageJson(baseDir: string): Promise<unknown> {
   }
 }
 
+/**
+ * Resolve a relative path against `baseDir` and return the absolute path if
+ * the file exists, otherwise `undefined`.
+ */
 async function resolveCandidate(
   baseDir: string,
   candidate: string,

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -14,6 +14,15 @@ const VALID_EXTENSIONS: ReadonlySet<string> = new Set([
   ".cts",
 ]);
 
+const FALLBACK_FILES: readonly string[] = [
+  "server.js",
+  "app.js",
+  "index.js",
+  "server.ts",
+  "app.ts",
+  "index.ts",
+];
+
 function hasValidExtension(filePath: string): boolean {
   return VALID_EXTENSIONS.has(path.extname(filePath));
 }
@@ -111,6 +120,13 @@ export class NodejsAppDetector implements ContentTypeDetector {
         if (resolved !== undefined) {
           return [makeConfig(baseDir, resolved)];
         }
+      }
+    }
+
+    for (const name of FALLBACK_FILES) {
+      const resolved = await resolveCandidate(baseDir, name);
+      if (resolved !== undefined) {
+        return [makeConfig(baseDir, resolved)];
       }
     }
 

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { ContentTypeDetector, PartialConfig } from "../types";
+
+export class NodejsAppDetector implements ContentTypeDetector {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async inferType(
+    baseDir: string,
+    entrypoint?: string,
+  ): Promise<PartialConfig[]> {
+    return [];
+  }
+}

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -60,8 +60,9 @@ function readStart(pkg: unknown): string | undefined {
 
 function parseStartScript(start: string): string | undefined {
   const match = start.match(/\bnode\s+(.+)/);
-  if (!match) return undefined;
-  const args = match[1].trim().split(/\s+/);
+  const rest = match?.[1];
+  if (rest === undefined) return undefined;
+  const args = rest.trim().split(/\s+/);
   return args.find((a) => !a.startsWith("-") && hasValidExtension(a));
 }
 

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -1,13 +1,50 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
+import * as path from "path";
+import { ContentType } from "src/api/types/configurations";
+import { fileExistsAt } from "src/interpreters/fsUtils";
 import { ContentTypeDetector, PartialConfig } from "../types";
 
+const VALID_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".mts",
+  ".cts",
+]);
+
+function hasValidExtension(filePath: string): boolean {
+  return VALID_EXTENSIONS.has(path.extname(filePath));
+}
+
+function toRelForwardSlash(baseDir: string, abs: string): string {
+  return path.relative(baseDir, abs).split(path.sep).join("/");
+}
+
+function makeConfig(baseDir: string, abs: string): PartialConfig {
+  return {
+    type: ContentType.NODEJS,
+    entrypoint: toRelForwardSlash(baseDir, abs),
+  };
+}
+
 export class NodejsAppDetector implements ContentTypeDetector {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async inferType(
     baseDir: string,
     entrypoint?: string,
   ): Promise<PartialConfig[]> {
+    if (entrypoint !== undefined) {
+      if (!hasValidExtension(entrypoint)) {
+        return [];
+      }
+      const resolved = path.resolve(baseDir, entrypoint);
+      if (!(await fileExistsAt(resolved))) {
+        return [];
+      }
+      return [makeConfig(baseDir, resolved)];
+    }
+
     return [];
   }
 }

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -65,7 +65,7 @@ function parseStartScript(start: string): string | undefined {
   return args.find((a) => !a.startsWith("-") && hasValidExtension(a));
 }
 
-async function readPackageJson(baseDir: string): Promise<unknown | undefined> {
+async function readPackageJson(baseDir: string): Promise<unknown> {
   const text = await readFileText(path.join(baseDir, "package.json"));
   if (text === null) return undefined;
   try {

--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -40,6 +40,22 @@ function readMain(pkg: unknown): string | undefined {
   return main;
 }
 
+function readStart(pkg: unknown): string | undefined {
+  if (!isRecord(pkg)) return undefined;
+  const scripts = pkg.scripts;
+  if (!isRecord(scripts)) return undefined;
+  const start = scripts.start;
+  if (typeof start !== "string" || start.length === 0) return undefined;
+  return start;
+}
+
+function parseStartScript(start: string): string | undefined {
+  const match = start.match(/\bnode\s+(.+)/);
+  if (!match) return undefined;
+  const args = match[1].trim().split(/\s+/);
+  return args.find((a) => !a.startsWith("-") && hasValidExtension(a));
+}
+
 async function readPackageJson(baseDir: string): Promise<unknown | undefined> {
   const text = await readFileText(path.join(baseDir, "package.json"));
   if (text === null) return undefined;
@@ -84,6 +100,17 @@ export class NodejsAppDetector implements ContentTypeDetector {
       const resolved = await resolveCandidate(baseDir, main);
       if (resolved !== undefined) {
         return [makeConfig(baseDir, resolved)];
+      }
+    }
+
+    const start = readStart(pkg);
+    if (start !== undefined) {
+      const candidate = parseStartScript(start);
+      if (candidate !== undefined) {
+        const resolved = await resolveCandidate(baseDir, candidate);
+        if (resolved !== undefined) {
+          return [makeConfig(baseDir, resolved)];
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds `NodejsAppDetector`, a 1:1 port of Connect's `resolveEntrypoint` from `nodejs/run_app.js`, so Publisher and Connect agree on which file Connect will run.
- Resolution priority mirrors Connect exactly: caller-provided entrypoint → `package.json` `main` → `scripts.start` (`/\bnode\s+(.+)/` regex, first non-flag arg with valid extension) → conventional fallback (`server.js, app.js, index.js, server.ts, app.ts, index.ts`).
- Wired into `detectorRunner.ts` between the Python framework detectors and `StaticHTMLDetector`.

Closes #3997. Part of epic #3964.

## Test plan

- [x] `npm run test-unit --prefix extensions/vscode` — all green, including 35 new tests in `nodejs.test.ts` (1716 total).
- [x] `npm run lint --prefix extensions/vscode` — clean.
- [ ] Manual end-to-end deploy of a Node.js project (deferred: homeView-side rendering and publish pipeline arrive in later issues of #3964; this PR's behavior is observable via unit tests).

## Notes for reviewers

- **CHANGELOG / docs intentionally deferred** to #4123, scheduled to land alongside shipped end-to-end behavior at the close of the #3964 epic. No user-visible behavior ships in this PR alone.
- **Detector vs runtime divergences** (intentional): caller entrypoint with bad extension or missing file → `[]` (Connect runtime warns and proceeds); malformed `package.json` → silent `[]` (Connect runtime warns and falls through to conventional files). Rationale: detection is identification, not best-effort execution; we'd rather surface Unknown than guess.
- **Test fixture style** uses real filesystem via `os.tmpdir()` + `fs.mkdtempSync`, mirroring `bundler.test.ts` rather than mocking `fs/promises`.
- **Subdir paths from `main`** (e.g., `"main": "src/index.js"`) are preserved with forward-slash normalization. This is a deliberate scope expansion vs. existing detectors (which only emit basenames).
- `ts-node` parity: the regex matches inside `ts-node app.ts` because of the `\b` word boundary at `-`→`n`. This is Connect's exact behavior; pinned by an explicit test so a future "fix" can't silently diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)