### PR TITLE
clean up generated renv.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Publisher creating a persistent `renv.lock` and `renv/` folder in R projects that don't use renv, which caused re-deploys to fail when new packages were added. (#4233)
+
 ## [2.6.0]
 
 ### Added

--- a/extensions/vscode/src/interpreters/rPackages.test.ts
+++ b/extensions/vscode/src/interpreters/rPackages.test.ts
@@ -423,4 +423,72 @@ describe("scanRPackages", () => {
       "Project path contains invalid characters",
     );
   });
+
+  test("uses renvTargetDir for renv init/hydrate/snapshot when provided", async () => {
+    setupExecFileSuccess();
+    mockFileExistsAt.mockResolvedValue(true);
+
+    await scanRPackages("/project", "R", "renv.lock", undefined, "/tmp/renv");
+
+    const [, script] = mockWriteFile.mock.calls[0]!;
+    // Deps scan still points at the user's project
+    expect(script).toContain('rPathsVec <- c("/project")');
+    // renv target is the temp dir, not the project
+    expect(script).toContain('targetPath <- "/tmp/renv"');
+    expect(script).toContain('lockfile <- file.path(targetPath, "renv.lock")');
+
+    // Lockfile existence checked in the temp dir, not the project
+    expect(mockFileExistsAt).toHaveBeenCalledWith(
+      path.join("/tmp/renv", "renv.lock"),
+    );
+  });
+
+  test("cwd stays as projectDir even when renvTargetDir differs", async () => {
+    setupExecFileSuccess();
+    mockFileExistsAt.mockResolvedValue(true);
+
+    await scanRPackages("/project", "R", "renv.lock", undefined, "/tmp/renv");
+
+    const [, , opts] = mockExecFile.mock.calls[0]!;
+    expect(opts.cwd).toBe("/project");
+  });
+
+  test("renvTargetDir with spaces is handled correctly", async () => {
+    setupExecFileSuccess();
+    mockFileExistsAt.mockResolvedValue(true);
+
+    await scanRPackages(
+      "/project",
+      "R",
+      "renv.lock",
+      undefined,
+      "/tmp/my renv dir",
+    );
+
+    const [, script] = mockWriteFile.mock.calls[0]!;
+    expect(script).toContain('targetPath <- "/tmp/my renv dir"');
+    expect(mockFileExistsAt).toHaveBeenCalledWith(
+      path.join("/tmp/my renv dir", "renv.lock"),
+    );
+  });
+
+  test("rejects renvTargetDir with double-quote character", async () => {
+    await expect(
+      scanRPackages("/project", "R", "renv.lock", undefined, '/tmp/bad"dir'),
+    ).rejects.toThrow("renv target path contains invalid characters");
+  });
+
+  test("defaults to projectDir when renvTargetDir is not provided", async () => {
+    setupExecFileSuccess();
+    mockFileExistsAt.mockResolvedValue(true);
+
+    await scanRPackages("/project", "R");
+
+    const [, script] = mockWriteFile.mock.calls[0]!;
+    expect(script).toContain('rPathsVec <- c("/project")');
+    expect(script).toContain('targetPath <- "/project"');
+    expect(mockFileExistsAt).toHaveBeenCalledWith(
+      path.join("/project", "renv.lock"),
+    );
+  });
 });

--- a/extensions/vscode/src/interpreters/rPackages.ts
+++ b/extensions/vscode/src/interpreters/rPackages.ts
@@ -179,18 +179,25 @@ export async function scanRPackages(
   rPath: string,
   saveName?: string,
   positronR?: PositronRSettings,
+  renvTargetDir?: string,
 ): Promise<void> {
   const lockfileName = saveName || DEFAULT_RENV_LOCKFILE;
   validateSaveName(lockfileName);
+
+  // renvTargetDir separates where renv runs (init/hydrate/snapshot) from where
+  // deps are scanned. Defaults to projectDir so existing callers are unchanged.
+  const targetDir = renvTargetDir ?? projectDir;
 
   const repoURL = repoURLFromOptions(positronR);
 
   // Normalize paths for the R script (use forward slashes)
   const normalizedProjectPath = projectDir.split(path.sep).join("/");
+  const normalizedTargetPath = targetDir.split(path.sep).join("/");
   const normalizedLockfile = lockfileName.split(path.sep).join("/");
 
   // Validate strings before injecting into R code
   validateRStringLiteral(normalizedProjectPath, "Project path");
+  validateRStringLiteral(normalizedTargetPath, "renv target path");
   validateRStringLiteral(normalizedLockfile, "Lockfile name");
   validateRStringLiteral(repoURL, "Repository URL");
 
@@ -210,9 +217,8 @@ export async function scanRPackages(
     })
   }
   deps <- setdiff(deps, c("renv"))
