### PR TITLE
feat: add docs PR preview deployments on GitHub Pages

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -9,8 +9,9 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
-concurrency: preview-${{ github.ref }}
+concurrency: preview-${{ github.event.pull_request.number }}
 
 jobs:
   cleanup:

--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -1,0 +1,24 @@
+name: Docs PR Preview Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-preview.yaml"
+
+permissions:
+  contents: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: docs/_site
+          action: remove

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency: preview-${{ github.ref }}
 

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -1,0 +1,27 @@
+name: Docs PR Preview
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-preview.yaml"
+
+permissions:
+  contents: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render
+        run: quarto render docs
+
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: docs/_site

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  pages: write
+  id-token: write
 
 concurrency:
   group: "pages"
@@ -15,6 +16,9 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
 
@@ -23,9 +27,9 @@ jobs:
       - name: Render
         run: quarto render docs
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_site
-          keep_files: true
+          path: docs/_site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
@@ -16,9 +15,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,9 +23,8 @@ jobs:
       - name: Render
         run: quarto render docs
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
-          path: docs/_site
-
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_site
+          keep_files: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
@@ -16,9 +15,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
 
@@ -27,9 +23,9 @@ jobs:
       - name: Render
         run: quarto render docs
 
-      - uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: docs/_site
-
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_site
+          keep_files: true


### PR DESCRIPTION
## Summary

Closes #4145

- Adds a workflow to deploy per-PR documentation previews to the `gh-pages` branch under `pr-preview/pr-<number>/` using [rossjrw/pr-preview-action](https://github.com/rossjrw/pr-preview-action)
- Adds a cleanup workflow to remove previews when PRs are closed/merged
- Updates the main docs deployment to use `peaceiris/actions-gh-pages` (pushes to `gh-pages` branch) instead of `actions/deploy-pages` for consistency

## Manual steps required after merge

Update the GitHub Pages source in repo settings:

1. Go to **Settings → Pages**
2. Change source from "GitHub Actions" to **"Deploy from a branch"**
3. Select branch: `gh-pages`, folder: `/ (root)`
4. Save

This is required because both the main deploy and PR previews now use the `gh-pages` branch. The `keep_files: true` option on the main deploy ensures PR preview directories are preserved.

## Test plan

- [ ] Verify the preview workflow triggers on a PR with docs changes
- [ ] Verify the preview URL is posted as a comment on the PR
- [ ] Verify the cleanup workflow removes the preview when the PR is closed
- [ ] Verify the main docs deploy still works on push to main after updating Pages settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)