### PR TITLE
fix: upgrade to shiny==1.6.2 to fix e2e tests

### DIFF
--- a/test/e2e/content-workspace/examples-shiny-python/requirements.txt
+++ b/test/e2e/content-workspace/examples-shiny-python/requirements.txt
@@ -1,5 +1,5 @@
 faicons==0.2.2
-shiny==1.6.1
+shiny==1.6.2
 shinywidgets==0.8.0
 plotly==6.7.0
 pandas==3.0.2


### PR DESCRIPTION
Fixes failing e2e deployment test of Shiny Python. See https://github.com/posit-dev/py-shiny/pull/2244