### PR TITLE
fix: Add llms.txt and llms-full.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ docs/_site/
 docs/.quarto/
 docs/_variables.yml
 docs/changelog.md
+docs/llms.txt
+docs/llms-full.txt


### PR DESCRIPTION
## Summary

- Adds `docs/llms.txt` and `docs/llms-full.txt` to `.gitignore` under the existing Quarto docs build output section
- These files are generated by `quarto render` and should not be checked into the repository

Closes #4182