### PR TITLE
fix: honour disabled TLS certificate verification when deploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The "missing package-lock.json" error when publishing Node.js content now states that Connect installs Node.js dependencies with npm, helping publishers who build with yarn or pnpm understand why a `package-lock.json` is required. (#4260)
 
+### Fixed
+
+- Turning off `positPublisher.verifyCertificates` now skips certificate checks as expected, so you can deploy to Connect servers with self-signed or otherwise untrusted certificates. (#4265)
+
 ## [2.8.0]
 
 ### Added

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -51,7 +51,8 @@
           "positPublisher.verifyCertificates": {
             "markdownDescription": "Verify TLS certificates for connections. Only **disable** this setting if you experience certificate verification errors and the Posit Connect server is using a self-signed, expired, or otherwise misconfigured certificate.",
             "type": "boolean",
-            "default": true
+            "default": true,
+            "scope": "machine-overridable"
           },
           "positPublisher.defaultConnectServer": {
             "markdownDescription": "Provides the default URL for the Posit Connect server when defining new credentials.",

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -1562,6 +1562,9 @@ describe("connectPublish — error classification", () => {
     "SELF_SIGNED_CERT_IN_CHAIN",
     "ERR_TLS_CERT_ALTNAME_INVALID",
     "CERT_HAS_EXPIRED",
+    "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+    "UNABLE_TO_GET_ISSUER_CERT",
+    "CERT_UNTRUSTED",
   ])(
     "certificate error (%s) classifies as errorCertificateVerification",
     async (code) => {

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -830,6 +830,15 @@ function classifyDeploymentError(
   // Must be checked before the generic network error check below, because
   // TLS failures also have no `response`.
   if (isAxiosError(err) && isCertificateError(err)) {
+    // Surface the underlying TLS error code in the logs. The user-facing
+    // message is intentionally generic, but the code (e.g.
+    // UNABLE_TO_GET_ISSUER_CERT_LOCALLY) is what tells you whether the server's
+    // CA is simply untrusted versus expired or hostname-mismatched.
+    logger.error(
+      `Certificate verification failed during ${lastStep ?? "deployment"}: ${
+        err.code ?? "unknown TLS error"
+      } (${fallbackMessage})`,
+    );
     return {
       code: "errorCertificateVerification",
       message:

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -128,6 +128,7 @@ import { PublisherState } from "src/state";
 import { throttleWithLastPending } from "src/utils/throttle";
 import { showAssociateGUID } from "src/actions/showAssociateGUID";
 import { extensionSettings } from "src/extension";
+import { logger } from "src/logging";
 import { openFileInEditor } from "src/commands";
 import {
   SelectionCredentialMatch,
@@ -489,12 +490,18 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
           ...progressOptions,
         });
       } else {
+        const verifyCertificates = extensionSettings.verifyCertificates();
+        logger.info(
+          `Deploying to ${credential.url} with TLS certificate verification ${
+            verifyCertificates ? "enabled" : "disabled"
+          }`,
+        );
         const connectApi = new ConnectAPI(
           await connectAPIOptionsFromCredential(
             this.state.credentialsService,
             credential,
             {
-              rejectUnauthorized: extensionSettings.verifyCertificates(),
+              rejectUnauthorized: verifyCertificates,
             },
           ),
         );

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -274,6 +274,27 @@ describe("TLS certificate verification", () => {
     expect(call?.httpsAgent).toBeDefined();
     expect(call?.httpsAgent?.options?.rejectUnauthorized).toBe(false);
   });
+
+  it("installs a transport injecting rejectUnauthorized:false when option is false", () => {
+    // A custom Agent's rejectUnauthorized is ignored by VS Code's proxy
+    // patch; the per-request transport is what actually disables verification.
+    new ConnectAPI({
+      url: BASE_URL,
+      apiKey: API_KEY,
+      rejectUnauthorized: false,
+    });
+
+    // `transport` is typed `any` on the axios config; no cast needed.
+    const call = vi.mocked(axios.create).mock.calls.at(-1)?.[0];
+    expect(typeof call?.transport?.request).toBe("function");
+  });
+
+  it("does not install a custom transport when verification is enabled", () => {
+    new ConnectAPI({ url: BASE_URL, apiKey: API_KEY });
+
+    const call = vi.mocked(axios.create).mock.calls.at(-1)?.[0];
+    expect(call?.transport).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -419,6 +440,9 @@ describe("testAuthentication", () => {
     "SELF_SIGNED_CERT_IN_CHAIN",
     "ERR_TLS_CERT_ALTNAME_INVALID",
     "CERT_HAS_EXPIRED",
+    "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+    "UNABLE_TO_GET_ISSUER_CERT",
+    "CERT_UNTRUSTED",
   ])("certificate error (%s) is not wrapped as network error", async (code) => {
     // TLS/certificate errors also have no `response`, but they should NOT
     // be caught by the network-error check — callers need the original

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
 import https from "https";
+import type { ClientRequest, IncomingMessage } from "http";
 import axios from "axios";
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
@@ -106,11 +107,24 @@ export class ConnectAPI {
       };
     }
 
-    // Support disabling TLS certificate verification (for self-signed certs)
+    // Support disabling TLS certificate verification (for self-signed certs).
     if (options.rejectUnauthorized === false) {
-      config.httpsAgent = new https.Agent({
-        rejectUnauthorized: false,
-      });
+      config.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+      // VS Code's proxy support (the `http.proxySupport` setting, "override"
+      // by default) patches Node's https module in the extension host and
+      // discards the `rejectUnauthorized` option configured on a custom Agent,
+      // so the httpsAgent above is not enough on its own. The patch does
+      // honour `rejectUnauthorized` when it is set on the per-request options,
+      // so we route requests through a transport that injects it. This
+      // transport does not follow redirects, which is acceptable for the
+      // misconfigured servers where a user has explicitly disabled verification.
+      config.transport = {
+        request: (
+          reqOptions: https.RequestOptions,
+          callback: (res: IncomingMessage) => void,
+        ): ClientRequest =>
+          https.request({ ...reqOptions, rejectUnauthorized: false }, callback),
+      };
     }
 
     if (options.timeout !== undefined) {
@@ -523,6 +537,11 @@ export function isCertificateError(err: { code?: string }): boolean {
     "SELF_SIGNED_CERT_IN_CHAIN",
     "ERR_TLS_CERT_ALTNAME_INVALID",
     "CERT_HAS_EXPIRED",
+    // "signed by unknown authority": the issuing CA is not in the trust
+    // store. Common behind internal/corporate CAs and TLS-intercepting proxies.
+    "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+    "UNABLE_TO_GET_ISSUER_CERT",
+    "CERT_UNTRUSTED",
   ];
   return !!err.code && certCodes.includes(err.code);
 }


### PR DESCRIPTION
Disabling `positPublisher.verifyCertificates` had no effect when deploying, because VS Code's proxy support patches Node's https module in the extension host and discards `rejectUnauthorized` when it is set on a custom agent.

- Route requests through a transport that sets `rejectUnauthorized` on the per-request options, which the proxy patch honours, so disabling verification works.
- Allow `positPublisher.verifyCertificates` to be set in machine and remote (e.g., WSL, SSH) settings.
- Classify the "unknown authority" TLS error codes as certificate verification failures.
- Log the verification mode and the underlying TLS error code on failure.

Fixes #4265

---

For transparency, I had Claude (Opus 4.8) review the code before the PR, he did few small tweaks and added comments.