-  targetPath <- "${normalizedProjectPath}"
-  # initialize project with bare = TRUE to avoid polluting user's project
-  # then hydrate() manually to copy installed packages over
+  targetPath <- "${normalizedTargetPath}"
+  # bare = TRUE skips auto-installing packages; hydrate() does it explicitly below
   renv::init(project = targetPath, bare = TRUE, force = TRUE)
   renv::hydrate(packages = deps, project = targetPath, prompt = FALSE)
   lockfile <- file.path(targetPath, "${normalizedLockfile}")
@@ -238,8 +244,8 @@ export async function scanRPackages(
     }
   }
 
-  // Verify the lockfile was created
-  const lockfilePath = path.join(projectDir, lockfileName);
+  // Verify the lockfile was created in the target directory
+  const lockfilePath = path.join(targetDir, lockfileName);
   const exists = await fileExistsAt(lockfilePath);
   if (!exists) {
     throw new Error(`renv could not create lockfile: ${lockfilePath}`);

--- a/extensions/vscode/src/interpreters/rPackages.ts
+++ b/extensions/vscode/src/interpreters/rPackages.ts
@@ -184,8 +184,9 @@ export async function scanRPackages(
   const lockfileName = saveName || DEFAULT_RENV_LOCKFILE;
   validateSaveName(lockfileName);
 
-  // renvTargetDir separates where renv runs (init/hydrate/snapshot) from where
-  // deps are scanned. Defaults to projectDir so existing callers are unchanged.
+  // renvTargetDir gives the ability to separate where renv runs
+  // (init/hydrate/snapshot) from where deps are scanned. Defaults to the
+  // project dir but can be set to elsewhere.
   const targetDir = renvTargetDir ?? projectDir;
 
   const repoURL = repoURLFromOptions(positronR);

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -38,6 +38,8 @@ vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   copyFile: vi.fn().mockResolvedValue(undefined),
   unlink: vi.fn().mockResolvedValue(undefined),
+  mkdtemp: vi.fn().mockResolvedValue("/tmp/publisher-renv-test"),
+  rm: vi.fn().mockResolvedValue(undefined),
   stat: vi.fn(),
 }));
 
@@ -1029,6 +1031,7 @@ describe("connectPublish — R package resolution", () => {
       "/usr/bin/R",
       "renv.lock",
       undefined, // positronR
+      "/tmp/publisher-renv-test", // tmpDir from mkdtemp mock
     );
   });
 

