### PR TITLE
fix: Upgrade axios to 1.16.1 to solve proxy issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Quarto availability check opening a visible terminal and showing a confusing "process exited with code 1" error when Quarto is not installed. The check now runs silently in the background. (#3801)
 - Fixed deploying content to Connect running within the Posit Team Native App in Snowpark Container Services from Publisher running outside of SPCS. Users with existing credentials for SPCS servers must delete and recreate those credentials. Credentials now require a valid Snowflake connection and valid Connect authentication (either API key or token). (#3465)
 - Cancelling the "new credential" flow at the final step (input credential name) actually cancels instead of saving the new credential. (#4159)
+- Upgraded project dependencies to improve proxy support. (#3102)
 
 ## [2.4.0]
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -691,7 +691,7 @@
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "async-mutex": "^0.5.0",
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "debounce": "^3.0.0",
     "entities": "^8.0.0",
     "filenamify": "^7.0.1",

--- a/extensions/vscode/webviews/homeView/package.json
+++ b/extensions/vscode/webviews/homeView/package.json
@@ -8,7 +8,7 @@
     "test": "TZ=UTC vitest"
   },
   "dependencies": {
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.34",
     "vue-virtual-scroller": "2.0.0-beta.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "async-mutex": "^0.5.0",
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "debounce": "^3.0.0",
         "entities": "^8.0.0",
         "filenamify": "^7.0.1",
@@ -76,7 +76,7 @@
       "name": "project-selector-web-view-view",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "pinia": "^3.0.4",
         "vue": "^3.5.34",
         "vue-virtual-scroller": "2.0.0-beta.8"
@@ -3081,14 +3081,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -3848,7 +3874,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10163,7 +10188,7 @@
       "name": "@posit-dev/connect-api",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.16.0"
+        "axios": "^1.16.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -10175,7 +10200,7 @@
       "name": "@posit-dev/connect-cloud-api",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "eventsource": "^4.1.0"
       },
       "devDependencies": {
@@ -10188,7 +10213,7 @@
       "dependencies": {
         "@posit-dev/connect-api": "*",
         "@posit-dev/mock-connect": "*",
-        "axios": "^1.16.0"
+        "axios": "^1.16.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/connect-api/package.json
+++ b/packages/connect-api/package.json
@@ -9,7 +9,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "axios": "^1.16.0"
+    "axios": "^1.16.1"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/connect-cloud-api/package.json
+++ b/packages/connect-cloud-api/package.json
@@ -9,7 +9,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "eventsource": "^4.1.0"
   },
   "devDependencies": {

--- a/test/connect-api-contracts/package.json
+++ b/test/connect-api-contracts/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@posit-dev/connect-api": "*",
     "@posit-dev/mock-connect": "*",
-    "axios": "^1.16.0"
+    "axios": "^1.16.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -13,7 +13,7 @@
         "@cypress/grep": "^6.0.0",
         "@eslint/js": "^10.0.0",
         "@testing-library/cypress": "^10.1.3",
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "cypress": "^15.14.2",
         "cypress-network-idle": "^2.0.1",
         "cypress-terminal-report": "^7.3.3",
@@ -727,6 +727,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -860,14 +873,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2290,6 +2304,20 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -16,7 +16,7 @@
     "@eslint/js": "^10.0.0",
     "globals": "^17.6.0",
     "@testing-library/cypress": "^10.1.3",
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "cypress": "^15.14.2",
     "cypress-network-idle": "^2.0.1",
     "cypress-terminal-report": "^7.3.3",


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Upgrade axios to 1.16.1.

This includes a fix to proxy support:

https://github.com/axios/axios/pull/10858

With this fix, axios should correctly use CONNECT tunneling for HTTPS requests through a proxy.

Fixes #3102

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

### repro

I installed squid locally and used this config (`/opt/homebrew/etc/squid.conf):

```
# Listen on port 3128
http_port 3128

# Allow CONNECT tunnels to HTTPS ports
acl SSL_ports port 443
acl CONNECT method CONNECT
http_access allow CONNECT SSL_ports

# DENY direct (non-CONNECT) requests to HTTPS URLs
# This mimics the corporate proxy behavior from the bug report
acl direct_https url_regex ^https://
http_access deny direct_https

# Allow everything else (HTTP)
http_access allow all
debug_options ALL,1 11,2 85,2
```

and ran squid with `squid -N -d2`.

I launched VS Code with

```shell
HTTP_PROXY=http://localhost:3128 HTTPS_PROXY=http://localhost:3128 code .
```

I tried to add a Cloud credential and the proxy rejected the request:

```shell
2026/05/15 16:55:01.549| 11,2| Stream.cc(275) sendStartOfMessage: HTTP Client REPLY:
---------
HTTP/1.1 403 Forbidden
Server: squid/7.5
Mime-Version: 1.0
Date: Fri, 15 May 2026 20:55:01 GMT
Content-Type: text/html;charset=utf-8
Content-Length: 3112
X-Squid-Error: ERR_ACCESS_DENIED 0
Vary: Accept-Language
Content-Language: en
Cache-Status: localhost
Via: 1.1 localhost (squid/7.5)
Connection: close


----------
```

With the upgraded axios, the credential flow succeeds and squid shows tunneling:

```shell
2026/05/15 16:15:49.312| 11,2| client_side.cc(1292) parseHttpRequest: HTTP Client REQUEST:
      ---------
      CONNECT login.posit.cloud:443 HTTP/1.1
      Host: login.posit.cloud:443
      Proxy-Connection: close


      ----------
      2026/05/15 16:15:49.312| 85,2| client_side_request.cc(623) clientAccessCheckDone: The request CONNECT
  login.posit.cloud:443 is ALLOWED; last ACL checked: SSL_ports
      2026/05/15 16:15:49.312| 85,2| client_side_request.cc(601) clientAccessCheck2: No adapted_http_access
  configuration. default: ALLOW
      2026/05/15 16:15:49.312| 85,2| client_side_request.cc(623) clientAccessCheckDone: The request CONNECT
  login.posit.cloud:443 is ALLOWED; last ACL checked: [no-ACL]
```

### details

It was a little hard to figure out what was going on here with proxy support. As best as I can tell, VS Code has partial proxy support for extensions (via the `http.proxySupport` option) but it is confusing how it works. From my research this explanation seems plausible:

  With only HTTP_PROXY:
  - Axios calls getProxyForUrl('https://login.posit.cloud/...') (from proxy-from-env)
  - It checks HTTPS_PROXY / https_proxy for https:// URLs — not set
  - Axios's setProxy() never activates
  - The request goes through Node's https.request() normally
  - VS Code's patched global agent sees HTTP_PROXY, opens a CONNECT tunnel
  - Works correctly

  With HTTPS_PROXY set:
  - Axios calls getProxyForUrl('https://login.posit.cloud/...') — finds HTTPS_PROXY
  - Axios's setProxy() activates and rewrites the request: changes hostname to localhost, port to 3128, path to the
  full https://login.posit.cloud/... URL
  - The request is now sent as a plain HTTP POST https://login.posit.cloud/... HTTP/1.1 directly to the proxy
  - VS Code's agent patching is bypassed — axios already rewrote the destination
  - Proxy rejects it because it expects CONNECT for HTTPS destinations

Of note, in some places we use a custom http agent with axios, but according to axios' fix that should still work:

> if a plain httpsAgent is provided, we still tunnel and forward its TLS options (CA, client certs, rejectUnauthorized) to the tunnel.

## User Impact

Users running publisher behind proxies should see improved behavior.

## Automated Tests

An automated test for this would be pretty fragile and the fix was entirely in axios, so I think this is not worth automating.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
