### PR TITLE
feat(nodejs): generate Node.js manifest without packages block

### DIFF
--- a/extensions/vscode/src/bundler/bundler.test.ts
+++ b/extensions/vscode/src/bundler/bundler.test.ts
@@ -177,6 +177,51 @@ describe("createBundle", () => {
     expect(entries.has("node_modules/pkg/index.js")).toBe(false);
   });
 
+  it("bundles a Node.js project with package files and no packages block", async () => {
+    makeFile("index.js", "console.log('hi');");
+    makeFile("package.json", '{"name":"app","version":"1.0.0"}');
+    makeFile("package-lock.json", '{"lockfileVersion":3}');
+    makeFile("node_modules/foo/index.js", "module.exports = {};");
+
+    const manifest = manifestFromConfig({
+      $schema: "" as never,
+      productType: ProductType.CONNECT,
+      type: ContentType.NODEJS,
+      entrypoint: "index.js",
+      validate: true,
+    });
+
+    const result = await createBundle({
+      projectPath: tmpDir,
+      manifest,
+      filePatterns: ["/index.js", "/package.json", "/package-lock.json"],
+    });
+
+    // Package files are present in the manifest with valid checksums
+    expect(result.manifest.files["index.js"]?.checksum).toMatch(/^[0-9a-f]+$/);
+    expect(result.manifest.files["package.json"]?.checksum).toMatch(
+      /^[0-9a-f]+$/,
+    );
+    expect(result.manifest.files["package-lock.json"]?.checksum).toMatch(
+      /^[0-9a-f]+$/,
+    );
+
+    // node_modules/ is excluded
+    expect(
+      Object.keys(result.manifest.files).some((k) =>
+        k.startsWith("node_modules/"),
+      ),
+    ).toBe(false);
+
+    // The bundled manifest.json has no packages block (Node.js manifests omit it)
+    const entries = await extractTarEntries(result.bundle);
+    const manifestContent = JSON.parse(
+      entries.get("manifest.json")!.data.toString(),
+    );
+    expect(manifestContent.metadata.appmode).toBe("nodejs");
+    expect(manifestContent.packages).toBeUndefined();
+  });
+
   it("creates a bundle from a single file path", async () => {
     makeFile("app.py", "main app");
     makeFile("other.py", "other file");

--- a/extensions/vscode/src/bundler/manifestFromConfig.golden.test.ts
+++ b/extensions/vscode/src/bundler/manifestFromConfig.golden.test.ts
@@ -176,6 +176,16 @@ describe("golden file tests", () => {
     expect(actual).toEqual(loadGolden("html-static"));
   });
 
+  it("nodejs", () => {
+    const actual = buildAndParse(
+      cfg({
+        type: ContentType.NODEJS,
+        entrypoint: "index.js",
+      }),
+    );
+    expect(actual).toEqual(loadGolden("nodejs"));
+  });
+
   it("rmd-shiny", () => {
     const actual = buildAndParse(
       cfg({

--- a/extensions/vscode/src/bundler/manifestFromConfig.test.ts
+++ b/extensions/vscode/src/bundler/manifestFromConfig.test.ts
@@ -407,6 +407,50 @@ describe("manifestFromConfig", () => {
     });
   });
 
+  describe("Node.js section", () => {
+    it("sets appmode to nodejs and entrypoint", () => {
+      const m = manifestFromConfig(
+        minimalConfig({
+          type: ContentType.NODEJS,
+          entrypoint: "index.js",
+        }),
+      );
+      expect(m.metadata.appmode).toBe("nodejs");
+      expect(m.metadata.entrypoint).toBe("index.js");
+    });
+
+    it("omits packages block for NODEJS", () => {
+      const m = manifestFromConfig(
+        minimalConfig({
+          type: ContentType.NODEJS,
+          entrypoint: "index.js",
+        }),
+      );
+      expect(m.packages).toBeUndefined();
+    });
+
+    it("does not set python, jupyter, quarto, environment, or platform for NODEJS", () => {
+      const m = manifestFromConfig(
+        minimalConfig({
+          type: ContentType.NODEJS,
+          entrypoint: "index.js",
+        }),
+      );
+      expect(m.python).toBeUndefined();
+      expect(m.jupyter).toBeUndefined();
+      expect(m.quarto).toBeUndefined();
+      expect(m.environment).toBeUndefined();
+      expect(m.platform).toBeUndefined();
+    });
+
+    it("emits packages: {} for non-NODEJS types", () => {
+      const m = manifestFromConfig(
+        minimalConfig({ type: ContentType.PYTHON_DASH }),
+      );
+      expect(m.packages).toEqual({});
+    });
+  });
+
   describe("combined R and Python environment", () => {
     it("sets both environment.r and environment.python", () => {
       const m = manifestFromConfig(

--- a/extensions/vscode/src/bundler/manifestFromConfig.ts
+++ b/extensions/vscode/src/bundler/manifestFromConfig.ts
@@ -47,7 +47,7 @@ export function manifestFromConfig(cfg: ConfigurationDetails): Manifest {
       },
     }),
     ...(environment && { environment }),
-    packages: {},
+    ...(cfg.type !== ContentType.NODEJS && { packages: {} }),
     files: {},
     ...(cfg.integrationRequests && {
       integration_requests: cfg.integrationRequests.map((r) => ({

--- a/extensions/vscode/src/bundler/testdata/nodejs.json
+++ b/extensions/vscode/src/bundler/testdata/nodejs.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "metadata": {
+    "appmode": "nodejs",
+    "entrypoint": "index.js"
+  },
+  "files": {}
+}

--- a/extensions/vscode/src/bundler/types.ts
+++ b/extensions/vscode/src/bundler/types.ts
@@ -11,7 +11,7 @@ export type Manifest = {
   jupyter?: ManifestJupyter;
   quarto?: ManifestQuarto;
   environment?: ManifestEnvironment;
-  packages: Record<string, ManifestPackage>;
+  packages?: Record<string, ManifestPackage>;
   files: Record<string, ManifestFile>;
   integration_requests?: ManifestIntegrationRequest[];
 };


### PR DESCRIPTION
## Summary

Avoids writing a consistently empty `packages: {}` field for Node.js content types since Connect always reads from `package.json` and `package-lock.json`

- Mark `Manifest.packages` optional in `bundler/types.ts`.

- Add unit + golden tests for the Node.js manifest path; existing golden tests cover the regression case (R/Python/Quarto/HTML manifests still emit `"packages": {}`).

- Add an end-to-end bundler test that walks a Node.js project through `manifestFromConfig` + `createBundle` and asserts the bundled `manifest.json` has the package files with checksums, no `packages` block, and excludes `node_modules/`.

Resolves #3999

## Expected manifest output for Node.js

```json
{
  "version": 1,
  "metadata": {
    "appmode": "nodejs",
    "entrypoint": "index.js"
  },
  "files": {
    "index.js": { "checksum": "..." },
    "package.json": { "checksum": "..." },
    "package-lock.json": { "checksum": "..." }
  }
}
```

No `python`, `jupyter`, `quarto`, `environment`, `platform`, or `packages` blocks. (Connect's Go deserializer treats a missing field as the zero value, so omitting these is safe.)

## Test plan

- [x] `npx vitest run src/bundler/manifestFromConfig.test.ts src/bundler/manifestFromConfig.golden.test.ts src/bundler/bundler.test.ts` — 96 tests pass, including:
  - 4 new unit tests under `Node.js section` (appmode/entrypoint, packages omitted, no other blocks, regression: non-NODEJS still emits `packages: {}`)
  - 1 new golden test (`testdata/nodejs.json`)
  - 1 new bundler integration test (Node.js project end-to-end)
- [x] Verified the bundler integration test fails when `manifestFromConfig` is reverted to emit `packages: {}` for NODEJS — confirms it catches the regression.
- [x] `npm run test-unit` — 1713 tests pass; the lone failure (`@posit-dev/mock-connect` import in `integrationRequests.e2e.test.ts`) reproduces on `main` and is unrelated.
- [x] `just lint` — clean.
- [x] Audited callers of `manifest.packages`: only written (never read-without-write) and only on R-only code paths in `publish/publishShared.ts`. Making it optional is safe.

## Out of scope

- Pre-built `node_modules/` inclusion when `environment.environment_management.nodejs = false`.
- Changelog entry — deferred until the full Node.js deployment feature lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)