### PR TITLE
feat(nodejs): wire publishing flow preflight and version logging

### DIFF
--- a/extensions/vscode/src/inspect/detectors/nodejs.ts
+++ b/extensions/vscode/src/inspect/detectors/nodejs.ts
@@ -2,8 +2,9 @@
 
 import * as path from "path";
 import { ContentType } from "src/api/types/configurations";
-import { fileExistsAt, readFileText } from "src/interpreters/fsUtils";
+import { fileExistsAt } from "src/interpreters/fsUtils";
 import { ContentTypeDetector, PartialConfig } from "../types";
+import { readMain, readPackageJson, readStart } from "../nodejs/packageJson";
 
 const VALID_EXTENSIONS: ReadonlySet<string> = new Set([
   ".js",
@@ -45,35 +46,6 @@ function makeConfig(baseDir: string, abs: string): PartialConfig {
   };
 }
 
-/** Type guard narrowing parsed JSON to a plain object before field access. */
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null;
-}
-
-/**
- * Read a non-empty string `main` field from a parsed package.json, or
- * `undefined` if absent or not a usable string.
- */
-function readMain(pkg: unknown): string | undefined {
-  if (!isRecord(pkg)) return undefined;
-  const main = pkg.main;
-  if (typeof main !== "string" || main.length === 0) return undefined;
-  return main;
-}
-
-/**
- * Read a non-empty `scripts.start` string from a parsed package.json, or
- * `undefined` if absent or not a usable string.
- */
-function readStart(pkg: unknown): string | undefined {
-  if (!isRecord(pkg)) return undefined;
-  const scripts = pkg.scripts;
-  if (!isRecord(scripts)) return undefined;
-  const start = scripts.start;
-  if (typeof start !== "string" || start.length === 0) return undefined;
-  return start;
-}
-
 /**
  * Find the script file in a `scripts.start` command. Locates `node` (with a
  * word boundary so `ts-node` also matches — Connect parity, see test) and
@@ -86,22 +58,6 @@ function parseStartScript(start: string): string | undefined {
   if (rest === undefined) return undefined;
   const args = rest.trim().split(/\s+/);
   return args.find((a) => !a.startsWith("-") && hasValidExtension(a));
-}
-
-/**
- * Read and parse `<baseDir>/package.json`. Returns `undefined` when the file
- * is missing or unparseable so the caller treats both as "no package.json
- * signal" — Connect's runtime warns and falls through, but in detection we
- * prefer Unknown over guessing.
- */
-async function readPackageJson(baseDir: string): Promise<unknown> {
-  const text = await readFileText(path.join(baseDir, "package.json"));
-  if (text === null) return undefined;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return undefined;
-  }
 }
 
 /**

--- a/extensions/vscode/src/inspect/nodejs/packageJson.test.ts
+++ b/extensions/vscode/src/inspect/nodejs/packageJson.test.ts
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import {
+  isRecord,
+  readEnginesNode,
+  readMain,
+  readPackageJson,
+  readStart,
+} from "./packageJson";
+
+describe("isRecord", () => {
+  test("true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  test("false for null, arrays, primitives", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord("string")).toBe(false);
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord(true)).toBe(false);
+  });
+});
+
+describe("readPackageJson", () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(path.join(tmpdir(), "pkgjson-"));
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  test("returns parsed object when valid JSON", async () => {
+    await writeFile(
+      path.join(baseDir, "package.json"),
+      JSON.stringify({ name: "x" }),
+      "utf-8",
+    );
+    expect(await readPackageJson(baseDir)).toEqual({ name: "x" });
+  });
+
+  test("returns undefined when package.json missing", async () => {
+    expect(await readPackageJson(baseDir)).toBeUndefined();
+  });
+
+  test("returns undefined when package.json is invalid JSON", async () => {
+    await writeFile(path.join(baseDir, "package.json"), "not { valid", "utf-8");
+    expect(await readPackageJson(baseDir)).toBeUndefined();
+  });
+});
+
+describe("readMain", () => {
+  test("returns the string when main is a non-empty string", () => {
+    expect(readMain({ main: "index.js" })).toBe("index.js");
+  });
+
+  test("returns undefined when main is empty", () => {
+    expect(readMain({ main: "" })).toBeUndefined();
+  });
+
+  test("returns undefined when main is missing", () => {
+    expect(readMain({})).toBeUndefined();
+  });
+
+  test("returns undefined when main is not a string", () => {
+    expect(readMain({ main: 42 })).toBeUndefined();
+    expect(readMain({ main: null })).toBeUndefined();
+    expect(readMain({ main: ["a"] })).toBeUndefined();
+  });
+
+  test("returns undefined when input is not a record", () => {
+    expect(readMain(null)).toBeUndefined();
+    expect(readMain("string")).toBeUndefined();
+    expect(readMain([])).toBeUndefined();
+  });
+});
+
+describe("readStart", () => {
+  test("returns the string when scripts.start is a non-empty string", () => {
+    expect(readStart({ scripts: { start: "node app.js" } })).toBe(
+      "node app.js",
+    );
+  });
+
+  test("returns undefined when scripts.start is empty", () => {
+    expect(readStart({ scripts: { start: "" } })).toBeUndefined();
+  });
+
+  test("returns undefined when scripts is missing", () => {
+    expect(readStart({})).toBeUndefined();
+  });
+
+  test("returns undefined when scripts.start is missing", () => {
+    expect(readStart({ scripts: { test: "vitest" } })).toBeUndefined();
+  });
+
+  test("returns undefined when scripts.start is not a string", () => {
+    expect(readStart({ scripts: { start: 42 } })).toBeUndefined();
+  });
+
+  test("returns undefined when input is not a record", () => {
+    expect(readStart(null)).toBeUndefined();
+    expect(readStart("string")).toBeUndefined();
+  });
+});
+
+describe("readEnginesNode", () => {
+  test("returns the constraint when engines.node is a non-empty string", () => {
+    expect(readEnginesNode({ engines: { node: ">=22.18.0" } })).toBe(
+      ">=22.18.0",
+    );
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(readEnginesNode({ engines: { node: "  >=22.18.0  " } })).toBe(
+      ">=22.18.0",
+    );
+  });
+
+  test("returns undefined when engines is missing", () => {
+    expect(readEnginesNode({ name: "x" })).toBeUndefined();
+  });
+
+  test("returns undefined when engines.node is missing", () => {
+    expect(readEnginesNode({ engines: { npm: ">=10" } })).toBeUndefined();
+  });
+
+  test("returns undefined when engines.node is empty", () => {
+    expect(readEnginesNode({ engines: { node: "" } })).toBeUndefined();
+  });
+
+  test("returns undefined when engines.node is only whitespace", () => {
+    expect(readEnginesNode({ engines: { node: "   " } })).toBeUndefined();
+  });
+
+  test("returns undefined when engines.node is not a string", () => {
+    expect(readEnginesNode({ engines: { node: 22 } })).toBeUndefined();
+    expect(readEnginesNode({ engines: { node: null } })).toBeUndefined();
+    expect(readEnginesNode({ engines: { node: [">=22"] } })).toBeUndefined();
+  });
+
+  test("returns undefined when input is not a record", () => {
+    expect(readEnginesNode(null)).toBeUndefined();
+    expect(readEnginesNode("string")).toBeUndefined();
+    expect(readEnginesNode([])).toBeUndefined();
+  });
+});

--- a/extensions/vscode/src/inspect/nodejs/packageJson.ts
+++ b/extensions/vscode/src/inspect/nodejs/packageJson.ts
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import * as path from "path";
+
+import { readFileText } from "src/interpreters/fsUtils";
+
+/** Type guard narrowing parsed JSON to a plain object before field access. */
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Read and parse `<baseDir>/package.json`. Returns `undefined` when the file
+ * is missing or unparseable so callers treat both as "no package.json signal".
+ */
+export async function readPackageJson(baseDir: string): Promise<unknown> {
+  const text = await readFileText(path.join(baseDir, "package.json"));
+  if (text === null) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read a non-empty string `main` field from a parsed package.json, or
+ * `undefined` if absent or not a usable string.
+ */
+export function readMain(pkg: unknown): string | undefined {
+  if (!isRecord(pkg)) return undefined;
+  const main = pkg.main;
+  if (typeof main !== "string" || main.length === 0) return undefined;
+  return main;
+}
+
+/**
+ * Read a non-empty `scripts.start` string from a parsed package.json, or
+ * `undefined` if absent or not a usable string.
+ */
+export function readStart(pkg: unknown): string | undefined {
+  if (!isRecord(pkg)) return undefined;
+  const scripts = pkg.scripts;
+  if (!isRecord(scripts)) return undefined;
+  const start = scripts.start;
+  if (typeof start !== "string" || start.length === 0) return undefined;
+  return start;
+}
+
+/**
+ * Read the `engines.node` version constraint from a parsed package.json.
+ * Returns the trimmed constraint string when present and non-empty.
+ * Returns `undefined` for anything else. Used by the publish-time log to
+ * surface the runtime constraint Connect will read at deploy time.
+ */
+export function readEnginesNode(pkg: unknown): string | undefined {
+  if (!isRecord(pkg)) return undefined;
+  const engines = pkg.engines;
+  if (!isRecord(engines)) return undefined;
+  const node = engines.node;
+  if (typeof node !== "string") return undefined;
+  const trimmed = node.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -106,10 +106,20 @@ vi.mock("../interpreters/rPackages", () => ({
   repoURLFromOptions: vi.fn().mockReturnValue(""),
 }));
 
-// Mock fsUtils — default to true so preflight requirements check passes
-vi.mock("../interpreters/fsUtils", () => ({
-  fileExistsAt: vi.fn().mockResolvedValue(true),
-}));
+// Mock fsUtils — default to true so preflight requirements check passes.
+// readFileText delegates to the mocked node:fs/promises readFile so per-test
+// `vi.mocked(readFile).mockResolvedValue(...)` overrides still drive the
+// shared inspect/nodejs/packageJson helpers used during createManifest.
+vi.mock("../interpreters/fsUtils", async () => {
+  const fs = await import("node:fs/promises");
+  return {
+    fileExistsAt: vi.fn().mockResolvedValue(true),
+    readFileText: vi.fn(async (filePath: string): Promise<string | null> => {
+      const result = await fs.readFile(filePath, "utf-8");
+      return typeof result === "string" ? result : null;
+    }),
+  };
+});
 
 // Mock dependency source generation (pylock.toml / uv.lock / pyproject.toml fallback)
 vi.mock("../interpreters/pythonDependencySources", () => ({
@@ -2232,6 +2242,95 @@ describe("connectPublish — server settings validation", () => {
     await expect(connectPublish(opts)).rejects.toThrow(
       "API deployment is not licensed",
     );
+  });
+
+  // --- Node.js version constraint log ---
+
+  test("logs Node.js version constraint from engines.node", async () => {
+    const { readFile } = await import("node:fs/promises");
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({ engines: { node: ">=22.18.0" } }),
+    );
+
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+    });
+    const onProgress = vi.fn();
+    const opts = makeOptions({ config, onProgress });
+
+    await connectPublish(opts);
+
+    const logMessages = onProgress.mock.calls
+      .map((args) => args[0] as PublishEvent)
+      .filter((e) => e.status === "log" && typeof e.message === "string")
+      .map((e) => e.message as string);
+
+    expect(logMessages).toContain("Node.js version constraint >=22.18.0");
+  });
+
+  test("logs Node.js version constraint (any) when engines.node absent", async () => {
+    const { readFile } = await import("node:fs/promises");
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({ name: "x", version: "0.0.0" }),
+    );
+
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+    });
+    const onProgress = vi.fn();
+    const opts = makeOptions({ config, onProgress });
+
+    await connectPublish(opts);
+
+    const logMessages = onProgress.mock.calls
+      .map((args) => args[0] as PublishEvent)
+      .filter((e) => e.status === "log" && typeof e.message === "string")
+      .map((e) => e.message as string);
+
+    expect(logMessages).toContain("Node.js version constraint (any)");
+  });
+
+  test("logs (any) when package.json is malformed (no throw)", async () => {
+    const { readFile } = await import("node:fs/promises");
+    vi.mocked(readFile).mockResolvedValue("not { valid json");
+
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+    });
+    const onProgress = vi.fn();
+    const opts = makeOptions({ config, onProgress });
+
+    await expect(connectPublish(opts)).resolves.toBeDefined();
+
+    const logMessages = onProgress.mock.calls
+      .map((args) => args[0] as PublishEvent)
+      .filter((e) => e.status === "log" && typeof e.message === "string")
+      .map((e) => e.message as string);
+
+    expect(logMessages).toContain("Node.js version constraint (any)");
+  });
+
+  test("does not log Node.js version constraint for non-NODEJS types", async () => {
+    const config = makeConfig({ type: ContentType.PYTHON_SHINY });
+    const onProgress = vi.fn();
+    const opts = makeOptions({ config, onProgress });
+
+    await connectPublish(opts);
+
+    const logMessages = onProgress.mock.calls
+      .map((args) => args[0] as PublishEvent)
+      .filter((e) => e.status === "log" && typeof e.message === "string")
+      .map((e) => e.message as string);
+
+    expect(
+      logMessages.some((m) => m.startsWith("Node.js version constraint")),
+    ).toBe(false);
   });
 
   // --- Node.js licensing/configuration ---

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -841,8 +841,7 @@ describe("connectPublish", () => {
     // The deployment record written to disk reflects the Node.js config.
     const writeCalls = mockWriteFile.mock.calls;
     expect(writeCalls.length).toBeGreaterThan(0);
-    const lastWrite = writeCalls[writeCalls.length - 1];
-    const written = String(lastWrite[1]);
+    const written = String(writeCalls.at(-1)?.[1] ?? "");
     expect(written).toContain("nodejs");
   });
 });

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -2346,6 +2346,8 @@ describe("connectPublish — server settings validation", () => {
     const config = makeConfig({
       type: ContentType.NODEJS,
       python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+      entrypoint: "index.js",
     });
     const opts = makeOptions({ api, config });
 
@@ -2358,6 +2360,8 @@ describe("connectPublish — server settings validation", () => {
     const config = makeConfig({
       type: ContentType.NODEJS,
       python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+      entrypoint: "index.js",
     });
     const opts = makeOptions({ config });
 
@@ -2374,6 +2378,113 @@ describe("connectPublish — server settings validation", () => {
 
     const config = makeConfig({ type: ContentType.PYTHON_SHINY });
     const opts = makeOptions({ api, config });
+
+    await expect(connectPublish(opts)).resolves.toBeDefined();
+  });
+
+  // --- Node.js preflight package-file validation ---
+
+  test("nodejs preflight accepts package.json + package-lock.json present and in files", async () => {
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+      entrypoint: "index.js",
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).resolves.toBeDefined();
+  });
+
+  test("nodejs preflight rejects when package.json missing on disk", async () => {
+    const { fileExistsAt } = await import("../interpreters/fsUtils");
+    vi.mocked(fileExistsAt).mockImplementation((p: string) => {
+      return Promise.resolve(!p.endsWith("package.json"));
+    });
+
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+      entrypoint: "index.js",
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file package.json. This file must be included in the deployment.",
+    );
+  });
+
+  test("nodejs preflight rejects when package-lock.json missing on disk with npm install hint", async () => {
+    const { fileExistsAt } = await import("../interpreters/fsUtils");
+    vi.mocked(fileExistsAt).mockImplementation((p: string) => {
+      return Promise.resolve(!p.endsWith("package-lock.json"));
+    });
+
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json", "package-lock.json"],
+      entrypoint: "index.js",
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file package-lock.json. This file must be included in the deployment. Run `npm install` to generate it.",
+    );
+  });
+
+  test("nodejs preflight rejects when package.json on disk but absent from files (no hint)", async () => {
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package-lock.json"],
+      entrypoint: "index.js",
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file package.json. This file must be included in the deployment.",
+    );
+  });
+
+  test("nodejs preflight rejects when package-lock.json on disk but absent from files (no hint)", async () => {
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: ["index.js", "package.json"],
+      entrypoint: "index.js",
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file package-lock.json. This file must be included in the deployment.",
+    );
+
+    // Verify the npm-install hint is NOT appended when the failure is
+    // "not in files" rather than "missing on disk".
+    await expect(connectPublish(opts)).rejects.not.toThrow(/Run `npm install`/);
+  });
+
+  test("nodejs preflight rejects when files is undefined", async () => {
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      files: undefined,
+      entrypoint: "index.js",
+    });
+    const opts = makeOptions({ config });
+
+    await expect(connectPublish(opts)).rejects.toThrow(
+      "Missing dependency file package.json. This file must be included in the deployment.",
+    );
+  });
+
+  test("nodejs preflight skipped for non-NODEJS content types", async () => {
+    // Default config is python-shiny with no package.json in files.
+    // Confirm preflight does not fail looking for Node.js files.
+    const config = makeConfig({ type: ContentType.PYTHON_SHINY });
+    const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).resolves.toBeDefined();
   });

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -785,6 +785,66 @@ describe("connectPublish", () => {
 
     expect(config).toEqual(originalConfig);
   });
