### PR TITLE
docs: document @types/vscode and engines.vscode pinning policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,9 +350,7 @@ The VS Code extension declares two related versions:
 - `engines.vscode` in `extensions/vscode/package.json` — the minimum VS Code version users need to install the extension.
 - `@types/vscode` in `extensions/vscode/package.json` and `test/extension-contract-tests/package.json` — the API surface the TypeScript code compiles against.
 
-`vsce package` fails if the declared `@types/vscode` range is higher than the declared `engines.vscode` range (it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support). Keeping these two in lockstep avoids that failure and keeps `engines.vscode` honest — if it's lower than `@types/vscode`, the extension will install on VS Code versions that lack APIs the code calls, and crash at runtime.
-
-We pin both to the **same exact version, with no caret**:
+`vsce package` fails if `@types/vscode` is higher than `engines.vscode` — it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support. Pin both to the same version across all three places:
 
 ```jsonc
 // extensions/vscode/package.json
@@ -369,10 +367,4 @@ We pin both to the **same exact version, with no caret**:
 }
 ```
 
-Dropping the caret keeps Dependabot from drifting `@types/vscode` above `engines.vscode`. Both packages that depend on `@types/vscode` must use the same exact version so npm can hoist a single resolved version into the workspace.
-
-#### When to bump
-
-Bump the pin when adding code that needs a VS Code API not present in the current pinned version. Choose the **lowest** version that exposes the API you need (check the VS Code API release notes), and update all three places at once: `engines.vscode`, the extension's `@types/vscode`, and the contract-tests' `@types/vscode`. Then run `npm install` to refresh the lockfile.
-
-Raising the pin raises the minimum VS Code version users need, so don't bump further than the API requires.
+When adding code that needs a VS Code API not present in the current pinned version, bump all three places to the lowest version that exposes the API you need (check the VS Code API release notes), then run `npm install`. Raising the pin raises the minimum VS Code version users need, so don't bump further than required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,3 +342,37 @@ Any significantly difficult dependency updates should have an issue created to
 track the work and can be triaged alongside our other issues.
 
 Updates to dependencies should be done in a separate PR.
+
+### `engines.vscode` and `@types/vscode`
+
+The VS Code extension declares two related versions:
+
+- `engines.vscode` in `extensions/vscode/package.json` — the minimum VS Code version users need to install the extension.
+- `@types/vscode` in `extensions/vscode/package.json` and `test/extension-contract-tests/package.json` — the API surface the TypeScript code compiles against.
+
+`vsce package` fails if the declared `@types/vscode` range is higher than the declared `engines.vscode` range (it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support). Keeping these two in lockstep avoids that failure and keeps `engines.vscode` honest — if it's lower than `@types/vscode`, the extension will install on VS Code versions that lack APIs the code calls, and crash at runtime.
+
+We pin both to the **same exact version, with no caret**:
+
+```jsonc
+// extensions/vscode/package.json
+"engines": { "vscode": "1.105.0" },
+"devDependencies": {
+  "@types/vscode": "1.105.0"
+}
+```
+
+```jsonc
+// test/extension-contract-tests/package.json
+"devDependencies": {
+  "@types/vscode": "1.105.0"
+}
+```
+
+Dropping the caret keeps Dependabot from drifting `@types/vscode` above `engines.vscode`. Both packages that depend on `@types/vscode` must use the same exact version so npm can hoist a single resolved version into the workspace.
+
+#### When to bump
+
+Bump the pin when adding code that needs a VS Code API not present in the current pinned version. Choose the **lowest** version that exposes the API you need (check the VS Code API release notes), and update all three places at once: `engines.vscode`, the extension's `@types/vscode`, and the contract-tests' `@types/vscode`. Then run `npm install` to refresh the lockfile.
+
+Raising the pin raises the minimum VS Code version users need, so don't bump further than the API requires.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,7 +347,7 @@ Updates to dependencies should be done in a separate PR.
 
 The VS Code extension declares two related versions:
 
