### PR TITLE
fix: clarify Connect uses npm in Node.js lockfile preflight error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The "missing package-lock.json" error when publishing Node.js content now states that Connect installs Node.js dependencies with npm, helping publishers who build with yarn or pnpm understand why a `package-lock.json` is required. (#4253)
+- The "missing package-lock.json" error when publishing Node.js content now states that Connect installs Node.js dependencies with npm, helping publishers who build with yarn or pnpm understand why a `package-lock.json` is required. (#4260)
 
 ## [2.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The "missing package-lock.json" error when publishing Node.js content now states that Connect installs Node.js dependencies with npm, helping publishers who build with yarn or pnpm understand why a `package-lock.json` is required. (#4253)
+
 ## [2.8.0]
 
 ### Added

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -2492,7 +2492,7 @@ describe("connectPublish — server settings validation", () => {
     const opts = makeOptions({ config });
 
     await expect(connectPublish(opts)).rejects.toThrow(
-      "Missing package-lock.json — file not found in the project directory. Run `npm install` to generate it.",
+      "Missing package-lock.json — file not found in the project directory. Connect installs Node.js dependencies with npm. Run `npm install` to generate it.",
     );
   });
 

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -306,7 +306,8 @@ export async function connectPublish({
         },
         {
           name: "package-lock.json",
-          missingOnDiskHint: "Run `npm install` to generate it.",
+          missingOnDiskHint:
+            "Connect installs Node.js dependencies with npm. Run `npm install` to generate it.",
         },
       ] as const;
       const notIncludedHint =


### PR DESCRIPTION
## Intent

A publisher who builds a Node.js project with yarn or pnpm has no `package-lock.json`, so the publish preflight fails with an error that asks for `package-lock.json` without explaining that Connect specifically requires `npm`. This adds that clarification.

## Type of Change

- [x] Bug Fix

## Approach

`extensions/vscode/src/publish/connectPublish.ts`: the `missingOnDiskHint` for `package-lock.json` in the Node.js preflight now leads with "Connect installs Node.js dependencies with npm." The message is unconditional - no `yarn.lock`/`pnpm-lock.yaml` detection - so it reads correctly in every case. Only the missing-on-disk hint changed; the "not included in files" hint is untouched.

## Directions for Reviewers

Configure a Node.js deployment whose project directory has `package.json` but no `package-lock.json`, then publish. The preflight error names npm as the package manager Connect uses.

## Checklist

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.