### PR TITLE
fix: pin VSCode npm tasks to npm runner

### DIFF
--- a/extensions/vscode/.vscode/settings.json
+++ b/extensions/vscode/.vscode/settings.json
@@ -9,8 +9,11 @@
     "dist": true // set this to false to include "dist" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off",
-  "svg.preview.background": "editor",
+  "js/ts.tsc.autoDetect": "off",
+  // Force npm — package-lock.json lives at the repo root (npm workspaces), so
+  // VSCode's auto-detection from this folder would otherwise pick yarn.
+  "npm.packageManager": "npm",
+  "npm.scriptRunner": "npm",
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "editor.detectIndentation": false,
@@ -18,6 +21,5 @@
   "editor.formatOnPaste": true,
   "[vue]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "r.lsp.promptToInstall": false
+  }
 }


### PR DESCRIPTION
## Summary

- After the npm-workspaces migration, `package-lock.json` lives only at the repo root. When opening `extensions/vscode/` as the workspace, VSCode's package-manager auto-detection finds no lockfile in that folder and falls back to yarn, breaking the `tsc-watch` / `esbuild-watch` tasks for anyone without yarn installed.
- Pin `npm.scriptRunner` and `npm.packageManager` to `npm` in workspace settings so the tasks always invoke npm.
- Also picks up a couple of unrelated settings cleanups to avoid deprecations and stale settings

## Test plan

- [ ] Reload window with `extensions/vscode/` open
- [ ] Run "Run Extension" (F5) and confirm `tsc-watch` and `esbuild-watch` tasks launch via `npm run` without error