### PR TITLE
fix: inlining style and icon files to load in Workbench in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Publisher's sidebar rendering unstyled with missing icons in Positron on Posit Workbench when accessed via Firefox. (#4013)
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)
 - Fixed deploying content to Connect running within the Posit Team Native App in Snowpark Container Services from Publisher running outside of SPCS. Users with existing credentials for SPCS servers must delete and recreate those credentials. Credentials now require a valid Snowflake connection and valid Connect authentication (either API key or token). (#3465)
 - Cancelling the "new credential" flow at the final step (input credential name) actually cancels instead of saving the new credential. (#4159)

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -650,7 +650,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc-watch": "tsc --noEmit --watch --project tsconfig.json",
-    "build-font": "node -e \"require('fs').mkdirSync('dist', {recursive: true})\" && fantasticon",
+    "build-font": "fantasticon",
     "lint": "eslint src --max-warnings 0 && eslint webviews/homeView/src --max-warnings 0",
     "esbuild-tests": "node ./esbuild.tests.mjs",
     "pretest": "npm run esbuild-tests && npm run esbuild-base",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -650,7 +650,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc-watch": "tsc --noEmit --watch --project tsconfig.json",
-    "build-font": "fantasticon",
+    "build-font": "node -e \"require('fs').mkdirSync('dist', {recursive: true})\" && fantasticon",
     "lint": "eslint src --max-warnings 0 && eslint webviews/homeView/src --max-warnings 0",
     "esbuild-tests": "node ./esbuild.tests.mjs",
     "pretest": "npm run esbuild-tests && npm run esbuild-base",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -643,10 +643,10 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify",
+    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify && npm run build-font && npm run inline-icon-fonts",
     "copy-codicons": "node scripts/copy-codicons.mjs",
     "inline-icon-fonts": "node scripts/inline-icon-fonts.mjs",
-    "esbuild-base": "npm run copy-codicons && npm run build-font && npm run inline-icon-fonts && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "npm run copy-codicons && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc-watch": "tsc --noEmit --watch --project tsconfig.json",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -643,10 +643,10 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run build-font && npm run esbuild-base -- --minify",
+    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify",
     "copy-codicons": "node scripts/copy-codicons.mjs",
     "inline-icon-fonts": "node scripts/inline-icon-fonts.mjs",
-    "esbuild-base": "npm run copy-codicons && npm run inline-icon-fonts && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "npm run copy-codicons && npm run build-font && npm run inline-icon-fonts && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc-watch": "tsc --noEmit --watch --project tsconfig.json",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -643,9 +643,10 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify && npm run build-font",
+    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run build-font && npm run esbuild-base -- --minify",
     "copy-codicons": "node scripts/copy-codicons.mjs",
-    "esbuild-base": "npm run copy-codicons && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "inline-icon-fonts": "node scripts/inline-icon-fonts.mjs",
+    "esbuild-base": "npm run copy-codicons && npm run inline-icon-fonts && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc-watch": "tsc --noEmit --watch --project tsconfig.json",

--- a/extensions/vscode/scripts/inline-icon-fonts.mjs
+++ b/extensions/vscode/scripts/inline-icon-fonts.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Reads each icon-font CSS file under dist/ and rewrites its @font-face
+// `url("./<font>?<hash>")` reference to a base64 `data:` URI, writing the
+// result to a sibling `*.inlined.css`. The extension's webview HTML reads
+// these prebuilt files and injects them as inline <style> blocks so
+// Firefox's broken service-worker interception (in Posit Workbench) can't
+// fail the stylesheet/font fetches.
+// See https://github.com/posit-dev/publisher/issues/4013.
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename } from "node:path";
+
+const targets = [
+  {
+    cssPath: "dist/codicons/codicon.css",
+    fontPath: "dist/codicons/codicon.ttf",
+    mimeType: "font/ttf",
+    outPath: "dist/codicons/codicon.inlined.css",
+  },
+  {
+    cssPath: "dist/posit-publisher-icons.css",
+    fontPath: "dist/posit-publisher-icons.woff2",
+    mimeType: "font/woff2",
+    outPath: "dist/posit-publisher-icons.inlined.css",
+  },
+];
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+for (const { cssPath, fontPath, mimeType, outPath } of targets) {
+  const cssContent = readFileSync(cssPath, "utf8");
+  const fontBase64 = readFileSync(fontPath).toString("base64");
+  const fontBasename = basename(fontPath);
+  const pattern = new RegExp(
+    `url\\(\\s*["']\\.\\/${escapeRegExp(fontBasename)}[^"']*["']\\s*\\)`,
+  );
+  if (!pattern.test(cssContent)) {
+    throw new Error(
+      `inline-icon-fonts: did not find url("./${fontBasename}...") reference in ${cssPath}`,
+    );
+  }
+  const inlined = cssContent.replace(
+    pattern,
+    `url("data:${mimeType};base64,${fontBase64}")`,
+  );
+  writeFileSync(outPath, inlined);
+  console.log(`info: wrote ${outPath} (${inlined.length} bytes)`);
+}

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -1,5 +1,6 @@
 // Copyright (C) 2025 by Posit Software, PBC.
 
+import fs from "fs";
 import path from "path";
 import debounce from "debounce";
 
@@ -2094,32 +2095,43 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
    * rendered within the webview panel
    */
   private getWebviewContent(webview: Webview, extensionUri: Uri) {
-    // The CSS files from the Vue build output
-    const stylesUri = getUri(webview, extensionUri, [
-      "webviews",
-      "homeView",
-      "dist",
-      "index.css",
-    ]);
+    // Inline all stylesheets (and their fonts as data URIs) rather than
+    // linking to them. Firefox's service worker fails to intercept webview
+    // resource requests in some hosts (notably Posit Workbench), causing
+    // the fetches to fail with SSL_ERROR_BAD_CERT_DOMAIN. Inlining sidesteps
+    // the interception.
+    // See https://github.com/posit-dev/publisher/issues/4013.
+    const stylesContent = fs.readFileSync(
+      path.join(
+        extensionUri.fsPath,
+        "webviews",
+        "homeView",
+        "dist",
+        "index.css",
+      ),
+      "utf8",
+    );
+    // The *.inlined.css files are produced at build time by
+    // scripts/inline-icon-fonts.mjs, which rewrites each icon stylesheet's
+    // @font-face url() to a base64 data: URI.
+    const codiconsContent = fs.readFileSync(
+      path.join(extensionUri.fsPath, "dist", "codicons", "codicon.inlined.css"),
+      "utf8",
+    );
+    const positPublisherFontContent = fs.readFileSync(
+      path.join(
+        extensionUri.fsPath,
+        "dist",
+        "posit-publisher-icons.inlined.css",
+      ),
+      "utf8",
+    );
     // The JS file from the Vue build output
     const scriptUri = getUri(webview, extensionUri, [
       "webviews",
       "homeView",
       "dist",
       "index.js",
-    ]);
-    // The codicon css (and related ttf file) ship via the copy-codicons
-    // build step because vsce can't pack workspace-hoisted node_modules
-    // (see https://github.com/microsoft/vscode-vsce/issues/580).
-    const codiconsUri = getUri(webview, extensionUri, [
-      "dist",
-      "codicons",
-      "codicon.css",
-    ]);
-    // Custom Posit Publisher font
-    const positPublisherFontCssUri = getUri(webview, extensionUri, [
-      "dist",
-      "posit-publisher-icons.css",
     ]);
 
     const nonce = getNonce();
@@ -2134,13 +2146,13 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           <meta http-equiv="Content-Security-Policy"
             content="
               default-src 'none';
-              font-src ${webview.cspSource};
+              font-src data:;
               style-src ${webview.cspSource} 'unsafe-inline';
               script-src 'nonce-${nonce}';"
           />
-          <link rel="stylesheet" type="text/css" href="${stylesUri}">
-          <link rel="stylesheet" type="text/css" href="${codiconsUri}">
-          <link rel="stylesheet" type="text/css" href="${positPublisherFontCssUri}">
+          <style>${stylesContent}</style>
+          <style>${codiconsContent}</style>
+          <style>${positPublisherFontContent}</style>
           <title>Hello World</title>
         </head>
         <body>

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -2095,12 +2095,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
    * rendered within the webview panel
    */
   private getWebviewContent(webview: Webview, extensionUri: Uri) {
-    // Inline all stylesheets (and their fonts as data URIs) rather than
-    // linking to them. Firefox's service worker fails to intercept webview
-    // resource requests in some hosts (notably Posit Workbench), causing
-    // the fetches to fail with SSL_ERROR_BAD_CERT_DOMAIN. Inlining sidesteps
-    // the interception.
-    // See https://github.com/posit-dev/publisher/issues/4013.
+    // Inline stylesheets to work around Firefox's broken service-worker
+    // interception of webview resource requests in Posit Workbench (#4013).
     const stylesContent = fs.readFileSync(
       path.join(
         extensionUri.fsPath,
@@ -2111,21 +2107,52 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       ),
       "utf8",
     );
-    // The *.inlined.css files are produced at build time by
-    // scripts/inline-icon-fonts.mjs, which rewrites each icon stylesheet's
-    // @font-face url() to a base64 data: URI.
-    const codiconsContent = fs.readFileSync(
-      path.join(extensionUri.fsPath, "dist", "codicons", "codicon.inlined.css"),
-      "utf8",
+
+    // *.inlined.css is only produced during vscode:prepublish (fantasticon
+    // is broken on Windows, so it stays out of esbuild-base). When absent,
+    // fall back to webview URI links — the Workbench/Firefox bug doesn't
+    // apply in the Extension Development Host.
+    const codiconsInlinedPath = path.join(
+      extensionUri.fsPath,
+      "dist",
+      "codicons",
+      "codicon.inlined.css",
     );
-    const positPublisherFontContent = fs.readFileSync(
-      path.join(
-        extensionUri.fsPath,
+    const positPublisherIconsInlinedPath = path.join(
+      extensionUri.fsPath,
+      "dist",
+      "posit-publisher-icons.inlined.css",
+    );
+    const useInlinedIconFonts =
+      fs.existsSync(codiconsInlinedPath) &&
+      fs.existsSync(positPublisherIconsInlinedPath);
+
+    let iconStyleTags: string;
+    let fontSrcCsp: string;
+    if (useInlinedIconFonts) {
+      const codiconsContent = fs.readFileSync(codiconsInlinedPath, "utf8");
+      const positPublisherFontContent = fs.readFileSync(
+        positPublisherIconsInlinedPath,
+        "utf8",
+      );
+      iconStyleTags = `<style>${codiconsContent}</style>
+          <style>${positPublisherFontContent}</style>`;
+      fontSrcCsp = "data:";
+    } else {
+      const codiconsUri = getUri(webview, extensionUri, [
         "dist",
-        "posit-publisher-icons.inlined.css",
-      ),
-      "utf8",
-    );
+        "codicons",
+        "codicon.css",
+      ]);
+      const positPublisherFontCssUri = getUri(webview, extensionUri, [
+        "dist",
+        "posit-publisher-icons.css",
+      ]);
+      iconStyleTags = `<link rel="stylesheet" type="text/css" href="${codiconsUri}">
+          <link rel="stylesheet" type="text/css" href="${positPublisherFontCssUri}">`;
+      fontSrcCsp = webview.cspSource;
+    }
+
     // The JS file from the Vue build output
     const scriptUri = getUri(webview, extensionUri, [
       "webviews",
@@ -2146,13 +2173,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           <meta http-equiv="Content-Security-Policy"
             content="
               default-src 'none';
-              font-src data:;
+              font-src ${fontSrcCsp};
               style-src ${webview.cspSource} 'unsafe-inline';
               script-src 'nonce-${nonce}';"
           />
           <style>${stylesContent}</style>
-          <style>${codiconsContent}</style>
-          <style>${positPublisherFontContent}</style>
+          ${iconStyleTags}
           <title>Hello World</title>
         </head>
         <body>


### PR DESCRIPTION
## Intent
Resolves #4013

## Type of Change
- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach
It was suggested to follow a similar approach that Positron did by inlining the CSS file so the service worker in Firefox doesn't need to intercept a request. This worked, however, I noticed the icons need to be handled the same way. With only the styles, it looked like the following:

<details>
<summary>Without the Icon Fix</summary>
<img width="794" height="1242" alt="image" src="https://github.com/user-attachments/assets/10e15669-98cf-46ad-99be-aa03fa345d0e" />
</details>


## User Impact
The style and icons of the Publisher on Workbench in Firefox appeared like so: 

<details>
<summary>Bug</summary>
<img width="544" height="1170" alt="image" src="https://github.com/user-attachments/assets/3b6c0687-300e-46bc-a356-94ca4637ae03" />
</details>


Now both the styles and icons appear
<details>
<summary>Fixed Style and Icons</summary>
<img width="844" height="1350" alt="image" src="https://github.com/user-attachments/assets/e18e6b06-dd46-4c1e-a9c7-ed1f539efa76" />
</details>

## Automated Tests
WIP

## Directions for Reviewers
1. Build the extension: `just package` from `extensions/vscode/`.
2. Install the resulting `.vsix` in a Positron-on-Workbench session opened in Firefox
3. Open the Publisher sidebar and confirm styles + icons render correctly
4. There should be no requests for `codicon.css` or `posit-publisher-icons.css`, and the Console shows no CSP violations.

## Checklist
- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
