### PR TITLE
Replace HaaLeo/publish-vscode-extension with inline publish steps

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,12 +38,16 @@ jobs:
           echo "extension_path=dist/${name}-$(just version).vsix" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v2
-        with:
-          registryUrl: https://marketplace.visualstudio.com
-          pat: ${{ secrets.VSCE_PAT }}
-          extensionFile: ${{ steps.get-extension-path.outputs.extension_path }}
-          skipDuplicate: true
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          EXTENSION_FILE: ${{ steps.get-extension-path.outputs.extension_path }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$EXTENSION_FILE" ]]; then
+            echo "::error::extensionFile not found at: $EXTENSION_FILE"
+            exit 1
+          fi
+          npx --yes @vscode/vsce@2 publish --packagePath "$EXTENSION_FILE" --skip-duplicate
 
   publish-open-vsx:
     needs:
@@ -66,8 +70,13 @@ jobs:
           echo "extension_path=dist/${name}-$(just version).vsix" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v2
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ${{ steps.get-extension-path.outputs.extension_path }}
-          skipDuplicate: true
+        env:
+          OVSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+          EXTENSION_FILE: ${{ steps.get-extension-path.outputs.extension_path }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$EXTENSION_FILE" ]]; then
+            echo "::error::extensionFile not found at: $EXTENSION_FILE"
+            exit 1
+          fi
+          npx --yes ovsx@0 publish "$EXTENSION_FILE" --skip-duplicate

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,7 +47,7 @@ jobs:
             echo "::error::extensionFile not found at: $EXTENSION_FILE"
             exit 1
           fi
-          npx --yes @vscode/vsce@2 publish --packagePath "$EXTENSION_FILE" --skip-duplicate
+          npx --yes @vscode/vsce@3 publish --packagePath "$EXTENSION_FILE" --skip-duplicate
 
   publish-open-vsx:
     needs:
@@ -79,4 +79,4 @@ jobs:
             echo "::error::extensionFile not found at: $EXTENSION_FILE"
             exit 1
           fi
-          npx --yes ovsx@0 publish "$EXTENSION_FILE" --skip-duplicate
+          npx --yes ovsx@1 publish "$EXTENSION_FILE" --skip-duplicate

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Publish to Open VSX Registry
         env:
-          OVSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
           EXTENSION_FILE: ${{ steps.get-extension-path.outputs.extension_path }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Removes the dependency on `HaaLeo/publish-vscode-extension@v2` (a Node.js-based action with runtime version constraints)
- Replaces it with inline bash steps that call `@vscode/vsce` and `ovsx` directly via `npx`
- Auth is handled via environment variables (`VSCE_PAT` / `OVSX_TOKEN`) which is how both tools natively authenticate

Proves the viability of https://github.com/posit-dev/posit-gh-actions/pull/2 - which would expose a common drop-in replacement GHA for the HaaLeo dependency.
