### PR TITLE
Fix PRIVATE_KEY_PATH env override ignored when TOML has no private_key_file

### DIFF
--- a/extensions/vscode/src/snowflake/connections.test.ts
+++ b/extensions/vscode/src/snowflake/connections.test.ts
@@ -192,6 +192,26 @@ authenticator = "snowflake_jwt"
       expect(conns["default"]?.user).toBe("newuser");
     });
 
+    it("normalizes PRIVATE_KEY_PATH env override to private_key_file", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "connections.toml"),
+        `[default]
+account = "myaccount"
+user = "myuser"
+authenticator = "snowflake_jwt"
+`,
+      );
+
+      setEnv(
+        "SNOWFLAKE_CONNECTIONS_DEFAULT_PRIVATE_KEY_PATH",
+        "/env/path/to/key.p8",
+      );
+
+      const conns = listConnections();
+      expect(conns["default"]?.private_key_file).toBe("/env/path/to/key.p8");
+      expect(conns["default"]?.private_key_path).toBeUndefined();
+    });
+
     it("uses uppercase connection name in env var lookup", () => {
       fs.writeFileSync(
         path.join(tmpDir, "connections.toml"),

--- a/extensions/vscode/src/snowflake/connections.ts
+++ b/extensions/vscode/src/snowflake/connections.ts
@@ -229,8 +229,8 @@ export function listConnections(): Record<string, SnowflakeConnectionConfig> {
     ? parseConfigToml(content)
     : parseConnectionsToml(content);
 
-  normalizeKeyPaths(conns);
   applyEnvVarOverrides(conns);
+  normalizeKeyPaths(conns);
 
   return conns;
 }


### PR DESCRIPTION
Fixes #4217

Reorders `normalizeKeyPaths()` and `applyEnvVarOverrides()` in `listConnections()` so that env var overrides are applied before normalization. Previously, `SNOWFLAKE_CONNECTIONS_<NAME>_PRIVATE_KEY_PATH` was written into `private_key_path` after normalization had already run, so it was never folded into `private_key_file` and JWT auth failed.

Adds a unit test covering this scenario.

Generated with [Claude Code](https://claude.ai/claude-code)