--- a/extensions/vscode/src/publish/publishShared.test.ts
+++ b/extensions/vscode/src/publish/publishShared.test.ts
@@ -1,0 +1,279 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { buildManifest } from "./publishShared";
+import type { ConfigurationDetails } from "../api/types/configurations";
+import { ContentType } from "../api/types/configurations";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../interpreters/rPackages", () => ({
+  scanRPackages: vi.fn(),
+}));
+
+vi.mock("./dependencies", () => ({
+  resolveRPackages: vi.fn(),
+}));
+
+vi.mock("./extraDependencies", () => ({
+  findExtraDependencies: vi.fn().mockResolvedValue([]),
+  recordExtraDependencies: vi.fn().mockResolvedValue(undefined),
+  cleanupExtraDependencies: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../bundler/manifestFromConfig", () => ({
+  manifestFromConfig: vi.fn().mockReturnValue({
+    version: 1,
+    metadata: {},
+    packages: undefined,
+    files: {},
+  }),
+}));
+
+vi.mock("../utils/fsUtils", () => ({
+  fileExistsAt: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...actual,
+    mkdtemp: vi.fn(),
+    rm: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { scanRPackages } from "../interpreters/rPackages";
+import { resolveRPackages } from "./dependencies";
+import {
+  findExtraDependencies,
+  recordExtraDependencies,
+  cleanupExtraDependencies,
+} from "./extraDependencies";
+import { fileExistsAt } from "../utils/fsUtils";
+
+const mockScanRPackages = vi.mocked(scanRPackages);
+const mockResolveRPackages = vi.mocked(resolveRPackages);
+const mockFindExtraDependencies = vi.mocked(findExtraDependencies);
+const mockRecordExtraDependencies = vi.mocked(recordExtraDependencies);
+const mockCleanupExtraDependencies = vi.mocked(cleanupExtraDependencies);
+const mockFileExistsAt = vi.mocked(fileExistsAt);
+const mockMkdtemp = vi.mocked(fs.mkdtemp);
+const mockRm = vi.mocked(fs.rm);
+
+const noopProgress = () => {};
+
+function makeRConfig(overrides?: object): ConfigurationDetails {
+  return {
+    type: ContentType.R_SHINY,
+    entrypoint: "app.R",
+    r: {
+      version: "4.3.0",
+      packageFile: "renv.lock",
+      packageManager: "renv",
+      requiresR: true,
+    },
+    ...overrides,
+  } as unknown as ConfigurationDetails;
+}
+
+const FAKE_LOCKFILE_JSON = JSON.stringify({
+  R: {
+    Version: "4.3.0",
+    Repositories: [{ Name: "CRAN", URL: "https://cran.r-project.org" }],
+  },
+  Packages: {},
+});
+
+describe("buildManifest — auto-generate ephemeral branch (no renv.lock on disk)", () => {
+  const projectDir = "/project";
+  const tmpDir = "/tmp/publisher-renv-abc123";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFileExistsAt.mockResolvedValue(false); // no lockfile on disk
+    mockMkdtemp.mockResolvedValue(tmpDir);
+    mockScanRPackages.mockResolvedValue(undefined);
+    mockResolveRPackages.mockResolvedValue({
+      packages: {},
+      lockfilePath: path.join(tmpDir, "renv.lock"),
+      lockfile: JSON.parse(FAKE_LOCKFILE_JSON),
+    });
+    mockFindExtraDependencies.mockResolvedValue([]);
+    mockRecordExtraDependencies.mockResolvedValue(null);
+    mockCleanupExtraDependencies.mockResolvedValue(undefined);
+    mockRm.mockResolvedValue(undefined);
+  });
+
+  test("creates temp dir under os.tmpdir()", async () => {
+    const config = makeRConfig();
+    await buildManifest(
+      projectDir,
+      config,
+      "/usr/bin/R",
+      undefined,
+      noopProgress,
+    );
+
+    expect(mockMkdtemp).toHaveBeenCalledWith(
+      path.join(os.tmpdir(), "publisher-renv-"),
+    );
+  });
+
+  test("calls scanRPackages with tmpDir as renvTargetDir", async () => {
+    const config = makeRConfig();
+    await buildManifest(
+      projectDir,
+      config,
+      "/usr/bin/R",
+      undefined,
+      noopProgress,
+    );
+
+    expect(mockScanRPackages).toHaveBeenCalledWith(
+      projectDir,
+      "/usr/bin/R",
+      "renv.lock",
+      undefined,
+      tmpDir,
+    );
+  });
+
+  test("resolves packages from tmpDir, not projectDir", async () => {
+    const config = makeRConfig();
+    await buildManifest(
+      projectDir,
+      config,
+      "/usr/bin/R",
+      undefined,
+      noopProgress,
+    );
+
+    expect(mockResolveRPackages).toHaveBeenCalledWith(tmpDir, {
+      packageFile: "renv.lock",
+    });
+  });
+
+  test("returns lockfilePath undefined and lockfile populated", async () => {
+    const config = makeRConfig();
+    const result = await buildManifest(
+      projectDir,
+      config,
+      "/usr/bin/R",
+      undefined,
+      noopProgress,
+    );
+
+    // lockfilePath is undefined: renv.lock was never in the config's files list
+    // (it didn't exist at inspect time), so we don't add it to the bundle.
+    expect(result.lockfilePath).toBeUndefined();
+    // lockfile (parsed object) is still returned for the deployment record.
+    expect(result.lockfile).toBeDefined();
+  });
+
+  test("removes tmpDir in finally even when resolveRPackages throws", async () => {
+    const depsFile = path.join(projectDir, ".posit/__publisher_deps.R");
+    mockRecordExtraDependencies.mockResolvedValue(depsFile);
+    mockResolveRPackages.mockRejectedValue(new Error("parse error"));
+    const config = makeRConfig();
+
+    await expect(
+      buildManifest(projectDir, config, "/usr/bin/R", undefined, noopProgress),
+    ).rejects.toThrow("parse error");
+
+    expect(mockRm).toHaveBeenCalledWith(tmpDir, {
+      recursive: true,
+      force: true,
+    });
+    expect(mockCleanupExtraDependencies).toHaveBeenCalledWith(depsFile);
+  });
+
+  test("cleans up depsFile even when mkdtemp fails", async () => {
+    const depsFile = path.join(projectDir, ".posit/__publisher_deps.R");
+    mockRecordExtraDependencies.mockResolvedValue(depsFile);
+    mockMkdtemp.mockRejectedValue(new Error("ENOSPC"));
+    const config = makeRConfig();
+
+    await expect(
+      buildManifest(projectDir, config, "/usr/bin/R", undefined, noopProgress),
+    ).rejects.toThrow("ENOSPC");
+
+    expect(mockCleanupExtraDependencies).toHaveBeenCalledWith(depsFile);
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  test("removes tmpDir in finally even when scanRPackages throws", async () => {
+    mockScanRPackages.mockRejectedValue(new Error("R scan failed"));
+    const config = makeRConfig();
+
+    await expect(
+      buildManifest(projectDir, config, "/usr/bin/R", undefined, noopProgress),
+    ).rejects.toThrow("R scan failed");
+
+    expect(mockRm).toHaveBeenCalledWith(tmpDir, {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("removes tmpDir on success", async () => {
+    const config = makeRConfig();
+    await buildManifest(
+      projectDir,
+      config,
+      "/usr/bin/R",
+      undefined,
+      noopProgress,
+    );
+
+    expect(mockRm).toHaveBeenCalledWith(tmpDir, {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("throws when no R interpreter is available", async () => {
+    const config = makeRConfig();
+    await expect(
+      buildManifest(projectDir, config, undefined, undefined, noopProgress),
+    ).rejects.toThrow("R interpreter is required");
+
+    // No tmpDir created if R is missing
+    expect(mockMkdtemp).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildManifest — lockExists branch (existing renv.lock)", () => {
+  const projectDir = "/project";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFileExistsAt.mockResolvedValue(true); // lockfile present
+    mockResolveRPackages.mockResolvedValue({
+      packages: {},
+      lockfilePath: path.join(projectDir, "renv.lock"),
+      lockfile: JSON.parse(FAKE_LOCKFILE_JSON),
+    });
+  });
+
+  test("reads lockfile from project, skips scan and temp dir", async () => {
+    const config = makeRConfig();
+    const result = await buildManifest(
+      projectDir,
+      config,
+      "/usr/bin/R",
+      undefined,
+      noopProgress,
+    );
+
+    expect(result.lockfilePath).toBe(path.join(projectDir, "renv.lock"));
+    expect(mockScanRPackages).not.toHaveBeenCalled();
+    expect(mockMkdtemp).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/vscode/src/publish/publishShared.ts
+++ b/extensions/vscode/src/publish/publishShared.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
 import * as fs from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 import { stringify as stringifyTOML } from "smol-toml";
 
@@ -273,7 +274,12 @@ export async function buildManifest(
         lockfile = resolved.lockfile;
       }
     } else {
-      // No lockfile — scan project for R dependencies
+      // No lockfile — scan project for R dependencies ephemerally.
+      //
+      // We generate renv.lock in a temporary directory so nothing persists in
+      // the user's project (no renv/ folder, no renv.lock). Because no file is
+      // written to the project, every deploy re-scans and always picks up newly
+      // added packages.
       onProgress({
         step: "createManifest",
         status: "log",
@@ -293,7 +299,9 @@ export async function buildManifest(
         message: "Detect dependencies from project",
       });
 
-      // Inject implicit deps (e.g. shiny, rmarkdown) so renv can discover them
+      // Inject implicit deps (e.g. shiny, rmarkdown) so renv can discover them.
+      // The deps file is written to the project so renv::dependencies() finds it;
+      // it is cleaned up in the finally block below.
       const extraDeps = await findExtraDependencies(
         config.type,
         config.hasParameters,
@@ -301,25 +309,38 @@ export async function buildManifest(
       );
       const depsFile = await recordExtraDependencies(projectDir, extraDeps);
 
+      let tmpDir: string | undefined;
+
       try {
-        await scanRPackages(projectDir, rPath, packageFile, positronR);
+        // Create a temp dir for renv to initialize into so the user's project
+        // is not modified. The temp dir (including renv/ library) is removed
+        // in the finally block below.
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "publisher-renv-"));
+
+        // Scan deps from the project, but run renv init/hydrate/snapshot in
+        // tmpDir
+        await scanRPackages(projectDir, rPath, "renv.lock", positronR, tmpDir);
+
+        // Load the lockfile from the temp dir, not the project
+        onProgress({
+          step: "createManifest",
+          status: "log",
+          message: `Loading packages from renv.lock`,
+        });
+        const resolved = await resolveRPackages(tmpDir, {
+          packageFile: "renv.lock",
+        });
+        if (resolved) {
+          manifest.packages = resolved.packages;
+          lockfile = resolved.lockfile;
+        }
       } finally {
         if (depsFile) {
           await cleanupExtraDependencies(depsFile);
         }
-      }
-
-      // Now resolve from the generated lockfile
-      onProgress({
-        step: "createManifest",
-        status: "log",
-        message: `Loading packages from renv.lock`,
-      });
-      const resolved = await resolveRPackages(projectDir, config.r);
-      if (resolved) {
-        manifest.packages = resolved.packages;
-        lockfilePath = resolved.lockfilePath;
-        lockfile = resolved.lockfile;
+        if (tmpDir) {
+          await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        }
       }
     }
 


### PR DESCRIPTION
## Intent

closes #4233 

When a user without renv deploys an R project, Publisher wrote `renv.lock` and `renv/` into the project directory. On re-deploys, Publisher treated that on-disk lockfile as source of truth and never regenerated it, so adding a new `library()` call caused deploys to fail with a stale lockfile.

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [x] Bug Fix <!-- A change which fixes an existing issue -->
- - [ ] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Added an optional `renvTargetDir` parameter to `scanRPackages` that decouples where renv runs (init/hydrate/snapshot) from where dependencies are scanned. `buildManifest` now creates an OS temp directory, passes it as `renvTargetDir`, reads the lockfile for package metadata, then deletes the temp dir. Nothing persists in the user's project.

## User Impact

The `renv.lock` and `renv/` directories no longer persist on disk. Re-deploys correctly pick up new dependencies in the project. Projects that _do_ use renv are unaffected.

Note: we will not clean up any renv.lock files that publisher previously generated before this change.

## Automated Tests

- New tests in `rPackages.test.ts` for the `renvTargetDir` parameter.
- New `publishShared.test.ts` covering the ephemeral branch

I also manually tested that the files do not persist and that adding dependencies and re-deploying works. Also tested that projects that do use renv don't have their lockfiles removed.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
