### PR TITLE
docs: include changelog notes in GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,10 +34,28 @@ jobs:
           path: dist
       - id: get-prerelease
         run: echo "prerelease=$(just pre-release)" >> "$GITHUB_OUTPUT"
+      - id: extract-changelog
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          # Extract the section between this version's header and the next version header
+          changelog=$(awk -v ver="$version" '
+            /^## \[/ {
+              if (found) exit
+              if ($0 ~ "\\[" ver "\\]") found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+          {
+            echo "body<<CHANGELOG_EOF"
+            echo "$changelog"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
       - uses: softprops/action-gh-release@v3
         with:
           draft: false
           prerelease: ${{ steps.get-prerelease.outputs.prerelease == 'true' }}
+          body: ${{ steps.extract-changelog.outputs.body }}
           files: |
             dist/**/*
   # Slack notification on failure


### PR DESCRIPTION
## Summary

- Extracts the relevant changelog section for the tagged version during the release workflow and passes it as the GitHub release body.
- Users can now see what changed directly from the GitHub releases page or release notifications, instead of having to navigate to CHANGELOG.md.

Closes #4143

## Test plan

- [ ] Verify the awk extraction logic produces correct output for past versions (e.g., `2.4.0`, `2.0.0`)
- [ ] Verify the `[Unreleased]` section is not included
- [ ] Confirm the next release populates the GitHub release body with changelog notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)