+
+  test("happy path — Node.js content type", async () => {
+    const { readFile } = await import("node:fs/promises");
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({
+        name: "my-node-app",
+        version: "1.0.0",
+        main: "index.js",
+        engines: { node: ">=22.18.0" },
+      }),
+    );
+
+    const api = makeMockApi();
+    const config = makeConfig({
+      type: ContentType.NODEJS,
+      python: undefined,
+      entrypoint: "index.js",
+      files: ["index.js", "package.json", "package-lock.json"],
+    });
+    const onProgress = vi.fn();
+    const opts = makeOptions({ api, config, onProgress });
+
+    const result = await connectPublish(opts);
+
+    expect(result).toBeDefined();
+    expect(result.contentId).toBe("content-guid-123");
+
+    // All major steps were exercised.
+    const steps = progressSteps(onProgress);
+    expect(steps.map((s) => s.step)).toEqual(
+      expect.arrayContaining([
+        "createManifest",
+        "preflight",
+        "createNewDeployment",
+        "createBundle",
+        "uploadBundle",
+        "deployBundle",
+      ]),
+    );
+
+    // The version-constraint log fired.
+    const logMessages = onProgress.mock.calls
+      .map((args) => args[0] as PublishEvent)
+      .filter((e) => e.status === "log" && typeof e.message === "string")
+      .map((e) => e.message as string);
+    expect(logMessages).toContain("Node.js version constraint >=22.18.0");
+
+    // updateDeployment receives the connectContentFromConfig payload; reaching
+    // deployBundle means it didn't throw for the Node.js config.
+    expect(api.createDeployment).toHaveBeenCalledTimes(1);
+    expect(api.updateDeployment).toHaveBeenCalledTimes(1);
+    expect(api.deployBundle).toHaveBeenCalledTimes(1);
+
+    // The deployment record written to disk reflects the Node.js config.
+    const writeCalls = mockWriteFile.mock.calls;
+    expect(writeCalls.length).toBeGreaterThan(0);
+    const lastWrite = writeCalls[writeCalls.length - 1];
+    const written = String(lastWrite[1]);
+    expect(written).toContain("nodejs");
+  });
 });
 
 describe("connectPublish — R package resolution", () => {

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -2470,7 +2470,7 @@ describe("connectPublish — server settings validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).rejects.toThrow(
-      "Missing dependency file package.json. This file must be included in the deployment.",
+      "Missing package.json — file not found in the project directory. Run `npm init` to create one.",
     );
   });
 
