### PR TITLE
docs(connect-contracts): Replace references to "Swagger" with "OpenAPI"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ just test-connect-contracts
 # Run Python script tests (license checker, prepare-release, etc.).
 just test-scripts
 
-# Validate Connect API fixtures against the public Swagger spec.
+# Validate Connect API fixtures against the public OpenAPI spec.
 just validate-fixtures
 
 # Print pre-release status based on the version.

--- a/justfile
+++ b/justfile
@@ -101,7 +101,7 @@ test-connect-contracts:
 
     cd test/connect-api-contracts && npm test
 
-# Validate mock Connect server fixtures and responses against the public Swagger spec
+# Validate mock Connect server fixtures and responses against the public OpenAPI spec
 validate-fixtures:
     #!/usr/bin/env bash
     set -eou pipefail

--- a/test/connect-api-contracts/README.md
+++ b/test/connect-api-contracts/README.md
@@ -68,7 +68,7 @@ cd test/connect-api-contracts && npm test
 # Update snapshots (currently only one inline snapshot in authentication.test.ts)
 cd test/connect-api-contracts && npm run test:update
 
-# Validate mock server and fixtures against the Connect Swagger spec
+# Validate mock server and fixtures against the Connect OpenAPI spec
 just validate-fixtures
 ```
 
@@ -94,7 +94,7 @@ describe("NewMethod", () => {
 ```
 
 4. Add a fixture file in `test/mock-connect/fixtures/connect-responses/`
-5. Add a fixture mapping in `test/mock-connect/src/validation/fixture-map.ts` for Swagger validation
+5. Add a fixture mapping in `test/mock-connect/src/validation/fixture-map.ts` for OpenAPI validation
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

Updates lingering "Swagger" references to "OpenAPI" across the repo's docs and build tooling:

- `test/connect-api-contracts/README.md` — two mentions
- `justfile` — comment on the `validate-fixtures` recipe
- `CLAUDE.md` — comment on the `just validate-fixtures` step

The fixture validator behind the Connect contract tests was already migrated from the Swagger 2.0 spec (`swagger.json`) to the OpenAPI 3.0 spec (`openapi.json`) in #4164 (commit 6bcfd828b, merged 2026-05-13). That PR renamed `swagger-helpers.ts` → `openapi-helpers.ts`, switched the fetched spec URL, and updated `fixture-map.ts`. These were the remaining stale doc/comment mentions. No code changes.

(Note: `extensions/vscode/src/inspect/detectors/pythonApp.test.ts` also contains "Swagger", but that is `from flasgger import Swagger` — Flask app-type detection, unrelated to the Connect spec — and is intentionally left unchanged.)

Resolves #4274.

## Test plan

- [x] Docs/comments-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)