### PR TITLE
Update GitHub Actions running on deprecated Node.js 20

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,7 +8,7 @@ runs:
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       shell: bash
       run: cargo install just
-    - uses: extractions/setup-just@v3
+    - uses: extractions/setup-just@v4
       if: runner.os != 'Windows' || runner.arch != 'ARM64'
     - if: ${{ runner.os == 'Linux' }}
       uses: t1m0thyj/unlock-keyring@v1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_site


### PR DESCRIPTION
## Summary

- Update `extractions/setup-just` from v3 to v4 in the composite setup action (internally upgrades setup-crate from v1.4.0/Node 20 to v2.0.0/Node 24)
- Update `peaceiris/actions-gh-pages` from v4 to v4.1.0 (Node 20 → Node 24)

`HaaLeo/publish-vscode-extension@v2` still uses Node 20 with no newer release available — tracked in #4172.

Closes #4115

## Test plan

- [ ] CI workflows pass without Node.js 20 deprecation warnings
- [ ] Docs deploy workflow still publishes correctly
- [ ] Package/test workflows using the composite setup action still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)