### PR TITLE
Fix docs deployment not triggering on new releases

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,8 +1,9 @@
 name: Deploy docs
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -15,17 +16,34 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
 
-      - uses: quarto-dev/quarto-actions/setup@v2
+      - name: Check if production release
+        if: github.event_name == 'workflow_run'
+        id: check-release
+        run: |
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          MINOR=$(echo "$TAG" | sed 's/^v//' | cut -d. -f2)
+          if [ $((MINOR % 2)) -ne 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping docs deploy for pre-release tag: $TAG"
+          fi
+
+      - if: steps.check-release.outputs.skip != 'true'
+        uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Render
+        if: steps.check-release.outputs.skip != 'true'
         run: quarto render docs
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - uses: peaceiris/actions-gh-pages@v4.1.0
+      - if: steps.check-release.outputs.skip != 'true'
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_site

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,36 +14,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  check-release:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
 
-      - name: Check if production release
+      - name: Check if pre-release
         if: github.event_name == 'workflow_run'
-        id: check-release
+        id: check
         run: |
-          TAG="${{ github.event.workflow_run.head_branch }}"
-          MINOR=$(echo "$TAG" | sed 's/^v//' | cut -d. -f2)
-          if [ $((MINOR % 2)) -ne 0 ]; then
+          if [ "$(./scripts/is-pre-release.bash)" = "true" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping docs deploy for pre-release tag: $TAG"
+            echo "Skipping docs deploy for pre-release"
           fi
 
-      - if: steps.check-release.outputs.skip != 'true'
-        uses: quarto-dev/quarto-actions/setup@v2
+  deploy:
+    needs: check-release
+    runs-on: ubuntu-latest
+    if: >-
+      needs.check-release.outputs.skip != 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Render
-        if: steps.check-release.outputs.skip != 'true'
         run: quarto render docs
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - if: steps.check-release.outputs.skip != 'true'
-        uses: peaceiris/actions-gh-pages@v4.1.0
+      - uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_site


### PR DESCRIPTION
## Summary

- Fixes #4228 — docs site was stuck showing version 2.4.0 because the deploy workflow never triggered automatically on releases.
- **Root cause:** The `release: [published]` trigger never fired because the Release workflow creates the GitHub release using `GITHUB_TOKEN`, and [events created by `GITHUB_TOKEN` do not trigger other workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).
- Switches to `workflow_run` on the Release workflow completion, with a guard to skip pre-release versions (odd minor numbers).

## Test plan

- [ ] Manually trigger the docs workflow (`workflow_dispatch`) to verify it still works
- [ ] On the next production release (even minor), confirm the docs workflow triggers automatically via `workflow_run`
- [ ] Verify pre-release tags (odd minor) do _not_ trigger a docs deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)