### PR TITLE
feat: support metrics_collection_enabled in connect.runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a `metrics_collection_enabled` configuration option under `[connect.runtime]` to enable or disable per-content resource metrics (CPU, memory, connections) at deploy time when publishing to Posit Connect. Omit the field to inherit the server-wide default. The setting has no effect on Connect Cloud deployments. (#4201)
+
 ## [2.6.0]
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -355,7 +355,7 @@ Controls how aggressively new processes are spawned. The valid range is between 
 
 #### metrics_collection_enabled
 
-_Valid only when `product_type` is `connect`._
+_Only valid when `product_type` is `connect`_
 
 Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default (`Applications.MetricsCollectionEnabled`). Has no effect on Connect Cloud deployments.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,7 +357,7 @@ Controls how aggressively new processes are spawned. The valid range is between 
 
 _Only valid when `product_type` is `connect`_
 
-Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default (`Applications.MetricsCollectionEnabled`). Has no effect on Connect Cloud deployments.
+Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default (`Applications.MetricsCollectionEnabled`).
 
 #### max_conns_per_process
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -353,6 +353,12 @@ The maximum number of seconds allowed for an interactive application to start. P
 
 Controls how aggressively new processes are spawned. The valid range is between 0.0 and 1.0.
 
+#### metrics_collection_enabled
+
+_Valid only when `product_type` is `connect`._
+
+Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default (`Applications.MetricsCollectionEnabled`). Has no effect on Connect Cloud deployments.
+
 #### max_conns_per_process
 
 Specifies the maximum number of client connections allowed to an individual process. Incoming connections which will exceed this limit are routed to a new process or rejected.
@@ -379,6 +385,7 @@ init_timeout = 60
 load_factor = 0.5
 max_conns_per_process = 50
 max_processes = 5
+metrics_collection_enabled = true
 min_processes = 1
 read_timeout = 30
 ```

--- a/extensions/vscode/src/api/types/connect.ts
+++ b/extensions/vscode/src/api/types/connect.ts
@@ -20,6 +20,7 @@ export type ConnectRuntime = {
   minProcesses?: number;
   maxConnsPerProcess?: number;
   loadFactor?: number;
+  metricsCollectionEnabled?: boolean;
 };
 
 export type ConnectKubernetes = {

--- a/extensions/vscode/src/bundler/connectContentFromConfig.test.ts
+++ b/extensions/vscode/src/bundler/connectContentFromConfig.test.ts
@@ -52,6 +52,7 @@ describe("connectContentFromConfig", () => {
             minProcesses: 1,
             maxConnsPerProcess: 50,
             loadFactor: 0.75,
+            metricsCollectionEnabled: true,
           },
         },
       }),
@@ -66,6 +67,7 @@ describe("connectContentFromConfig", () => {
       min_processes: 1,
       max_conns_per_process: 50,
       load_factor: 0.75,
+      metrics_collection_enabled: true,
     });
   });
 
@@ -143,6 +145,7 @@ describe("connectContentFromConfig", () => {
       cfg({
         connect: {
           access: { runAsCurrentUser: false },
+          runtime: { metricsCollectionEnabled: false },
           kubernetes: {
             defaultREnvironmentManagement: false,
             defaultPyEnvironmentManagement: false,
@@ -151,8 +154,22 @@ describe("connectContentFromConfig", () => {
       }),
     );
     expect(result.run_as_current_user).toBe(false);
+    expect(result.metrics_collection_enabled).toBe(false);
     expect(result.default_r_environment_management).toBe(false);
     expect(result.default_py_environment_management).toBe(false);
+  });
+
+  it("omits metrics_collection_enabled when not set", () => {
+    const result = connectContentFromConfig(
+      cfg({
+        connect: {
+          runtime: { maxProcesses: 5 },
+        },
+      }),
+    );
+    expect(result.metrics_collection_enabled).toBeUndefined();
+    const json = JSON.parse(JSON.stringify(result));
+    expect("metrics_collection_enabled" in json).toBe(false);
   });
 
   it("access with runAs only, no runAsCurrentUser", () => {

--- a/extensions/vscode/src/bundler/connectContentFromConfig.ts
+++ b/extensions/vscode/src/bundler/connectContentFromConfig.ts
@@ -26,6 +26,7 @@ export function connectContentFromConfig(
     min_processes: rt?.minProcesses,
     max_conns_per_process: rt?.maxConnsPerProcess,
     load_factor: rt?.loadFactor,
+    metrics_collection_enabled: rt?.metricsCollectionEnabled,
 
     // Access
     run_as: access?.runAs || undefined,

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -182,6 +182,7 @@ const TEST_CONTENT: ContentDetailsDTO = {
   min_processes: null,
   max_conns_per_process: null,
   load_factor: null,
+  metrics_collection_enabled: null,
   created_time: "2024-01-01T00:00:00Z",
   last_deployed_time: "2024-01-01T00:00:00Z",
   bundle_id: null,

--- a/extensions/vscode/src/toml/schema.test.ts
+++ b/extensions/vscode/src/toml/schema.test.ts
@@ -123,6 +123,36 @@ describe("schema rejects invalid integration_requests", () => {
   });
 });
 
+describe("schema validates connect.runtime.metrics_collection_enabled", () => {
+  it("accepts true", () => {
+    const data = baseConfig("connect");
+    setNested(data, ["connect", "runtime"], "metrics_collection_enabled", true);
+    expectValid(data);
+  });
+
+  it("accepts false", () => {
+    const data = baseConfig("connect");
+    setNested(
+      data,
+      ["connect", "runtime"],
+      "metrics_collection_enabled",
+      false,
+    );
+    expectValid(data);
+  });
+
+  it("rejects non-boolean value", () => {
+    const data = baseConfig("connect");
+    setNested(
+      data,
+      ["connect", "runtime"],
+      "metrics_collection_enabled",
+      "yes",
+    );
+    expectInvalid(data);
+  });
+});
+
 describe("schema rejects disallowed properties for Connect", () => {
   it("rejects python.garbage", () => {
     const data = baseConfig("connect");

--- a/extensions/vscode/src/toml/schemas/example-config.toml
+++ b/extensions/vscode/src/toml/schemas/example-config.toml
@@ -44,6 +44,7 @@ max_processes = 5
 min_processes = 1
 max_conns_per_process = 50
 load_factor = 0.5
+metrics_collection_enabled = true
 
 [connect.kubernetes]
 amd_gpu_limit = 0

--- a/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
@@ -518,7 +518,7 @@
             },
             "metrics_collection_enabled": {
               "type": "boolean",
-              "description": "Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default. Only forwarded for Posit Connect deployments; ignored for Connect Cloud.",
+              "description": "Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default.",
               "examples": [true]
             }
           }

--- a/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
@@ -515,6 +515,11 @@
               "maximum": 1,
               "description": "Controls how aggressively new processes are spawned. The valid range is between 0.0 and 1.0.",
               "examples": [0.5]
+            },
+            "metrics_collection_enabled": {
+              "type": "boolean",
+              "description": "Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default. Only forwarded for Posit Connect deployments; ignored for Connect Cloud.",
+              "examples": [true]
             }
           }
         }

--- a/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
+++ b/extensions/vscode/src/toml/schemas/posit-publishing-schema-v3.json
@@ -518,7 +518,7 @@
             },
             "metrics_collection_enabled": {
               "type": "boolean",
-              "description": "Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default.",
+              "description": "Controls whether per-job resource metrics (CPU, memory, connections) are collected for this content item. When omitted, the content inherits the server-wide default. Applies to Posit Connect deployments only.",
               "examples": [true]
             }
           }

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -514,6 +514,7 @@ describe("contentDetails", () => {
     min_processes: null,
     max_conns_per_process: null,
     load_factor: null,
+    metrics_collection_enabled: null,
     created_time: "2024-01-01T00:00:00Z",
     last_deployed_time: "2024-01-01T00:00:00Z",
     bundle_id: "bundle-1",
@@ -531,6 +532,7 @@ describe("contentDetails", () => {
     content_url: "https://connect.example.com/content/content-guid-abc/",
     dashboard_url:
       "https://connect.example.com/connect/#/apps/content-guid-abc",
+    locked: false,
     app_role: "owner",
     id: "42",
   };

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -129,6 +129,7 @@ export interface ConnectContent {
   min_processes?: number | null;
   max_conns_per_process?: number | null;
   load_factor?: number | null;
+  metrics_collection_enabled?: boolean | null;
   run_as?: string;
   run_as_current_user?: boolean;
   memory_request?: number | null;
@@ -159,6 +160,7 @@ export interface ContentDetailsDTO {
   min_processes: number | null;
   max_conns_per_process: number | null;
   load_factor: number | null;
+  metrics_collection_enabled: boolean | null;
   created_time: string;
   last_deployed_time: string;
   bundle_id: string | null;


### PR DESCRIPTION
## Intent

Resolves #4201.

Adds a `metrics_collection_enabled` boolean under `[connect.runtime]` in `.posit/publish/*.toml` so users can toggle per-content resource metrics collection at deploy time instead of flipping it manually in the Connect Dashboard or via a follow-up API call.

## Type of Change

- [x] New Feature

## Approach

The TOML key reaches the Connect content body via the existing `connectContentFromConfig` mapping that builds the PATCH payload for both first-deploy and redeploy. Added to the JSON schema, `ConnectRuntime`, and `ConnectContent`/`ContentDetailsDTO`.

The Cloud publish path enumerates the runtime fields it forwards (`cloudContentRequest.ts::mapRuntimeToConnectOptions`), so the new key is silently dropped for `connect_cloud` deployments. That is intentional - Connect Cloud has no equivalent field.

Drive-by: `packages/connect-api/src/client.test.ts` fixture was missing the already-required `locked: boolean` on `ContentDetailsDTO`. Added `locked: false` while updating the same fixture for the new field.

## User Impact

Users deploying to Posit Connect can now set:

```toml
[connect.runtime]
metrics_collection_enabled = true
```

Omitting the key leaves the field untouched (server-wide `Applications.MetricsCollectionEnabled` applies). Setting `false` explicitly disables collection for the content item. No effect on Connect Cloud deployments.

## Automated Tests

- Schema (`schema.test.ts`): accepts `true`, accepts `false`, rejects non-boolean.
- Mapping (`connectContentFromConfig.test.ts`): runtime mapping covered for `true`; explicit `false`-preservation; omission asserts the field is dropped from the serialized JSON body (not sent as `null`, which would reset the server-side override).
- `example-config.toml` fixture exercises round-trip schema validation with the new key.

## Directions for Reviewers

1. Inspect the mapping at `extensions/vscode/src/bundler/connectContentFromConfig.ts:29` and the schema entry around `posit-publishing-schema-v3.json:519`.
2. Optional manual smoke test: set `metrics_collection_enabled = true` in a workspace's `.posit/publish/<config>.toml`, deploy (F5), then `GET /v1/content/{guid}` on the target Connect server and confirm the field is set on the content item.

## Checklist

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
