### PR TITLE
feat(nodejs): fetch nodejs server settings and gate publishes

### DIFF
--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -290,6 +290,7 @@ function makeSettings(overrides?: Partial<AllSettings>): AllSettings {
     python: { installations: [], api_enabled: true, ...overrides?.python },
     r: { installations: [], ...overrides?.r },
     quarto: { installations: [], ...overrides?.quarto },
+    nodejs: { installations: [], enabled: true, ...overrides?.nodejs },
   };
 }
 
@@ -2231,6 +2232,51 @@ describe("connectPublish — server settings validation", () => {
     await expect(connectPublish(opts)).rejects.toThrow(
       "API deployment is not licensed",
     );
+  });
+
+  // --- Node.js licensing/configuration ---
+
+  test("rejects Node.js content when nodejs.enabled is false", async () => {
+    const api = makeMockApi();
+    vi.mocked(api.getSettings).mockResolvedValue(
+      makeSettings({
+        nodejs: { installations: [], enabled: false },
+      }),
+    );
+
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+    });
+    const opts = makeOptions({ api, config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Node.js content is not enabled or licensed on this Connect server",
+    );
+  });
+
+  test("accepts Node.js content when nodejs.enabled is true", async () => {
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).resolves.toBeDefined();
+  });
+
+  test("does not block Python content when nodejs.enabled is false", async () => {
+    const api = makeMockApi();
+    vi.mocked(api.getSettings).mockResolvedValue(
+      makeSettings({
+        nodejs: { installations: [], enabled: false },
+      }),
+    );
+
+    const config = makeConfig({ type: ContentType.PYTHON_SHINY });
+    const opts = makeOptions({ api, config });
+
+    await expect(connectPublish(opts)).resolves.toBeDefined();
   });
 
   // --- RACU (run_as_current_user) ---

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -897,6 +897,11 @@ function isAPIContentType(contentType: string): boolean {
   );
 }
 
