### PR TITLE
fix: actually cancel new credential flow when "input credential name" step is dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)
 - Fixed deploying content to Connect running within the Posit Team Native App in Snowpark Container Services from Publisher running outside of SPCS. Users with existing credentials for SPCS servers must delete and recreate those credentials. Credentials now require a valid Snowflake connection and valid Connect authentication (either API key or token). (#3465)
+- Cancelling the "new credential" flow at the final step (input credential name) actually cancels instead of saving the new credential. (#4159)
 
 ## [2.4.0]
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -10,9 +10,11 @@ class InputFlowAction {
   static resume = new InputFlowAction();
 }
 
-// Track how many showInputBox calls have been made so we can cancel at a specific step
-let showInputBoxCallCount = 0;
-let cancelAtCall = Infinity;
+// Per-step responses for showInputBox, keyed by step name
+const inputBoxResponses: Record<string, string> = {
+  inputServerUrl: "https://connect.example.com",
+  inputAPIKey: "mock-api-key-value",
+};
 
 // Mock the MultiStepInput module with a real step-through implementation
 vi.mock("./multiStepHelper", () => {
@@ -21,45 +23,45 @@ vi.mock("./multiStepHelper", () => {
   return {
     AbortError,
     MultiStepInput: {
-      run: vi.fn(async (start: { step: (input: unknown) => unknown }) => {
-        let currentStep:
-          | { step: (input: unknown) => unknown }
-          | void
-          | undefined = start;
-        const mockInput = {
-          showInputBox: vi.fn(() => {
-            showInputBoxCallCount++;
-            if (showInputBoxCallCount >= cancelAtCall) {
-              return Promise.reject(InputFlowAction.cancel);
-            }
-            // First call is URL step — must be a valid URL so hostname pre-population works
-            if (showInputBoxCallCount === 1) {
-              return Promise.resolve("https://connect.example.com");
-            }
-            return Promise.resolve("mocked-value");
-          }),
-          showQuickPick: vi.fn(({ items }: { items: { label: string }[] }) => {
-            return Promise.resolve(
-              items.find((i) => i.label === "API Key") || items[0],
-            );
-          }),
-          showInfoMessage: vi.fn(() => Promise.resolve()),
-        };
+      run: vi.fn(
+        async (start: { name?: string; step: (input: unknown) => unknown }) => {
+          let currentStep:
+            | { name?: string; step: (input: unknown) => unknown }
+            | void
+            | undefined = start;
 
-        while (currentStep) {
-          try {
-            currentStep = (await currentStep.step(mockInput)) as {
-              step: (input: unknown) => unknown;
-            } | void;
-          } catch (e) {
-            if (e === InputFlowAction.cancel) {
-              currentStep = undefined;
-            } else {
-              throw e;
+          while (currentStep) {
+            const stepName = currentStep.name || "";
+            const mockInput = {
+              showInputBox: vi.fn(() => {
+                const value = inputBoxResponses[stepName] || "mocked-value";
+                return Promise.resolve(value);
+              }),
+              showQuickPick: vi.fn(
+                ({ items }: { items: { label: string }[] }) => {
+                  return Promise.resolve(
+                    items.find((i) => i.label === "API Key") || items[0],
+                  );
+                },
+              ),
+              showInfoMessage: vi.fn(() => Promise.resolve()),
+            };
+
+            try {
+              currentStep = (await currentStep.step(mockInput)) as {
+                name?: string;
+                step: (input: unknown) => unknown;
+              } | void;
+            } catch (e) {
+              if (e === InputFlowAction.cancel) {
+                currentStep = undefined;
+              } else {
+                throw e;
+              }
             }
           }
-        }
-      }),
+        },
+      ),
     },
     assignStep: (
       state: { step: number; promptStepNumbers: Record<string, number> },
@@ -217,8 +219,6 @@ vi.mock("src/utils/errors", () => ({
 describe("newConnectCredential cancellation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    showInputBoxCallCount = 0;
-    cancelAtCall = Infinity;
 
     mockCredentialsServiceList.mockResolvedValue([]);
     mockCredentialsServiceCreate.mockResolvedValue({
@@ -235,10 +235,6 @@ describe("newConnectCredential cancellation", () => {
   });
 
   test("cancelling at credential name step does not save the credential", async () => {
-    // The flow for API key auth is: inputServerUrl (1 showInputBox) → inputAPIKey (1 showInputBox) → inputCredentialName
-    // Cancel at the 3rd showInputBox call (the credential name step)
-    cancelAtCall = 3;
-
     // Mock inputCredentialNameStep to throw cancel (simulating user pressing Escape)
     const { inputCredentialNameStep } =
       await import("src/multiStepInputs/common");

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -4,13 +4,61 @@ import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { ServerType } from "src/api/types/contentRecords";
 import { newConnectCredential } from "./newConnectCredential";
 
-// Mock the MultiStepInput module
+class InputFlowAction {
+  static back = new InputFlowAction();
+  static cancel = new InputFlowAction();
+  static resume = new InputFlowAction();
+}
+
+// Track how many showInputBox calls have been made so we can cancel at a specific step
+let showInputBoxCallCount = 0;
+let cancelAtCall = Infinity;
+
+// Mock the MultiStepInput module with a real step-through implementation
 vi.mock("./multiStepHelper", () => {
+  class AbortError extends Error {}
+
   return {
+    AbortError,
     MultiStepInput: {
-      run: vi.fn((_callback) => {
-        // This simplified mock just returns without executing the callback
-        return Promise.resolve();
+      run: vi.fn(async (start: { step: (input: unknown) => unknown }) => {
+        let currentStep:
+          | { step: (input: unknown) => unknown }
+          | void
+          | undefined = start;
+        const mockInput = {
+          showInputBox: vi.fn(() => {
+            showInputBoxCallCount++;
+            if (showInputBoxCallCount >= cancelAtCall) {
+              return Promise.reject(InputFlowAction.cancel);
+            }
+            // First call is URL step — must be a valid URL so hostname pre-population works
+            if (showInputBoxCallCount === 1) {
+              return Promise.resolve("https://connect.example.com");
+            }
+            return Promise.resolve("mocked-value");
+          }),
+          showQuickPick: vi.fn(({ items }: { items: { label: string }[] }) => {
+            return Promise.resolve(
+              items.find((i) => i.label === "API Key") || items[0],
+            );
+          }),
+          showInfoMessage: vi.fn(() => Promise.resolve()),
+        };
+
+        while (currentStep) {
+          try {
+            currentStep = (await currentStep.step(mockInput)) as {
+              step: (input: unknown) => unknown;
+            } | void;
+          } catch (e) {
+            if (e === InputFlowAction.cancel) {
+              currentStep = undefined;
+            } else {
+              throw e;
+            }
+          }
+        }
       }),
     },
     assignStep: (
@@ -21,14 +69,13 @@ vi.mock("./multiStepHelper", () => {
       state.promptStepNumbers[stepName] = state.step;
       return state.step;
     },
-    isString: vi.fn(() => true),
+    isString: (d: unknown): d is string => typeof d === "string",
     isQuickPickItemWithIndex: vi.fn(() => false),
   };
 });
 
 // Mock vscode
 vi.mock("vscode", () => {
-  // Create a mock for the OutputChannel
   const mockOutputChannel = {
     appendLine: vi.fn(),
     append: vi.fn(),
@@ -54,7 +101,7 @@ vi.mock("vscode", () => {
       Information: 1,
     },
     Uri: {
-      parse: vi.fn((url) => ({ toString: () => url })),
+      parse: vi.fn((url: string) => ({ toString: () => url })),
     },
     ThemeIcon: function (iconId: string) {
       return { id: iconId };
@@ -101,19 +148,78 @@ vi.mock("src/credentials/service", () => ({
   CredentialsService: vi.fn(),
 }));
 
-//Removed logging mock since we're using vscode OutputChannel directly
-
 vi.mock("src/utils/progress", () => {
   return {
-    showProgress: vi.fn((_title, _view, callback) => callback()),
+    showProgress: vi.fn(
+      (_title: string, _view: string, callback: () => unknown) => callback(),
+    ),
   };
 });
 
-describe("newConnectCredential API calls", () => {
+vi.mock("src/multiStepInputs/common", () => {
+  return {
+    findExistingCredentialByURL: vi.fn(() => undefined),
+    fetchSnowflakeConnections: vi.fn(() =>
+      Promise.resolve({ connections: [], connectionQuickPicks: [] }),
+    ),
+    inputCredentialNameStep: vi.fn(() => Promise.resolve("My Credential")),
+    getExistingCredentials: vi.fn(() => Promise.resolve([])),
+  };
+});
+
+vi.mock("src/utils/multiStepHelpers", () => ({
+  isConnect: vi.fn(() => true),
+  isSnowflake: vi.fn(() => false),
+}));
+
+vi.mock("src/snowflake/connections", () => ({
+  listConnections: vi.fn(() => ({})),
+}));
+
+vi.mock("src/snowflake/tokenProviders", () => ({
+  createTokenProvider: vi.fn(),
+}));
+
+vi.mock("src/commands", () => ({
+  openConfigurationCommand: "command:open-config",
+}));
+
+vi.mock("src/extension", () => ({
+  extensionSettings: {
+    defaultConnectServer: vi.fn(() => Promise.resolve("")),
+    verifyCertificates: vi.fn(() => true),
+  },
+}));
+
+vi.mock("src/utils/url", () => ({
+  formatURL: vi.fn((url: string) => url),
+}));
+
+vi.mock("src/utils/apiKeys", () => ({
+  checkSyntaxApiKey: vi.fn(() => undefined),
+}));
+
+vi.mock("src/utils/testCredentials", () => ({
+  testServerURL: vi.fn(() => Promise.resolve({ serverType: "connect" })),
+  testAuthentication: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock("src/auth/ConnectAuthTokenActivator", () => ({
+  ConnectAuthTokenActivator: vi.fn(),
+  TokenAuthResult: {},
+}));
+
+vi.mock("src/utils/errors", () => ({
+  getMessageFromError: vi.fn((e: unknown) => String(e)),
+  getSummaryStringFromError: vi.fn((loc: string, e: unknown) => `${loc}: ${e}`),
+}));
+
+describe("newConnectCredential cancellation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    showInputBoxCallCount = 0;
+    cancelAtCall = Infinity;
 
-    // Setup default responses
     mockCredentialsServiceList.mockResolvedValue([]);
     mockCredentialsServiceCreate.mockResolvedValue({
       guid: "credential-123",
@@ -128,32 +234,51 @@ describe("newConnectCredential API calls", () => {
     vi.clearAllMocks();
   });
 
-  test("credential creation flow can be initiated", async () => {
-    // Call newConnectCredential with credentialsService
+  test("cancelling at credential name step does not save the credential", async () => {
+    // The flow for API key auth is: inputServerUrl (1 showInputBox) → inputAPIKey (1 showInputBox) → inputCredentialName
+    // Cancel at the 3rd showInputBox call (the credential name step)
+    cancelAtCall = 3;
+
+    // Mock inputCredentialNameStep to throw cancel (simulating user pressing Escape)
+    const { inputCredentialNameStep } =
+      await import("src/multiStepInputs/common");
+    vi.mocked(inputCredentialNameStep).mockRejectedValue(
+      InputFlowAction.cancel,
+    );
+
+    let threw = false;
     try {
       await newConnectCredential(
         "test-view-id",
         "Create a New Credential",
         mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+        "https://connect.example.com",
       );
     } catch {
-      /* the user dismissed this flow, do nothing more */
+      threw = true;
     }
 
-    // Since MultiStepInput.run is mocked to do nothing, verify the flow
-    // initializes without error and the credentials service is available
-    await mockCredentialsServiceCreate({
-      name: "My Connect Server",
-      url: "https://connect.example.com",
-      serverType: ServerType.CONNECT,
-      apiKey: "test-api-key",
-    });
+    expect(threw).toBe(true);
+    expect(mockCredentialsServiceCreate).not.toHaveBeenCalled();
+  });
 
-    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith({
-      name: "My Connect Server",
-      url: "https://connect.example.com",
-      serverType: ServerType.CONNECT,
-      apiKey: "test-api-key",
-    });
+  test("completing credential name step saves the credential", async () => {
+    const { inputCredentialNameStep } =
+      await import("src/multiStepInputs/common");
+    vi.mocked(inputCredentialNameStep).mockResolvedValue("My Server");
+
+    const result = await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "My Server",
+      }),
+    );
+    expect(result).toEqual(expect.objectContaining({ guid: "credential-123" }));
   });
 });

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -4,11 +4,7 @@ import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { ServerType } from "src/api/types/contentRecords";
 import { newConnectCredential } from "./newConnectCredential";
 
-class InputFlowAction {
-  static back = new InputFlowAction();
-  static cancel = new InputFlowAction();
-  static resume = new InputFlowAction();
-}
+const CANCEL = Symbol("cancel");
 
 // Per-step responses for showInputBox, keyed by step name
 const inputBoxResponses: Record<string, string> = {
@@ -53,7 +49,7 @@ vi.mock("./multiStepHelper", () => {
                 step: (input: unknown) => unknown;
               } | void;
             } catch (e) {
-              if (e === InputFlowAction.cancel) {
+              if (e === CANCEL) {
                 currentStep = undefined;
               } else {
                 throw e;
@@ -238,9 +234,7 @@ describe("newConnectCredential cancellation", () => {
     // Mock inputCredentialNameStep to throw cancel (simulating user pressing Escape)
     const { inputCredentialNameStep } =
       await import("src/multiStepInputs/common");
-    vi.mocked(inputCredentialNameStep).mockRejectedValue(
-      InputFlowAction.cancel,
-    );
+    vi.mocked(inputCredentialNameStep).mockRejectedValue(CANCEL);
 
     let threw = false;
     try {

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -562,6 +562,7 @@ export async function newConnectCredential(
   ) {
     if (!state.data.name && typeof state.data.url === "string") {
       try {
+        // suggest a default name
         const url = new URL(state.data.url);
         state.data.name = url.hostname;
       } catch {

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -569,13 +569,19 @@ export async function newConnectCredential(
       }
     }
 
-    state.data.name = await inputCredentialNameStep(
-      input,
-      state,
-      serverType,
-      productName,
-      credentials,
-    );
+    try {
+      state.data.name = await inputCredentialNameStep(
+        input,
+        state,
+        serverType,
+        productName,
+        credentials,
+      );
+    } catch (e) {
+      // the user cancelled - clear the default name so that validation fails and the credential isn't saved
+      state.data.name = undefined;
+      throw e;
+    }
 
     // last step to create a new credential
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

When a user dismisses the "input credential name" step (last step of the new credential wizard) the credential is not saved.

Fixes #4159

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Cancelling works by exiting early out of `MultiStepInput.run`: 
https://github.com/posit-dev/publisher/blob/5c8621a91c9476ac248c82813029fc799e759332/extensions/vscode/src/multiStepInputs/multiStepHelper.ts#L187-L189

https://github.com/posit-dev/publisher/blob/5c8621a91c9476ac248c82813029fc799e759332/extensions/vscode/src/multiStepInputs/newConnectCredential.ts#L193-L201

Then we check if the state is valid before proceeding to save the credential: https://github.com/posit-dev/publisher/blob/5c8621a91c9476ac248c82813029fc799e759332/extensions/vscode/src/multiStepInputs/newConnectCredential.ts#L590-L603

In the final step, we prefill the input with a suggested name, which is passed in via the state:
https://github.com/posit-dev/publisher/blob/5c8621a91c9476ac248c82813029fc799e759332/extensions/vscode/src/multiStepInputs/newConnectCredential.ts#L564-L578

This means that even if the user cancels, `state.data.name` is already set. The previous steps filled in all the other required state. So now state is considered valid: https://github.com/posit-dev/publisher/blob/5c8621a91c9476ac248c82813029fc799e759332/extensions/vscode/src/multiStepInputs/newConnectCredential.ts#L184

The fix is to throw away the default state if the user cancels (or if `inputCredentialNameStep` throws any error). Then `isValid()` will fail as expected and the credential will not be saved.

## User Impact

Users can now cancel without saving at any step.

## Automated Tests

There were minimal existing tests of this code. I added tests targeted at just this bug, showing that the final step can either be cancelled or completed.

## Directions for Reviewers

I ran these manual validations:

- [x] cancel at last step: credential is not saved
- [x] complete flow with default name: credential is saved with default name
- [x] complete flow with custom name: credential is saved with custom name 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
