### PR TITLE
feat: display Publisher version in docs site

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Render
         run: quarto render docs
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: rossjrw/pr-preview-action@v1
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Render
         run: quarto render docs
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ test/e2e/**/.positron_workspace
 # Quarto docs build output
 docs/_site/
 docs/.quarto/
+docs/_variables.yml

--- a/docs/_prerender.sh
+++ b/docs/_prerender.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Generates _variables.yml with the current Publisher version from package.json
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION=$(node -p "require('$SCRIPT_DIR/../extensions/vscode/package.json').version")
+
+cat > "$SCRIPT_DIR/_variables.yml" <<EOF
+version: "$VERSION"
+EOF

--- a/docs/_prerender.sh
+++ b/docs/_prerender.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
-# Generates _variables.yml with the current Publisher version from package.json
+# Generates _variables.yml with the latest stable Publisher release version.
+# Uses the GitHub API (via gh CLI) to fetch the latest non-pre-release version.
+# Falls back to package.json when gh is unavailable (e.g., local development).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VERSION=$(node -p "require('$SCRIPT_DIR/../extensions/vscode/package.json').version")
+
+VERSION=""
+if command -v gh &> /dev/null; then
+  VERSION=$(gh api repos/posit-dev/publisher/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^v//' || true)
+fi
+
+# Fallback to package.json if gh is not available or the API call failed
+if [ -z "$VERSION" ]; then
+  VERSION=$(node -p "require('$SCRIPT_DIR/../extensions/vscode/package.json').version")
+fi
 
 cat > "$SCRIPT_DIR/_variables.yml" <<EOF
 version: "$VERSION"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,5 +1,6 @@
 project:
   type: posit-docs
+  pre-render: _prerender.sh
 
 website:
   title: "Posit Publisher"
@@ -16,5 +17,8 @@ website:
         href: collaboration.md
       - text: "Troubleshooting"
         href: troubleshooting.md
+    tools:
+      - icon: github
+        href: https://github.com/posit-dev/publisher
   search:
     keyboard-shortcut: ["/"]

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,6 +1,6 @@
 project:
   type: posit-docs
-  pre-render: _prerender.sh
+  pre-render: ./_prerender.sh
 
 website:
   title: "Posit Publisher"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 title: "Posit Publisher"
 ---
 
-**Current version: {{< var version >}}** | [Release notes](https://github.com/posit-dev/publisher/releases)
+**Current version: {{< var version >}}** | [Changelog](https://github.com/posit-dev/publisher/blob/main/CHANGELOG.md)
 
 Posit Publisher lets you deploy projects to Connect from VS Code and Positron.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 title: "Posit Publisher"
 ---
 
+**Current version: {{< var version >}}** | [Release notes](https://github.com/posit-dev/publisher/releases)
+
 Posit Publisher lets you deploy projects to Connect from VS Code and Positron.
 
 Key concepts:


### PR DESCRIPTION
## Summary
- Adds a pre-render script (`docs/_prerender.sh`) that reads the version from `extensions/vscode/package.json` and generates `docs/_variables.yml`
- Displays the current version on the docs homepage with a link to release notes
- Adds a GitHub icon link to the navbar

The version will be accurate at deploy time since the docs workflow runs on release (per #4140).

Closes #4137

## Test plan
- [ ] Run `cd docs && ./_prerender.sh && cat _variables.yml` to verify version extraction
- [ ] Run `quarto render docs` locally and confirm the version appears on the index page
- [ ] Verify the `{{< var version >}}` shortcode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)