### PR TITLE
fix: only deploy docs on release or manual dispatch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,11 +1,9 @@
 name: Deploy docs
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "docs/**"
-      - ".github/workflows/docs.yaml"
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   pages: write


### PR DESCRIPTION
## Summary
- Changes the docs deployment workflow to trigger on releases and manual dispatch instead of every push to main that touches `docs/`

Closes #4140

## Test plan
- [ ] Verify workflow no longer triggers on pushes to main
- [ ] Verify workflow can be manually dispatched via GitHub Actions UI
- [ ] Verify workflow triggers on a published release

🤖 Generated with [Claude Code](https://claude.com/claude-code)