-- `engines.vscode` in `extensions/vscode/package.json` — the minimum VS Code version users need to install the extension.
+- [`engines.vscode`](https://code.visualstudio.com/api/references/extension-manifest) in `extensions/vscode/package.json` — the minimum VS Code version users need to install the extension.
 - `@types/vscode` in `extensions/vscode/package.json` and `test/extension-contract-tests/package.json` — the API surface the TypeScript code compiles against.
 
 `vsce package` fails if `@types/vscode` is higher than `engines.vscode` — it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support. Pin both to the same version across all three places:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,4 +367,4 @@ The VS Code extension declares two related versions:
 }
 ```
 
-When adding code that needs a VS Code API not present in the current pinned version, bump all three places to the lowest version that exposes the API you need (check the VS Code API release notes), then run `npm install`. Raising the pin raises the minimum VS Code version users need, so don't bump further than required.
+When adding code that needs a VS Code API not present in the current pinned version, bump all three places to the lowest version that exposes the API you need (check the [VS Code API release notes](https://code.visualstudio.com/updates/)), then run `npm install`. Raising the pin raises the minimum VS Code version users need, so don't bump further than required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,11 +350,11 @@ The VS Code extension declares two related versions:
 - [`engines.vscode`](https://code.visualstudio.com/api/references/extension-manifest) in `extensions/vscode/package.json` — the minimum VS Code version users need to install the extension.
 - `@types/vscode` in `extensions/vscode/package.json` and `test/extension-contract-tests/package.json` — the API surface the TypeScript code compiles against.
 
-`vsce package` fails if `@types/vscode` is higher than `engines.vscode` — it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support. Pin both to the same version across all three places:
+`vsce package` fails if `@types/vscode` is higher than `engines.vscode` — it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support. Pin `@types/vscode` to an exact version (so the code can't drift onto newer APIs) and use a caret on `engines.vscode` (so the extension installs on that VS Code version and any newer one). Use the same version number in all three places:
 
 ```jsonc
 // extensions/vscode/package.json
-"engines": { "vscode": "1.105.0" },
+"engines": { "vscode": "^1.105.0" },
 "devDependencies": {
   "@types/vscode": "1.105.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,7 +350,7 @@ The VS Code extension declares two related versions:
 - [`engines.vscode`](https://code.visualstudio.com/api/references/extension-manifest) in `extensions/vscode/package.json` — the minimum VS Code version users need to install the extension.
 - `@types/vscode` in `extensions/vscode/package.json` and `test/extension-contract-tests/package.json` — the API surface the TypeScript code compiles against.
 
-`vsce package` fails if `@types/vscode` is higher than `engines.vscode` — it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support. Pin `@types/vscode` to an exact version (so the code can't drift onto newer APIs) and use a caret on `engines.vscode` (so the extension installs on that VS Code version and any newer one). Use the same version number in all three places:
+[`vsce package`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#vsce) fails if `@types/vscode` is higher than `engines.vscode` — it refuses to ship an extension that compiles against APIs newer than the minimum runtime it claims to support. Pin `@types/vscode` to an exact version (so the code can't drift onto newer APIs) and use a caret on `engines.vscode` (so the extension installs on that VS Code version and any newer one). Use the same version number in all three places:
 
 ```jsonc
 // extensions/vscode/package.json


### PR DESCRIPTION
## Summary
- Adds a section to `CONTRIBUTING.md` (under *Updating Dependencies*) describing how we pin `engines.vscode` and `@types/vscode`, why `vsce package` requires their ranges to line up, and how to bump them.
- Codifies the rule from #4193: pin both to the same exact version (no caret) across `extensions/vscode/package.json` and `test/extension-contract-tests/package.json` so Dependabot can't drift them apart.

## Test plan
- [ ] Read the rendered diff and confirm the policy matches what we want contributors (and future-us) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)