@@ -2489,11 +2489,11 @@ describe("connectPublish — server settings validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).rejects.toThrow(
-      "Missing dependency file package-lock.json. This file must be included in the deployment. Run `npm install` to generate it.",
+      "Missing package-lock.json — file not found in the project directory. Run `npm install` to generate it.",
     );
   });
 
-  test("nodejs preflight rejects when package.json on disk but absent from files (no hint)", async () => {
+  test("nodejs preflight rejects when package.json on disk but absent from files", async () => {
     const config = makeConfig({
       type: ContentType.NODEJS,
       python: undefined,
@@ -2503,11 +2503,11 @@ describe("connectPublish — server settings validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).rejects.toThrow(
-      "Missing dependency file package.json. This file must be included in the deployment.",
+      "Missing package.json — file is not included in the deployment configuration. Add it to the `files` list in your configuration.",
     );
   });
 
-  test("nodejs preflight rejects when package-lock.json on disk but absent from files (no hint)", async () => {
+  test("nodejs preflight rejects when package-lock.json on disk but absent from files", async () => {
     const config = makeConfig({
       type: ContentType.NODEJS,
       python: undefined,
@@ -2517,11 +2517,11 @@ describe("connectPublish — server settings validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).rejects.toThrow(
-      "Missing dependency file package-lock.json. This file must be included in the deployment.",
+      "Missing package-lock.json — file is not included in the deployment configuration. Add it to the `files` list in your configuration.",
     );
 
-    // Verify the npm-install hint is NOT appended when the failure is
-    // "not in files" rather than "missing on disk".
+    // Confirm the not-in-files failure does NOT include the
+    // missing-on-disk hint (Run `npm install`).
     await expect(connectPublish(opts)).rejects.not.toThrow(/Run `npm install`/);
   });
 
@@ -2535,7 +2535,7 @@ describe("connectPublish — server settings validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).rejects.toThrow(
-      "Missing dependency file package.json. This file must be included in the deployment.",
+      "Missing package.json — file is not included in the deployment configuration. Add it to the `files` list in your configuration.",
     );
   });
 

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -21,6 +21,10 @@ import type { PositronRSettings } from "../api/types/positron";
 import { appModeFromType, contentTypeFromAppMode } from "../bundler/appMode";
 import { connectContentFromConfig } from "../bundler/connectContentFromConfig";
 import { getFilenames } from "../bundler/manifest";
+import {
+  readEnginesNode,
+  readPackageJson,
+} from "../inspect/nodejs/packageJson";
 
 import { readPythonRequirements } from "./dependencies";
 import {
@@ -203,6 +207,16 @@ export async function connectPublish({
         ? `Local Python version ${manifest.python.version}`
         : "Local Python not in use",
     });
+
+    if (config.type === ContentType.NODEJS) {
+      const pkg = await readPackageJson(projectDir);
+      const constraint = readEnginesNode(pkg);
+      onProgress({
+        step: "createManifest",
+        status: "log",
+        message: `Node.js version constraint ${constraint ?? "(any)"}`,
+      });
+    }
 
     onProgress({ step: "createManifest", status: "success" });
 

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -298,6 +298,34 @@ export async function connectPublish({
       }
     }
 
+    if (config.type === ContentType.NODEJS) {
+      const requiredFiles = ["package.json", "package-lock.json"] as const;
+      for (const fileName of requiredFiles) {
+        const filePath = path.join(projectDir, fileName);
+        const exists = await fileExistsAt(filePath);
+        if (!exists) {
+          const hint =
+            fileName === "package-lock.json"
+              ? " Run `npm install` to generate it."
+              : "";
+          throw new Error(
+            `Missing dependency file ${fileName}. ` +
+              `This file must be included in the deployment.${hint}`,
+          );
+        }
+        const filePatterns = config.files ?? [];
+        const isIncluded = filePatterns.some((pattern) =>
+          pattern.endsWith(fileName),
+        );
+        if (!isIncluded) {
+          throw new Error(
+            `Missing dependency file ${fileName}. ` +
+              `This file must be included in the deployment.`,
+          );
+        }
+      }
+    }
+
     // Fetch server settings and validate config against capabilities
     onProgress({
       step: "preflight",

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -299,28 +299,36 @@ export async function connectPublish({
     }
 
     if (config.type === ContentType.NODEJS) {
-      const requiredFiles = ["package.json", "package-lock.json"] as const;
-      for (const fileName of requiredFiles) {
-        const filePath = path.join(projectDir, fileName);
+      const requiredFiles = [
+        {
+          name: "package.json",
+          missingOnDiskHint: "Run `npm init` to create one.",
+        },
+        {
+          name: "package-lock.json",
+          missingOnDiskHint: "Run `npm install` to generate it.",
+        },
+      ] as const;
+      const notIncludedHint =
+        "Add it to the `files` list in your configuration.";
+
+      for (const { name, missingOnDiskHint } of requiredFiles) {
+        const filePath = path.join(projectDir, name);
         const exists = await fileExistsAt(filePath);
         if (!exists) {
-          const hint =
-            fileName === "package-lock.json"
-              ? " Run `npm install` to generate it."
-              : "";
           throw new Error(
-            `Missing dependency file ${fileName}. ` +
-              `This file must be included in the deployment.${hint}`,
+            `Missing ${name} — file not found in the project directory. ` +
+              missingOnDiskHint,
           );
         }
         const filePatterns = config.files ?? [];
         const isIncluded = filePatterns.some((pattern) =>
-          pattern.endsWith(fileName),
+          pattern.endsWith(name),
         );
         if (!isIncluded) {
           throw new Error(
-            `Missing dependency file ${fileName}. ` +
-              `This file must be included in the deployment.`,
+            `Missing ${name} — file is not included in the deployment configuration. ` +
+              notIncludedHint,
           );
         }
       }


### PR DESCRIPTION
Adds a preflight check when deploying a Node.js app that checks for `package.json` and `package-lock.json` since Connect requires them.

Below are screenshots of each error state.

<details><summary>Missing `package.json`</summary>
<p>

<img width="457" height="134" alt="CleanShot 2026-05-13 at 13 58 01" src="https://github.com/user-attachments/assets/a1d469a5-b6f0-48be-82ca-3761da3f575e" />

</p>
</details> 

<details><summary>Missing `package-lock.json`</summary>
<p>

<img width="453" height="132" alt="CleanShot 2026-05-13 at 13 58 32" src="https://github.com/user-attachments/assets/501e7b2b-f88a-4ccc-9133-e12d85303a9f" />

</p>
</details> 

<details><summary>`package.json` not in Configuration's `files` list</summary>
<p>

<img width="451" height="132" alt="CleanShot 2026-05-13 at 13 59 08" src="https://github.com/user-attachments/assets/23f4eab6-c31e-425c-9845-d3be0380e261" />

</p>
</details> 

<details><summary>`package-lock.json` not in Configuration's `files` list</summary>
<p>

<img width="455" height="133" alt="CleanShot 2026-05-13 at 13 59 32" src="https://github.com/user-attachments/assets/d7917743-8f8e-42e0-b103-d15fbee67b54" />

</p>
</details> 

This also adds Node.js version constraint logging. It will say "Node.js version constraint (any)" if `engines.node` is not specified in `package.json`.

<details><summary>Node.js version logging</summary>
<p>

<img width="318" height="133" alt="CleanShot 2026-05-13 at 14 00 10" src="https://github.com/user-attachments/assets/a988b301-491d-44da-995c-3ba848b62743" />

</p>
</details> 

Shared code was moved to `inspect/nodejs/packageJson.ts` which reads `package.json` for the different spots in the extension code we need to do that.

Closes #4001

## Test plan

- [x] `cd extensions/vscode && just lint` passes
- [x] `cd extensions/vscode && npm run test-unit` passes
- [x] Happy-path: deploy a real Node.js project (e.g., minimal Express app) to a Connect server with Node.js enabled — verify success
- [x] Missing lockfile: delete `package-lock.json`, attempt deploy, verify the error message includes "Run `npm install` to generate it."
- [x] Missing inclusion: keep both files but remove `package-lock.json` from `files` patterns, verify the error message says "must be included in the deployment" (no npm-install hint)
- [x] Server without Node.js: target a Connect server with `nodejs.enabled === false`, verify the licensing rejection