### PR TITLE
test: rename `@pcc` Cypress tag to `@uses-posit-connect-cloud`

### DIFF
--- a/.claude/skills/dev-setup/SKILL.md
+++ b/.claude/skills/dev-setup/SKILL.md
@@ -170,7 +170,7 @@ The E2E tests need `CONNECT_LICENSE_FILE` and (on macOS) `DOCKER_HOST` set.
 
 Run a quick smoke test excluding Connect Cloud tests (which need 1Password):
 
-- **Act:** `cd test/e2e && just e2e --env grepTags=-@pcc`
+- **Act:** `cd test/e2e && just e2e --env grepTags=-@uses-posit-connect-cloud`
 - **Verify:** Tests pass (the Workbench tests may fail if no Workbench container is set up — that's expected and fine).
 
 **Troubleshooting:** If it fails with `port 3939 already allocated`, a stale Connect container is lingering from a previous run:
@@ -186,20 +186,20 @@ After tests complete, clean up: `just stop`
 
 ### Step 16: 1Password CLI (Optional, Connect Cloud only)
 
-For Connect Cloud tests (tagged `@pcc`), credentials are fetched from 1Password.
+For Connect Cloud tests (tagged `@uses-posit-connect-cloud`), credentials are fetched from 1Password.
 
 - **Check:** `op --version` — must be the system-wide install, not the local `test/bin/op`.
 - **Act:** If missing: `brew install 1password-cli`. Then enable the desktop app integration: 1Password > Settings > Developer > "Integrate with 1Password CLI".
 - **Verify:** `op item get "pcc_user_ccqa3" --field "password" --vault "Publisher" --reveal` succeeds.
 
-If the developer doesn't have access to the Publisher vault, let them know that cloud tests can be skipped with `--env grepTags=-@pcc` or `SKIP_1PASSWORD=true`.
+If the developer doesn't have access to the Publisher vault, let them know that cloud tests can be skipped with `--env grepTags=-@uses-posit-connect-cloud` or `SKIP_1PASSWORD=true`.
 
 ### E2E Setup Complete
 
 Summarize what's available:
 
 - `just e2e` — run all E2E tests
-- `just e2e --env grepTags=-@pcc` — skip cloud tests
+- `just e2e --env grepTags=-@uses-posit-connect-cloud` — skip cloud tests
 - `just e2e-open` — interactive Cypress UI
 - `just stop` — stop Docker containers
 - Point them to `test/e2e/CONTRIBUTING.md` for more details

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -227,7 +227,7 @@ jobs:
               CYPRESS_BOOTSTRAP_ADMIN_API_KEY=$CONNECT_API_KEY npx cypress run --headless --browser chrome
             else
               # Exclude @uses-posit-connect-cloud cloud tests for non-release versions
-              CYPRESS_BOOTSTRAP_ADMIN_API_KEY=$CONNECT_API_KEY npx cypress run --headless --browser chrome --env grepFilterSpecs=true,grepOmitFiltered=true,grepTags=-@uses-posit-connect-cloud
+              CYPRESS_BOOTSTRAP_ADMIN_API_KEY=$CONNECT_API_KEY npx cypress run --headless --browser chrome --expose grepTags=-@uses-posit-connect-cloud,grepOmitFiltered=true
             fi
         env:
           CONNECT_CLOUD_ENV: staging

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Connect Server versions - tests exclude @pcc tags
+        # Connect Server versions - tests exclude @uses-posit-connect-cloud tags
         # Simplified to reduce CI time: preview, release, one recent, one old
         connect-version:
           - "preview" # Nightly builds of Connect - catch regressions early
@@ -211,8 +211,8 @@ jobs:
           docker exec publisher-e2e.code-server rm -f /home/coder/workspace/static*.toml || true
 
       # Run Cypress tests
-      # - For "release": run ALL tests (including @pcc cloud tests)
-      # - For other versions: exclude @pcc tests (cloud tests only run once on release)
+      # - For "release": run ALL tests (including @uses-posit-connect-cloud cloud tests)
+      # - For other versions: exclude @uses-posit-connect-cloud tests (cloud tests only run once on release)
       - name: Run Cypress tests (${{ matrix.connect-version }})
         id: run_tests
         uses: posit-dev/with-connect@main
@@ -223,11 +223,11 @@ jobs:
           command: |
             cd test/e2e
             if [ "${{ matrix.connect-version }}" = "release" ]; then
-              # Run all tests (including @pcc cloud tests)
+              # Run all tests (including @uses-posit-connect-cloud cloud tests)
               CYPRESS_BOOTSTRAP_ADMIN_API_KEY=$CONNECT_API_KEY npx cypress run --headless --browser chrome
             else
-              # Exclude @pcc cloud tests for non-release versions
-              CYPRESS_BOOTSTRAP_ADMIN_API_KEY=$CONNECT_API_KEY npx cypress run --headless --browser chrome --env grepFilterSpecs=true,grepOmitFiltered=true,grepTags=-@pcc
+              # Exclude @uses-posit-connect-cloud cloud tests for non-release versions
+              CYPRESS_BOOTSTRAP_ADMIN_API_KEY=$CONNECT_API_KEY npx cypress run --headless --browser chrome --env grepFilterSpecs=true,grepOmitFiltered=true,grepTags=-@uses-posit-connect-cloud
             fi
         env:
           CONNECT_CLOUD_ENV: staging

--- a/test/e2e/CONTRIBUTING.md
+++ b/test/e2e/CONTRIBUTING.md
@@ -39,13 +39,13 @@ Run `direnv allow` after creating the file. Without direnv, export these variabl
 
 ### 1Password CLI (optional, for Connect Cloud tests)
 
-Tests tagged `@pcc` fetch credentials from 1Password. To run these locally:
+Tests tagged `@uses-posit-connect-cloud` fetch credentials from 1Password. To run these locally:
 
 1. Install the 1Password CLI: `brew install 1password-cli`
 2. Enable the desktop app integration: 1Password > Settings > Developer > "Integrate with 1Password CLI"
 3. Verify access: `op item get "pcc_user_ccqa3" --field "password" --vault "Publisher" --reveal`
 
-If you don't have 1Password access, you can skip cloud tests with `--env grepTags=-@pcc` or set `SKIP_1PASSWORD=true` to use placeholder credentials.
+If you don't have 1Password access, you can skip cloud tests with `--env grepTags=-@uses-posit-connect-cloud` or set `SKIP_1PASSWORD=true` to use placeholder credentials.
 
 ### Workbench License (optional)
 
@@ -90,8 +90,8 @@ just e2e --spec "tests/credentials.cy.js"
 # Run multiple test files
 just e2e --spec "tests/common.cy.js,tests/deployments.cy.js"
 
-# Exclude @pcc tests (no cloud credentials needed)
-just e2e --env grepTags=-@pcc
+# Exclude @uses-posit-connect-cloud tests (no cloud credentials needed)
+just e2e --env grepTags=-@uses-posit-connect-cloud
 
 # Interactive Cypress UI
 just e2e-open
@@ -125,12 +125,12 @@ Containers reach Connect via `connect-publisher-e2e` hostname mapped to host-gat
 
 Most tests use the local Connect server. These work with just a Connect license.
 
-### Connect Cloud Tests (@pcc)
+### Connect Cloud Tests (@uses-posit-connect-cloud)
 
-Tests tagged `@pcc` require Posit Connect Cloud credentials configured in `config/staging-pccqa.json`. Exclude them with:
+Tests tagged `@uses-posit-connect-cloud` require Posit Connect Cloud credentials configured in `config/staging-pccqa.json`. Exclude them with:
 
 ```bash
-just e2e --env grepTags=-@pcc
+just e2e --env grepTags=-@uses-posit-connect-cloud
 ```
 
 ### Workbench Tests

--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -95,7 +95,6 @@ module.exports = defineConfig({
   ...(isMockMode && {
     expose: {
       grepTags: "-@uses-posit-connect-cloud",
-      grepFilterSpecs: true,
       grepOmitFiltered: true,
     },
   }),

--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -18,7 +18,7 @@ const pccConfig = JSON.parse(fs.readFileSync(configPath, "utf8"));
 // Rewrite placeholder password with actual secret and handle failures.
 // Skip in mock mode — PCC/OAuth tests are excluded and secrets are unavailable.
 if (isMockMode) {
-  // No-op: leave pccConfig password as-is (tests tagged @pcc are excluded)
+  // No-op: leave pccConfig password as-is (tests tagged @uses-posit-connect-cloud are excluded)
 } else if (process.env.CI === "true" && process.env.PCC_USER_CCQA3) {
   pccConfig.pcc_user_ccqa3.auth.password = process.env.PCC_USER_CCQA3;
 } else if (pccConfig.pcc_user_ccqa3.auth.password === "UPDATE") {
@@ -91,10 +91,10 @@ module.exports = defineConfig({
     WORKBENCH_URL: "http://localhost:8787",
     pccConfig,
   },
-  // When running in mock mode, exclude @pcc tests via @cypress/grep
+  // When running in mock mode, exclude @uses-posit-connect-cloud tests via @cypress/grep
   ...(isMockMode && {
     expose: {
-      grepTags: "-@pcc",
+      grepTags: "-@uses-posit-connect-cloud",
       grepFilterSpecs: true,
       grepOmitFiltered: true,
     },

--- a/test/e2e/justfile
+++ b/test/e2e/justfile
@@ -184,7 +184,7 @@ e2e-mock *cypress_args:
     VSIX_FILENAME=$(ls -Art ../../dist/*.vsix | xargs -n1 basename | tail -n 1)
     docker compose exec code-server code-server --install-extension "/home/coder/vsix/${VSIX_FILENAME}"
 
-    # Run Cypress excluding @pcc tests (which require real OAuth).
+    # Run Cypress excluding @uses-posit-connect-cloud tests (which require real OAuth).
     # CYPRESS_MOCK_CONNECT triggers grep filtering via cypress.config.js expose section.
     export CYPRESS_MOCK_CONNECT=true
     # The mock server accepts any key, but the extension validates the format:

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -4,7 +4,7 @@ import { configure } from "@testing-library/cypress";
 // Import cypress-terminal-report for browser log collection
 import "cypress-terminal-report/src/installLogsCollector";
 
-// Import @cypress/grep for test filtering by tags (@pcc, etc.)
+// Import @cypress/grep for test filtering by tags (@uses-posit-connect-cloud, etc.)
 import { register as registerCypressGrep } from "@cypress/grep";
 registerCypressGrep();
 

--- a/test/e2e/tests/credentials.cy.js
+++ b/test/e2e/tests/credentials.cy.js
@@ -76,21 +76,25 @@ describe("Credentials Section", () => {
       .should("have.text", "admin-code-server");
   });
 
-  it("New PCC Credential - OAuth Device Code", { tags: "@pcc" }, () => {
-    const user = Cypress.env("pccConfig").pcc_user_ccqa3;
-    // Drive full OAuth UI flow and nickname entry via helper
-    cy.addPCCCredential(user, "connect-cloud-credential");
+  it(
+    "New PCC Credential - OAuth Device Code",
+    { tags: "@uses-posit-connect-cloud" },
+    () => {
+      const user = Cypress.env("pccConfig").pcc_user_ccqa3;
+      // Drive full OAuth UI flow and nickname entry via helper
+      cy.addPCCCredential(user, "connect-cloud-credential");
 
-    // Verify the credential appears in the list
-    cy.ensureCredentialsSectionExpanded();
-    cy.refreshCredentials();
+      // Verify the credential appears in the list
+      cy.ensureCredentialsSectionExpanded();
+      cy.refreshCredentials();
 
-    cy.findInPublisherWebview(
-      '[data-automation="connect-cloud-credential-list"]',
-    )
-      .find(".tree-item-title")
-      .should("have.text", "connect-cloud-credential");
-  });
+      cy.findInPublisherWebview(
+        '[data-automation="connect-cloud-credential-list"]',
+      )
+        .find(".tree-item-title")
+        .should("have.text", "connect-cloud-credential");
+    },
+  );
 
   it("Existing Credentials Load", () => {
     // Creates admin credential via UI and validates it renders correctly in the list.

--- a/test/e2e/tests/deployments.cy.js
+++ b/test/e2e/tests/deployments.cy.js
@@ -81,88 +81,94 @@ describe("Deployments Section", () => {
   });
 
   describe("Connect Cloud Deployments", () => {
-    it("PCC Shiny Python Deployment", { tags: "@pcc" }, () => {
-      // Setup - moved from beforeEach to avoid running when @pcc tests are filtered
-      cy.clearupDeployments();
-      cy.visit("/");
-      cy.getPublisherSidebarIcon().click();
-      cy.waitForPublisherIframe();
-      cy.resetCredentials();
-      const user = Cypress.env("pccConfig").pcc_user_ccqa3;
-      cy.log("PCC user for addPCCCredential: " + JSON.stringify(user));
-      cy.addPCCCredential(user, "pcc-deploy-credential", {
-        assertEmpty: false,
-      });
+    it(
+      "PCC Shiny Python Deployment",
+      { tags: "@uses-posit-connect-cloud" },
+      () => {
+        // Setup - moved from beforeEach to avoid running when @uses-posit-connect-cloud tests are filtered
+        cy.clearupDeployments();
+        cy.visit("/");
+        cy.getPublisherSidebarIcon().click();
+        cy.waitForPublisherIframe();
+        cy.resetCredentials();
+        const user = Cypress.env("pccConfig").pcc_user_ccqa3;
+        cy.log("PCC user for addPCCCredential: " + JSON.stringify(user));
+        cy.addPCCCredential(user, "pcc-deploy-credential", {
+          assertEmpty: false,
+        });
 
-      // Verify credential is ready before proceeding
-      cy.ensureCredentialsSectionExpanded();
-      cy.refreshCredentials();
-      cy.findInPublisherWebview(
-        '[data-automation="pcc-deploy-credential-list"]',
-      )
-        .find(".tree-item-title")
-        .should("have.text", "pcc-deploy-credential");
+        // Verify credential is ready before proceeding
+        cy.ensureCredentialsSectionExpanded();
+        cy.refreshCredentials();
+        cy.findInPublisherWebview(
+          '[data-automation="pcc-deploy-credential-list"]',
+        )
+          .find(".tree-item-title")
+          .should("have.text", "pcc-deploy-credential");
 
-      // Ensure Publisher is in the expected initial state
-      cy.expectInitialPublisherState();
+        // Ensure Publisher is in the expected initial state
+        cy.expectInitialPublisherState();
 
-      // Select files to include in deployment
-      const filesToSelect = ["data", "README.md", "styles.css"];
-      cy.createPCCDeployment(
-        "examples-shiny-python",
-        "app.py",
-        "shiny-python-pcc",
-        (tomlFiles) => {
-          const config = tomlFiles.config.contents;
-          expect(config.title).to.equal("shiny-python-pcc");
-          expect(config.type).to.equal("python-shiny");
-          expect(config.entrypoint).to.equal("app.py");
-          // Check that all selected files are included (note: requirements.txt is auto-managed)
-          ["/app.py", "/data", "/README.md", "/styles.css"].forEach((file) => {
-            expect(config.files).to.include(file);
-          });
-        },
-        filesToSelect,
-      );
+        // Select files to include in deployment
+        const filesToSelect = ["data", "README.md", "styles.css"];
+        cy.createPCCDeployment(
+          "examples-shiny-python",
+          "app.py",
+          "shiny-python-pcc",
+          (tomlFiles) => {
+            const config = tomlFiles.config.contents;
+            expect(config.title).to.equal("shiny-python-pcc");
+            expect(config.type).to.equal("python-shiny");
+            expect(config.entrypoint).to.equal("app.py");
+            // Check that all selected files are included (note: requirements.txt is auto-managed)
+            ["/app.py", "/data", "/README.md", "/styles.css"].forEach(
+              (file) => {
+                expect(config.files).to.include(file);
+              },
+            );
+          },
+          filesToSelect,
+        );
 
-      // Set public access via helper and then deploy
-      cy.getPublisherTomlFilePaths("examples-shiny-python").then(
-        ({ config }) => {
-          // Write both Python version and public access in one operation
-          return cy.writeTomlFile(
-            config.path,
-            "version = '3.11'\n[connect_cloud]\n[connect_cloud.access_control]\npublic_access = true",
-          );
-        },
-      );
+        // Set public access via helper and then deploy
+        cy.getPublisherTomlFilePaths("examples-shiny-python").then(
+          ({ config }) => {
+            // Write both Python version and public access in one operation
+            return cy.writeTomlFile(
+              config.path,
+              "version = '3.11'\n[connect_cloud]\n[connect_cloud.access_control]\npublic_access = true",
+            );
+          },
+        );
 
-      cy.deployCurrentlySelected();
+        cy.deployCurrentlySelected();
 
-      cy.findUniqueInPublisherWebview(
-        '[data-automation="publisher-deployment-section"]',
-      ).should("exist");
+        cy.findUniqueInPublisherWebview(
+          '[data-automation="publisher-deployment-section"]',
+        ).should("exist");
 
-      // Load the deployment TOML to get the published URL and verify app
-      cy.getPublisherTomlFilePaths("examples-shiny-python").then(
-        (filePaths) => {
-          cy.loadTomlFile(filePaths.contentRecord.path).then(
-            (contentRecord) => {
-              const publishedUrl = contentRecord.direct_url;
+        // Load the deployment TOML to get the published URL and verify app
+        cy.getPublisherTomlFilePaths("examples-shiny-python").then(
+          (filePaths) => {
+            cy.loadTomlFile(filePaths.contentRecord.path).then(
+              (contentRecord) => {
+                const publishedUrl = contentRecord.direct_url;
 
-              const expectedTitle = "Restaurant tipping";
-              cy.task("confirmPCCPublishSuccess", {
-                publishedUrl,
-                expectedTitle,
-              }).then((result) => {
-                expect(
-                  result.success,
-                  result.error || "Publish confirmation failed",
-                ).to.be.true;
-              });
-            },
-          );
-        },
-      );
-    });
+                const expectedTitle = "Restaurant tipping";
+                cy.task("confirmPCCPublishSuccess", {
+                  publishedUrl,
+                  expectedTitle,
+                }).then((result) => {
+                  expect(
+                    result.success,
+                    result.error || "Publish confirmation failed",
+                  ).to.be.true;
+                });
+              },
+            );
+          },
+        );
+      },
+    );
   });
 });

--- a/test/e2e/tests/integration-requests.cy.js
+++ b/test/e2e/tests/integration-requests.cy.js
@@ -37,9 +37,9 @@ describe("IntegrationRequests Section", () => {
   describe("Connect Cloud", () => {
     it(
       "PCC deployment hides Integration Requests Section",
-      { tags: "@pcc" },
+      { tags: "@uses-posit-connect-cloud" },
       () => {
-        // Setup - moved from before/beforeEach to avoid running when @pcc tests are filtered
+        // Setup - moved from before/beforeEach to avoid running when @uses-posit-connect-cloud tests are filtered
         cy.initializeConnect();
 
         const user = Cypress.env("pccConfig").pcc_user_ccqa3;

--- a/test/e2e/tests/multi-stepper-negative.cy.js
+++ b/test/e2e/tests/multi-stepper-negative.cy.js
@@ -17,7 +17,7 @@ describe("Multi-Stepper Negative Cases", () => {
   describe("OAuth Cancellation Cases", () => {
     it(
       "OAuth error handling and cancellation scenarios",
-      { tags: "@pcc" },
+      { tags: "@uses-posit-connect-cloud" },
       () => {
         // Tests OAuth cancellation scenarios:
         // - OAuth cancellation when adding credential (with existing credentials)


### PR DESCRIPTION
## Summary

In support of https://github.com/posit-dev/publisher/issues/3995#issuecomment-4392992542

Renames the Cypress test tag `@pcc` to `@uses-posit-connect-cloud`. The new name describes what the tagged tests actually require (real Posit Connect Cloud credentials), making the mock-mode and CI exclusion filters self-documenting, and less likely to accidentally tag GitHub users in the future.

This is a tag-only rename — no test logic, no CI behavior, no fixtures changed.

Unrelated `pcc` identifiers (`pccConfig`, `pcc_user_ccqa3`, `addPCCCredential`, `createPCCDeployment`, test/describe titles) are intentionally left alone — they're variable, helper, and fixture names.

## Test plan

- [x] CI passes on this PR (mock-mode e2e job excludes `@uses-posit-connect-cloud` and runs the rest)
- [x] On a `release`-tagged run (that is, the latest stable Connect Server release as a matrix label, not a Publisher release), the cloud tests still execute (no longer filtered out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Edit: Also resolves #4192, which was **re**-discovered while verifying this change.
Edit to the edit: this was the original bug that #3995 was pointing at. So, this fixes #3995 (and #4192 duplicates it).