### PR TITLE
Remove vestigial API_BACKEND env var from contract tests

### DIFF
--- a/.github/workflows/connect-contract-tests.yaml
+++ b/.github/workflows/connect-contract-tests.yaml
@@ -18,8 +18,6 @@ jobs:
       - run: npm run typecheck
         working-directory: test/connect-api-contracts
       - run: just test-connect-contracts
-        env:
-          API_BACKEND: typescript
 
   validate-fixtures:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Removes the `API_BACKEND: typescript` env var from `connect-contract-tests.yaml`, the only remaining reference after the Go backend was removed in #4030.
- The README and test code were already cleaned up — no other references exist.

Closes #4032

## Test plan

- [ ] Connect contract tests CI job passes without the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)