### PR TITLE
fix: follow HTTP redirects client-wide, including bundle upload (#4262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed deploying large projects (multiple GiB) failing at the "Create Bundle" step. The bundle is now streamed to disk and uploaded as a stream instead of being held in memory, so bundles are no longer limited by available memory. (#4249)
+- Publisher now follows HTTP redirects when talking to Connect, including during bundle upload — for example when a server redirects `http://` to `https://` or has moved to a new hostname. Bundle uploads re-stream from disk on each redirect, so large bundles still never need to be held in memory. (#4262)
 - Turning off `positPublisher.verifyCertificates` now skips certificate checks as expected, so you can deploy to Connect servers with self-signed or otherwise untrusted certificates. (#4265)
 
 ## [2.8.0]

--- a/extensions/vscode/src/publish/connectCloudPublish.test.ts
+++ b/extensions/vscode/src/publish/connectCloudPublish.test.ts
@@ -168,15 +168,6 @@ vi.mock("../toml/configCompliance", () => ({
   forceProductTypeCompliance: vi.fn(),
 }));
 
-// stream/promises.finished listens for the stream 'close' event which fires
-// via process.nextTick — not faked by vi.useFakeTimers(). If finished() were
-// real, cleanUpBundle's extra await would fire after vi.runAllTimersAsync()
-// returns, causing the log-watching timer setup to miss the run-all window.
-// Mock it to resolve immediately so the async chain stays in sync.
-vi.mock("stream/promises", () => ({
-  finished: vi.fn().mockResolvedValue(undefined),
-}));
-
 // Mock watchCloudLogs - DO NOT mock the entire @posit-dev/connect-cloud-api
 // Instead, mock just the watchCloudLogs function
 vi.mock("@posit-dev/connect-cloud-api", async (importOriginal) => {
@@ -623,14 +614,23 @@ describe("connectCloudPublish", () => {
     await vi.runAllTimersAsync();
     await resultPromise;
 
-    expect(api.uploadBundle).toHaveBeenCalledWith(
-      "https://s3.example.com/upload",
-      expect.any(Readable),
-      expect.any(Number),
-      // The abort signal is forwarded so cancellation aborts the in-flight
-      // upload promptly. It is undefined here because no signal was supplied.
-      undefined,
-    );
+    const call = vi.mocked(api.uploadBundle).mock.calls[0]!;
+    expect(call[0]).toBe("https://s3.example.com/upload");
+    // The second argument is a stream factory: the client opens a fresh read
+    // stream from the bundle file for each redirect hop.
+    const makeBody = call[1];
+    expect(typeof makeBody).toBe("function");
+    const s1 = makeBody();
+    const s2 = makeBody();
+    expect(s1).toBeInstanceOf(Readable);
+    expect(s2).toBeInstanceOf(Readable);
+    expect(s1).not.toBe(s2);
+    s1.destroy();
+    s2.destroy();
+    expect(call[2]).toEqual(expect.any(Number));
+    // The abort signal is forwarded so cancellation aborts the in-flight
+    // upload promptly. It is undefined here because no signal was supplied.
+    expect(call[3]).toBeUndefined();
   });
 
   test("forwards the abort signal to uploadBundle", async () => {
@@ -641,12 +641,11 @@ describe("connectCloudPublish", () => {
     await vi.runAllTimersAsync();
     await resultPromise;
 
-    expect(opts.api.uploadBundle).toHaveBeenCalledWith(
-      "https://s3.example.com/upload",
-      expect.any(Readable),
-      expect.any(Number),
-      controller.signal,
-    );
+    const call = vi.mocked(opts.api.uploadBundle).mock.calls[0]!;
+    expect(call[0]).toBe("https://s3.example.com/upload");
+    expect(typeof call[1]).toBe("function");
+    expect(call[2]).toEqual(expect.any(Number));
+    expect(call[3]).toBe(controller.signal);
   });
 
   test("removes the streamed bundle's temp dir after a successful publish", async () => {

--- a/extensions/vscode/src/publish/connectCloudPublish.ts
+++ b/extensions/vscode/src/publish/connectCloudPublish.ts
@@ -159,9 +159,6 @@ export async function connectCloudPublish({
   // Temp directory holding the streamed bundle; cleaned up in the finally
   // block, regardless of how publishing ends.
   let bundleTmpDir: string | undefined;
-  // ReadStream for the bundle file; closed in the finally block,
-  // regardless of how publishing ends.
-  let bundleReadStream: fs.ReadStream | undefined;
 
   /** Check if canceled; if so, write dismissedAt and throw CanceledError. */
   async function throwIfCanceled(): Promise<void> {
@@ -494,11 +491,16 @@ export async function connectCloudPublish({
       message: "Uploading files",
     });
 
-    // The bundle is streamed from its temp file so it never has to be held in
-    // memory. The temp directory is removed in the finally block below,
-    // regardless of how publishing ends.
-    bundleReadStream = fs.createReadStream(bundlePath);
-    await api.uploadBundle(uploadUrl, bundleReadStream, bundleSize, signal);
+    // The client owns the stream lifecycle — it opens a fresh read stream from
+    // the temp file for each redirect hop and destroys the streams it created,
+    // so the bundle is never held in memory. The temp directory is removed here
+    // on success and in the finally block otherwise.
+    await api.uploadBundle(
+      uploadUrl,
+      () => fs.createReadStream(bundlePath),
+      bundleSize,
+      signal,
+    );
 
     record.bundleId = bundleId;
     await writePublishRecord(deploymentPath, record);
@@ -512,8 +514,7 @@ export async function connectCloudPublish({
     onProgress({ step: "uploadBundle", status: "success" });
 
     // we no longer need the bundle so try to clean it up right away
-    await cleanUpBundle(bundleReadStream, bundleTmpDir);
-    bundleReadStream = undefined;
+    await cleanUpBundle(bundleTmpDir);
     bundleTmpDir = undefined;
 
     await throwIfCanceled();
@@ -679,7 +680,7 @@ export async function connectCloudPublish({
     }
     throw err;
   } finally {
-    await cleanUpBundle(bundleReadStream, bundleTmpDir);
+    await cleanUpBundle(bundleTmpDir);
   }
 }
 

--- a/extensions/vscode/src/publish/connectPublish.test.ts
+++ b/extensions/vscode/src/publish/connectPublish.test.ts
@@ -61,11 +61,11 @@ vi.mock("node:fs/promises", () => ({
   stat: vi.fn(),
 }));
 
-// Production streams the bundle via fs.createReadStream(bundlePath). In tests
-// the upload API is mocked and never consumes that stream, while cleanUpBundle
-// destroys the stream and removes the temp dir as soon as the upload mock
-// returns. A lazily-opened read stream can therefore lose a race with that
-// destruction and emit an ENOENT with no listener — an unhandled exception
+// Production passes a stream factory (`() => fs.createReadStream(bundlePath)`)
+// to the upload API, which owns the stream lifecycle. In tests the upload API
+// is mocked and never invokes the factory, but tests that do invoke it (to
+// assert factory behavior) open a read stream after the temp dir has been
+// removed, so it can emit an ENOENT with no listener — an unhandled exception
 // (real axios consumes the body before cleanup runs, so this is a test-only
 // concern). Attach a swallowing error handler to every bundle read stream so
 // that race can't surface as an unhandled error.
@@ -482,13 +482,23 @@ describe("connectPublish", () => {
     // unchanged into the correct uploadBundle arguments — token-auth request
     // signing depends on the checksum matching the streamed bytes.
     const bundle = await firstBundleResult();
-    expect(opts.api.uploadBundle).toHaveBeenCalledWith(
-      expect.anything(), // ContentID branded type
-      expect.any(Readable),
-      bundle.bundleSize,
-      bundle.bundleChecksum,
-      undefined, // signal
-    );
+    const call = vi.mocked(opts.api.uploadBundle).mock.calls[0]!;
+    expect(call[0]).toEqual(expect.anything()); // ContentID branded type
+    // The second argument is a stream factory: the client opens a fresh read
+    // stream from the bundle file for each redirect hop, so invoking it twice
+    // yields two distinct fs.ReadStreams rather than one reusable stream.
+    const makeBody = call[1];
+    expect(typeof makeBody).toBe("function");
+    const s1 = makeBody();
+    const s2 = makeBody();
+    expect(s1).toBeInstanceOf(Readable);
+    expect(s2).toBeInstanceOf(Readable);
+    expect(s1).not.toBe(s2);
+    s1.destroy();
+    s2.destroy();
+    expect(call[2]).toBe(bundle.bundleSize);
+    expect(call[3]).toBe(bundle.bundleChecksum);
+    expect(call[4]).toBeUndefined(); // signal
   });
 
   test("removes the streamed bundle's temp dir after a successful publish", async () => {

--- a/extensions/vscode/src/publish/connectPublish.ts
+++ b/extensions/vscode/src/publish/connectPublish.ts
@@ -156,9 +156,6 @@ export async function connectPublish({
   // Temp directory holding the streamed bundle; cleaned up in the finally
   // block, regardless of how publishing ends.
   let bundleTmpDir: string | undefined;
-  // ReadStream for the bundle file; closed in the finally block,
-  // regardless of how publishing ends.
-  let bundleReadStream: fs.ReadStream | undefined;
 
   /** Check if canceled; if so, write dismissedAt and throw CanceledError. */
   async function throwIfCanceled(): Promise<void> {
@@ -587,9 +584,10 @@ export async function connectPublish({
 
     await throwIfCanceled();
 
-    // Step 5: Upload bundle. The bundle is streamed from its temp file so it
-    // never has to be held in memory. The temp directory is removed in the
-    // finally block below, regardless of how publishing ends.
+    // Step 5: Upload bundle. The client owns the stream lifecycle — it opens a
+    // fresh read stream from the temp file for each redirect hop and destroys
+    // the streams it created, so the bundle is never held in memory. The temp
+    // directory is removed here on success and in the finally block otherwise.
     lastStep = "uploadBundle";
     onProgress({ step: "uploadBundle", status: "start" });
     onProgress({
@@ -597,10 +595,9 @@ export async function connectPublish({
       status: "log",
       message: "Uploading files",
     });
-    bundleReadStream = fs.createReadStream(bundlePath);
     const { data: bundleDTO } = await api.uploadBundle(
       ContentID(contentId),
-      bundleReadStream,
+      () => fs.createReadStream(bundlePath),
       bundleSize,
       bundleChecksum,
       signal,
@@ -618,8 +615,7 @@ export async function connectPublish({
     onProgress({ step: "uploadBundle", status: "success" });
 
     // we no longer need the bundle so try to clean it up right away
-    await cleanUpBundle(bundleReadStream, bundleTmpDir);
-    bundleReadStream = undefined;
+    await cleanUpBundle(bundleTmpDir);
     bundleTmpDir = undefined;
 
     await throwIfCanceled();
@@ -836,7 +832,7 @@ export async function connectPublish({
     }
     throw err;
   } finally {
-    await cleanUpBundle(bundleReadStream, bundleTmpDir);
+    await cleanUpBundle(bundleTmpDir);
   }
 }
 

--- a/extensions/vscode/src/publish/publishShared.test.ts
+++ b/extensions/vscode/src/publish/publishShared.test.ts
@@ -3,7 +3,6 @@
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
-import { PassThrough } from "stream";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { buildManifest, cleanUpBundle } from "./publishShared";
@@ -285,53 +284,21 @@ describe("cleanUpBundle", () => {
     mockRm.mockResolvedValue(undefined);
   });
 
-  test("no-op when both args are undefined", async () => {
-    await expect(cleanUpBundle(undefined, undefined)).resolves.toBeUndefined();
+  test("no-op when tmpDir is undefined", async () => {
+    await expect(cleanUpBundle(undefined)).resolves.toBeUndefined();
     expect(mockRm).not.toHaveBeenCalled();
   });
 
-  test("destroys an open stream and removes tmpDir", async () => {
-    const stream = new PassThrough();
-    await cleanUpBundle(stream, "/tmp/bundle-dir");
-
-    expect(stream.destroyed).toBe(true);
+  test("removes tmpDir", async () => {
+    await cleanUpBundle("/tmp/bundle-dir");
     expect(mockRm).toHaveBeenCalledWith("/tmp/bundle-dir", {
       recursive: true,
       force: true,
     });
-  });
-
-  test("skips destroy when stream is already closed", async () => {
-    const stream = new PassThrough();
-    stream.destroy();
-    await new Promise<void>((resolve) => stream.once("close", resolve));
-
-    const destroySpy = vi.spyOn(stream, "destroy");
-    await cleanUpBundle(stream, undefined);
-
-    expect(destroySpy).not.toHaveBeenCalled();
   });
 
   test("does not throw if fs.rm rejects", async () => {
     mockRm.mockRejectedValueOnce(new Error("EACCES: permission denied"));
-    await expect(
-      cleanUpBundle(undefined, "/tmp/bundle-dir"),
-    ).resolves.toBeUndefined();
-  });
-
-  test("does not throw if stream finalization rejects", async () => {
-    const stream = new PassThrough();
-    // destroy() with no error causes finished() to reject with
-    // ERR_STREAM_PREMATURE_CLOSE — cleanUpBundle must swallow it
-    await expect(cleanUpBundle(stream, undefined)).resolves.toBeUndefined();
-    expect(stream.destroyed).toBe(true);
-  });
-
-  test("removes tmpDir even when no stream is provided", async () => {
-    await cleanUpBundle(undefined, "/tmp/bundle-dir");
-    expect(mockRm).toHaveBeenCalledWith("/tmp/bundle-dir", {
-      recursive: true,
-      force: true,
-    });
+    await expect(cleanUpBundle("/tmp/bundle-dir")).resolves.toBeUndefined();
   });
 });

--- a/extensions/vscode/src/publish/publishShared.ts
+++ b/extensions/vscode/src/publish/publishShared.ts
@@ -3,8 +3,6 @@
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
-import { Readable } from "stream";
-import { finished } from "stream/promises";
 import { stringify as stringifyTOML } from "smol-toml";
 
 import { manifestFromConfig } from "../bundler/manifestFromConfig";
@@ -409,17 +407,10 @@ export async function buildBundleArchive(
 }
 
 // Helper for consistent bundle tempfile cleanup, as it is used in multiple
-// places (Connect, Cloud, on success, on failure/cancellation).
-export async function cleanUpBundle(
-  readStream: Readable | undefined,
-  tmpDir: string | undefined,
-): Promise<void> {
-  // best effort cleanup: destroy the stream and remove the temp dir, but don't
-  // throw if they fail as that might mask other errors
-  if (readStream !== undefined && !readStream.closed) {
-    readStream.destroy();
-    await finished(readStream).catch(() => {});
-  }
+// places (Connect, Cloud, on success, on failure/cancellation). Upload
+// streams are owned and destroyed by the API clients, so only the temp
+// directory needs removing here.
+export async function cleanUpBundle(tmpDir: string | undefined): Promise<void> {
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -4,6 +4,8 @@ import crypto from "crypto";
 import { Readable } from "stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectAPI } from "./client.js";
+import { MAX_REDIRECTS } from "./redirects.js";
+import { buildCanonicalRequest, rsaSha1Sign } from "./auth.js";
 import { ContentID, BundleID, TaskID } from "./types.js";
 import type { UserDTO, ContentDetailsDTO } from "./types.js";
 
@@ -13,35 +15,83 @@ import type { UserDTO, ContentDetailsDTO } from "./types.js";
 
 const mockRequest = vi.fn();
 
-type RequestInterceptor = (
-  config: Record<string, unknown>,
-) => Record<string, unknown>;
-
 vi.mock("axios", () => {
-  type InterceptorFn = (
-    value: Record<string, unknown>,
-  ) => Record<string, unknown>;
+  type Cfg = Record<string, unknown>;
+  type Resp = { status: number; headers?: Record<string, unknown> } & Record<
+    string,
+    unknown
+  >;
+  type Fulfilled = (value: Cfg) => Cfg;
+  type ResFulfilled = (resp: Resp) => Resp | Promise<Resp>;
+  type ResRejected = (error: unknown) => unknown;
 
-  function createInterceptorManager() {
-    const handlers: InterceptorFn[] = [];
+  // Request interceptors are onFulfilled-only in our client.
+  function createRequestManager() {
+    const handlers: Fulfilled[] = [];
     return {
-      use: (fn: InterceptorFn) => {
+      use: (fn: Fulfilled) => {
         handlers.push(fn);
       },
       _handlers: handlers,
     };
   }
 
+  // Response interceptors store (onFulfilled, onRejected) pairs so the
+  // redirect handler's rejected handler runs and can recover by returning a
+  // new request promise, just like real axios.
+  function createResponseManager() {
+    const handlers: Array<{
+      onFulfilled?: ResFulfilled;
+      onRejected?: ResRejected;
+    }> = [];
+    return {
+      use: (onFulfilled?: ResFulfilled, onRejected?: ResRejected) => {
+        handlers.push({ onFulfilled, onRejected });
+      },
+      _handlers: handlers,
+    };
+  }
+
+  const defaultValidate = (s: number) => s >= 200 && s < 300;
+
   return {
     default: {
-      create: vi.fn(() => {
-        const reqInterceptors = createInterceptorManager();
-        const resInterceptors = createInterceptorManager();
+      create: vi.fn((createConfig: Cfg = {}) => {
+        const reqInterceptors = createRequestManager();
+        const resInterceptors = createResponseManager();
+        const instanceHeaders = (createConfig.headers ?? {}) as Record<
+          string,
+          unknown
+        >;
 
-        async function request(config: Record<string, unknown>) {
-          // Add a mock headers object with .set() to simulate AxiosHeaders
+        // Runs the request and applies validateStatus. Resolves the response
+        // on success; on a non-2xx status rejects with an AxiosError that
+        // carries `config` (like real axios) so the redirect handler can
+        // re-issue it.
+        async function dispatch(cfg: Cfg): Promise<Resp> {
+          const resp: Resp = await mockRequest(cfg);
+          const validate =
+            (cfg.validateStatus as ((s: number) => boolean) | undefined) ??
+            defaultValidate;
+          if (!validate(resp.status)) {
+            return Promise.reject(
+              Object.assign(
+                new Error(`Request failed with status code ${resp.status}`),
+                { isAxiosError: true, response: resp, config: cfg },
+              ),
+            );
+          }
+          return resp;
+        }
+
+        async function request(config: Cfg): Promise<Resp> {
+          // Add a mock headers object with .set() to simulate AxiosHeaders.
+          // Instance default headers merge under per-request headers.
           const headerStore: Record<string, string> = {};
-          const baseHeaders = (config.headers ?? {}) as Record<string, unknown>;
+          const baseHeaders: Record<string, unknown> = {
+            ...instanceHeaders,
+            ...((config.headers ?? {}) as Record<string, unknown>),
+          };
           const headers: Record<string, unknown> = {
             ...baseHeaders,
             set: (key: string, value: string) => {
@@ -57,7 +107,11 @@ vi.mock("axios", () => {
             },
           };
 
-          let cfg: Record<string, unknown> = {
+          // Instance defaults (baseURL, maxRedirects) merge under the
+          // per-request config, matching real axios mergeConfig behavior.
+          let cfg: Cfg = {
+            baseURL: createConfig.baseURL,
+            maxRedirects: createConfig.maxRedirects,
             ...config,
             headers,
           };
@@ -72,44 +126,33 @@ vi.mock("axios", () => {
             cfg._signedHeaders = headerStore;
           }
 
-          let resp = await mockRequest(cfg);
-          const validate =
-            (cfg.validateStatus as ((s: number) => boolean) | undefined) ??
-            ((s: number) => s >= 200 && s < 300);
-          if (!validate(resp.status as number)) {
-            throw Object.assign(
-              new Error(`Request failed with status code ${resp.status}`),
-              { isAxiosError: true, response: resp },
-            );
+          // Dispatch, then run the response interceptor chain in registration
+          // order. An onRejected handler may recover by returning a promise
+          // (the redirect handler returns instance.request(...)).
+          let result: Promise<Resp> = dispatch(cfg);
+          for (const { onFulfilled, onRejected } of resInterceptors._handlers) {
+            result = result.then(
+              onFulfilled ?? ((r: Resp) => r),
+              onRejected,
+            ) as Promise<Resp>;
           }
-
-          // Apply response interceptors
-          for (const handler of resInterceptors._handlers) {
-            resp = handler(resp);
-          }
-
-          return resp;
+          return result;
         }
 
-        return {
+        const instance = {
           request,
-          get: (url: string, config?: Record<string, unknown>) =>
+          get: (url: string, config?: Cfg) =>
             request({ method: "GET", url, ...config }),
-          post: (
-            url: string,
-            data?: unknown,
-            config?: Record<string, unknown>,
-          ) => request({ method: "POST", url, data, ...config }),
-          patch: (
-            url: string,
-            data?: unknown,
-            config?: Record<string, unknown>,
-          ) => request({ method: "PATCH", url, data, ...config }),
+          post: (url: string, data?: unknown, config?: Cfg) =>
+            request({ method: "POST", url, data, ...config }),
+          patch: (url: string, data?: unknown, config?: Cfg) =>
+            request({ method: "PATCH", url, data, ...config }),
           interceptors: {
             request: reqInterceptors,
             response: resInterceptors,
           },
         };
+        return instance;
       }),
       isAxiosError: (err: unknown): boolean =>
         typeof err === "object" &&
@@ -141,6 +184,7 @@ function jsonResponse(
   body: unknown,
   status = 200,
   statusText = "OK",
+  headers: Record<string, string> = { "content-type": "application/json" },
 ): {
   status: number;
   statusText: string;
@@ -152,7 +196,7 @@ function jsonResponse(
     status,
     statusText,
     data: body,
-    headers: { "content-type": "application/json" },
+    headers,
     config: {},
   };
 }
@@ -161,6 +205,7 @@ function textResponse(
   body: string,
   status = 200,
   statusText = "OK",
+  headers: Record<string, string> = {},
 ): {
   status: number;
   statusText: string;
@@ -172,7 +217,30 @@ function textResponse(
     status,
     statusText,
     data: body,
-    headers: {},
+    headers,
+    config: {},
+  };
+}
+
+/**
+ * A 3xx redirect response. `location` is lower-cased to match how Node and
+ * AxiosHeaders normalize the header the redirect handler reads.
+ */
+function redirectResponse(
+  status: number,
+  location?: string,
+): {
+  status: number;
+  statusText: string;
+  data: unknown;
+  headers: Record<string, string>;
+  config: object;
+} {
+  return {
+    status,
+    statusText: "Redirect",
+    data: "",
+    headers: location !== undefined ? { location } : {},
     config: {},
   };
 }
@@ -746,7 +814,12 @@ describe("uploadBundle", () => {
 
     const body = Readable.from(Buffer.from([0x1f, 0x8b, 0x08]));
     const client = createClient();
-    const { data } = await client.uploadBundle(contentId, body, 3, "abc123==");
+    const { data } = await client.uploadBundle(
+      contentId,
+      () => body,
+      3,
+      "abc123==",
+    );
 
     expect(data).toEqual(bundleResponse);
     const call = mockRequest.mock.calls[0][0];
@@ -756,23 +829,29 @@ describe("uploadBundle", () => {
     expect(call.headers["Content-Type"]).toBe("application/gzip");
     expect(call.headers["Content-Length"]).toBe(3);
     expect(call.headers["X-Content-Checksum"]).toBe("abc123==");
-    // Forces axios's native streaming transport instead of follow-redirects,
-    // which would otherwise buffer the whole body in memory.
-    expect(call.maxRedirects).toBe(0);
   });
 
-  it("forwards the stream body unchanged", async () => {
+  it("forwards the freshly created stream body", async () => {
     mockRequest.mockResolvedValue(
       jsonResponse({ id: "b-1", content_guid: contentId, active: true }),
     );
 
     const body = Readable.from(Buffer.from([0x1f, 0x8b, 0x08, 0x00]));
     const client = createClient();
-    await client.uploadBundle(contentId, body, 4, "deadbeef==");
+    await client.uploadBundle(contentId, () => body, 4, "deadbeef==");
 
     const call = mockRequest.mock.calls[0][0];
     expect(call.data).toBe(body);
     expect(call.headers["Content-Length"]).toBe(4);
+  });
+
+  it("keeps axios on its native transport (instance maxRedirects: 0)", () => {
+    // Instance-level maxRedirects: 0 forces axios's native streaming transport
+    // instead of follow-redirects, which would otherwise buffer the whole body
+    // in memory. Redirects are then followed manually per hop.
+    createClient();
+    const call = vi.mocked(axios.create).mock.calls.at(-1)?.[0];
+    expect(call?.maxRedirects).toBe(0);
   });
 
   it("throws on non-2xx", async () => {
@@ -782,8 +861,321 @@ describe("uploadBundle", () => {
 
     const client = createClient();
     await expect(
-      client.uploadBundle(contentId, Readable.from(Buffer.from([1])), 1, "x=="),
+      client.uploadBundle(
+        contentId,
+        () => Readable.from(Buffer.from([1])),
+        1,
+        "x==",
+      ),
     ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redirect handling (client-wide, via attachRedirectHandling)
+// ---------------------------------------------------------------------------
+
+describe("Redirect handling", () => {
+  it("follows a 302 (GET) to an absolute Location and returns the final payload", async () => {
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(302, "https://new-host.example.com/__api__/v1/user"),
+      )
+      .mockResolvedValueOnce(jsonResponse(validUserDTO()));
+
+    const client = createClient();
+    const user = await client.getCurrentUser();
+
+    expect(user.id).toBe("user-guid-123");
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    const second = mockRequest.mock.calls[1][0] as Record<string, unknown>;
+    expect(second.url).toBe("https://new-host.example.com/__api__/v1/user");
+  });
+
+  it.each([301, 302, 307, 308])(
+    "preserves POST method and JSON body across a %i redirect",
+    async (status) => {
+      mockRequest
+        .mockResolvedValueOnce(
+          redirectResponse(
+            status,
+            "https://connect.example.com/__api__/v1/content-moved",
+          ),
+        )
+        .mockResolvedValueOnce(jsonResponse({ guid: "new-content" }, 201));
+
+      const client = createClient();
+      await client.createDeployment({ name: "my-app" });
+
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+      const second = mockRequest.mock.calls[1][0] as Record<string, unknown>;
+      expect(second.method).toBe("POST");
+      expect(second.data).toEqual({ name: "my-app" });
+      expect(second.url).toBe(
+        "https://connect.example.com/__api__/v1/content-moved",
+      );
+    },
+  );
+
+  it.each([
+    ["/after", "https://connect.example.com/after"],
+    ["after", "https://connect.example.com/rsc/__api__/v1/after"],
+  ])(
+    "resolves a relative Location (%s) against the request's full URL",
+    async (location, expected) => {
+      const client = new ConnectAPI({
+        url: "https://connect.example.com/rsc",
+        apiKey: API_KEY,
+      });
+      mockRequest
+        .mockResolvedValueOnce(redirectResponse(302, location))
+        .mockResolvedValueOnce(jsonResponse(validUserDTO()));
+
+      await client.getCurrentUser();
+
+      const second = mockRequest.mock.calls[1][0] as Record<string, unknown>;
+      expect(second.url).toBe(expected);
+    },
+  );
+
+  it("forwards credentials across a cross-origin (http→https) redirect", async () => {
+    const client = new ConnectAPI({
+      url: "http://old-host.example.com",
+      apiKey: API_KEY,
+    });
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(301, "https://new-host.example.com/__api__/v1/user"),
+      )
+      .mockResolvedValueOnce(jsonResponse(validUserDTO()));
+
+    await client.getCurrentUser();
+
+    const second = mockRequest.mock.calls[1][0] as Record<string, unknown>;
+    expect(second.url).toBe("https://new-host.example.com/__api__/v1/user");
+    const headers = second.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Key ${API_KEY}`);
+  });
+
+  it("re-signs token auth against the redirect target's pathname", async () => {
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privateKeyBase64 = Buffer.from(
+      privateKey.export({ format: "der", type: "pkcs1" }),
+    ).toString("base64");
+    const TOKEN = "Tredirect-signing";
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      token: TOKEN,
+      privateKey: privateKeyBase64,
+    });
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(
+          307,
+          "https://other.example.com/__api__/v1/user-moved",
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse(validUserDTO()));
+
+    await client.getCurrentUser();
+
+    const first = (mockRequest.mock.calls[0][0] as Record<string, unknown>)
+      ._signedHeaders as Record<string, string>;
+    const second = (mockRequest.mock.calls[1][0] as Record<string, unknown>)
+      ._signedHeaders as Record<string, string>;
+
+    // The second hop signs the redirect target's PATHNAME (not the absolute
+    // URL, and not the original path). Re-sign the canonical string ourselves
+    // and compare (RSA-SHA1 PKCS#1 v1.5 is deterministic).
+    const expectedSig = rsaSha1Sign(
+      buildCanonicalRequest(
+        "GET",
+        "/__api__/v1/user-moved",
+        second["Date"],
+        second["X-Content-Checksum"],
+      ),
+      privateKeyBase64,
+    );
+    expect(second["X-Auth-Signature"]).toBe(expectedSig);
+
+    // It must not be signing the whole absolute URL.
+    const absoluteSig = rsaSha1Sign(
+      buildCanonicalRequest(
+        "GET",
+        "https://other.example.com/__api__/v1/user-moved",
+        second["Date"],
+        second["X-Content-Checksum"],
+      ),
+      privateKeyBase64,
+    );
+    expect(second["X-Auth-Signature"]).not.toBe(absoluteSig);
+    // Different path than hop 1, so the signature changes.
+    expect(second["X-Auth-Signature"]).not.toBe(first["X-Auth-Signature"]);
+    expect(second["X-Auth-Token"]).toBe(TOKEN);
+  });
+
+  it("re-signs a streamed upload redirect with the same precomputed checksum", async () => {
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privateKeyBase64 = Buffer.from(
+      privateKey.export({ format: "der", type: "pkcs1" }),
+    ).toString("base64");
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      token: "Tupload",
+      privateKey: privateKeyBase64,
+    });
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(308, "https://cdn.example.com/upload"),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ id: "b-1", content_guid: "c-1", active: true }),
+      );
+
+    await client.uploadBundle(
+      ContentID("c-1"),
+      () => Readable.from(Buffer.from([1, 2, 3])),
+      3,
+      "CHK==",
+    );
+
+    const first = (mockRequest.mock.calls[0][0] as Record<string, unknown>)
+      ._signedHeaders as Record<string, string>;
+    const second = (mockRequest.mock.calls[1][0] as Record<string, unknown>)
+      ._signedHeaders as Record<string, string>;
+    expect(first["X-Content-Checksum"]).toBe("CHK==");
+    expect(second["X-Content-Checksum"]).toBe("CHK==");
+  });
+
+  it("opens a fresh stream from the factory on each redirect hop", async () => {
+    // Capture the body/headers each hop actually sends. We snapshot at call
+    // time because the redirect handler mutates the config in place to re-issue
+    // (real axios clones per request; our mock records the live object).
+    const responses = [
+      redirectResponse(307, "https://a.example.com/1"),
+      redirectResponse(307, "https://b.example.com/2"),
+      jsonResponse({ id: "b-1", content_guid: "c-1", active: true }),
+    ];
+    const sentData: unknown[] = [];
+    const sentHeaders: Array<Record<string, unknown>> = [];
+    let hop = 0;
+    mockRequest.mockImplementation((cfg: Record<string, unknown>) => {
+      sentData.push(cfg.data);
+      sentHeaders.push(cfg.headers as Record<string, unknown>);
+      return Promise.resolve(responses[hop++]);
+    });
+
+    const streams: Readable[] = [];
+    const makeBody = (): Readable => {
+      const s = Readable.from(Buffer.from([0x1f, 0x8b]));
+      streams.push(s);
+      return s;
+    };
+
+    const client = createClient();
+    await client.uploadBundle(ContentID("c-1"), makeBody, 2, "abc==");
+
+    // Initial request + 2 redirects = 3 factory calls, each a distinct stream.
+    expect(streams).toHaveLength(3);
+    expect(new Set(streams).size).toBe(3);
+
+    // Each hop sent the stream created for it; the final hop sent the last one.
+    expect(sentData).toEqual([streams[0], streams[1], streams[2]]);
+
+    // Content-Length and checksum are identical on every hop.
+    for (const headers of sentHeaders) {
+      expect(headers["Content-Length"]).toBe(2);
+      expect(headers["X-Content-Checksum"]).toBe("abc==");
+    }
+
+    // Each consumed stream is destroyed before the next hop opens a new one;
+    // the final one is destroyed by uploadBundle's finally.
+    expect(streams[0].destroyed).toBe(true);
+    expect(streams[1].destroyed).toBe(true);
+    expect(streams[2].destroyed).toBe(true);
+  });
+
+  it("gives up after MAX_REDIRECTS hops with a descriptive error", async () => {
+    for (let i = 0; i <= MAX_REDIRECTS; i++) {
+      mockRequest.mockResolvedValueOnce(
+        redirectResponse(302, `https://h${i}.example.com/x`),
+      );
+    }
+
+    const client = createClient();
+    await expect(client.getCurrentUser()).rejects.toThrow(/Too many redirects/);
+    expect(mockRequest).toHaveBeenCalledTimes(MAX_REDIRECTS + 1);
+  });
+
+  it("does not follow a 303 and rejects with the original error", async () => {
+    mockRequest.mockResolvedValueOnce(
+      redirectResponse(303, "https://x.example.com/y"),
+    );
+
+    const client = createClient();
+    await expect(client.getCurrentUser()).rejects.toMatchObject({
+      response: { status: 303 },
+    });
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not follow a 302 without a Location header", async () => {
+    mockRequest.mockResolvedValueOnce(redirectResponse(302));
+
+    const client = createClient();
+    await expect(client.getCurrentUser()).rejects.toMatchObject({
+      response: { status: 302 },
+    });
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates an abort mid-redirect and destroys the live upload stream", async () => {
+    const cancelErr = Object.assign(new Error("canceled"), {
+      __CANCEL__: true,
+    });
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(307, "https://cdn.example.com/upload"),
+      )
+      .mockRejectedValueOnce(cancelErr);
+
+    const streams: Readable[] = [];
+    const makeBody = (): Readable => {
+      const s = Readable.from(Buffer.from([1, 2, 3]));
+      streams.push(s);
+      return s;
+    };
+
+    const client = createClient();
+    await expect(
+      client.uploadBundle(
+        ContentID("c-1"),
+        makeBody,
+        3,
+        "abc==",
+        AbortSignal.abort(),
+      ),
+    ).rejects.toBe(cancelErr);
+
+    // Initial stream + one redirect hop = 2 streams, both destroyed: the first
+    // by the redirect factory, the second by uploadBundle's finally.
+    expect(streams).toHaveLength(2);
+    expect(streams[0].destroyed).toBe(true);
+    expect(streams[1].destroyed).toBe(true);
+  });
+
+  it.each([404, 500])("does not re-issue on a %i error", async (status) => {
+    mockRequest.mockResolvedValueOnce(textResponse("err", status));
+
+    const client = createClient();
+    await expect(client.getCurrentUser()).rejects.toThrow(/status code/);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1510,7 +1902,7 @@ describe("Token authentication", () => {
     const client = createTokenClient();
     await client.uploadBundle(
       ContentID("c-1"),
-      Readable.from(gzipBytes),
+      () => Readable.from(gzipBytes),
       gzipBytes.length,
       checksum,
     );
@@ -1941,7 +2333,7 @@ describe("AbortSignal support", () => {
     await expect(
       client.uploadBundle(
         ContentID("c-1"),
-        Readable.from(Buffer.from([1, 2])),
+        () => Readable.from(Buffer.from([1, 2])),
         2,
         "x==",
         abortedSignal(),

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -7,6 +7,7 @@ import axios from "axios";
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { md5Checksum, signRequestWithChecksum } from "./auth.js";
+import { attachRedirectHandling } from "./redirects.js";
 import type {
   AllSettings,
   ApplicationSettings,
@@ -91,8 +92,14 @@ export class ConnectAPI {
       );
     }
 
+    // The whole client stays on axios's native http/https transport
+    // (`maxRedirects: 0`), which truly streams request bodies rather than
+    // buffering them to replay on a redirect. Redirects are instead followed
+    // manually by `attachRedirectHandling` below, which re-issues each hop
+    // through this instance so token-auth signing and cookie forwarding rerun.
     const config: AxiosRequestConfig = {
       baseURL: options.url,
+      maxRedirects: 0,
     };
 
     if (hasSnowflake) {
@@ -134,6 +141,13 @@ export class ConnectAPI {
 
     this.client = axios.create(config);
 
+    // Follow redirects manually (see the config comment above). Registered
+    // before the token/cookie interceptors: the cookie-capture response
+    // interceptor has no rejected handler, so 3xx rejections flow past it into
+    // this handler regardless of ordering, and request interceptors re-run on
+    // each re-issued hop either way.
+    attachRedirectHandling(this.client);
+
     // For token auth, add a request interceptor that computes per-request signing headers
     if (hasToken) {
       const token = options.token!;
@@ -141,8 +155,15 @@ export class ConnectAPI {
 
       this.client.interceptors.request.use((reqConfig) => {
         const method = (reqConfig.method ?? "GET").toUpperCase();
-        // Extract the path from the url (which is relative to baseURL)
-        const path = reqConfig.url ?? "/";
+        // Extract the path from the url (which is relative to baseURL).
+        // After a redirect the re-issued request carries an absolute URL; the
+        // signature covers only the path, matching what we sign for relative
+        // URLs (the query never participates — getTaskLogs' params are unsigned
+        // today).
+        const rawUrl = reqConfig.url ?? "/";
+        const path = /^https?:\/\//i.test(rawUrl)
+          ? new URL(rawUrl).pathname
+          : rawUrl;
 
         // The signature covers a base64 MD5 of the exact bytes Connect
         // receives. Streamed bodies (large bundle uploads) can't be hashed
@@ -375,31 +396,49 @@ export class ConnectAPI {
    * `checksum` is sent as X-Content-Checksum so token-auth request signing can
    * cover the body without re-reading it.
    *
-   * `maxRedirects: 0` keeps axios on its native http/https transport, which
-   * truly streams the body. The default follow-redirects transport buffers the
-   * entire request body in memory (so it can replay it on a redirect), which
-   * would defeat streaming and exhaust memory on large bundles.
+   * `makeBody` is a factory that opens a fresh read stream from the bundle file
+   * on disk. A stream can only be consumed once, so on each redirect hop the
+   * redirect handler destroys the consumed stream and calls the factory again
+   * for a new one — the bundle is re-streamed from disk, never buffered in
+   * memory. `Content-Length` and `X-Content-Checksum` are constant across hops
+   * (the file on disk does not change) and ride on the request headers; the
+   * token-auth interceptor re-signs each redirect target's path against that
+   * same precomputed checksum. `Date` and `X-Auth-*` are recomputed per hop.
    */
   async uploadBundle(
     contentId: ContentID,
-    body: Readable,
+    makeBody: () => Readable,
     contentLength: number,
     checksum: string,
     signal?: AbortSignal,
   ): Promise<AxiosResponse<BundleDTO>> {
-    return this.client.post<BundleDTO>(
-      `/__api__/v1/content/${contentId}/bundles`,
-      body,
-      {
-        headers: {
-          "Content-Type": "application/gzip",
-          "Content-Length": contentLength,
-          "X-Content-Checksum": checksum,
+    // Track the live stream so each redirect hop can destroy the consumed
+    // one before opening a fresh read from disk, and so the final stream is
+    // always cleaned up even when the request fails or is aborted.
+    let current: Readable | undefined;
+    const bodyFactory = (): Readable => {
+      current?.destroy();
+      current = makeBody();
+      return current;
+    };
+    try {
+      return await this.client.post<BundleDTO>(
+        `/__api__/v1/content/${contentId}/bundles`,
+        bodyFactory(),
+        {
+          headers: {
+            "Content-Type": "application/gzip",
+            "Content-Length": contentLength,
+            "X-Content-Checksum": checksum,
+          },
+          bodyFactory,
+          signal,
         },
-        maxRedirects: 0,
-        signal,
-      },
-    );
+      );
+    } finally {
+      // On success the stream is fully consumed; destroy() is then a no-op.
+      current?.destroy();
+    }
   }
 
   /** Downloads a bundle archive as raw bytes. */

--- a/packages/connect-api/src/redirects.test.ts
+++ b/packages/connect-api/src/redirects.test.ts
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { describe, expect, it } from "vitest";
+import { resolveRequestUrl, MAX_REDIRECTS } from "./redirects.js";
+
+describe("resolveRequestUrl", () => {
+  it("joins a relative url with a baseURL without a trailing slash", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com",
+        url: "/__api__/v1/user",
+      }),
+    ).toBe("https://host.example.com/__api__/v1/user");
+  });
+
+  it("joins a relative url with a baseURL that has a trailing slash", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com/",
+        url: "/__api__/v1/user",
+      }),
+    ).toBe("https://host.example.com/__api__/v1/user");
+  });
+
+  it("concatenates against a baseURL path prefix (axios-style, not URL resolution)", () => {
+    // axios joins by concatenation: `https://host/rsc` + `/__api__/x` yields
+    // `https://host/rsc/__api__/x`, NOT `https://host/__api__/x`.
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com/rsc",
+        url: "/__api__/x",
+      }),
+    ).toBe("https://host.example.com/rsc/__api__/x");
+  });
+
+  it("returns an absolute url verbatim, ignoring baseURL", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com",
+        url: "https://other-host.example.com/__api__/x",
+      }),
+    ).toBe("https://other-host.example.com/__api__/x");
+  });
+
+  it("returns the baseURL when the url is empty", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com/rsc",
+        url: "",
+      }),
+    ).toBe("https://host.example.com/rsc");
+  });
+
+  it("returns the baseURL when the url is absent", () => {
+    expect(resolveRequestUrl({ baseURL: "https://host.example.com" })).toBe(
+      "https://host.example.com",
+    );
+  });
+});
+
+describe("MAX_REDIRECTS", () => {
+  it("is 5", () => {
+    expect(MAX_REDIRECTS).toBe(5);
+  });
+});

--- a/packages/connect-api/src/redirects.ts
+++ b/packages/connect-api/src/redirects.ts
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { Readable } from "stream";
+import axios from "axios";
+import type { AxiosInstance, AxiosRequestConfig } from "axios";
+
+// Custom per-request config fields used by the redirect interceptor.
+// Declaration merging keeps this type-safe without `as` casts. Both
+// @posit-dev/connect-api and @posit-dev/connect-cloud-api declare identical
+// augmentations, which TypeScript merges cleanly.
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    /** Recreates a streamed request body for redirect re-issue. */
+    bodyFactory?: () => Readable;
+    /** Number of redirect hops already followed for this logical request. */
+    redirectCount?: number;
+  }
+}
+
+/**
+ * Statuses we follow, preserving method and body on all of them (libcurl
+ * CURLOPT_POSTREDIR semantics, matching posit-sdk-py). 303 is intentionally
+ * excluded: Connect never emits it, and following it as GET against e.g. the
+ * bundles endpoint would do something surprising — better to fail loudly.
+ */
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+
+export const MAX_REDIRECTS = 5;
+
+/**
+ * Replicates axios's baseURL + url combination (plain concatenation, not
+ * URL resolution) so relative Location headers resolve against the URL the
+ * request was actually sent to.
+ */
+export function resolveRequestUrl(config: AxiosRequestConfig): string {
+  const url = config.url ?? "";
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+  const base = (config.baseURL ?? "").replace(/\/+$/, "");
+  return url ? `${base}/${url.replace(/^\/+/, "")}` : base;
+}
+
+/**
+ * Installs manual redirect handling on an axios instance.
+ *
+ * The instance MUST be created with `maxRedirects: 0` so axios stays on its
+ * native http/https transport (which truly streams request bodies); 3xx
+ * responses then reject via validateStatus and land in this error handler,
+ * which re-issues the request through the same instance. Re-issuing through
+ * the instance re-runs the request interceptors, so token-auth signing (which
+ * covers the request path) and cookie forwarding stay correct on every hop.
+ *
+ * Method and body are preserved on 301/302/307/308. Streamed bodies are
+ * recreated per hop via `config.bodyFactory` — never buffered, never dropped.
+ * Credentials are forwarded wherever Location points (the redirect comes from
+ * the user's own configured server), matching rsconnect and posit-sdk-py.
+ */
+export function attachRedirectHandling(instance: AxiosInstance): void {
+  instance.interceptors.response.use(undefined, (error: unknown) => {
+    if (!axios.isAxiosError(error) || !error.response || !error.config) {
+      return Promise.reject(error);
+    }
+    const { status, headers } = error.response;
+    if (!REDIRECT_STATUSES.has(status)) {
+      return Promise.reject(error);
+    }
+    const location = headers["location"];
+    if (typeof location !== "string" || location === "") {
+      return Promise.reject(error);
+    }
+
+    const config = error.config;
+    const redirectCount = (config.redirectCount ?? 0) + 1;
+    const currentUrl = resolveRequestUrl(config);
+    const target = new URL(location, currentUrl).toString();
+
+    if (redirectCount > MAX_REDIRECTS) {
+      return Promise.reject(
+        new Error(
+          `Too many redirects: gave up after ${MAX_REDIRECTS} while requesting ` +
+            `${currentUrl} (next redirect target was ${target})`,
+        ),
+      );
+    }
+
+    // Streamed bodies were consumed (or partially consumed) by the redirected
+    // attempt; a stream cannot be replayed, so recreate it from the factory.
+    if (config.data instanceof Readable) {
+      if (config.bodyFactory === undefined) {
+        return Promise.reject(error);
+      }
+      config.data = config.bodyFactory();
+    }
+
+    config.url = target;
+    // Location is authoritative for the full target URL, query included;
+    // leaving params set would append them a second time.
+    config.params = undefined;
+    config.redirectCount = redirectCount;
+    return instance.request(config);
+  });
+}

--- a/packages/connect-cloud-api/src/client.golden.test.ts
+++ b/packages/connect-cloud-api/src/client.golden.test.ts
@@ -30,8 +30,8 @@ vi.mock("axios", () => {
     const resp = await mockRequest(processedConfig);
     const validate =
       (processedConfig.validateStatus as
-        ((s: number) => boolean) | undefined) ??
-      ((s: number) => s >= 200 && s < 300);
+        | ((s: number) => boolean)
+        | undefined) ?? ((s: number) => s >= 200 && s < 300);
     if (!validate(resp.status as number)) {
       throw Object.assign(
         new Error(`Request failed with status code ${resp.status}`),
@@ -61,6 +61,11 @@ vi.mock("axios", () => {
             ) => {
               requestInterceptors.push(fn);
             },
+          },
+          // Redirect handling registers a response interceptor; golden
+          // fixtures never return 3xx, so a no-op is sufficient here.
+          response: {
+            use: () => {},
           },
         },
       })),

--- a/packages/connect-cloud-api/src/client.test.ts
+++ b/packages/connect-cloud-api/src/client.test.ts
@@ -3,6 +3,7 @@
 import { Readable } from "stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectCloudAPI } from "./client.js";
+import { MAX_REDIRECTS } from "./redirects.js";
 import {
   ContentID,
   ContentAccess,
@@ -28,87 +29,115 @@ import type {
 const mockRequest = vi.fn();
 
 vi.mock("axios", () => {
-  // Store request interceptors so we can apply them
-  const requestInterceptors: Array<
-    (config: Record<string, unknown>) => Record<string, unknown>
-  > = [];
+  type Cfg = Record<string, unknown>;
+  type Resp = { status: number; headers?: Record<string, unknown> } & Record<
+    string,
+    unknown
+  >;
+  type Fulfilled = (config: Cfg) => Cfg;
+  type ResFulfilled = (resp: Resp) => Resp | Promise<Resp>;
+  type ResRejected = (error: unknown) => unknown;
 
-  async function request(config: Record<string, unknown>) {
-    // Apply request interceptors
-    let processedConfig = { ...config };
-    for (const interceptor of requestInterceptors) {
-      processedConfig = interceptor(processedConfig);
+  const defaultValidate = (s: number) => s >= 200 && s < 300;
+
+  // Each created instance gets its own interceptor managers so, e.g., the
+  // main client's Bearer interceptor is not attached to the presigned-upload
+  // instance.
+  function makeInstance(createConfig: Cfg = {}) {
+    const reqInterceptors: Fulfilled[] = [];
+    const resInterceptors: Array<{
+      onFulfilled?: ResFulfilled;
+      onRejected?: ResRejected;
+    }> = [];
+    const instanceHeaders = (createConfig.headers ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    // Runs the request and applies validateStatus. On a non-2xx status rejects
+    // with an AxiosError carrying `config` (like real axios) so the redirect
+    // handler can re-issue it.
+    async function dispatch(cfg: Cfg): Promise<Resp> {
+      const resp: Resp = await mockRequest(cfg);
+      const validate =
+        (cfg.validateStatus as ((s: number) => boolean) | undefined) ??
+        defaultValidate;
+      if (!validate(resp.status)) {
+        return Promise.reject(
+          Object.assign(
+            new Error(`Request failed with status code ${resp.status}`),
+            { isAxiosError: true, response: resp, config: cfg },
+          ),
+        );
+      }
+      return resp;
     }
 
-    const resp = await mockRequest(processedConfig);
-    const validate =
-      (processedConfig.validateStatus as
-        ((s: number) => boolean) | undefined) ??
-      ((s: number) => s >= 200 && s < 300);
-    if (!validate(resp.status as number)) {
-      throw Object.assign(
-        new Error(`Request failed with status code ${resp.status}`),
-        { isAxiosError: true, response: resp },
-      );
+    async function request(config: Cfg): Promise<Resp> {
+      // Instance defaults (baseURL, maxRedirects, headers) merge under the
+      // per-request config, matching real axios mergeConfig behavior.
+      const headers: Record<string, unknown> = {
+        ...instanceHeaders,
+        ...((config.headers ?? {}) as Record<string, unknown>),
+      };
+      let cfg: Cfg = {
+        baseURL: createConfig.baseURL,
+        maxRedirects: createConfig.maxRedirects,
+        ...config,
+        headers,
+      };
+
+      for (const handler of reqInterceptors) {
+        cfg = handler(cfg);
+      }
+
+      let result: Promise<Resp> = dispatch(cfg);
+      for (const { onFulfilled, onRejected } of resInterceptors) {
+        result = result.then(
+          onFulfilled ?? ((r: Resp) => r),
+          onRejected,
+        ) as Promise<Resp>;
+      }
+      return result;
     }
-    return resp;
+
+    return {
+      request,
+      get: (url: string, config?: Cfg) =>
+        request({ method: "GET", url, ...config }),
+      post: (url: string, data?: unknown, config?: Cfg) =>
+        request({ method: "POST", url, data, ...config }),
+      patch: (url: string, data?: unknown, config?: Cfg) =>
+        request({ method: "PATCH", url, data, ...config }),
+      interceptors: {
+        request: {
+          use: (fn: Fulfilled) => {
+            reqInterceptors.push(fn);
+          },
+        },
+        response: {
+          use: (onFulfilled?: ResFulfilled, onRejected?: ResRejected) => {
+            resInterceptors.push({ onFulfilled, onRejected });
+          },
+        },
+      },
+    };
   }
 
   return {
     default: {
-      create: vi.fn(() => ({
-        request,
-        get: (url: string, config?: Record<string, unknown>) =>
-          request({ method: "GET", url, ...config }),
-        post: (url: string, data?: unknown, config?: Record<string, unknown>) =>
-          request({ method: "POST", url, data, ...config }),
-        patch: (
-          url: string,
-          data?: unknown,
-          config?: Record<string, unknown>,
-        ) => request({ method: "PATCH", url, data, ...config }),
-        interceptors: {
-          request: {
-            use: (
-              fn: (config: Record<string, unknown>) => Record<string, unknown>,
-            ) => {
-              requestInterceptors.push(fn);
-            },
-          },
-        },
-      })),
-      post: vi.fn(
-        async (
-          url: string,
-          data?: unknown,
-          config?: Record<string, unknown>,
-        ) => {
-          const resp = await mockRequest({
-            method: "POST",
-            url,
-            data,
-            ...config,
-          });
-          const validate = (s: number) => s >= 200 && s < 300;
-          if (!validate(resp.status as number)) {
-            throw Object.assign(
-              new Error(`Request failed with status code ${resp.status}`),
-              { isAxiosError: true, response: resp },
-            );
-          }
-          return resp;
-        },
-      ),
+      create: vi.fn((createConfig: Cfg = {}) => makeInstance(createConfig)),
       isAxiosError: (err: unknown): boolean =>
         typeof err === "object" &&
         err !== null &&
         (err as Record<string, unknown>).isAxiosError === true,
+      isCancel: (err: unknown): boolean =>
+        typeof err === "object" &&
+        err !== null &&
+        (err as Record<string, unknown>).__CANCEL__ === true,
     },
   };
 });
-
-// Re-import axios so we can inspect axios.create calls
-import axios from "axios";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -128,6 +157,7 @@ function jsonResponse(
   body: unknown,
   status = 200,
   statusText = "OK",
+  headers: Record<string, string> = { "content-type": "application/json" },
 ): {
   status: number;
   statusText: string;
@@ -139,7 +169,7 @@ function jsonResponse(
     status,
     statusText,
     data: body,
-    headers: { "content-type": "application/json" },
+    headers,
     config: {},
   };
 }
@@ -148,6 +178,7 @@ function textResponse(
   body: string,
   status = 200,
   statusText = "OK",
+  headers: Record<string, string> = {},
 ): {
   status: number;
   statusText: string;
@@ -159,7 +190,27 @@ function textResponse(
     status,
     statusText,
     data: body,
-    headers: {},
+    headers,
+    config: {},
+  };
+}
+
+/** A 3xx redirect response with a lower-cased `location` header. */
+function redirectResponse(
+  status: number,
+  location?: string,
+): {
+  status: number;
+  statusText: string;
+  data: unknown;
+  headers: Record<string, string>;
+  config: object;
+} {
+  return {
+    status,
+    statusText: "Redirect",
+    data: "",
+    headers: location !== undefined ? { location } : {},
     config: {},
   };
 }
@@ -567,20 +618,23 @@ describe("uploadBundle", () => {
 
     const body = Readable.from(Buffer.from([0x1f, 0x8b, 0x08]));
     const client = createClient();
-    await client.uploadBundle("https://upload.example.com/presigned", body, 3);
-
-    // uploadBundle uses axios.post directly, not the instance
-    expect(axios.post).toHaveBeenCalledWith(
+    await client.uploadBundle(
       "https://upload.example.com/presigned",
-      body,
-      {
-        headers: {
-          "Content-Type": "application/gzip",
-          "Content-Length": 3,
-        },
-        maxRedirects: 0,
-      },
+      () => body,
+      3,
     );
+
+    // The upload goes through a dedicated created instance (not the
+    // authenticated client, and no Authorization header).
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.url).toBe("https://upload.example.com/presigned");
+    expect(call.data).toBe(body);
+    expect(call.headers["Content-Type"]).toBe("application/gzip");
+    expect(call.headers["Content-Length"]).toBe(3);
+    expect(call.headers.Authorization).toBeUndefined();
+    // The upload instance keeps axios on its native streaming transport.
+    expect(call.maxRedirects).toBe(0);
   });
 
   it("throws on non-2xx", async () => {
@@ -592,7 +646,7 @@ describe("uploadBundle", () => {
     await expect(
       client.uploadBundle(
         "https://upload.example.com/presigned",
-        Readable.from(Buffer.from([1])),
+        () => Readable.from(Buffer.from([1])),
         1,
       ),
     ).rejects.toThrow();
@@ -610,7 +664,7 @@ describe("uploadBundle", () => {
     await expect(
       client.uploadBundle(
         "https://upload.example.com/presigned",
-        Readable.from(Buffer.from([1])),
+        () => Readable.from(Buffer.from([1])),
         1,
         controller.signal,
       ),
@@ -618,6 +672,145 @@ describe("uploadBundle", () => {
 
     const call = mockRequest.mock.calls[0][0];
     expect(call.signal).toBe(controller.signal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redirect handling (client-wide + presigned upload)
+// ---------------------------------------------------------------------------
+
+describe("Redirect handling", () => {
+  it("follows a 302 on an instance call and keeps the Authorization header", async () => {
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(302, "https://api2.connect.posit.cloud/v1/users/me"),
+      )
+      .mockResolvedValueOnce(jsonResponse({ account_roles: {} }));
+
+    const client = createClient();
+    await client.getCurrentUser();
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    const second = mockRequest.mock.calls[1][0];
+    expect(second.url).toBe("https://api2.connect.posit.cloud/v1/users/me");
+    expect(second.headers.Authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
+  });
+
+  it("follows a 307 from the presigned URL with a fresh stream per hop", async () => {
+    const responses = [
+      redirectResponse(307, "https://region2.example.com/presigned"),
+      jsonResponse(null, 200),
+    ];
+    const sentData: unknown[] = [];
+    const sentHeaders: Array<Record<string, unknown>> = [];
+    let hop = 0;
+    mockRequest.mockImplementation((cfg: Record<string, unknown>) => {
+      sentData.push(cfg.data);
+      sentHeaders.push(cfg.headers as Record<string, unknown>);
+      return Promise.resolve(responses[hop++]);
+    });
+
+    const streams: Readable[] = [];
+    const makeBody = (): Readable => {
+      const s = Readable.from(Buffer.from([0x1f, 0x8b]));
+      streams.push(s);
+      return s;
+    };
+
+    const client = createClient();
+    await client.uploadBundle(
+      "https://region1.example.com/presigned",
+      makeBody,
+      2,
+    );
+
+    // Initial request + 1 redirect = 2 distinct streams, each sent to its hop.
+    expect(streams).toHaveLength(2);
+    expect(new Set(streams).size).toBe(2);
+    expect(sentData).toEqual([streams[0], streams[1]]);
+    for (const headers of sentHeaders) {
+      expect(headers["Content-Type"]).toBe("application/gzip");
+      expect(headers["Content-Length"]).toBe(2);
+    }
+    // Consumed stream destroyed by the factory; final by uploadBundle's finally.
+    expect(streams[0].destroyed).toBe(true);
+    expect(streams[1].destroyed).toBe(true);
+  });
+
+  it("gives up after MAX_REDIRECTS hops on the presigned upload", async () => {
+    for (let i = 0; i <= MAX_REDIRECTS; i++) {
+      mockRequest.mockResolvedValueOnce(
+        redirectResponse(307, `https://h${i}.example.com/x`),
+      );
+    }
+
+    const client = createClient();
+    await expect(
+      client.uploadBundle(
+        "https://region1.example.com/presigned",
+        () => Readable.from(Buffer.from([1])),
+        1,
+      ),
+    ).rejects.toThrow(/Too many redirects/);
+    expect(mockRequest).toHaveBeenCalledTimes(MAX_REDIRECTS + 1);
+  });
+
+  it("does not follow a 303 and rejects with the original error", async () => {
+    mockRequest.mockResolvedValueOnce(
+      redirectResponse(303, "https://x.example.com/y"),
+    );
+
+    const client = createClient();
+    await expect(
+      client.uploadBundle(
+        "https://region1.example.com/presigned",
+        () => Readable.from(Buffer.from([1])),
+        1,
+      ),
+    ).rejects.toMatchObject({ response: { status: 303 } });
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not follow a 302 without a Location header", async () => {
+    mockRequest.mockResolvedValueOnce(redirectResponse(302));
+
+    const client = createClient();
+    await expect(client.getCurrentUser()).rejects.toMatchObject({
+      response: { status: 302 },
+    });
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates an abort mid-redirect and destroys the live upload stream", async () => {
+    const cancelErr = Object.assign(new Error("canceled"), {
+      __CANCEL__: true,
+    });
+    mockRequest
+      .mockResolvedValueOnce(
+        redirectResponse(307, "https://region2.example.com/x"),
+      )
+      .mockRejectedValueOnce(cancelErr);
+
+    const streams: Readable[] = [];
+    const makeBody = (): Readable => {
+      const s = Readable.from(Buffer.from([1, 2, 3]));
+      streams.push(s);
+      return s;
+    };
+
+    const client = createClient();
+    await expect(
+      client.uploadBundle(
+        "https://region1.example.com/presigned",
+        makeBody,
+        3,
+        AbortSignal.abort(),
+      ),
+    ).rejects.toBe(cancelErr);
+
+    expect(streams).toHaveLength(2);
+    expect(streams[0].destroyed).toBe(true);
+    expect(streams[1].destroyed).toBe(true);
   });
 });
 

--- a/packages/connect-cloud-api/src/client.ts
+++ b/packages/connect-cloud-api/src/client.ts
@@ -5,6 +5,7 @@ import axios from "axios";
 import type { AxiosInstance } from "axios";
 
 import { CloudAuthClient } from "./auth.js";
+import { attachRedirectHandling } from "./redirects.js";
 import type {
   Account,
   AccountListResponse,
@@ -20,6 +21,13 @@ import type {
   UpdateContentRequest,
   UserResponse,
 } from "./types.js";
+
+// Presigned-URL uploads bypass the authenticated client; give them their own
+// instance so redirect handling (fresh stream per hop) still applies.
+// `maxRedirects: 0` keeps axios on its native streaming transport. Created once
+// at module load — it holds no per-request or credential state.
+const uploadClient = axios.create({ maxRedirects: 0 });
+attachRedirectHandling(uploadClient);
 
 /**
  * TypeScript client for the Posit Connect Cloud API.
@@ -43,9 +51,16 @@ export class ConnectCloudAPI {
     this.environment = options.environment;
     this.onTokenRefresh = options.onTokenRefresh;
 
+    // `maxRedirects: 0` keeps axios on its native http/https transport (which
+    // truly streams request bodies); redirects are followed manually by
+    // `attachRedirectHandling`, which re-issues each hop through this instance
+    // so the Bearer-token request interceptor re-runs and forwards the token to
+    // the redirect target.
     this.client = axios.create({
       baseURL: options.apiBaseUrl,
+      maxRedirects: 0,
     });
+    attachRedirectHandling(this.client);
 
     // Use request interceptor to set auth header dynamically (token may change after refresh)
     this.client.interceptors.request.use((config) => {
@@ -199,31 +214,48 @@ export class ConnectCloudAPI {
 
   /**
    * Uploads a bundle to a pre-signed URL.
-   * This does not use the authenticated client since the URL is pre-signed.
+   * This does not use the authenticated client since the URL is pre-signed; it
+   * goes through a dedicated `uploadClient` instance that follows redirects.
    *
    * The body is streamed from the staged bundle file so uploads of arbitrary
    * size never have to be buffered in memory. `contentLength` is already known
    * from writing that temp file to disk (its byte size), so we pass it here
    * rather than have axios try to derive it from the stream.
    *
-   * `maxRedirects: 0` keeps axios on its native http/https transport, which
-   * truly streams the body. The default follow-redirects transport buffers the
-   * entire request body in memory (so it can replay it on a redirect), which
-   * would defeat streaming and exhaust memory on large bundles.
+   * `makeBody` is a factory that opens a fresh read stream from the bundle file
+   * on disk. A stream can only be consumed once, so on each redirect hop the
+   * redirect handler destroys the consumed stream and calls the factory again
+   * for a new one — the bundle is re-streamed from disk, never buffered in
+   * memory. S3-style presigned endpoints can themselves redirect (e.g. region
+   * redirects), which is why this parity with the Connect client matters.
    */
   async uploadBundle(
     uploadUrl: string,
-    body: Readable,
+    makeBody: () => Readable,
     contentLength: number,
     signal?: AbortSignal,
   ): Promise<void> {
-    await axios.post(uploadUrl, body, {
-      headers: {
-        "Content-Type": "application/gzip",
-        "Content-Length": contentLength,
-      },
-      maxRedirects: 0,
-      signal,
-    });
+    // Track the live stream so each redirect hop can destroy the consumed one
+    // before opening a fresh read from disk, and so the final stream is always
+    // cleaned up even when the request fails or is aborted.
+    let current: Readable | undefined;
+    const bodyFactory = (): Readable => {
+      current?.destroy();
+      current = makeBody();
+      return current;
+    };
+    try {
+      await uploadClient.post(uploadUrl, bodyFactory(), {
+        headers: {
+          "Content-Type": "application/gzip",
+          "Content-Length": contentLength,
+        },
+        bodyFactory,
+        signal,
+      });
+    } finally {
+      // On success the stream is fully consumed; destroy() is then a no-op.
+      current?.destroy();
+    }
   }
 }

--- a/packages/connect-cloud-api/src/redirects.test.ts
+++ b/packages/connect-cloud-api/src/redirects.test.ts
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { describe, expect, it } from "vitest";
+import { resolveRequestUrl, MAX_REDIRECTS } from "./redirects.js";
+
+describe("resolveRequestUrl", () => {
+  it("joins a relative url with a baseURL without a trailing slash", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://api.connect.posit.cloud",
+        url: "/v1/users/me",
+      }),
+    ).toBe("https://api.connect.posit.cloud/v1/users/me");
+  });
+
+  it("joins a relative url with a baseURL that has a trailing slash", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://api.connect.posit.cloud/",
+        url: "/v1/users/me",
+      }),
+    ).toBe("https://api.connect.posit.cloud/v1/users/me");
+  });
+
+  it("concatenates against a baseURL path prefix (axios-style, not URL resolution)", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com/api",
+        url: "/v1/x",
+      }),
+    ).toBe("https://host.example.com/api/v1/x");
+  });
+
+  it("returns an absolute url verbatim, ignoring baseURL", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://api.connect.posit.cloud",
+        url: "https://upload.example.com/presigned",
+      }),
+    ).toBe("https://upload.example.com/presigned");
+  });
+
+  it("returns the baseURL when the url is empty", () => {
+    expect(
+      resolveRequestUrl({
+        baseURL: "https://host.example.com/api",
+        url: "",
+      }),
+    ).toBe("https://host.example.com/api");
+  });
+
+  it("returns the baseURL when the url is absent", () => {
+    expect(
+      resolveRequestUrl({ baseURL: "https://api.connect.posit.cloud" }),
+    ).toBe("https://api.connect.posit.cloud");
+  });
+});
+
+describe("MAX_REDIRECTS", () => {
+  it("is 5", () => {
+    expect(MAX_REDIRECTS).toBe(5);
+  });
+});

--- a/packages/connect-cloud-api/src/redirects.ts
+++ b/packages/connect-cloud-api/src/redirects.ts
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { Readable } from "stream";
+import axios from "axios";
+import type { AxiosInstance, AxiosRequestConfig } from "axios";
+
+// Custom per-request config fields used by the redirect interceptor.
+// Declaration merging keeps this type-safe without `as` casts. Both
+// @posit-dev/connect-api and @posit-dev/connect-cloud-api declare identical
+// augmentations, which TypeScript merges cleanly.
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    /** Recreates a streamed request body for redirect re-issue. */
+    bodyFactory?: () => Readable;
+    /** Number of redirect hops already followed for this logical request. */
+    redirectCount?: number;
+  }
+}
+
+/**
+ * Statuses we follow, preserving method and body on all of them (libcurl
+ * CURLOPT_POSTREDIR semantics, matching posit-sdk-py). 303 is intentionally
+ * excluded: Connect never emits it, and following it as GET against e.g. the
+ * bundles endpoint would do something surprising — better to fail loudly.
+ */
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+
+export const MAX_REDIRECTS = 5;
+
+/**
+ * Replicates axios's baseURL + url combination (plain concatenation, not
+ * URL resolution) so relative Location headers resolve against the URL the
+ * request was actually sent to.
+ */
+export function resolveRequestUrl(config: AxiosRequestConfig): string {
+  const url = config.url ?? "";
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+  const base = (config.baseURL ?? "").replace(/\/+$/, "");
+  return url ? `${base}/${url.replace(/^\/+/, "")}` : base;
+}
+
+/**
+ * Installs manual redirect handling on an axios instance.
+ *
+ * The instance MUST be created with `maxRedirects: 0` so axios stays on its
+ * native http/https transport (which truly streams request bodies); 3xx
+ * responses then reject via validateStatus and land in this error handler,
+ * which re-issues the request through the same instance. Re-issuing through
+ * the instance re-runs the request interceptors, so token-auth signing (which
+ * covers the request path) and cookie forwarding stay correct on every hop.
+ *
+ * Method and body are preserved on 301/302/307/308. Streamed bodies are
+ * recreated per hop via `config.bodyFactory` — never buffered, never dropped.
+ * Credentials are forwarded wherever Location points (the redirect comes from
+ * the user's own configured server), matching rsconnect and posit-sdk-py.
+ */
+export function attachRedirectHandling(instance: AxiosInstance): void {
+  instance.interceptors.response.use(undefined, (error: unknown) => {
+    if (!axios.isAxiosError(error) || !error.response || !error.config) {
+      return Promise.reject(error);
+    }
+    const { status, headers } = error.response;
+    if (!REDIRECT_STATUSES.has(status)) {
+      return Promise.reject(error);
+    }
+    const location = headers["location"];
+    if (typeof location !== "string" || location === "") {
+      return Promise.reject(error);
+    }
+
+    const config = error.config;
+    const redirectCount = (config.redirectCount ?? 0) + 1;
+    const currentUrl = resolveRequestUrl(config);
+    const target = new URL(location, currentUrl).toString();
+
+    if (redirectCount > MAX_REDIRECTS) {
+      return Promise.reject(
+        new Error(
+          `Too many redirects: gave up after ${MAX_REDIRECTS} while requesting ` +
+            `${currentUrl} (next redirect target was ${target})`,
+        ),
+      );
+    }
+
+    // Streamed bodies were consumed (or partially consumed) by the redirected
+    // attempt; a stream cannot be replayed, so recreate it from the factory.
+    if (config.data instanceof Readable) {
+      if (config.bodyFactory === undefined) {
+        return Promise.reject(error);
+      }
+      config.data = config.bodyFactory();
+    }
+
+    config.url = target;
+    // Location is authoritative for the full target URL, query included;
+    // leaving params set would append them a second time.
+    config.params = undefined;
+    config.redirectCount = redirectCount;
+    return instance.request(config);
+  });
+}

--- a/test/connect-api-contracts/src/clients/ts-direct-client.ts
+++ b/test/connect-api-contracts/src/clients/ts-direct-client.ts
@@ -123,7 +123,7 @@ export class TypeScriptDirectClient implements ConnectContractClient {
         // Map id → bundleId to match contract expectations
         const { data } = await c.uploadBundle(
           ContentID(params.contentId as string),
-          Readable.from(Buffer.from(bundleData)),
+          () => Readable.from(Buffer.from(bundleData)),
           bundleData.length,
           checksum,
         );


### PR DESCRIPTION
## Summary

Fixes #4262.

PR #4263 (fixing #4249) made bundle uploads stream from a staged temp file instead of buffering in memory, and set `maxRedirects: 0` on the two upload requests so axios stays on its native http/https transport that truly streams (its default `follow-redirects` transport buffers the whole body in RAM to replay on a redirect, which would reintroduce the OOM #4249 fixed). The regression: a 3xx on upload now surfaces as a raw `Request failed with status code 302` — triggered by `http://`→`https://` upgrades and renamed hosts (e.g. `colorado.rstudio.com` → `colorado.posit.co`).

It also turned out that **every other** Connect request still used axios's `follow-redirects` transport, which on 301/302 rewrites POST→GET, drops the body, and never re-signs the token-auth signature against the redirected path. So redirect handling was broken client-wide, not just for uploads.

## Approach

Manual, client-wide redirect handling in both `@posit-dev/connect-api` and `@posit-dev/connect-cloud-api`:

- A small `redirects.ts` module (duplicated per package — they share no dependency) installs an axios **response error interceptor**. Each instance is created with `maxRedirects: 0` (native streaming transport); a 3xx rejects via `validateStatus` and the interceptor re-issues the request **through the same instance**, so token signing and cookie forwarding re-run per hop.
- Follows **301/302/307/308**, preserving method and body on all of them (libcurl `CURLOPT_POSTREDIR` semantics, matching posit-sdk-py). **303** and Location-less 3xx are deliberately not followed — the original error propagates. Hop limit is **5**, after which a descriptive error names the last Location.
- **Credentials are forwarded** across cross-origin redirects. The redirect target comes from the user's own configured server, so this matches the sibling clients (rsconnect, posit-sdk-py). `http`→`https` scheme upgrades and host renames both work.

## Stream-factory approach (never buffer the bundle)

`uploadBundle` now takes a stream **factory** `() => Readable` instead of a `Readable`. On each redirect hop the interceptor destroys the consumed stream and calls the factory to open a **fresh read stream from disk** — the bundle is re-streamed, never held in memory and never dropped. The API client owns the stream lifecycle end-to-end, so the extension's `cleanUpBundle` now only removes the temp directory. Connect Cloud's presigned-URL upload gets the same treatment via a dedicated redirect-following instance (S3-style presigned endpoints can region-redirect).

Cancellation is unchanged: the original `AbortSignal` rides on the config through every hop, and axios rejects promptly on abort.

## Testing

- `packages/connect-api`: 157 tests (new `redirects.test.ts` + a full redirect matrix through `ConnectAPI` — GET/POST across 301/302/307/308, relative/absolute/cross-origin Location, token re-signing against the target pathname, fresh-stream-per-hop, hop limit, 303, missing Location, abort mid-chain, non-redirect errors). Typecheck clean.
- `packages/connect-cloud-api`: 93 tests incl. instance + presigned-upload redirect coverage. Typecheck clean.
- `extensions/vscode`: full unit suite (1844) green; lint clean.
- `test/connect-api-contracts`: 69 contract tests green (normal-path request shape unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)