### PR TITLE
ci: add CI health gate to release tagging and skip CI for release PRs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,66 +28,10 @@ jobs:
           fetch-depth: 0 # Need full history for diff
       - name: Check for code changes
         id: check
-        run: |
-          # Get the base ref for comparison
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            # For workflow_dispatch, compare with main
-            BASE_SHA="origin/main"
-          fi
-
-          # Get list of changed files
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD 2>/dev/null || git diff --name-only "$BASE_SHA" HEAD)
-
-          if [[ -z "$CHANGED_FILES" ]]; then
-            echo "No files changed"
-            echo "has-code=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-          echo ""
-
-          # Check if any file is NOT a doc file
-          # Doc files: *.md, LICENSE, .gitignore, .gitattributes
-          has_code="false"
-          while IFS= read -r file; do
-            case "$file" in
-              *.md|LICENSE|.gitignore|.gitattributes)
-                # This is a doc file, skip
-                ;;
-              *)
-                # This is a code file
-                echo "Code file found: $file"
-                has_code="true"
-                break
-                ;;
-            esac
-          done <<< "$CHANGED_FILES"
-
-          # Check if any doc files under docs/ changed
-          has_docs="false"
-          while IFS= read -r file; do
-            case "$file" in
-              docs/*|.github/workflows/docs.yaml)
-                has_docs="true"
-                break
-                ;;
-            esac
-          done <<< "$CHANGED_FILES"
-
-          if [[ "$has_code" == "true" ]]; then
-            echo "has-code=true" >> $GITHUB_OUTPUT
-            echo "Code files changed"
-          else
-            echo "has-code=false" >> $GITHUB_OUTPUT
-            echo "Only documentation files changed"
-          fi
-
-          echo "has-docs=$has_docs" >> $GITHUB_OUTPUT
-          echo "Has doc changes: $has_docs"
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'origin/main' }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: python3 scripts/detect-code-changes.py
 
   # Linting and formatting - always runs
   lint:

--- a/.github/workflows/tag-on-release-merge.yaml
+++ b/.github/workflows/tag-on-release-merge.yaml
@@ -19,6 +19,29 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
+      - name: Verify main branch CI is green
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'main.yaml',
+              branch: 'main',
+              status: 'completed',
+              per_page: 1,
+            });
+            if (runs.data.workflow_runs.length === 0) {
+              core.setFailed('No completed main.yaml runs found');
+              return;
+            }
+            const lastRun = runs.data.workflow_runs[0];
+            console.log(`Last main.yaml run: ${lastRun.html_url}`);
+            console.log(`Conclusion: ${lastRun.conclusion}`);
+            if (lastRun.conclusion !== 'success') {
+              core.setFailed(`Cannot tag release: last main.yaml run was '${lastRun.conclusion}'. Fix CI on main before releasing.`);
+            }
+
       - name: Generate token for GitHub App
         id: generate-token
         uses: actions/create-github-app-token@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ minor version number is odd.
 
 - Merge any "Update licenses" PRs to `main`
 - Merge any Dependabot PRs to `main`
-- Wait for the `main.yaml` workflows to complete
+- Ensure CI is green on `main` (the tag-on-release-merge workflow will verify this automatically)
 
 ### Instructions
 

--- a/justfile
+++ b/justfile
@@ -110,6 +110,7 @@ test-scripts:
     python3 scripts/test_prepare_release.py
     (cd scripts && python3 -m unittest test_audit_gha_security -v)
     (cd scripts && python3 -m unittest test_generate_llms_txt -v)
+    (cd scripts && python3 -m unittest test_detect_code_changes -v)
 
 # Prints the pre-release status based on the version (see `just version`).
 pre-release:

--- a/scripts/detect-code-changes.py
+++ b/scripts/detect-code-changes.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Determines whether a PR contains code changes that require full CI,
+or only documentation/release-metadata changes that can skip it.
+
+Outputs (via GITHUB_OUTPUT file):
+  has-code=true|false
+  has-docs=true|false
+
+Required environment variables:
+  BASE_SHA  — the base commit to diff against
+  BRANCH    — the PR head branch name
+  GITHUB_OUTPUT — path to the GitHub Actions output file
+"""
+
+import os
+import subprocess
+import sys
+
+
+DOC_FILES = {"LICENSE", ".gitignore", ".gitattributes"}
+DOC_EXTENSIONS = {".md"}
+PACKAGE_JSON_FILES = {"package.json", "extensions/vscode/package.json"}
+LOCKFILE = "package-lock.json"
+DOCS_PREFIXES = ("docs/", ".github/workflows/docs.yaml")
+
+
+def get_changed_files(base_sha: str) -> list[str]:
+    """Get the list of files changed between base_sha and HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_sha}...HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", base_sha, "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    return [f for f in result.stdout.strip().split("\n") if f]
+
+
+def get_file_diff(base_sha: str, file_path: str) -> str:
+    """Get the unified diff for a specific file."""
+    result = subprocess.run(
+        ["git", "diff", f"{base_sha}...HEAD", "--", file_path],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def is_version_only_change(diff_output: str) -> bool:
+    """Check if a diff only modifies the 'version' field in a JSON file."""
+    for line in diff_output.split("\n"):
+        if not line.startswith(("+", "-")):
+            continue
+        # Skip diff header lines (+++, ---)
+        if line.startswith(("+++", "---")):
+            continue
+        # Every added/removed line must contain "version"
+        if '"version"' not in line:
+            return False
+    return True
+
+
+def is_release_branch(branch: str) -> bool:
+    """Check if the branch is a release branch."""
+    return branch.startswith("release/v")
+
+
+def is_doc_file(file_path: str) -> bool:
+    """Check if a file is a documentation file."""
+    if file_path in DOC_FILES:
+        return True
+    _, ext = os.path.splitext(file_path)
+    return ext in DOC_EXTENSIONS
+
+
+def is_docs_content(file_path: str) -> bool:
+    """Check if a file is documentation site content."""
+    return any(file_path.startswith(prefix) or file_path == prefix for prefix in DOCS_PREFIXES)
+
+
+def classify_changes(
+    changed_files: list[str],
+    branch: str,
+    get_diff_fn=None,
+) -> tuple[bool, bool]:
+    """Classify changed files into code vs docs/metadata.
+
+    Returns (has_code, has_docs).
+    """
+    release = is_release_branch(branch)
+    has_code = False
+    has_docs = False
+
+    for file_path in changed_files:
+        if is_docs_content(file_path):
+            has_docs = True
+
+        if has_code:
+            continue
+
+        if is_doc_file(file_path):
+            continue
+
+        if file_path in PACKAGE_JSON_FILES:
+            if release and get_diff_fn:
+                diff = get_diff_fn(file_path)
+                if is_version_only_change(diff):
+                    continue
+            has_code = True
+            continue
+
+        if file_path == LOCKFILE:
+            if release:
+                continue
+            has_code = True
+            continue
+
+        has_code = True
+
+    return has_code, has_docs
+
+
+def main() -> None:
+    base_sha = os.environ.get("BASE_SHA")
+    branch = os.environ.get("BRANCH", "")
+    output_file = os.environ.get("GITHUB_OUTPUT")
+
+    if not base_sha:
+        print("::error::BASE_SHA must be set", file=sys.stderr)
+        sys.exit(1)
+
+    if not output_file:
+        print("::error::GITHUB_OUTPUT must be set", file=sys.stderr)
+        sys.exit(1)
+
+    changed_files = get_changed_files(base_sha)
+
+    if not changed_files:
+        print("No files changed")
+        with open(output_file, "a") as f:
+            f.write("has-code=false\n")
+            f.write("has-docs=false\n")
+        return
+
+    print("Changed files:")
+    for file_path in changed_files:
+        print(f"  {file_path}")
+    print()
+
+    def get_diff_fn(file_path: str) -> str:
+        return get_file_diff(base_sha, file_path)
+
+    has_code, has_docs = classify_changes(changed_files, branch, get_diff_fn)
+
+    if has_code:
+        print("Code files changed — full CI required")
+    else:
+        print("Only documentation/release-metadata files changed — skipping full CI")
+
+    with open(output_file, "a") as f:
+        f.write(f"has-code={'true' if has_code else 'false'}\n")
+        f.write(f"has-docs={'true' if has_docs else 'false'}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_detect_code_changes.py
+++ b/scripts/test_detect_code_changes.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for detect-code-changes.py script."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "detect_code_changes",
+    Path(__file__).parent / "detect-code-changes.py",
+)
+detect_code_changes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(detect_code_changes)
+
+
+class TestIsDocFile(unittest.TestCase):
+    def test_markdown_files(self):
+        self.assertTrue(detect_code_changes.is_doc_file("README.md"))
+        self.assertTrue(detect_code_changes.is_doc_file("CHANGELOG.md"))
+        self.assertTrue(detect_code_changes.is_doc_file("docs/guide.md"))
+
+    def test_special_doc_files(self):
+        self.assertTrue(detect_code_changes.is_doc_file("LICENSE"))
+        self.assertTrue(detect_code_changes.is_doc_file(".gitignore"))
+        self.assertTrue(detect_code_changes.is_doc_file(".gitattributes"))
+
+    def test_code_files(self):
+        self.assertFalse(detect_code_changes.is_doc_file("src/index.ts"))
+        self.assertFalse(detect_code_changes.is_doc_file("package.json"))
+        self.assertFalse(detect_code_changes.is_doc_file(".github/workflows/ci.yaml"))
+
+
+class TestIsReleaseBranch(unittest.TestCase):
+    def test_release_branches(self):
+        self.assertTrue(detect_code_changes.is_release_branch("release/v1.34.0"))
+        self.assertTrue(detect_code_changes.is_release_branch("release/v2.0.0"))
+
+    def test_non_release_branches(self):
+        self.assertFalse(detect_code_changes.is_release_branch("main"))
+        self.assertFalse(detect_code_changes.is_release_branch("feature/something"))
+        self.assertFalse(detect_code_changes.is_release_branch("fix/release/v1"))
+
+
+class TestIsVersionOnlyChange(unittest.TestCase):
+    def test_version_only(self):
+        diff = """\
+--- a/package.json
++++ b/package.json
+-  "version": "1.33.0",
++  "version": "1.34.0",
+"""
+        self.assertTrue(detect_code_changes.is_version_only_change(diff))
+
+    def test_version_plus_other_changes(self):
+        diff = """\
+--- a/package.json
++++ b/package.json
+-  "version": "1.33.0",
++  "version": "1.34.0",
++  "scripts": { "new-script": "echo hello" },
+"""
+        self.assertFalse(detect_code_changes.is_version_only_change(diff))
+
+    def test_no_version_change(self):
+        diff = """\
+--- a/package.json
++++ b/package.json
+-  "description": "old",
++  "description": "new",
+"""
+        self.assertFalse(detect_code_changes.is_version_only_change(diff))
+
+    def test_empty_diff(self):
+        self.assertTrue(detect_code_changes.is_version_only_change(""))
+
+
+class TestIsDocsContent(unittest.TestCase):
+    def test_docs_directory(self):
+        self.assertTrue(detect_code_changes.is_docs_content("docs/index.md"))
+        self.assertTrue(detect_code_changes.is_docs_content("docs/guide/install.md"))
+
+    def test_docs_workflow(self):
+        self.assertTrue(detect_code_changes.is_docs_content(".github/workflows/docs.yaml"))
+
+    def test_non_docs(self):
+        self.assertFalse(detect_code_changes.is_docs_content("src/index.ts"))
+        self.assertFalse(detect_code_changes.is_docs_content(".github/workflows/ci.yaml"))
+
+
+class TestClassifyChanges(unittest.TestCase):
+    def test_only_docs(self):
+        files = ["README.md", "CONTRIBUTING.md", "LICENSE"]
+        has_code, has_docs = detect_code_changes.classify_changes(files, "main")
+        self.assertFalse(has_code)
+        self.assertFalse(has_docs)
+
+    def test_docs_site_content(self):
+        files = ["docs/guide.md", "README.md"]
+        has_code, has_docs = detect_code_changes.classify_changes(files, "main")
+        self.assertFalse(has_code)
+        self.assertTrue(has_docs)
+
+    def test_code_changes(self):
+        files = ["src/index.ts", "README.md"]
+        has_code, has_docs = detect_code_changes.classify_changes(files, "main")
+        self.assertTrue(has_code)
+        self.assertFalse(has_docs)
+
+    def test_package_json_on_non_release_branch(self):
+        files = ["package.json"]
+        has_code, has_docs = detect_code_changes.classify_changes(files, "feature/foo")
+        self.assertTrue(has_code)
+
+    def test_package_json_version_only_on_release_branch(self):
+        version_diff = """\
+--- a/package.json
++++ b/package.json
+-  "version": "1.33.0",
++  "version": "1.34.0",
+"""
+        files = ["package.json"]
+        has_code, _ = detect_code_changes.classify_changes(
+            files, "release/v1.34.0", get_diff_fn=lambda f: version_diff
+        )
+        self.assertFalse(has_code)
+
+    def test_package_json_non_version_on_release_branch(self):
+        diff = """\
+--- a/package.json
++++ b/package.json
+-  "version": "1.33.0",
++  "version": "1.34.0",
++  "dependencies": { "new-dep": "^1.0.0" },
+"""
+        files = ["package.json"]
+        has_code, _ = detect_code_changes.classify_changes(
+            files, "release/v1.34.0", get_diff_fn=lambda f: diff
+        )
+        self.assertTrue(has_code)
+
+    def test_vscode_package_json_on_release_branch(self):
+        version_diff = """\
+--- a/extensions/vscode/package.json
++++ b/extensions/vscode/package.json
+-  "version": "1.33.0",
++  "version": "1.34.0",
+"""
+        files = ["extensions/vscode/package.json", "CHANGELOG.md"]
+        has_code, _ = detect_code_changes.classify_changes(
+            files, "release/v1.34.0", get_diff_fn=lambda f: version_diff
+        )
+        self.assertFalse(has_code)
+
+    def test_lockfile_on_release_branch(self):
+        files = ["package-lock.json", "CHANGELOG.md"]
+        has_code, _ = detect_code_changes.classify_changes(files, "release/v1.34.0")
+        self.assertFalse(has_code)
+
+    def test_lockfile_on_non_release_branch(self):
+        files = ["package-lock.json"]
+        has_code, _ = detect_code_changes.classify_changes(files, "feature/foo")
+        self.assertTrue(has_code)
+
+    def test_full_release_pr(self):
+        """Simulates a typical release PR with changelog + version bump."""
+        version_diff = """\
+--- a/extensions/vscode/package.json
++++ b/extensions/vscode/package.json
+-  "version": "2.6.0",
++  "version": "2.8.0",
+"""
+        files = [
+            "CHANGELOG.md",
+            "extensions/vscode/CHANGELOG.md",
+            "extensions/vscode/package.json",
+            "package-lock.json",
+        ]
+        has_code, has_docs = detect_code_changes.classify_changes(
+            files, "release/v2.8.0", get_diff_fn=lambda f: version_diff
+        )
+        self.assertFalse(has_code)
+        self.assertFalse(has_docs)
+
+    def test_release_branch_without_diff_fn_treats_package_json_as_code(self):
+        files = ["extensions/vscode/package.json"]
+        has_code, _ = detect_code_changes.classify_changes(files, "release/v1.34.0")
+        self.assertTrue(has_code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a CI health check to `tag-on-release-merge.yaml` that verifies the last `main.yaml` run succeeded before creating a release tag. This replaces the manual "wait for main.yaml to complete" step in the release process.
- Extracts the `detect-changes` logic from `pull-request.yaml` into a testable Python script (`scripts/detect-code-changes.py`). On release branches, package.json changes are validated to contain only version bumps — if they do, full CI is skipped.
- Updates `CONTRIBUTING.md` to reflect the automated gate.

## Test plan

- [ ] Verify `just test-scripts` passes (includes 23 new unit tests for the detection logic)
- [ ] Confirm PR CI still runs full suite for non-release branches
- [ ] On a future release, verify the tag workflow checks main CI status before tagging

Closes #4188

🤖 Generated with [Claude Code](https://claude.com/claude-code)