### PR TITLE
test(nodejs): add Node.js server_settings fixture

### DIFF
--- a/test/mock-connect/fixtures/connect-responses/server-settings-nodejs.json
+++ b/test/mock-connect/fixtures/connect-responses/server-settings-nodejs.json
@@ -1,0 +1,6 @@
+{
+  "installations": [
+    { "version": "22.11.0", "cluster_name": "", "image_name": "" }
+  ],
+  "enabled": true
+}

--- a/test/mock-connect/src/mock-connect-server.ts
+++ b/test/mock-connect/src/mock-connect-server.ts
@@ -183,6 +183,12 @@ export class MockConnectServer {
         200,
         loadFixture("server-settings-quarto.json"),
       ],
+      [
+        "GET",
+        /^\/__api__\/v1\/server_settings\/nodejs$/,
+        200,
+        loadFixture("server-settings-nodejs.json"),
+      ],
       // Content Validation (non-API path)
       ["GET", /^\/content\/[^/]+\/$/, 200, "<html>OK</html>", "text/html"],
     ];

--- a/test/mock-connect/src/validation/fixture-map.ts
+++ b/test/mock-connect/src/validation/fixture-map.ts
@@ -131,6 +131,13 @@ export const fixtureMappings: FixtureMapping[] = [
     status: 200,
     description: "GET /server_settings/quarto — Quarto installations",
   },
+  {
+    fixture: "server-settings-nodejs.json",
+    path: "/v1/server_settings/nodejs",
+    method: "get",
+    status: 200,
+    description: "GET /server_settings/nodejs — Node.js installations",
+  },
 
   // Integrations endpoint
   {


### PR DESCRIPTION
## Summary
- Adds `server-settings-nodejs.json` fixture, registers the `GET /v1/server_settings/nodejs` route on the mock Connect server, and records the fixture-map entry so it's validated against the public OpenAPI 3.0 spec.
- Unblocks the deferred work from #4000 now that the validator migration (#4161) has landed.

Closes #4162

## Test plan
- [x] `just validate-fixtures` — passes; new fixture validates against the OpenAPI 3.0 schema (visible as `GET /server_settings/nodejs — Node.js installations`).
- [x] `just test-connect-contracts` — 69 tests pass; `getNodejsSettings()` now hits a real 200 instead of relying on the 404 fallback.