### PR TITLE
docs: update README links to point to GitHub Pages site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Key concepts:
 - Records of where you have deployed are kept in `.posit/publish/deployments`.
 
 For a full list of features and supported content types, see the
-[extension README](../extensions/vscode/README.md).
+[extension README](https://github.com/posit-dev/publisher/blob/main/extensions/vscode/README.md).
 
 ## Installation
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -37,7 +37,7 @@ Once you are ready, deploy your content to Posit Connect (as shown in the screen
 
 Configure your content with ease.
 
-[Configuration files](https://github.com/posit-dev/publisher/blob/main/docs/configuration.md)
+[Configuration files](https://posit-dev.github.io/publisher/configuration.html)
 allow setting up how you want your content to look and run — from
 choosing a title and description to
 [Runtime process settings](https://docs.posit.co/connect/user/content-settings/#content-runtime).
@@ -67,7 +67,7 @@ using just the content's URL. Note: This is only supported for Posit Connect, no
 Posit Connect Cloud.
 
 See the
-[Updating Previously Deployed Content](https://github.com/posit-dev/publisher/blob/main/docs/vscode.md#updating-previously-deployed-content)
+[Updating Previously Deployed Content](https://posit-dev.github.io/publisher/vscode.html#updating-previously-deployed-content)
 documentation for more information.
 
 ### Seamless collaboration
@@ -75,7 +75,7 @@ documentation for more information.
 Collaborate with your team using shared configurations and deployments. Easily
 pick up where others left off with deployed content.
 
-See [Collaborative Publishing with Posit Publisher](https://github.com/posit-dev/publisher/blob/main/docs/collaboration.md)
+See [Collaborative Publishing with Posit Publisher](https://posit-dev.github.io/publisher/collaboration.html)
 for more information.
 
 ### Multiple deployments and configurations
@@ -98,8 +98,8 @@ Specify OAuth Integrations requirements directly in the "Integration Requests" p
 
 ## Help and feedback
 
-Documentation can be found in the
-[open source repository](https://github.com/posit-dev/publisher/blob/main/docs/index.md).
+Documentation can be found on the
+[Posit Publisher documentation site](https://posit-dev.github.io/publisher/).
 
 Report bugs or request features using
 [GitHub Issues](https://github.com/posit-dev/publisher/issues).


### PR DESCRIPTION
## Intent

Update documentation links in the VSCode extension README to point to the new GitHub Pages hosted site (`https://posit-dev.github.io/publisher/`) instead of linking directly to markdown files in the repository.

## Type of Change

- - [x] Documentation <!-- User or developer documentation -->

## Approach

Replaced all `github.com/posit-dev/publisher/blob/main/docs/...` links with their corresponding GitHub Pages URLs:
- `configuration.md` → `configuration.html`
- `vscode.md#updating-previously-deployed-content` → `vscode.html#updating-previously-deployed-content`
- `collaboration.md` → `collaboration.html`
- `docs/index.md` → site root (`/publisher/`)

## User Impact

Users clicking documentation links in the README or VS Code Marketplace will now land on the rendered documentation site rather than raw markdown on GitHub.

## Automated Tests

N/A — documentation-only change.

## Directions for Reviewers

Verify that the updated links resolve correctly on https://posit-dev.github.io/publisher/.

## Checklist

- [ ] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.