### PR TITLE
test(mock-connect): migrate fixture validator to OpenAPI 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the mock-connect fixture validator to consume the Connect OpenAPI 3.0 spec (`openapi.json`) instead of the deprecated Swagger 2.0 spec (`swagger.json`). Internal tooling change only. (#4161)
+
 ### Fixed
 
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Updated the mock-connect fixture validator to consume the Connect OpenAPI 3.0 spec (`openapi.json`) instead of the deprecated Swagger 2.0 spec (`swagger.json`). Internal tooling change only. (#4161)
-
 ### Fixed
 
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)

--- a/test/mock-connect/src/validation/fixture-map.ts
+++ b/test/mock-connect/src/validation/fixture-map.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
 /**
- * Maps fixture filenames to their corresponding Connect API Swagger spec
+ * Maps fixture filenames to their corresponding Connect API OpenAPI spec
  * endpoint (path + method + status code). Used by the validation tests to
  * look up the expected response schema for each fixture.
  */
@@ -9,7 +9,7 @@
 export interface FixtureMapping {
   /** Fixture filename (relative to connect-responses/) */
   fixture: string;
-  /** Swagger path, e.g. "/v1/user" */
+  /** OpenAPI path, e.g. "/v1/user" */
   path: string;
   /** HTTP method */
   method: "get" | "post" | "put" | "patch" | "delete";
@@ -149,15 +149,15 @@ export const fixtureMappings: FixtureMapping[] = [
 export const skippedFixtures: { fixture: string; reason: string }[] = [
   {
     fixture: "server-settings.json",
-    reason: "Undocumented internal endpoint — not in the public Swagger spec",
+    reason: "Undocumented internal endpoint — not in the public OpenAPI spec",
   },
   {
     fixture: "server-settings-applications.json",
-    reason: "Undocumented internal endpoint — not in the public Swagger spec",
+    reason: "Undocumented internal endpoint — not in the public OpenAPI spec",
   },
   {
     fixture: "server-settings-scheduler.json",
-    reason: "Undocumented internal endpoint — not in the public Swagger spec",
+    reason: "Undocumented internal endpoint — not in the public OpenAPI spec",
   },
   {
     fixture: "error-401.json",

--- a/test/mock-connect/src/validation/openapi-helpers.ts
+++ b/test/mock-connect/src/validation/openapi-helpers.ts
@@ -12,29 +12,35 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, "..", "..", ".cache");
-const CACHE_FILE = join(CACHE_DIR, "swagger.json");
-const SWAGGER_URL = "https://docs.posit.co/connect/api/swagger.json";
+const CACHE_FILE = join(CACHE_DIR, "openapi.json");
+const OPENAPI_URL = "https://docs.posit.co/connect/api/openapi.json";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-// ---------- Types for the subset of Swagger 2.0 we care about ----------
+// ---------- Types for the subset of OpenAPI 3.0 we care about ----------
 
-export interface SwaggerSpec {
-  swagger: string;
-  paths: Record<string, SwaggerPathItem>;
-  definitions: Record<string, JsonSchema>;
+export interface OpenAPISpec {
+  openapi: string;
+  paths: Record<string, OpenAPIPathItem>;
+  components: {
+    schemas: Record<string, JsonSchema>;
+  };
 }
 
-export interface SwaggerPathItem {
-  [method: string]: SwaggerOperation;
+export interface OpenAPIPathItem {
+  [method: string]: OpenAPIOperation;
 }
 
-export interface SwaggerOperation {
-  responses: Record<string, SwaggerResponse>;
+export interface OpenAPIOperation {
+  responses: Record<string, OpenAPIResponse>;
 }
 
-export interface SwaggerResponse {
+export interface OpenAPIResponse {
   description?: string;
-  schema?: JsonSchema;
+  content?: {
+    "application/json"?: {
+      schema?: JsonSchema;
+    };
+  };
 }
 
 export interface JsonSchema {
@@ -43,7 +49,7 @@ export interface JsonSchema {
   properties?: Record<string, JsonSchema>;
   required?: string[];
   $ref?: string;
-  "x-nullable"?: boolean;
+  nullable?: boolean;
   additionalProperties?: boolean | JsonSchema;
   allOf?: JsonSchema[];
   oneOf?: JsonSchema[];
@@ -61,15 +67,15 @@ function isCacheValid(): boolean {
   return Date.now() - mtime < CACHE_TTL_MS;
 }
 
-export async function getSwaggerSpec(): Promise<SwaggerSpec> {
+export async function getOpenAPISpec(): Promise<OpenAPISpec> {
   if (isCacheValid()) {
-    return JSON.parse(readFileSync(CACHE_FILE, "utf-8")) as SwaggerSpec;
+    return JSON.parse(readFileSync(CACHE_FILE, "utf-8")) as OpenAPISpec;
   }
 
-  const res = await fetch(SWAGGER_URL);
+  const res = await fetch(OPENAPI_URL);
   if (!res.ok) {
     throw new Error(
-      `Failed to fetch Swagger spec: ${res.status} ${res.statusText}`,
+      `Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`,
     );
   }
 
@@ -78,37 +84,37 @@ export async function getSwaggerSpec(): Promise<SwaggerSpec> {
   mkdirSync(CACHE_DIR, { recursive: true });
   writeFileSync(CACHE_FILE, text, "utf-8");
 
-  return JSON.parse(text) as SwaggerSpec;
+  return JSON.parse(text) as OpenAPISpec;
 }
 
 // ---------- $ref resolution ----------
 
 /**
  * Recursively resolve all `$ref` pointers in a schema against the spec's
- * `definitions` section. Returns a new schema object with all references
- * inlined (with cycle protection).
+ * `components.schemas` section. Returns a new schema object with all
+ * references inlined (with cycle protection).
  */
 export function dereferenceSchema(
   schema: JsonSchema,
-  definitions: Record<string, JsonSchema>,
+  schemas: Record<string, JsonSchema>,
   seen: Set<string> = new Set(),
 ): JsonSchema {
   if (schema.$ref) {
-    const refPath = schema.$ref; // e.g. "#/definitions/User"
-    const defName = refPath.replace("#/definitions/", "");
+    const refPath = schema.$ref; // e.g. "#/components/schemas/User"
+    const defName = refPath.replace("#/components/schemas/", "");
 
     if (seen.has(defName)) {
       // Cycle detected — return a permissive schema to avoid infinite recursion
       return {};
     }
 
-    const def = definitions[defName];
+    const def = schemas[defName];
     if (!def) {
-      throw new Error(`Missing definition: ${refPath}`);
+      throw new Error(`Missing schema: ${refPath}`);
     }
 
     seen.add(defName);
-    return dereferenceSchema(def, definitions, seen);
+    return dereferenceSchema(def, schemas, seen);
   }
 
   const resolved: JsonSchema = { ...schema };
@@ -116,22 +122,30 @@ export function dereferenceSchema(
   if (resolved.properties) {
     const props: Record<string, JsonSchema> = {};
     for (const [key, prop] of Object.entries(resolved.properties)) {
-      props[key] = dereferenceSchema(prop, definitions, new Set(seen));
+      props[key] = dereferenceSchema(prop, schemas, new Set(seen));
     }
     resolved.properties = props;
   }
 
   if (resolved.items) {
-    resolved.items = dereferenceSchema(
-      resolved.items,
-      definitions,
-      new Set(seen),
-    );
+    resolved.items = dereferenceSchema(resolved.items, schemas, new Set(seen));
   }
 
   if (resolved.allOf) {
     resolved.allOf = resolved.allOf.map((s) =>
-      dereferenceSchema(s, definitions, new Set(seen)),
+      dereferenceSchema(s, schemas, new Set(seen)),
+    );
+  }
+
+  if (resolved.oneOf) {
+    resolved.oneOf = resolved.oneOf.map((s) =>
+      dereferenceSchema(s, schemas, new Set(seen)),
+    );
+  }
+
+  if (resolved.anyOf) {
+    resolved.anyOf = resolved.anyOf.map((s) =>
+      dereferenceSchema(s, schemas, new Set(seen)),
     );
   }
 
@@ -141,7 +155,7 @@ export function dereferenceSchema(
   ) {
     resolved.additionalProperties = dereferenceSchema(
       resolved.additionalProperties as JsonSchema,
-      definitions,
+      schemas,
       new Set(seen),
     );
   }
@@ -149,19 +163,20 @@ export function dereferenceSchema(
   return resolved;
 }
 
-// ---------- x-nullable → JSON Schema nullable ----------
+// ---------- nullable → JSON Schema nullable ----------
 
 /**
- * Recursively transforms Swagger 2.0 `x-nullable: true` into
- * JSON Schema Draft 4 compatible `type: ["<original>", "null"]`.
+ * Recursively transforms OpenAPI 3.0 `nullable: true` into JSON Schema
+ * Draft 4 compatible `type: ["<original>", "null"]`. Ajv does not understand
+ * OpenAPI's `nullable` keyword on its own.
  */
 export function transformNullable(schema: JsonSchema): JsonSchema {
   const result: JsonSchema = { ...schema };
 
-  if (result["x-nullable"] === true && typeof result.type === "string") {
+  if (result.nullable === true && typeof result.type === "string") {
     result.type = [result.type, "null"];
-    delete result["x-nullable"];
   }
+  delete result.nullable;
 
   if (result.properties) {
     const props: Record<string, JsonSchema> = {};
@@ -177,6 +192,14 @@ export function transformNullable(schema: JsonSchema): JsonSchema {
 
   if (result.allOf) {
     result.allOf = result.allOf.map(transformNullable);
+  }
+
+  if (result.oneOf) {
+    result.oneOf = result.oneOf.map(transformNullable);
+  }
+
+  if (result.anyOf) {
+    result.anyOf = result.anyOf.map(transformNullable);
   }
 
   if (
@@ -195,10 +218,10 @@ export function transformNullable(schema: JsonSchema): JsonSchema {
 
 /**
  * Extract the fully resolved and nullable-transformed response schema for
- * a given endpoint from the Swagger spec.
+ * a given endpoint from the OpenAPI spec.
  */
 export function getResponseSchema(
-  spec: SwaggerSpec,
+  spec: OpenAPISpec,
   path: string,
   method: string,
   status: number,
@@ -210,9 +233,10 @@ export function getResponseSchema(
   if (!operation) return null;
 
   const response = operation.responses[String(status)];
-  if (!response?.schema) return null;
+  const schema = response?.content?.["application/json"]?.schema;
+  if (!schema) return null;
 
-  const dereffed = dereferenceSchema(response.schema, spec.definitions);
+  const dereffed = dereferenceSchema(schema, spec.components.schemas);
   return transformNullable(dereffed);
 }
 

--- a/test/mock-connect/src/validation/openapi-helpers.ts
+++ b/test/mock-connect/src/validation/openapi-helpers.ts
@@ -214,6 +214,47 @@ export function transformNullable(schema: JsonSchema): JsonSchema {
   return result;
 }
 
+// ---------- additionalProperties relaxation ----------
+
+/**
+ * Recursively set `additionalProperties: true` on every object schema so
+ * that extra fields in a payload do not cause validation failures. Callers
+ * decide separately whether to surface extras (e.g. as warnings).
+ */
+export function allowAdditionalProperties(schema: JsonSchema): JsonSchema {
+  const result: JsonSchema = { ...schema };
+
+  if (result.type === "object" || result.properties) {
+    result.additionalProperties = true;
+  }
+
+  if (result.properties) {
+    const props: Record<string, JsonSchema> = {};
+    for (const [key, prop] of Object.entries(result.properties)) {
+      props[key] = allowAdditionalProperties(prop);
+    }
+    result.properties = props;
+  }
+
+  if (result.items && typeof result.items === "object") {
+    result.items = allowAdditionalProperties(result.items);
+  }
+
+  if (result.allOf) {
+    result.allOf = result.allOf.map(allowAdditionalProperties);
+  }
+
+  if (result.oneOf) {
+    result.oneOf = result.oneOf.map(allowAdditionalProperties);
+  }
+
+  if (result.anyOf) {
+    result.anyOf = result.anyOf.map(allowAdditionalProperties);
+  }
+
+  return result;
+}
+
 // ---------- High-level schema extraction ----------
 
 /**

--- a/test/mock-connect/src/validation/validate-fixtures.test.ts
+++ b/test/mock-connect/src/validation/validate-fixtures.test.ts
@@ -8,20 +8,20 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { FIXTURES_DIR } from "../mock-connect-server.js";
 import { fixtureMappings, skippedFixtures } from "./fixture-map.js";
 import {
-  getSwaggerSpec,
+  getOpenAPISpec,
   getResponseSchema,
   findExtraFields,
-  type SwaggerSpec,
+  type OpenAPISpec,
   type JsonSchema,
-} from "./swagger-helpers.js";
+} from "./openapi-helpers.js";
 
-let spec: SwaggerSpec;
+let spec: OpenAPISpec;
 
 beforeAll(async () => {
-  spec = await getSwaggerSpec();
+  spec = await getOpenAPISpec();
 });
 
-describe("Fixture validation against Swagger spec", () => {
+describe("Fixture validation against OpenAPI spec", () => {
   for (const mapping of fixtureMappings) {
     it(`${mapping.description} (${mapping.fixture})`, () => {
       const fixtureRaw = readFileSync(

--- a/test/mock-connect/src/validation/validate-fixtures.test.ts
+++ b/test/mock-connect/src/validation/validate-fixtures.test.ts
@@ -8,11 +8,11 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { FIXTURES_DIR } from "../mock-connect-server.js";
 import { fixtureMappings, skippedFixtures } from "./fixture-map.js";
 import {
+  allowAdditionalProperties,
   getOpenAPISpec,
   getResponseSchema,
   findExtraFields,
   type OpenAPISpec,
-  type JsonSchema,
 } from "./openapi-helpers.js";
 
 let spec: OpenAPISpec;
@@ -91,34 +91,3 @@ describe("Fixture validation against OpenAPI spec", () => {
     });
   }
 });
-
-/**
- * Recursively set `additionalProperties: true` on all object schemas so
- * that extra fixture fields do not cause validation failures. We report
- * extra fields as warnings instead.
- */
-function allowAdditionalProperties(schema: JsonSchema): JsonSchema {
-  const result: JsonSchema = { ...schema };
-
-  if (result.type === "object" || result.properties) {
-    result.additionalProperties = true;
-  }
-
-  if (result.properties) {
-    const props: Record<string, JsonSchema> = {};
-    for (const [key, prop] of Object.entries(result.properties)) {
-      props[key] = allowAdditionalProperties(prop);
-    }
-    result.properties = props;
-  }
-
-  if (result.items && typeof result.items === "object") {
-    result.items = allowAdditionalProperties(result.items);
-  }
-
-  if (result.allOf) {
-    result.allOf = result.allOf.map(allowAdditionalProperties);
-  }
-
-  return result;
-}

--- a/test/mock-connect/src/validation/validate-mock-server.test.ts
+++ b/test/mock-connect/src/validation/validate-mock-server.test.ts
@@ -2,7 +2,7 @@
 
 /**
  * Validates that the MockConnectServer's runtime responses match the
- * Swagger spec. This catches:
+ * OpenAPI spec. This catches:
  * - Route-to-fixture mapping errors (wrong fixture served for an endpoint)
  * - Status code mismatches between the mock and the spec
  * - Response bodies that don't conform to the spec schema
@@ -14,22 +14,22 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { MockConnectServer } from "../mock-connect-server.js";
 import { fixtureMappings } from "./fixture-map.js";
 import {
-  getSwaggerSpec,
+  getOpenAPISpec,
   getResponseSchema,
-  type SwaggerSpec,
+  type OpenAPISpec,
   type JsonSchema,
-} from "./swagger-helpers.js";
+} from "./openapi-helpers.js";
 
 let server: MockConnectServer;
 let baseUrl: string;
-let spec: SwaggerSpec;
+let spec: OpenAPISpec;
 let ajv: Ajv;
 
 beforeAll(async () => {
   server = new MockConnectServer();
   await server.start();
   baseUrl = server.url;
-  spec = await getSwaggerSpec();
+  spec = await getOpenAPISpec();
   ajv = new Ajv({
     allErrors: true,
     strict: false,
@@ -43,12 +43,12 @@ afterAll(async () => {
 });
 
 /**
- * Convert a Swagger path like "/v1/content/{guid}/bundles/{id}" into
+ * Convert an OpenAPI path like "/v1/content/{guid}/bundles/{id}" into
  * a concrete URL path with unique placeholders per parameter position.
  */
-function swaggerPathToUrl(swaggerPath: string): string {
+function openapiPathToUrl(openapiPath: string): string {
   let paramIndex = 0;
-  const concrete = swaggerPath.replace(/\{[^}]+\}/g, () => {
+  const concrete = openapiPath.replace(/\{[^}]+\}/g, () => {
     paramIndex++;
     return `test-param-${paramIndex}-00000000-0000-0000-0000-000000000000`;
   });
@@ -93,10 +93,10 @@ function allowAdditionalProperties(schema: JsonSchema): JsonSchema {
   return result;
 }
 
-describe("Mock server responses match Swagger spec", () => {
+describe("Mock server responses match OpenAPI spec", () => {
   for (const mapping of fixtureMappings) {
     it(`${mapping.method.toUpperCase()} ${mapping.path} — ${mapping.description}`, async () => {
-      const url = `${baseUrl}${swaggerPathToUrl(mapping.path)}`;
+      const url = `${baseUrl}${openapiPathToUrl(mapping.path)}`;
 
       const response = await fetch(url, {
         method: mapping.method.toUpperCase(),
@@ -156,7 +156,7 @@ describe("Mock server responses match Swagger spec", () => {
           .join("\n");
         expect.fail(
           `Mock response for ${mapping.method.toUpperCase()} ${mapping.path} ` +
-            `(status ${response.status}) does not match Swagger schema:\n${errors}`,
+            `(status ${response.status}) does not match OpenAPI schema:\n${errors}`,
         );
       }
     });

--- a/test/mock-connect/src/validation/validate-mock-server.test.ts
+++ b/test/mock-connect/src/validation/validate-mock-server.test.ts
@@ -14,10 +14,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { MockConnectServer } from "../mock-connect-server.js";
 import { fixtureMappings } from "./fixture-map.js";
 import {
+  allowAdditionalProperties,
   getOpenAPISpec,
   getResponseSchema,
   type OpenAPISpec,
-  type JsonSchema,
 } from "./openapi-helpers.js";
 
 let server: MockConnectServer;
@@ -53,44 +53,6 @@ function openapiPathToUrl(openapiPath: string): string {
     return `test-param-${paramIndex}-00000000-0000-0000-0000-000000000000`;
   });
   return `/__api__${concrete}`;
-}
-
-/**
- * Recursively set `additionalProperties: true` on all object schemas so
- * that extra fixture fields do not cause validation failures.
- */
-function allowAdditionalProperties(schema: JsonSchema): JsonSchema {
-  const result: JsonSchema = { ...schema };
-
-  if (result.type === "object" || result.properties) {
-    result.additionalProperties = true;
-  }
-
-  if (result.properties) {
-    const props: Record<string, JsonSchema> = {};
-    for (const [key, prop] of Object.entries(result.properties)) {
-      props[key] = allowAdditionalProperties(prop);
-    }
-    result.properties = props;
-  }
-
-  if (result.items && typeof result.items === "object") {
-    result.items = allowAdditionalProperties(result.items);
-  }
-
-  if (result.allOf) {
-    result.allOf = result.allOf.map(allowAdditionalProperties);
-  }
-
-  if (result.oneOf) {
-    result.oneOf = result.oneOf.map(allowAdditionalProperties);
-  }
-
-  if (result.anyOf) {
-    result.anyOf = result.anyOf.map(allowAdditionalProperties);
-  }
-
-  return result;
 }
 
 describe("Mock server responses match OpenAPI spec", () => {


### PR DESCRIPTION
## Summary
- Renames `swagger-helpers.ts` → `openapi-helpers.ts` and switches the source spec from `swagger.json` to `openapi.json`.
- `definitions` → `components.schemas`; `$ref` resolution updated to `#/components/schemas/...`.
- Response schemas now read from `response.content["application/json"].schema`.
- `x-nullable` (Swagger 2.0) → `nullable` (OpenAPI 3.0) in `transformNullable`.
- Cache file renamed `.cache/swagger.json` → `.cache/openapi.json`.

Resolves #4161. Unblocks #4162 (Node.js fixture).

## Test plan
- [x] `just validate-fixtures` passes against the OpenAPI 3.0 spec (30 passed, 6 skipped)
- [x] `just test-connect-contracts` passes (68 passed)
- [x] `.cache/openapi.json` is created and `.cache/swagger.json` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)