### PR TITLE
feat(nodejs): normalize Node.js configs and bundle package files

### DIFF
--- a/extensions/vscode/src/inspect/normalize.test.ts
+++ b/extensions/vscode/src/inspect/normalize.test.ts
@@ -306,6 +306,44 @@ describe("normalizeConfig", () => {
     expect(result.alternatives).toBeUndefined();
   });
 
+  test("adds package.json and package-lock.json to files list for NODEJS type", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.NODEJS,
+      entrypoint: "index.js",
+    };
+    setupDefaultMocks();
+
+    const result = await normalizeConfig(cfg, "/project");
+    expect(result.files).toContain("/index.js");
+    expect(result.files).toContain("/package.json");
+    expect(result.files).toContain("/package-lock.json");
+  });
+
+  test("does not trigger renv.lock R detection for NODEJS type", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.NODEJS,
+      entrypoint: "index.js",
+    };
+    // renv.lock exists, but NODEJS type should skip renv.lock check
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await normalizeConfig(cfg, "/project");
+    expect(result.r).toBeUndefined();
+  });
+
+  test("does not set python or r config for NODEJS type", async () => {
+    const cfg: PartialConfig = {
+      type: ContentType.NODEJS,
+      entrypoint: "index.js",
+    };
+    setupDefaultMocks();
+
+    const result = await normalizeConfig(cfg, "/project");
+    expect(result.python).toBeUndefined();
+    expect(result.r).toBeUndefined();
+  });
+
   test("uses entrypoint parameter as fallback when cfg.entrypoint is empty", async () => {
     const cfg: PartialConfig = {
       type: ContentType.UNKNOWN,

--- a/extensions/vscode/src/inspect/normalize.ts
+++ b/extensions/vscode/src/inspect/normalize.ts
@@ -95,6 +95,7 @@ export async function normalizeConfig(
   if (
     !needR &&
     cfg.type !== ContentType.HTML &&
+    cfg.type !== ContentType.NODEJS &&
     !isPythonContentType(cfg.type)
   ) {
     // For non-HTML, non-Python content: check for renv.lock
@@ -124,6 +125,13 @@ export async function normalizeConfig(
     if (result.config.packageFile) {
       files.push(`/${result.config.packageFile}`);
     }
+  }
+
+  // Node.js: bundle package.json and package-lock.json. There is no [node]
+  // section to populate — Connect picks the runtime from package.json's
+  // engines.node at build time.
+  if (cfg.type === ContentType.NODEJS) {
+    files.push("/package.json", "/package-lock.json");
   }
 
   const comments = initialComment.split("\n");


### PR DESCRIPTION
## Summary

Adds Node.js normalization that adds `package.json` and `package-lock.sjon` to the files list in the configuration.

- Guard the existing renv.lock R-detection check to exclude `ContentType.NODEJS`, so a Node.js project doesn't get an unwanted R config attached.

- No `[node]` section is populated — `type = "nodejs"` is sufficient signal, consistent with the design decision in #3996. Connect picks the runtime from `package.json`'s `engines.node` at build time, so no local Node.js detection or `InterpreterDefaults` plumbing is required here.

Resolves #3998.

Builds on the `NodejsAppDetector` from #4129.

## Test plan

- [x] `npx vitest run src/inspect/normalize.test.ts` — all 20 tests pass, including three new tests:
  - adds `package.json` and `package-lock.json` to files list for NODEJS type
  - does not trigger renv.lock R detection for NODEJS type
  - does not set python or r config for NODEJS type
- [x] `npm run test-unit` — 1708 tests pass; the one pre-existing failure (`@posit-dev/mock-connect` import) is unrelated and reproduces on `main`.
- [x] `just lint` — clean.

## Out of scope

- Changelog entry — deferred until the full Node.js deployment feature lands.
- Yarn / pnpm lockfile alternatives.
- Local Node.js binary detection.
- Node Packages sidebar view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)