### PR TITLE
docs(nodejs): document nodejs type in configuration reference and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for deploying Node.js applications (Express, Fastify, Hono, etc.) to Posit Connect. (#3964)
+
 ### Fixed
 
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Indicates the type of content being deployed. Valid values are:
 - `html`
 - `jupyter-notebook`
 - `jupyter-voila`
+- `nodejs`
 - `python-bokeh`
 - `python-dash`
 - `python-fastapi`
@@ -222,6 +223,28 @@ Quarto version. The server must have a similar Quarto version in order to run th
 [quarto]
 version = "1.4.554"
 engines = ["knitr"]
+```
+
+## Node.js settings
+
+_Only valid when `product_type` is `connect`_
+
+[Posit Connect supports deploying Node.js applications](https://docs.posit.co/connect/user/nodejs/).
+
+Both `package.json` and `package-lock.json` must be present and listed under `files`. Connect uses `npm ci` to install dependencies; if `package-lock.json` is missing, run `npm install` to generate it.
+
+If `package.json` specifies an [`engines.node`](https://docs.npmjs.com/cli/configuring-npm/package-json#engines) constraint, Connect uses it to select the runtime version. Otherwise Connect uses the latest version of Node.js available on the server.
+
+Node.js deployment requires an Advanced Connect license, and the server administrator must enable Node.js support. Publisher reports when the target server has Node.js disabled.
+
+Connect Cloud does not support Node.js content.
+
+Example:
+
+```toml
+type = "nodejs"
+entrypoint = "index.js"
+files = ["*.js", "package.json", "package-lock.json"]
 ```
 
 ## Connect-specific settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,7 +235,7 @@ Both `package.json` and `package-lock.json` must be present and listed under `fi
 
 If `package.json` specifies an [`engines.node`](https://docs.npmjs.com/cli/configuring-npm/package-json#engines) constraint, Connect uses it to select the runtime version. Otherwise Connect uses the latest version of Node.js available on the server.
 
-Node.js deployment requires an Advanced Connect license, and the server administrator must enable Node.js support. Publisher reports when the target server has Node.js disabled.
+Node.js deployment requires an [Advanced Connect license](https://docs.posit.co/connect/user/licensing/), and the server administrator must enable Node.js support. Publisher reports when the target server has Node.js disabled.
 
 Connect Cloud does not support Node.js content.
 


### PR DESCRIPTION
## Summary

Final piece of the #3964 Node.js deployment epic. Updates `docs/configuration.md` and the root `CHANGELOG.md` so users can find and configure Node.js deployments.

- Adds `nodejs` to the `#### type` bullet list alphabetically.
- Adds a `## Node.js settings` section after `## Quarto settings`, covering:
  - `package.json` / `package-lock.json` requirements (`npm ci`-only install path)
  - `engines.node` runtime selection
  - Server license gating (Advanced + admin enable)
  - Connect Cloud non-support
- Adds `### Added` entry under `## [Unreleased]` referencing the epic (#3964).

Closes #4123.

## Merge timing

Last item from the epic to merge.