### PR TITLE
fix: keep fantasticon out of esbuild-base to unbreak Windows CI

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -643,10 +643,10 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify",
+    "vscode:prepublish": "npm run --prefix webviews/homeView build && npm run esbuild-base -- --minify && npm run build-font && npm run inline-icon-fonts",
     "copy-codicons": "node scripts/copy-codicons.mjs",
     "inline-icon-fonts": "node scripts/inline-icon-fonts.mjs",
-    "esbuild-base": "npm run copy-codicons && npm run build-font && npm run inline-icon-fonts && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "npm run copy-codicons && tsc --noEmit --project tsconfig.json && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc-watch": "tsc --noEmit --watch --project tsconfig.json",

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -2095,12 +2095,8 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
    * rendered within the webview panel
    */
   private getWebviewContent(webview: Webview, extensionUri: Uri) {
-    // Inline all stylesheets (and their fonts as data URIs) rather than
-    // linking to them. Firefox's service worker fails to intercept webview
-    // resource requests in some hosts (notably Posit Workbench), causing
-    // the fetches to fail with SSL_ERROR_BAD_CERT_DOMAIN. Inlining sidesteps
-    // the interception.
-    // See https://github.com/posit-dev/publisher/issues/4013.
+    // Inline stylesheets to work around Firefox's broken service-worker
+    // interception of webview resource requests in Posit Workbench (#4013).
     const stylesContent = fs.readFileSync(
       path.join(
         extensionUri.fsPath,
@@ -2111,21 +2107,52 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       ),
       "utf8",
     );
-    // The *.inlined.css files are produced at build time by
-    // scripts/inline-icon-fonts.mjs, which rewrites each icon stylesheet's
-    // @font-face url() to a base64 data: URI.
-    const codiconsContent = fs.readFileSync(
-      path.join(extensionUri.fsPath, "dist", "codicons", "codicon.inlined.css"),
-      "utf8",
+
+    // *.inlined.css is only produced during vscode:prepublish (fantasticon
+    // is broken on Windows, so it stays out of esbuild-base). When absent,
+    // fall back to webview URI links — the Workbench/Firefox bug doesn't
+    // apply in the Extension Development Host.
+    const codiconsInlinedPath = path.join(
+      extensionUri.fsPath,
+      "dist",
+      "codicons",
+      "codicon.inlined.css",
     );
-    const positPublisherFontContent = fs.readFileSync(
-      path.join(
-        extensionUri.fsPath,
+    const positPublisherIconsInlinedPath = path.join(
+      extensionUri.fsPath,
+      "dist",
+      "posit-publisher-icons.inlined.css",
+    );
+    const useInlinedIconFonts =
+      fs.existsSync(codiconsInlinedPath) &&
+      fs.existsSync(positPublisherIconsInlinedPath);
+
+    let iconStyleTags: string;
+    let fontSrcCsp: string;
+    if (useInlinedIconFonts) {
+      const codiconsContent = fs.readFileSync(codiconsInlinedPath, "utf8");
+      const positPublisherFontContent = fs.readFileSync(
+        positPublisherIconsInlinedPath,
+        "utf8",
+      );
+      iconStyleTags = `<style>${codiconsContent}</style>
+          <style>${positPublisherFontContent}</style>`;
+      fontSrcCsp = "data:";
+    } else {
+      const codiconsUri = getUri(webview, extensionUri, [
         "dist",
-        "posit-publisher-icons.inlined.css",
-      ),
-      "utf8",
-    );
+        "codicons",
+        "codicon.css",
+      ]);
+      const positPublisherFontCssUri = getUri(webview, extensionUri, [
+        "dist",
+        "posit-publisher-icons.css",
+      ]);
+      iconStyleTags = `<link rel="stylesheet" type="text/css" href="${codiconsUri}">
+          <link rel="stylesheet" type="text/css" href="${positPublisherFontCssUri}">`;
+      fontSrcCsp = webview.cspSource;
+    }
+
     // The JS file from the Vue build output
     const scriptUri = getUri(webview, extensionUri, [
       "webviews",
@@ -2146,13 +2173,12 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           <meta http-equiv="Content-Security-Policy"
             content="
               default-src 'none';
-              font-src data:;
+              font-src ${fontSrcCsp};
               style-src ${webview.cspSource} 'unsafe-inline';
               script-src 'nonce-${nonce}';"
           />
           <style>${stylesContent}</style>
-          <style>${codiconsContent}</style>
-          <style>${positPublisherFontContent}</style>
+          ${iconStyleTags}
           <title>Hello World</title>
         </head>
         <body>


### PR DESCRIPTION
## Intent

Unbreak the Windows ``vscode / native`` CI jobs on #4174.

## Type of Change

- - [x] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

``fantasticon@4.1.0`` is broken on Windows: it calls ``path.join(inputDir, "**/*.svg")`` then passes the result to ``glob@13``. On Windows the joined path uses backslashes, which ``glob`` treats as escape characters, so it matches zero files and fantasticon throws ``No SVGs found in ./assets/icons``.

#4174 moved ``build-font`` (and the new ``inline-icon-fonts``) into ``esbuild-base``. Because ``pretest`` runs ``esbuild-base``, the Windows native test matrix started invoking fantasticon for the first time and failed. macOS / Linux passed; Windows didn't.

This PR moves both back to ``vscode:prepublish`` only, which runs Ubuntu-only via the ``package`` job. ``esbuild-base`` is restored to its pre-#4174 shape and no longer touches fantasticon.

To keep the Workbench/Firefox fix from #4013 working, ``homeView.getWebviewContent()`` now picks its strategy based on whether the prebuilt ``*.inlined.css`` files exist:

- Packaged extension (``.vsix``): inlined files are present, embed them as ``<style>`` blocks with ``font-src data:`` — same behavior as #4174.
- F5 Extension Development Host: inlined files are absent, fall back to ``<link rel=\"stylesheet\">`` via webview URIs with ``font-src \${webview.cspSource}``. The Firefox/Workbench service-worker interception bug doesn't apply in the Extension Development Host, so plain stylesheet links work.

Trade-off: ``homeView`` has two output shapes guarded by a single ``existsSync`` check, but the duplication is small and the CSP differs honestly between contexts.

## User Impact

None. Users continue to get the #4013 fix in the packaged extension. Windows CI is green again.

## Automated Tests

No new tests — the change is build-config plus a runtime fallback. Validation is CI passing on this branch (which is what failed on #4174).

## Directions for Reviewers

1. Confirm the Windows ``vscode / native (windows-latest)`` and ``windows-11-arm`` jobs go green on this PR.
2. Confirm ``package / vscode`` still produces a working ``.vsix`` (it runs on Ubuntu, so fantasticon executes there).
3. Optional: ``just vscode package`` locally, install the ``.vsix``, open the sidebar in Workbench/Firefox, verify icons and styles still render (the #4174 behavior).

## Checklist

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
  - No CHANGELOG entry — this is internal build tooling, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)