### PR TITLE
fix(nodejs): list Node.js entrypoints in the new-deployment picker

### DIFF
--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -16,15 +16,21 @@ export const DEFAULT_R_PACKAGE_FILE = "renv.lock";
 
 // should all be lowercase!
 export const ENTRYPOINT_FILE_EXTENSIONS = [
+  ".cjs",
+  ".cts",
   ".htm",
   ".html",
   ".ipynb",
+  ".js",
+  ".mjs",
+  ".mts",
   ".py",
   ".qmd",
   ".r",
   ".rmd",
-  ".yml",
+  ".ts",
   ".yaml",
+  ".yml",
 ];
 
 export enum BooleanContextValues {


### PR DESCRIPTION
## Summary

- Add `.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, `.cts` to `ENTRYPOINT_FILE_EXTENSIONS` so the "Create a New Deployment" quick picker lists Node.js files under "Open Files" — matching the editor-bar "Deploy with Posit Publisher" button, which already runs the full detector chain.
- Alphabetize the list while editing so future additions stay easy to scan.

Closes #4169.

## Background

The picker and the editor-bar button take different code paths:

- Editor-bar button → `entrypointTracker.ts` `isEntrypoint()` → `inspectProject(...)` → full detector chain (Node.js detector matches, button appears).
- New-deployment picker → static `ENTRYPOINT_FILE_EXTENSIONS` filter in `newDeployment.ts` (Node.js extensions were never added, so files were filtered out).

The six extensions added here are the same set declared in `NodejsAppDetector` (`extensions/vscode/src/inspect/detectors/nodejs.ts`).

No CHANGELOG entry — Node.js publishing itself is still in-progress under #4123, so this fix rides along with that feature's eventual entry.

## Test plan

- [ ] Open `app.ts` in a Node.js project; click **Add Deployment**; `app.ts` appears under "Open Files".
- [ ] Repeat for `app.js`, `index.mjs`, `server.cjs`, `app.mts`, `app.cts`.
- [ ] Confirm Python/R/Quarto/HTML/notebook entrypoints still show up (no regression).
- [x] `npm run test-unit` passes (1738 tests).
- [x] `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)