+/** Content types that require Node.js to be enabled and licensed on the server. */
+function isNodeJsContentType(contentType: string): boolean {
+  return contentType === ContentType.NODEJS;
+}
+
 /** App content types that support run_as_current_user. */
 function isAppContentType(contentType: string): boolean {
   return (
@@ -923,6 +928,13 @@ function checkServerSettings(
     !settings.general.license["allow-apis"]
   ) {
     throw new Error("API deployment is not licensed on this Connect server");
+  }
+
+  // Node.js licensing/configuration check
+  if (isNodeJsContentType(config.type) && !settings.nodejs.enabled) {
+    throw new Error(
+      "Node.js content is not enabled or licensed on this Connect server",
+    );
   }
 
   if (config.connect) {

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -1262,6 +1262,25 @@ describe("getSettings", () => {
     );
   });
 
+  it('uses scheduler/nodejs path when appMode is "nodejs"', async () => {
+    const appModeMap: Record<string, unknown> = {
+      ...urlResponseMap,
+      "/__api__/server_settings/scheduler/nodejs": scheduler,
+    };
+    mockRequest.mockImplementation((config: { url: string }) =>
+      Promise.resolve(jsonResponse(appModeMap[config.url])),
+    );
+
+    const client = createClient();
+    await client.getSettings("nodejs");
+
+    const urls = mockRequest.mock.calls.map(
+      (call: unknown[]) => (call[0] as { url: string }).url,
+    );
+    expect(urls).toContain("/__api__/server_settings/scheduler/nodejs");
+    expect(urls).not.toContain("/__api__/server_settings/scheduler");
+  });
+
   it("uses base scheduler path when no appMode is provided", async () => {
     mockSettingsRoutes();
 

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -1170,6 +1170,10 @@ describe("getSettings", () => {
   const quarto = {
     installations: [{ version: "1.4.0", cluster_name: "", image_name: "" }],
   };
+  const nodejs = {
+    installations: [{ version: "22.11.0", cluster_name: "", image_name: "" }],
+    enabled: true,
+  };
 
   const urlResponseMap: Record<string, unknown> = {
     "/__api__/v1/user": userDTO,
@@ -1179,6 +1183,7 @@ describe("getSettings", () => {
     "/__api__/v1/server_settings/python": python,
     "/__api__/v1/server_settings/r": r,
     "/__api__/v1/server_settings/quarto": quarto,
+    "/__api__/v1/server_settings/nodejs": nodejs,
   };
 
   function mockSettingsRoutes() {
@@ -1187,13 +1192,13 @@ describe("getSettings", () => {
     );
   }
 
-  it("makes 7 request calls to the correct URLs", async () => {
+  it("makes 8 request calls to the correct URLs", async () => {
     mockSettingsRoutes();
 
     const client = createClient();
     await client.getSettings();
 
-    expect(mockRequest).toHaveBeenCalledTimes(7);
+    expect(mockRequest).toHaveBeenCalledTimes(8);
 
     const urls = mockRequest.mock.calls
       .map((call: unknown[]) => (call[0] as { url: string }).url)
@@ -1214,6 +1219,7 @@ describe("getSettings", () => {
     expect(settings.python).toEqual(python);
     expect(settings.r).toEqual(r);
     expect(settings.quarto).toEqual(quarto);
+    expect(settings.nodejs).toEqual(nodejs);
   });
 
   it("uses app-mode-specific scheduler path when appMode is provided", async () => {
@@ -1291,6 +1297,43 @@ describe("getSettings", () => {
       (call: unknown[]) => (call[0] as { url: string }).url,
     );
     expect(urls).toContain("/__api__/server_settings/scheduler");
+  });
+
+  it("falls back to empty NodejsInfo when /server_settings/nodejs 404s", async () => {
+    mockRequest.mockImplementation((config: { url: string }) => {
+      if (config.url === "/__api__/v1/server_settings/nodejs") {
+        return Promise.resolve(
+          jsonResponse({ error: "Not found" }, 404, "Not Found"),
+        );
+      }
+      return Promise.resolve(jsonResponse(urlResponseMap[config.url]));
+    });
+
+    const client = createClient();
+    const settings = await client.getSettings();
+
+    expect(settings.nodejs).toEqual({ installations: [], enabled: false });
+    // The other 7 settings must still come through correctly.
+    expect(settings.general).toEqual(general);
+    expect(settings.python).toEqual(python);
+    expect(settings.r).toEqual(r);
+    expect(settings.quarto).toEqual(quarto);
+  });
+
+  it("propagates non-404 errors from /server_settings/nodejs", async () => {
+    mockRequest.mockImplementation((config: { url: string }) => {
+      if (config.url === "/__api__/v1/server_settings/nodejs") {
+        return Promise.resolve(
+          jsonResponse({ error: "Boom" }, 500, "Internal Server Error"),
+        );
+      }
+      return Promise.resolve(jsonResponse(urlResponseMap[config.url]));
+    });
+
+    const client = createClient();
+    await expect(client.getSettings()).rejects.toThrow(
+      /Request failed with status code 500/,
+    );
   });
 });
 
@@ -1938,7 +1981,7 @@ describe("AbortSignal support", () => {
     expect(call.signal).toBeDefined();
   });
 
-  it("getSettings forwards signal to all 7 requests", async () => {
+  it("getSettings forwards signal to all 8 requests", async () => {
     mockRequest.mockRejectedValue(
       Object.assign(new Error("canceled"), { code: "ERR_CANCELED" }),
     );
@@ -1948,7 +1991,7 @@ describe("AbortSignal support", () => {
       client.getSettings(undefined, abortedSignal()),
     ).rejects.toThrow();
 
-    // All 7 requests should have been initiated with the signal
+    // All 8 requests should have been initiated with the signal
     expect(mockRequest).toHaveBeenCalled();
     for (const call of mockRequest.mock.calls) {
       const config = call[0] as Record<string, unknown>;

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -16,6 +16,7 @@ import type {
   ContentID,
   DeployOutput,
   Integration,
+  NodejsInfo,
   PyInfo,
   QuartoInfo,
   RInfo,
@@ -450,7 +451,14 @@ export class ConnectAPI {
   }
 
   /**
-   * Fetches composite server settings from 7 separate endpoints.
+   * Fetches composite server settings from 8 separate endpoints.
+   *
+   * The Node.js settings endpoint (`/v1/server_settings/nodejs`) returns a
+   * 404 on older Connect servers that predate Connect 2026.04.0; in
+   * that case `getSettings` falls back to `{ installations: [], enabled: false }`
+   * rather than failing the entire call. Any other error (network failure,
+   * 5xx, auth) on the Node.js request still fails `getSettings` — only 404
+   * is swallowed.
    *
    * @param appMode - Connect app mode string (e.g. "python-shiny", "static").
    *   When provided and not "static", the scheduler endpoint is fetched with
@@ -479,6 +487,7 @@ export class ConnectAPI {
       { data: python },
       { data: r },
       { data: quarto },
+      { data: nodejs },
     ] = await Promise.all([
       this.client.get<UserDTO>("/__api__/v1/user", { signal }),
       this.client.get<ServerSettings>("/__api__/server_settings", { signal }),
@@ -492,9 +501,17 @@ export class ConnectAPI {
       this.client.get<QuartoInfo>("/__api__/v1/server_settings/quarto", {
         signal,
       }),
+      this.client
+        .get<NodejsInfo>("/__api__/v1/server_settings/nodejs", { signal })
+        .catch((err): { data: NodejsInfo } => {
+          if (axios.isAxiosError(err) && err.response?.status === 404) {
+            return { data: { installations: [], enabled: false } };
+          }
+          throw err;
+        }),
     ]);
 
-    return { general, user, application, scheduler, python, r, quarto };
+    return { general, user, application, scheduler, python, r, quarto, nodejs };
   }
 }
 

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -49,6 +49,7 @@ export class ConnectAPIError extends Error {
 const knownAppModes = new Set([
   "jupyter-static",
   "jupyter-voila",
+  "nodejs",
   "python-bokeh",
   "python-dash",
   "python-fastapi",

--- a/packages/connect-api/src/index.ts
+++ b/packages/connect-api/src/index.ts
@@ -15,6 +15,8 @@ export type {
   EnvVar,
   Integration,
   LicenseStatus,
+  NodejsInfo,
+  NodejsInstallation,
   PyInfo,
   PyInstallation,
   QuartoInfo,

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -335,7 +335,24 @@ export interface QuartoInfo {
   installations: QuartoInstallation[];
 }
 
-/** Composite settings from all 7 server endpoints. */
+export interface NodejsInstallation {
+  version: string;
+  cluster_name: string;
+  image_name: string;
+}
+
+export interface NodejsInfo {
+  installations: NodejsInstallation[];
+  /**
+   * True only when Node.js support is enabled in Connect's configuration AND
+   * the license permits Node.js content (Advanced tier or Evaluation).
+   * Older Connect servers that predate the field are treated as `false`
+   * (graceful 404 fallback in getSettings).
+   */
+  enabled: boolean;
+}
+
+/** Composite settings from all 8 server endpoints. */
 export interface AllSettings {
   general: ServerSettings;
   user: UserDTO;
@@ -344,4 +361,5 @@ export interface AllSettings {
   python: PyInfo;
   r: RInfo;
   quarto: QuartoInfo;
+  nodejs: NodejsInfo;
 }

--- a/test/connect-api-contracts/src/endpoints/get-settings.test.ts
+++ b/test/connect-api-contracts/src/endpoints/get-settings.test.ts
@@ -71,9 +71,16 @@ describe("GetSettings", () => {
       expect(matched[0].method).toBe("GET");
     });
 
-    it("sends Authorization header on all 7 requests", async () => {
+    it("sends GET to /__api__/v1/server_settings/nodejs", async () => {
       const { all } = await callAndCapture();
-      expect(all.length).toBeGreaterThanOrEqual(7);
+      const matched = filterByPath(all, "/__api__/v1/server_settings/nodejs");
+      expect(matched.length).toBeGreaterThanOrEqual(1);
+      expect(matched[0].method).toBe("GET");
+    });
+
+    it("sends Authorization header on all 8 requests", async () => {
+      const { all } = await callAndCapture();
+      expect(all.length).toBeGreaterThanOrEqual(8);
 
       for (const req of all) {
         expect(req.headers["authorization"]).toBe(`Key ${TEST_API_KEY}`);


### PR DESCRIPTION
## Summary

- Extends `@posit-dev/connect-api` to fetch `/v1/server_settings/nodejs` alongside the other server-settings endpoints, with an inline 404 fallback for older Connect servers (predating posit-dev/connect#39012).
- Adds a Node.js precheck in `connectPublish` that refuses Node.js publishes when the server reports `nodejs.enabled === false`, replacing the reverted `allow-apis` gate. Connect's `AllowNodeJs()` is independent of `AllowAPIs`, so the server-reported `nodejs.enabled` flag is the correct single source of truth.
- Adds `NodejsInfo` and `NodejsInstallation` types mirrored verbatim from Connect's Go structs at `src/connect/api/serversettings/nodejsinfo.go`, exported from the package index.

Closes #4000

## Out of scope (tracked separately)

Mock-connect fixture + route + Swagger validation entry are deferred to #4162

## Test plan

- [x] \`npm test --prefix packages/connect-api\` — 123/123 passing (added 404 fallback, non-404 propagation, scheduler/nodejs path, count bumps, AllSettings.nodejs assertion).
- [x] \`just test-connect-contracts\` — 69/69 passing (added request-correctness for nodejs path, bumped auth-header count to 8).
- [x] \`cd extensions/vscode && npm run test-unit\` — 1737 passing / 4 todo (added 3 precheck cases: rejects on disabled, accepts on enabled, doesn't false-positive Python).
- [x] Format check on changed files — clean (\`prettier --check\` on the 7 modified files).