### PR TITLE
feat(auth): Connect OAuth authentication (#3878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for signing in to Posit Connect with OAuth when creating a credential. When the server supports it, Publisher signs you in through your browser (no API key or token to copy) and keeps the session fresh automatically, prompting you to sign in again only if it can't. You can still choose to enter an API key instead, and existing API key and token credentials keep working unchanged. (#3878)
+- Support for signing in to Posit Connect with OAuth when creating a credential. When the server supports it, Publisher signs you in through your browser (no API key or token to copy) and keeps the session fresh automatically, prompting you to sign in again only if it can't. You can still choose to enter an API key instead, and existing API key and token credentials keep working unchanged. OAuth requires Posit Connect 2026.02.0 or later; against older servers the browser sign-in uses the existing token flow. (#3878)
+- Added a `positPublisher.useDeviceCodeAuth` setting to always use the OAuth device-code flow for browser sign-in instead of the default loopback redirect, for environments where the redirect back to `localhost` can't complete (for example a browser-based IDE). The device-code flow requires Posit Connect 2026.06.0 or later. (#3878)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for signing in to Posit Connect with OAuth when creating a credential. When the server supports it, Publisher signs you in through your browser (no API key or token to copy) and keeps the session fresh automatically, prompting you to sign in again only if it can't. You can still choose to enter an API key instead, and existing API key and token credentials keep working unchanged. OAuth requires Posit Connect 2026.02.0 or later; against older servers the browser sign-in uses the existing token flow. (#3878)
-- Added a `positPublisher.useDeviceCodeAuth` setting to always use the OAuth device-code flow for browser sign-in instead of the default loopback redirect, for environments where the redirect back to `localhost` can't complete (for example a browser-based IDE). The device-code flow requires Posit Connect 2026.06.0 or later. (#3878)
+- Browser sign-in now works in VS Code and Positron served through Posit Workbench, completing the sign-in through Workbench's OAuth redirect instead of falling back to a code you confirm by hand. This requires a Connect administrator to allow your Workbench server's `/oauth_redirect_callback` URL as a redirect URI; when it isn't allowed, Publisher falls back to the device-code flow automatically. (#3878)
+- Added a `positPublisher.useDeviceCodeAuth` setting as a backup for environments where browser sign-in can't finish redirecting back to the editor. Publisher normally chooses a working redirect on its own, so enable this only if sign-in is having trouble. The device-code flow requires Posit Connect 2026.06.0 or later. (#3878)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for signing in to Posit Connect with OAuth when creating a credential. When the server supports it, Publisher signs you in through your browser (no API key or token to copy) and keeps the session fresh automatically, prompting you to sign in again only if it can't. You can still choose to enter an API key instead, and existing API key and token credentials keep working unchanged. (#3878)
+
 ### Changed
 
 - The "missing package-lock.json" error when publishing Node.js content now states that Connect installs Node.js dependencies with npm, helping publishers who build with yarn or pnpm understand why a `package-lock.json` is required. (#4260)

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -68,6 +68,12 @@
             "markdownDescription": "Controls whether Posit Connect Cloud is available as a publishing destination.",
             "type": "boolean",
             "default": true
+          },
+          "positPublisher.useDeviceCodeAuth": {
+            "markdownDescription": "Always use the OAuth **device-code** flow for browser sign-in, instead of the default loopback (`127.0.0.1` redirect) flow. Enable this if the loopback redirect can't complete in your environment — for example when the editor's browser can't reach the extension host over `localhost`.",
+            "type": "boolean",
+            "default": false,
+            "scope": "machine-overridable"
           }
         }
       }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -70,7 +70,7 @@
             "default": true
           },
           "positPublisher.useDeviceCodeAuth": {
-            "markdownDescription": "Always use the OAuth **device-code** flow for browser sign-in, instead of the default loopback (`127.0.0.1` redirect) flow. Enable this if the loopback redirect can't complete in your environment — for example when the editor's browser can't reach the extension host over `localhost`.",
+            "markdownDescription": "Use the OAuth **device-code** flow for Posit Connect browser sign-in instead of redirecting back to the editor automatically. Publisher normally picks a redirect that works in your environment, and falls back to the device-code flow on its own when none does. Enable this as a backup if browser sign-in is having trouble completing — you'll confirm a short code in the browser instead. Requires Posit Connect 2026.06.0 or later.",
             "type": "boolean",
             "default": false,
             "scope": "machine-overridable"

--- a/extensions/vscode/src/__mocks__/logging.ts
+++ b/extensions/vscode/src/__mocks__/logging.ts
@@ -8,5 +8,3 @@ export const logger = {
   warn: vi.fn(),
   error: vi.fn(),
 };
-
-export const logSignInDiagnostic = vi.fn();

--- a/extensions/vscode/src/__mocks__/logging.ts
+++ b/extensions/vscode/src/__mocks__/logging.ts
@@ -8,3 +8,5 @@ export const logger = {
   warn: vi.fn(),
   error: vi.fn(),
 };
+
+export const logSignInDiagnostic = vi.fn();

--- a/extensions/vscode/src/api/types/credentials.ts
+++ b/extensions/vscode/src/api/types/credentials.ts
@@ -5,8 +5,9 @@ import { GUID } from "@posit-dev/connect-api";
 import { AgentError } from "./error";
 import { ServerType } from "./contentRecords";
 
-// NOTE: If you add or remove fields here, also update
-// REQUIRED_CREDENTIAL_FIELDS in credentials/storage.ts.
+// NOTE: If you add or remove fields here, also update the field lists in
+// credentials/storage.ts (REQUIRED_CREDENTIAL_FIELDS and, for fields added after
+// v1 shipped, OPTIONAL_CREDENTIAL_FIELDS so older stored records still parse).
 export type Credential = {
   guid: GUID;
   name: string;
@@ -20,6 +21,10 @@ export type Credential = {
   cloudEnvironment: string;
   token: string;
   privateKey: string;
+  /** OAuth 2.0 dynamic-client-registration client id (Connect OAuth). "" when unused. */
+  oauthClientId: string;
+  /** ISO-8601 access-token expiry for Connect OAuth. "" when unused/unknown. */
+  tokenExpiresAt: string;
   serverType: ServerType;
 };
 

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({
   uiKind: 1, // UIKind.Desktop
   remoteName: undefined as string | undefined,
+  forceDeviceCode: false,
   registerClient: vi.fn(),
   buildAuthorizeUrl: vi.fn(),
   exchangeAuthCode: vi.fn(),
@@ -28,6 +29,11 @@ vi.mock("vscode", () => ({
   UIKind: { Desktop: 1, Web: 2 },
   Uri: { parse: (s: string) => ({ toString: () => s }) },
   window: { showInformationMessage: vi.fn(() => Promise.resolve(undefined)) },
+  workspace: {
+    getConfiguration: () => ({
+      get: (_key: string, _def?: unknown) => h.forceDeviceCode,
+    }),
+  },
 }));
 
 vi.mock("src/logging", () => ({
@@ -95,6 +101,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.uiKind = 1;
   h.remoteName = undefined;
+  h.forceDeviceCode = false;
   h.registerClient.mockResolvedValue({ client_id: "client-abc" });
 });
 
@@ -188,6 +195,18 @@ describe("ConnectOAuthActivator redirect selection", () => {
   it("uses the device flow when attached to a remote host", async () => {
     h.uiKind = 1; // Desktop UI…
     h.remoteName = "ssh-remote"; // …but the extension host is remote
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the device flow on desktop when useDeviceCodeAuth is enabled", async () => {
+    h.uiKind = 1; // Desktop, local…
+    h.remoteName = undefined;
+    h.forceDeviceCode = true; // …but the override forces device code
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
 
     await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  uiKind: 1, // UIKind.Desktop
+  remoteName: undefined as string | undefined,
+  registerClient: vi.fn(),
+  buildAuthorizeUrl: vi.fn(),
+  exchangeAuthCode: vi.fn(),
+  startDeviceAuth: vi.fn(),
+  pollDeviceToken: vi.fn(),
+  startLoopbackServer: vi.fn(),
+  getCurrentUser: vi.fn(),
+  openExternal: vi.fn((..._args: unknown[]) => Promise.resolve(true)),
+}));
+
+vi.mock("vscode", () => ({
+  env: {
+    get uiKind() {
+      return h.uiKind;
+    },
+    get remoteName() {
+      return h.remoteName;
+    },
+    openExternal: (...args: unknown[]) => h.openExternal(...args),
+  },
+  UIKind: { Desktop: 1, Web: 2 },
+  Uri: { parse: (s: string) => ({ toString: () => s }) },
+  window: { showInformationMessage: vi.fn(() => Promise.resolve(undefined)) },
+}));
+
+vi.mock("src/logging", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("src/utils/progress", () => ({
+  showProgress: (_t: string, _v: string, cb: () => unknown) => cb(),
+}));
+
+vi.mock("src/utils/errors", () => ({
+  getMessageFromError: (e: unknown) => String(e),
+}));
+
+vi.mock("@posit-dev/connect-api", () => ({
+  ConnectAPI: class {
+    getCurrentUser = h.getCurrentUser;
+  },
+}));
+
+vi.mock("./client", () => ({
+  OAuthClient: class {
+    registerClient = h.registerClient;
+    buildAuthorizeUrl = h.buildAuthorizeUrl;
+    exchangeAuthCode = h.exchangeAuthCode;
+    startDeviceAuth = h.startDeviceAuth;
+    pollDeviceToken = h.pollDeviceToken;
+  },
+  tokenExpiresAt: () => "2099-01-01T00:00:00.000Z",
+}));
+
+vi.mock("./discovery", () => ({ discoverOAuthMetadata: vi.fn() }));
+
+vi.mock("./loopback", () => ({
+  startLoopbackServer: (...args: unknown[]) => h.startLoopbackServer(...args),
+}));
+
+vi.mock("./pkce", () => ({
+  generatePkcePair: () => ({ verifier: "verifier", challenge: "challenge" }),
+  generateState: () => "state-123",
+}));
+
+import { ConnectOAuthActivator } from "./activator";
+import { OAuthMetadata } from "./types";
+
+const METADATA: OAuthMetadata = {
+  issuer: "https://connect.example.com",
+  authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+  token_endpoint: "https://connect.example.com/oauth/v1/token",
+  registration_endpoint: "https://connect.example.com/oauth/v1/register",
+  device_authorization_endpoint:
+    "https://connect.example.com/oauth/v1/device/authorize",
+};
+
+function makeActivator(): ConnectOAuthActivator {
+  return new ConnectOAuthActivator(
+    "https://connect.example.com",
+    METADATA,
+    "view-id",
+    false,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.uiKind = 1;
+  h.remoteName = undefined;
+  h.registerClient.mockResolvedValue({ client_id: "client-abc" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ConnectOAuthActivator redirect selection", () => {
+  it("uses loopback on desktop (local)", async () => {
+    h.uiKind = 1; // Desktop
+    h.remoteName = undefined;
+    h.startLoopbackServer.mockResolvedValue({
+      redirectUri: "http://127.0.0.1:5000/callback",
+      waitForCode: () => Promise.resolve("auth-code"),
+      close: vi.fn(),
+    });
+    h.buildAuthorizeUrl.mockReturnValue(
+      "https://connect.example.com/authorize",
+    );
+    h.exchangeAuthCode.mockResolvedValue({
+      access_token: "at",
+      token_type: "Bearer",
+      refresh_token: "rt",
+      expires_in: 3600,
+    });
+    h.getCurrentUser.mockResolvedValue({ username: "publisher1" });
+
+    const result = await makeActivator().authenticate();
+
+    expect(h.startLoopbackServer).toHaveBeenCalledTimes(1);
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      oauthClientId: "client-abc",
+      accessToken: "at",
+      refreshToken: "rt",
+      userName: "publisher1",
+    });
+  });
+
+  it("uses the device flow in a web UI (e.g. Positron on Workbench)", async () => {
+    h.uiKind = 2; // Web
+    h.remoteName = undefined;
+    // Sentinel: prove the device path was taken without running the poll loop.
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-opens the verification URL as a raw string before polling (device flow)", async () => {
+    vi.useFakeTimers();
+    try {
+      h.uiKind = 2; // Web
+      h.startDeviceAuth.mockResolvedValue({
+        device_code: "dc",
+        user_code: "WXYZ-1234",
+        verification_uri: "https://connect.example.com/device",
+        verification_uri_complete:
+          "https://connect.example.com/device?user_code=WXYZ-1234",
+        expires_in: 600,
+        interval: 1,
+      });
+      h.pollDeviceToken.mockResolvedValue({
+        done: true,
+        response: {
+          access_token: "at",
+          token_type: "Bearer",
+          refresh_token: "rt",
+        },
+      });
+      h.getCurrentUser.mockResolvedValue({ username: "publisher1" });
+
+      const promise = makeActivator().authenticate();
+      await vi.advanceTimersByTimeAsync(1500); // flush pre-poll awaits + 1s sleep
+      const result = await promise;
+
+      // Opened automatically (not gated on a button) and as a raw string, not a
+      // parsed Uri — the proven Workbench mechanism.
+      expect(h.openExternal).toHaveBeenCalledWith(
+        "https://connect.example.com/device?user_code=WXYZ-1234",
+      );
+      expect(h.startLoopbackServer).not.toHaveBeenCalled();
+      expect(result.accessToken).toBe("at");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the device flow when attached to a remote host", async () => {
+    h.uiKind = 1; // Desktop UI…
+    h.remoteName = "ssh-remote"; // …but the extension host is remote
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -319,48 +319,8 @@ describe("ConnectOAuthActivator Posit Workbench flow", () => {
 
 describe("ConnectOAuthActivator sign-in diagnostics", () => {
   // These lines are the artifact a user is asked to paste back when browser
-  // sign-in behaves unexpectedly, so the facts that determine the transport and
-  // the reason for any fallback must all be present.
-  it("records the full environment before choosing a transport", async () => {
-    h.uiKind = 2;
-    h.remoteName = "ssh-remote";
-    h.detectWorkbench.mockReturnValue(WORKBENCH);
-    h.isWorkbenchRelayReachable.mockResolvedValue(true);
-    h.pollWorkbenchAuthCode.mockResolvedValue("auth-code");
-    process.env.RS_SERVER_URL = "https://workbench.example.com/?token=abc";
-    process.env.RS_SERVER_ADDRESS = "http://localhost:8787";
-
-    try {
-      await makeActivator().authenticate();
-    } finally {
-      delete process.env.RS_SERVER_URL;
-      delete process.env.RS_SERVER_ADDRESS;
-    }
-
-    const log = signInLog();
-    expect(log).toContain("uiKind=web");
-    expect(log).toContain("remote=ssh-remote");
-    expect(log).toContain("useDeviceCodeAuth=false");
-    expect(log).toContain("workbench=yes");
-    expect(log).toContain(
-      "RS_SERVER_URL=https://workbench.example.com/?token=abc",
-    );
-    expect(log).toContain("RS_SERVER_ADDRESS=http://localhost:8787");
-    expect(log).toContain("deviceFlowAdvertised=yes");
-  });
-
-  it("distinguishes an undetected Workbench session from absent env vars", async () => {
-    h.uiKind = 2;
-    h.detectWorkbench.mockReturnValue(undefined);
-    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
-
-    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
-
-    const log = signInLog();
-    expect(log).toContain("workbench=no");
-    expect(log).toContain("RS_SERVER_URL=unset");
-  });
-
+  // sign-in behaves unexpectedly, so the transport chosen and the reason for
+  // any fallback must both be present.
   it("names the setting when the device-code override forces the flow", async () => {
     h.forceDeviceCode = true;
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
@@ -368,7 +328,6 @@ describe("ConnectOAuthActivator sign-in diagnostics", () => {
     await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
 
     const log = signInLog();
-    expect(log).toContain("useDeviceCodeAuth=true");
     expect(log).toContain("positPublisher.useDeviceCodeAuth");
     expect(log).toContain("will use the device code flow");
   });

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -17,11 +17,11 @@ const h = vi.hoisted(() => ({
   pollWorkbenchAuthCode: vi.fn(),
   getCurrentUser: vi.fn(),
   openExternal: vi.fn((..._args: unknown[]) => Promise.resolve(true)),
-  logSignInDiagnostic: vi.fn((..._args: unknown[]) => undefined),
+  loggerDebug: vi.fn((..._args: unknown[]) => undefined),
 }));
 
 /** Every sign-in diagnostic emitted during the current test, joined. */
-const signInLog = () => h.logSignInDiagnostic.mock.calls.flat().join("\n");
+const signInLog = () => h.loggerDebug.mock.calls.flat().join("\n");
 
 vi.mock("vscode", () => ({
   env: {
@@ -44,8 +44,12 @@ vi.mock("vscode", () => ({
 }));
 
 vi.mock("src/logging", () => ({
-  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-  logSignInDiagnostic: (...args: unknown[]) => h.logSignInDiagnostic(...args),
+  logger: {
+    debug: (...args: unknown[]) => h.loggerDebug(...args),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 vi.mock("src/utils/progress", () => ({

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -17,7 +17,11 @@ const h = vi.hoisted(() => ({
   pollWorkbenchAuthCode: vi.fn(),
   getCurrentUser: vi.fn(),
   openExternal: vi.fn((..._args: unknown[]) => Promise.resolve(true)),
+  logSignInDiagnostic: vi.fn((..._args: unknown[]) => undefined),
 }));
+
+/** Every sign-in diagnostic emitted during the current test, joined. */
+const signInLog = () => h.logSignInDiagnostic.mock.calls.flat().join("\n");
 
 vi.mock("vscode", () => ({
   env: {
@@ -41,6 +45,7 @@ vi.mock("vscode", () => ({
 
 vi.mock("src/logging", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logSignInDiagnostic: (...args: unknown[]) => h.logSignInDiagnostic(...args),
 }));
 
 vi.mock("src/utils/progress", () => ({
@@ -49,6 +54,7 @@ vi.mock("src/utils/progress", () => ({
 
 vi.mock("src/utils/errors", () => ({
   getMessageFromError: (e: unknown) => String(e),
+  describeError: (e: unknown) => String(e),
 }));
 
 vi.mock("@posit-dev/connect-api", () => ({
@@ -308,6 +314,144 @@ describe("ConnectOAuthActivator Posit Workbench flow", () => {
       "Authorization was denied.",
     );
     expect(h.startDeviceAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe("ConnectOAuthActivator sign-in diagnostics", () => {
+  // These lines are the artifact a user is asked to paste back when browser
+  // sign-in behaves unexpectedly, so the facts that determine the transport and
+  // the reason for any fallback must all be present.
+  it("records the full environment before choosing a transport", async () => {
+    h.uiKind = 2;
+    h.remoteName = "ssh-remote";
+    h.detectWorkbench.mockReturnValue(WORKBENCH);
+    h.isWorkbenchRelayReachable.mockResolvedValue(true);
+    h.pollWorkbenchAuthCode.mockResolvedValue("auth-code");
+    process.env.RS_SERVER_URL = "https://workbench.example.com/?token=abc";
+    process.env.RS_SERVER_ADDRESS = "http://localhost:8787";
+
+    try {
+      await makeActivator().authenticate();
+    } finally {
+      delete process.env.RS_SERVER_URL;
+      delete process.env.RS_SERVER_ADDRESS;
+    }
+
+    const log = signInLog();
+    expect(log).toContain("uiKind=web");
+    expect(log).toContain("remote=ssh-remote");
+    expect(log).toContain("useDeviceCodeAuth=false");
+    expect(log).toContain("workbench=yes");
+    expect(log).toContain(
+      "RS_SERVER_URL=https://workbench.example.com/?token=abc",
+    );
+    expect(log).toContain("RS_SERVER_ADDRESS=http://localhost:8787");
+    expect(log).toContain("deviceFlowAdvertised=yes");
+  });
+
+  it("distinguishes an undetected Workbench session from absent env vars", async () => {
+    h.uiKind = 2;
+    h.detectWorkbench.mockReturnValue(undefined);
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    const log = signInLog();
+    expect(log).toContain("workbench=no");
+    expect(log).toContain("RS_SERVER_URL=unset");
+  });
+
+  it("names the setting when the device-code override forces the flow", async () => {
+    h.forceDeviceCode = true;
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    const log = signInLog();
+    expect(log).toContain("useDeviceCodeAuth=true");
+    expect(log).toContain("positPublisher.useDeviceCodeAuth");
+    expect(log).toContain("will use the device code flow");
+  });
+
+  it("reports the chosen transport on the happy path", async () => {
+    stubLoopbackSuccess();
+
+    await makeActivator().authenticate();
+
+    expect(signInLog()).toContain("will use the loopback flow");
+  });
+
+  it("explains an unreachable Workbench relay, naming the address probed", async () => {
+    h.uiKind = 2;
+    h.detectWorkbench.mockReturnValue(WORKBENCH);
+    h.isWorkbenchRelayReachable.mockResolvedValue(false);
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    const log = signInLog();
+    expect(log).toContain(
+      "falling back from the Posit Workbench redirect relay flow to the device code flow",
+    );
+    expect(log).toContain("http://localhost:8787/oauth_code");
+  });
+
+  it("explains a rejected redirect URI, naming the URI to allowlist", async () => {
+    h.uiKind = 2;
+    h.detectWorkbench.mockReturnValue(WORKBENCH);
+    h.isWorkbenchRelayReachable.mockResolvedValue(true);
+    h.registerClient.mockRejectedValueOnce(new Error("invalid redirect_uri"));
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    const log = signInLog();
+    expect(log).toContain(
+      "https://workbench.example.com/oauth_redirect_callback",
+    );
+    expect(log).toContain("allowed redirect URIs");
+  });
+
+  it("explains a loopback bind failure", async () => {
+    h.startLoopbackServer.mockRejectedValue(new Error("EADDRINUSE"));
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    const log = signInLog();
+    expect(log).toContain(
+      "falling back from the loopback flow to the device code flow",
+    );
+    expect(log).toContain("EADDRINUSE");
+  });
+
+  it("never logs the authorization code, PKCE verifier, or tokens", async () => {
+    h.uiKind = 2;
+    h.detectWorkbench.mockReturnValue(WORKBENCH);
+    h.isWorkbenchRelayReachable.mockResolvedValue(true);
+    // Distinctive values so a match cannot be an incidental substring.
+    h.pollWorkbenchAuthCode.mockResolvedValue("SECRET-AUTH-CODE");
+    h.exchangeAuthCode.mockResolvedValue({
+      access_token: "SECRET-ACCESS-TOKEN",
+      token_type: "Bearer",
+      refresh_token: "SECRET-REFRESH-TOKEN",
+      expires_in: 3600,
+    });
+
+    const result = await makeActivator().authenticate();
+    // Guard against the flow short-circuiting and vacuously logging nothing.
+    expect(result.accessToken).toBe("SECRET-ACCESS-TOKEN");
+    expect(signInLog()).not.toBe("");
+
+    for (const secret of [
+      "SECRET-AUTH-CODE",
+      "SECRET-ACCESS-TOKEN",
+      "SECRET-REFRESH-TOKEN",
+      "verifier", // the PKCE verifier stubbed by the pkce mock
+      "challenge",
+    ]) {
+      expect(signInLog()).not.toContain(secret);
+    }
   });
 });
 

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -12,6 +12,9 @@ const h = vi.hoisted(() => ({
   startDeviceAuth: vi.fn(),
   pollDeviceToken: vi.fn(),
   startLoopbackServer: vi.fn(),
+  detectWorkbench: vi.fn(),
+  isWorkbenchRelayReachable: vi.fn(),
+  pollWorkbenchAuthCode: vi.fn(),
   getCurrentUser: vi.fn(),
   openExternal: vi.fn((..._args: unknown[]) => Promise.resolve(true)),
 }));
@@ -76,8 +79,24 @@ vi.mock("./pkce", () => ({
   generateState: () => "state-123",
 }));
 
+vi.mock("./workbench", async () => {
+  // Keep the real WorkbenchRelayError so `instanceof` narrowing in the activator
+  // is exercised, and the real redirect-URI builder (pure string math).
+  const actual =
+    await vi.importActual<typeof import("./workbench")>("./workbench");
+  return {
+    ...actual,
+    detectWorkbench: (...args: unknown[]) => h.detectWorkbench(...args),
+    isWorkbenchRelayReachable: (...args: unknown[]) =>
+      h.isWorkbenchRelayReachable(...args),
+    pollWorkbenchAuthCode: (...args: unknown[]) =>
+      h.pollWorkbenchAuthCode(...args),
+  };
+});
+
 import { ConnectOAuthActivator } from "./activator";
 import { OAuthMetadata } from "./types";
+import { WorkbenchRelayError } from "./workbench";
 
 const METADATA: OAuthMetadata = {
   issuer: "https://connect.example.com",
@@ -86,6 +105,18 @@ const METADATA: OAuthMetadata = {
   registration_endpoint: "https://connect.example.com/oauth/v1/register",
   device_authorization_endpoint:
     "https://connect.example.com/oauth/v1/device/authorize",
+};
+
+const WORKBENCH = {
+  externalServerUrl: "https://workbench.example.com",
+  serverAddress: "http://localhost:8787",
+};
+
+const TOKENS = {
+  access_token: "at",
+  token_type: "Bearer",
+  refresh_token: "rt",
+  expires_in: 3600,
 };
 
 function makeActivator(): ConnectOAuthActivator {
@@ -97,42 +128,45 @@ function makeActivator(): ConnectOAuthActivator {
   );
 }
 
+/** Makes the loopback transport succeed end to end. */
+function stubLoopbackSuccess(): void {
+  h.startLoopbackServer.mockResolvedValue({
+    redirectUri: "http://127.0.0.1:5000/callback",
+    waitForCode: () => Promise.resolve("auth-code"),
+    close: vi.fn(),
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   h.uiKind = 1;
   h.remoteName = undefined;
   h.forceDeviceCode = false;
   h.registerClient.mockResolvedValue({ client_id: "client-abc" });
+  h.buildAuthorizeUrl.mockReturnValue("https://connect.example.com/authorize");
+  h.exchangeAuthCode.mockResolvedValue(TOKENS);
+  h.getCurrentUser.mockResolvedValue({ username: "publisher1" });
+  // Not in Workbench unless a test says so.
+  h.detectWorkbench.mockReturnValue(undefined);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("ConnectOAuthActivator redirect selection", () => {
+describe("ConnectOAuthActivator transport selection", () => {
   it("uses loopback on desktop (local)", async () => {
-    h.uiKind = 1; // Desktop
-    h.remoteName = undefined;
-    h.startLoopbackServer.mockResolvedValue({
-      redirectUri: "http://127.0.0.1:5000/callback",
-      waitForCode: () => Promise.resolve("auth-code"),
-      close: vi.fn(),
-    });
-    h.buildAuthorizeUrl.mockReturnValue(
-      "https://connect.example.com/authorize",
-    );
-    h.exchangeAuthCode.mockResolvedValue({
-      access_token: "at",
-      token_type: "Bearer",
-      refresh_token: "rt",
-      expires_in: 3600,
-    });
-    h.getCurrentUser.mockResolvedValue({ username: "publisher1" });
+    stubLoopbackSuccess();
 
     const result = await makeActivator().authenticate();
 
     expect(h.startLoopbackServer).toHaveBeenCalledTimes(1);
     expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    // Loopback registers the port-less loopback redirect; Connect matches it
+    // against the ephemeral port per RFC 8252.
+    expect(h.registerClient).toHaveBeenCalledWith(METADATA, [
+      "http://127.0.0.1/callback",
+    ]);
     expect(result).toMatchObject({
       oauthClientId: "client-abc",
       accessToken: "at",
@@ -141,9 +175,16 @@ describe("ConnectOAuthActivator redirect selection", () => {
     });
   });
 
-  it("uses the device flow in a web UI (e.g. Positron on Workbench)", async () => {
+  it("falls back to the device flow when the loopback listener can't bind", async () => {
+    h.startLoopbackServer.mockRejectedValue(new Error("EADDRINUSE"));
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the device flow in a web UI outside Workbench", async () => {
     h.uiKind = 2; // Web
-    h.remoteName = undefined;
     // Sentinel: prove the device path was taken without running the poll loop.
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
 
@@ -151,45 +192,6 @@ describe("ConnectOAuthActivator redirect selection", () => {
 
     expect(h.startLoopbackServer).not.toHaveBeenCalled();
     expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
-  });
-
-  it("auto-opens the verification URL as a raw string before polling (device flow)", async () => {
-    vi.useFakeTimers();
-    try {
-      h.uiKind = 2; // Web
-      h.startDeviceAuth.mockResolvedValue({
-        device_code: "dc",
-        user_code: "WXYZ-1234",
-        verification_uri: "https://connect.example.com/device",
-        verification_uri_complete:
-          "https://connect.example.com/device?user_code=WXYZ-1234",
-        expires_in: 600,
-        interval: 1,
-      });
-      h.pollDeviceToken.mockResolvedValue({
-        done: true,
-        response: {
-          access_token: "at",
-          token_type: "Bearer",
-          refresh_token: "rt",
-        },
-      });
-      h.getCurrentUser.mockResolvedValue({ username: "publisher1" });
-
-      const promise = makeActivator().authenticate();
-      await vi.advanceTimersByTimeAsync(1500); // flush pre-poll awaits + 1s sleep
-      const result = await promise;
-
-      // Opened automatically (not gated on a button) and as a raw string, not a
-      // parsed Uri — the proven Workbench mechanism.
-      expect(h.openExternal).toHaveBeenCalledWith(
-        "https://connect.example.com/device?user_code=WXYZ-1234",
-      );
-      expect(h.startLoopbackServer).not.toHaveBeenCalled();
-      expect(result.accessToken).toBe("at");
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("uses the device flow when attached to a remote host", async () => {
@@ -203,15 +205,142 @@ describe("ConnectOAuthActivator redirect selection", () => {
     expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the device flow on desktop when useDeviceCodeAuth is enabled", async () => {
-    h.uiKind = 1; // Desktop, local…
-    h.remoteName = undefined;
-    h.forceDeviceCode = true; // …but the override forces device code
+  it("uses the device flow when useDeviceCodeAuth is enabled, even in Workbench", async () => {
+    h.forceDeviceCode = true;
+    h.detectWorkbench.mockReturnValue(WORKBENCH);
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
 
     await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
 
     expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(h.isWorkbenchRelayReachable).not.toHaveBeenCalled();
     expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ConnectOAuthActivator Posit Workbench flow", () => {
+  beforeEach(() => {
+    // Browser-served VS Code/Positron on Workbench.
+    h.uiKind = 2;
+    h.detectWorkbench.mockReturnValue(WORKBENCH);
+    h.isWorkbenchRelayReachable.mockResolvedValue(true);
+    h.pollWorkbenchAuthCode.mockResolvedValue("auth-code");
+  });
+
+  it("runs auth code + PKCE through the Workbench redirect relay", async () => {
+    const result = await makeActivator().authenticate();
+
+    const redirectUri = "https://workbench.example.com/oauth_redirect_callback";
+    expect(h.registerClient).toHaveBeenCalledWith(METADATA, [redirectUri]);
+    expect(h.buildAuthorizeUrl).toHaveBeenCalledWith(METADATA, {
+      clientId: "client-abc",
+      redirectUri,
+      codeChallenge: "challenge",
+      state: "state-123",
+    });
+    // Opened as a raw string so the percent-encoded redirect_uri survives.
+    expect(h.openExternal).toHaveBeenCalledWith(
+      "https://connect.example.com/authorize",
+    );
+    expect(h.pollWorkbenchAuthCode).toHaveBeenCalledWith(
+      WORKBENCH,
+      "state-123",
+      false,
+    );
+    expect(h.exchangeAuthCode).toHaveBeenCalledWith(METADATA, {
+      code: "auth-code",
+      codeVerifier: "verifier",
+      redirectUri,
+      clientId: "client-abc",
+    });
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      oauthClientId: "client-abc",
+      accessToken: "at",
+      userName: "publisher1",
+    });
+  });
+
+  it("falls back to the device flow when the relay is unreachable", async () => {
+    h.isWorkbenchRelayReachable.mockResolvedValue(false);
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    // No browser was sent anywhere before the fallback.
+    expect(h.openExternal).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the device flow when Connect rejects the Workbench redirect URI", async () => {
+    // Connect only accepts non-loopback redirect URIs an administrator has
+    // allowlisted, so registration is where an unlisted Workbench URL fails.
+    h.registerClient.mockRejectedValueOnce(new Error("invalid redirect_uri"));
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+
+    expect(h.openExternal).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+    // The device flow re-registers under the loopback URI Connect always allows.
+    expect(h.registerClient).toHaveBeenLastCalledWith(METADATA, [
+      "http://127.0.0.1/callback",
+    ]);
+  });
+
+  it("falls back to the device flow on a non-terminal relay failure", async () => {
+    h.pollWorkbenchAuthCode.mockRejectedValue(
+      new WorkbenchRelayError("unexpected status (500)", false),
+    );
+    h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
+
+    await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
+    expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a terminal relay failure instead of retrying elsewhere", async () => {
+    h.pollWorkbenchAuthCode.mockRejectedValue(
+      new WorkbenchRelayError("Authorization was denied.", true),
+    );
+
+    await expect(makeActivator().authenticate()).rejects.toThrow(
+      "Authorization was denied.",
+    );
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe("ConnectOAuthActivator device flow", () => {
+  it("auto-opens the verification URL as a raw string before polling", async () => {
+    vi.useFakeTimers();
+    try {
+      h.uiKind = 2; // Web, not Workbench → device flow
+      h.startDeviceAuth.mockResolvedValue({
+        device_code: "dc",
+        user_code: "WXYZ-1234",
+        verification_uri: "https://connect.example.com/device",
+        verification_uri_complete:
+          "https://connect.example.com/device?user_code=WXYZ-1234",
+        expires_in: 600,
+        interval: 1,
+      });
+      h.pollDeviceToken.mockResolvedValue({ done: true, response: TOKENS });
+
+      const promise = makeActivator().authenticate();
+      await vi.advanceTimersByTimeAsync(1500); // flush pre-poll awaits + 1s sleep
+      const result = await promise;
+
+      // Opened automatically (not gated on a button) and as a raw string, not a
+      // parsed Uri — the proven Workbench mechanism.
+      expect(h.openExternal).toHaveBeenCalledWith(
+        "https://connect.example.com/device?user_code=WXYZ-1234",
+      );
+      expect(h.startLoopbackServer).not.toHaveBeenCalled();
+      expect(result.accessToken).toBe("at");
+      expect(result.oauthClientId).toBe("client-abc");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
-import { env, UIKind, window } from "vscode";
+import { env, UIKind, window, workspace } from "vscode";
 import { ConnectAPI } from "@posit-dev/connect-api";
 
 import { logger } from "src/logging";
@@ -111,6 +111,15 @@ export class ConnectOAuthActivator {
    * until timeout. Detect those environments up front and use the device flow.
    */
   private isLoopbackViable(): boolean {
+    // Explicit override: `positPublisher.useDeviceCodeAuth` forces the
+    // device-code flow regardless of environment (e.g. when the loopback
+    // redirect can't complete even on desktop).
+    const useDeviceCodeAuth = workspace
+      .getConfiguration("positPublisher")
+      .get<boolean>("useDeviceCodeAuth", false);
+    if (useDeviceCodeAuth) {
+      return false;
+    }
     return env.uiKind === UIKind.Desktop && !env.remoteName;
   }
 
@@ -178,20 +187,12 @@ export class ConnectOAuthActivator {
     const verificationUri =
       device.verification_uri_complete ?? device.verification_uri;
 
-    // Surface the user code (verification_uri_complete usually pre-fills it, but
-    // show it in case it must be entered manually) with a one-click copy.
-    // Non-blocking — the poll below is what waits.
-    void window
-      .showInformationMessage(
-        `Posit Connect sign-in: enter code ${device.user_code} in the browser tab that opened (${device.verification_uri}).`,
-        "Copy Code",
-      )
-      .then((choice) => {
-        if (choice === "Copy Code") {
-          return env.clipboard.writeText(device.user_code);
-        }
-        return undefined;
-      });
+    // Show the user code so it can be visually confirmed against the code on
+    // Connect's device page (verification_uri_complete pre-fills it — the user
+    // just checks it matches). Non-blocking — the poll below is what waits.
+    void window.showInformationMessage(
+      `Posit Connect sign-in: confirm the code ${device.user_code} matches the one shown in the browser tab that opened.`,
+    );
 
     // Auto-open the verification page, mirroring
     // ConnectAuthTokenActivator.openTokenClaimUrl — the mechanism proven to work

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -24,7 +24,8 @@ export interface OAuthAuthResult extends OAuthTokens {
   userName: string;
 }
 
-const DEVICE_POLL_MS = 5_000;
+// Fallback device poll interval when the server omits `interval` (RFC 8628).
+const DEFAULT_DEVICE_POLL_MS = 5_000;
 const SLOW_DOWN_INCREMENT_MS = 5_000;
 
 /**
@@ -178,11 +179,19 @@ export class ConnectOAuthActivator {
       device.verification_uri_complete ?? device.verification_uri;
 
     // Surface the user code (verification_uri_complete usually pre-fills it, but
-    // show it in case it must be entered manually). Non-blocking — the poll below
-    // is what waits.
-    void window.showInformationMessage(
-      `Posit Connect sign-in: enter code ${device.user_code} in the browser tab that opened (${device.verification_uri}).`,
-    );
+    // show it in case it must be entered manually) with a one-click copy.
+    // Non-blocking — the poll below is what waits.
+    void window
+      .showInformationMessage(
+        `Posit Connect sign-in: enter code ${device.user_code} in the browser tab that opened (${device.verification_uri}).`,
+        "Copy Code",
+      )
+      .then((choice) => {
+        if (choice === "Copy Code") {
+          return env.clipboard.writeText(device.user_code);
+        }
+        return undefined;
+      });
 
     // Auto-open the verification page, mirroring
     // ConnectAuthTokenActivator.openTokenClaimUrl — the mechanism proven to work
@@ -201,7 +210,7 @@ export class ConnectOAuthActivator {
     clientId: string,
     device: DeviceAuthResponse,
   ): Promise<OAuthTokenResponse> {
-    let interval = (device.interval ?? 5) * 1000 || DEVICE_POLL_MS;
+    let interval = (device.interval ?? 5) * 1000 || DEFAULT_DEVICE_POLL_MS;
     const deadline = Date.now() + device.expires_in * 1000;
 
     while (Date.now() < deadline) {

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -3,7 +3,7 @@
 import { env, UIKind, window, workspace } from "vscode";
 import { ConnectAPI } from "@posit-dev/connect-api";
 
-import { logger, logSignInDiagnostic } from "src/logging";
+import { logger } from "src/logging";
 import { describeError, getMessageFromError } from "src/utils/errors";
 import { showProgress } from "src/utils/progress";
 import { OAuthClient, tokenExpiresAt } from "./client";
@@ -174,9 +174,7 @@ export class ConnectOAuthActivator {
 
   /** Announces the chosen transport and, in plain terms, why. */
   private logTransport(transport: string, why: string): void {
-    logSignInDiagnostic(
-      `OAuth sign-in will use the ${transport} flow — ${why}`,
-    );
+    logger.debug(`OAuth sign-in will use the ${transport} flow — ${why}`);
   }
 
   /**
@@ -185,7 +183,7 @@ export class ConnectOAuthActivator {
    * transport that was chosen and, if it didn't work out, why it was dropped.
    */
   private logFallback(transport: string, why: string): void {
-    logSignInDiagnostic(
+    logger.debug(
       `OAuth sign-in is falling back from the ${transport} flow to the ` +
         `device code flow — ${why}`,
     );
@@ -261,7 +259,7 @@ export class ConnectOAuthActivator {
         );
         return undefined;
       }
-      logSignInDiagnostic(
+      logger.debug(
         `OAuth sign-in through the Posit Workbench redirect relay failed and ` +
           `cannot fall back: ${describeError(err)}`,
       );

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -129,7 +129,6 @@ export class ConnectOAuthActivator {
    */
   private async authorize(): Promise<AuthorizeResult> {
     const workbench = detectWorkbench();
-    this.logEnvironment(workbench);
 
     if (this.deviceCodeForced()) {
       this.logTransport(
@@ -171,31 +170,6 @@ export class ConnectOAuthActivator {
       return result;
     }
     return this.deviceCodeFlow();
-  }
-
-  /**
-   * Records every input to the transport decision before it is made, so a single
-   * log excerpt explains any outcome without needing to reproduce it. Written at
-   * info level because it is the first thing to ask for when someone reports
-   * "browser sign-in didn't work here".
-   */
-  private logEnvironment(workbench: WorkbenchEnvironment | undefined): void {
-    const env_ = process.env;
-    logSignInDiagnostic(
-      "Posit Connect OAuth sign-in environment: " +
-        [
-          `uiKind=${env.uiKind === UIKind.Web ? "web" : "desktop"}`,
-          `remote=${env.remoteName ?? "none"}`,
-          `useDeviceCodeAuth=${this.deviceCodeForced()}`,
-          `workbench=${workbench ? "yes" : "no"}`,
-          // The raw env vars, so a Workbench session that wasn't detected can be
-          // told apart from one where the vars are missing or malformed. Neither
-          // is a secret — they are server URLs.
-          `RS_SERVER_URL=${env_.RS_SERVER_URL ?? "unset"}`,
-          `RS_SERVER_ADDRESS=${env_.RS_SERVER_ADDRESS ?? "unset"}`,
-          `deviceFlowAdvertised=${this.metadata.device_authorization_endpoint ? "yes" : "no"}`,
-        ].join(", "),
-    );
   }
 
   /** Announces the chosen transport and, in plain terms, why. */

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -3,8 +3,8 @@
 import { env, UIKind, window, workspace } from "vscode";
 import { ConnectAPI } from "@posit-dev/connect-api";
 
-import { logger } from "src/logging";
-import { getMessageFromError } from "src/utils/errors";
+import { logger, logSignInDiagnostic } from "src/logging";
+import { describeError, getMessageFromError } from "src/utils/errors";
 import { showProgress } from "src/utils/progress";
 import { OAuthClient, tokenExpiresAt } from "./client";
 import { discoverOAuthMetadata } from "./discovery";
@@ -128,18 +128,23 @@ export class ConnectOAuthActivator {
    * 4. **Device flow** — the universal fallback.
    */
   private async authorize(): Promise<AuthorizeResult> {
+    const workbench = detectWorkbench();
+    this.logEnvironment(workbench);
+
     if (this.deviceCodeForced()) {
-      logger.info(
-        "positPublisher.useDeviceCodeAuth is enabled; using the OAuth device flow.",
+      this.logTransport(
+        "device code",
+        "the positPublisher.useDeviceCodeAuth setting is enabled, which " +
+          "overrides automatic selection. Turn it off to let Publisher " +
+          "redirect back to the editor.",
       );
       return this.deviceCodeFlow();
     }
 
-    const workbench = detectWorkbench();
     if (workbench) {
-      logger.info(
-        "Detected a Posit Workbench session; using its OAuth redirect relay " +
-          `at ${workbench.externalServerUrl}.`,
+      this.logTransport(
+        "Posit Workbench redirect relay",
+        `redirecting through ${workbenchRedirectUri(workbench)}.`,
       );
       const result = await this.tryWorkbenchFlow(workbench);
       if (result) {
@@ -149,19 +154,67 @@ export class ConnectOAuthActivator {
     }
 
     if (env.uiKind !== UIKind.Desktop || env.remoteName) {
-      logger.info(
-        "A loopback redirect is unreachable from the browser in this " +
-          `environment (uiKind=${env.uiKind === UIKind.Web ? "web" : "desktop"}, ` +
-          `remote=${env.remoteName ?? "none"}); using the OAuth device flow.`,
+      this.logTransport(
+        "device code",
+        "a loopback redirect is unreachable from the browser in this " +
+          "environment, and no Posit Workbench session was detected.",
       );
       return this.deviceCodeFlow();
     }
 
+    this.logTransport(
+      "loopback",
+      "the editor and browser are on the same machine.",
+    );
     const result = await this.tryLoopbackFlow();
     if (result) {
       return result;
     }
     return this.deviceCodeFlow();
+  }
+
+  /**
+   * Records every input to the transport decision before it is made, so a single
+   * log excerpt explains any outcome without needing to reproduce it. Written at
+   * info level because it is the first thing to ask for when someone reports
+   * "browser sign-in didn't work here".
+   */
+  private logEnvironment(workbench: WorkbenchEnvironment | undefined): void {
+    const env_ = process.env;
+    logSignInDiagnostic(
+      "Posit Connect OAuth sign-in environment: " +
+        [
+          `uiKind=${env.uiKind === UIKind.Web ? "web" : "desktop"}`,
+          `remote=${env.remoteName ?? "none"}`,
+          `useDeviceCodeAuth=${this.deviceCodeForced()}`,
+          `workbench=${workbench ? "yes" : "no"}`,
+          // The raw env vars, so a Workbench session that wasn't detected can be
+          // told apart from one where the vars are missing or malformed. Neither
+          // is a secret — they are server URLs.
+          `RS_SERVER_URL=${env_.RS_SERVER_URL ?? "unset"}`,
+          `RS_SERVER_ADDRESS=${env_.RS_SERVER_ADDRESS ?? "unset"}`,
+          `deviceFlowAdvertised=${this.metadata.device_authorization_endpoint ? "yes" : "no"}`,
+        ].join(", "),
+    );
+  }
+
+  /** Announces the chosen transport and, in plain terms, why. */
+  private logTransport(transport: string, why: string): void {
+    logSignInDiagnostic(
+      `OAuth sign-in will use the ${transport} flow — ${why}`,
+    );
+  }
+
+  /**
+   * Announces that a transport was abandoned and the device flow will be tried
+   * instead. Paired with {@link logTransport} so the log always shows both the
+   * transport that was chosen and, if it didn't work out, why it was dropped.
+   */
+  private logFallback(transport: string, why: string): void {
+    logSignInDiagnostic(
+      `OAuth sign-in is falling back from the ${transport} flow to the ` +
+        `device code flow — ${why}`,
+    );
   }
 
   /** Whether the user has forced the device-code flow via settings. */
@@ -184,9 +237,10 @@ export class ConnectOAuthActivator {
     const redirectUri = workbenchRedirectUri(workbench);
 
     if (!(await isWorkbenchRelayReachable(workbench, this.insecure))) {
-      logger.info(
-        "The Posit Workbench OAuth redirect relay did not respond; falling " +
-          "back to the OAuth device flow.",
+      this.logFallback(
+        "Posit Workbench redirect relay",
+        `the relay did not respond at ${workbench.serverAddress}/oauth_code. ` +
+          "Check that RS_SERVER_ADDRESS is reachable from the extension host.",
       );
       return undefined;
     }
@@ -198,11 +252,11 @@ export class ConnectOAuthActivator {
       // Connect rejects a non-loopback redirect URI unless an administrator has
       // added it to the allowed redirect URIs, so this is the expected outcome
       // on a Workbench deployment Connect doesn't know about.
-      logger.info(
-        `Posit Connect did not accept the Posit Workbench redirect URI ` +
-          `${redirectUri} (${getMessageFromError(err)}); falling back to the ` +
-          "OAuth device flow. An administrator can allow this URI on Connect " +
-          "to enable browser sign-in here.",
+      this.logFallback(
+        "Posit Workbench redirect relay",
+        `Posit Connect did not accept the redirect URI ${redirectUri} ` +
+          `(${describeError(err)}). A Connect administrator can add this exact ` +
+          "URI to the allowed redirect URIs to enable browser sign-in here.",
       );
       return undefined;
     }
@@ -227,12 +281,16 @@ export class ConnectOAuthActivator {
       );
     } catch (err) {
       if (err instanceof WorkbenchRelayError && !err.terminal) {
-        logger.info(
-          `The Posit Workbench OAuth relay failed (${err.message}); falling ` +
-            "back to the OAuth device flow.",
+        this.logFallback(
+          "Posit Workbench redirect relay",
+          `the relay failed while waiting for the redirect (${err.message}).`,
         );
         return undefined;
       }
+      logSignInDiagnostic(
+        `OAuth sign-in through the Posit Workbench redirect relay failed and ` +
+          `cannot fall back: ${describeError(err)}`,
+      );
       throw err;
     }
 
@@ -259,9 +317,9 @@ export class ConnectOAuthActivator {
     try {
       loopback = await startLoopbackServer(state);
     } catch (err) {
-      logger.info(
-        `Loopback listener unavailable (${getMessageFromError(err)}); ` +
-          "falling back to OAuth device flow.",
+      this.logFallback(
+        "loopback",
+        `a listener could not be bound on 127.0.0.1 (${describeError(err)}).`,
       );
       return undefined;
     }

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -1,0 +1,244 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { env, UIKind, window } from "vscode";
+import { ConnectAPI } from "@posit-dev/connect-api";
+
+import { logger } from "src/logging";
+import { getMessageFromError } from "src/utils/errors";
+import { showProgress } from "src/utils/progress";
+import { OAuthClient, tokenExpiresAt } from "./client";
+import { discoverOAuthMetadata } from "./discovery";
+import { startLoopbackServer } from "./loopback";
+import { generatePkcePair, generateState } from "./pkce";
+import {
+  DeviceAuthResponse,
+  OAuthMetadata,
+  OAuthTokenResponse,
+  OAuthTokens,
+  OAUTH_LOOPBACK_REDIRECT,
+} from "./types";
+
+/** Result of a successful interactive OAuth sign-in. */
+export interface OAuthAuthResult extends OAuthTokens {
+  /** The authenticated user's username, if it could be retrieved. */
+  userName: string;
+}
+
+const DEVICE_POLL_MS = 5_000;
+const SLOW_DOWN_INCREMENT_MS = 5_000;
+
+/**
+ * Opens a URL in the user's browser, passing the raw string rather than
+ * `Uri.parse(url)`. VS Code's `env.openExternal(Uri.parse(...))` mis-encodes
+ * nested/redirect query params (e.g. the percent-encoded `redirect_uri` in an
+ * OAuth authorize URL) — the same hazard the Connect Cloud flow documents in
+ * multiStepHelper. Passing the string preserves the exact encoding. This routes
+ * to the user's browser in desktop, remote, and web hosts alike, which is why
+ * the device flow (browser Positron on Workbench) can rely on it — mirroring
+ * ConnectAuthTokenActivator.openTokenClaimUrl, the flow proven to work there.
+ */
+async function openExternalUrl(url: string): Promise<void> {
+  // @ts-expect-error env.openExternal is typed for Uri, but the string overload
+  // is what preserves nested-redirect encoding (see comment above).
+  await env.openExternal(url);
+}
+
+/**
+ * Drives the interactive Connect OAuth sign-in from the credential stepper,
+ * mirroring rsconnect-python's login command: discover metadata (if not already
+ * provided), register a public client, run the Authorization Code + PKCE flow
+ * over a loopback listener, and fall back to the device flow when a loopback
+ * port can't be bound. Analogous to {@link ConnectAuthTokenActivator}.
+ */
+export class ConnectOAuthActivator {
+  private readonly client: OAuthClient;
+
+  constructor(
+    private readonly serverUrl: string,
+    private readonly metadata: OAuthMetadata,
+    private readonly viewId: string,
+    private readonly insecure: boolean,
+  ) {
+    this.client = new OAuthClient(insecure);
+  }
+
+  /**
+   * Convenience: probe a server for OAuth metadata and build an activator, or
+   * return `undefined` when the server does not support OAuth.
+   */
+  static async forServer(
+    serverUrl: string,
+    viewId: string,
+    insecure: boolean,
+  ): Promise<ConnectOAuthActivator | undefined> {
+    const metadata = await discoverOAuthMetadata(serverUrl, insecure);
+    if (!metadata) {
+      return undefined;
+    }
+    return new ConnectOAuthActivator(serverUrl, metadata, viewId, insecure);
+  }
+
+  /** Runs the full sign-in flow and returns tokens for a new OAuth credential. */
+  async authenticate(): Promise<OAuthAuthResult> {
+    const registration = await showProgress(
+      "Registering with Posit Connect",
+      this.viewId,
+      () =>
+        this.client.registerClient(this.metadata, [OAUTH_LOOPBACK_REDIRECT]),
+    );
+    const clientId = registration.client_id;
+
+    const tokenResponse = await this.authorize(clientId);
+
+    const tokens: OAuthTokens = {
+      oauthClientId: clientId,
+      accessToken: tokenResponse.access_token,
+      refreshToken: tokenResponse.refresh_token ?? "",
+      tokenExpiresAt: tokenExpiresAt(tokenResponse),
+    };
+
+    const userName = await this.resolveUserName(tokens.accessToken);
+    return { ...tokens, userName };
+  }
+
+  /**
+   * A loopback redirect only works when the extension host and the user's
+   * browser are on the same machine. In a web UI (e.g. Positron served by Posit
+   * Workbench in a browser) or a remote setup (Remote-SSH, Codespaces, WSL), the
+   * browser cannot reach `127.0.0.1` on the extension host — the loopback socket
+   * binds fine on the server but the redirect never arrives, so it would hang
+   * until timeout. Detect those environments up front and use the device flow.
+   */
+  private isLoopbackViable(): boolean {
+    return env.uiKind === UIKind.Desktop && !env.remoteName;
+  }
+
+  /**
+   * Runs the Authorization Code + PKCE flow over loopback, falling back to the
+   * device flow in web/remote environments (where loopback is unreachable) or
+   * when the loopback listener can't start.
+   */
+  private async authorize(clientId: string): Promise<OAuthTokenResponse> {
+    if (!this.isLoopbackViable()) {
+      logger.info(
+        "Loopback redirect is not usable in this environment " +
+          `(uiKind=${env.uiKind === UIKind.Web ? "web" : "desktop"}, ` +
+          `remote=${env.remoteName ?? "none"}); using the OAuth device flow.`,
+      );
+      return this.authorizeWithDeviceCode(clientId);
+    }
+
+    const { verifier, challenge } = generatePkcePair();
+    const state = generateState();
+
+    let loopback;
+    try {
+      loopback = await startLoopbackServer(state);
+    } catch (err) {
+      logger.info(
+        `Loopback listener unavailable (${getMessageFromError(err)}); ` +
+          "falling back to OAuth device flow.",
+      );
+      return this.authorizeWithDeviceCode(clientId);
+    }
+
+    try {
+      const authorizeUrl = this.client.buildAuthorizeUrl(this.metadata, {
+        clientId,
+        redirectUri: loopback.redirectUri,
+        codeChallenge: challenge,
+        state,
+      });
+      await openExternalUrl(authorizeUrl);
+
+      const code = await showProgress(
+        "Waiting for authorization in your browser…",
+        this.viewId,
+        () => loopback.waitForCode(),
+      );
+
+      return await this.client.exchangeAuthCode(this.metadata, {
+        code,
+        codeVerifier: verifier,
+        redirectUri: loopback.redirectUri,
+        clientId,
+      });
+    } finally {
+      loopback.close();
+    }
+  }
+
+  /** RFC 8628 device flow: show the user code, then poll until authorized. */
+  private async authorizeWithDeviceCode(
+    clientId: string,
+  ): Promise<OAuthTokenResponse> {
+    const device = await this.client.startDeviceAuth(this.metadata, clientId);
+
+    const verificationUri =
+      device.verification_uri_complete ?? device.verification_uri;
+
+    // Surface the user code (verification_uri_complete usually pre-fills it, but
+    // show it in case it must be entered manually). Non-blocking — the poll below
+    // is what waits.
+    void window.showInformationMessage(
+      `Posit Connect sign-in: enter code ${device.user_code} in the browser tab that opened (${device.verification_uri}).`,
+    );
+
+    // Auto-open the verification page, mirroring
+    // ConnectAuthTokenActivator.openTokenClaimUrl — the mechanism proven to work
+    // in browser-based Positron on Posit Workbench. Await it before polling so
+    // the browser is up first, matching the token-claim flow's ordering.
+    await openExternalUrl(verificationUri);
+
+    return showProgress(
+      `Waiting for device authorization (code ${device.user_code})…`,
+      this.viewId,
+      () => this.pollDeviceToken(clientId, device),
+    );
+  }
+
+  private async pollDeviceToken(
+    clientId: string,
+    device: DeviceAuthResponse,
+  ): Promise<OAuthTokenResponse> {
+    let interval = (device.interval ?? 5) * 1000 || DEVICE_POLL_MS;
+    const deadline = Date.now() + device.expires_in * 1000;
+
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, interval));
+      const result = await this.client.pollDeviceToken(this.metadata, {
+        clientId,
+        deviceCode: device.device_code,
+      });
+      if (result.done) {
+        return result.response;
+      }
+      if (result.slowDown) {
+        interval += SLOW_DOWN_INCREMENT_MS;
+      }
+    }
+
+    throw new Error("Device authorization timed out.");
+  }
+
+  /**
+   * Best-effort lookup of the authenticated username via the bearer token, used
+   * to suggest a credential name. Never throws — returns "" on failure.
+   */
+  private async resolveUserName(accessToken: string): Promise<string> {
+    try {
+      const api = new ConnectAPI({
+        url: this.serverUrl,
+        accessToken,
+        rejectUnauthorized: this.insecure ? false : undefined,
+      });
+      const user = await api.getCurrentUser();
+      return user.username;
+    } catch (err) {
+      logger.debug(
+        `Could not resolve OAuth user name: ${getMessageFromError(err)}`,
+      );
+      return "";
+    }
+  }
+}

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -17,11 +17,25 @@ import {
   OAuthTokens,
   OAUTH_LOOPBACK_REDIRECT,
 } from "./types";
+import {
+  detectWorkbench,
+  isWorkbenchRelayReachable,
+  pollWorkbenchAuthCode,
+  workbenchRedirectUri,
+  WorkbenchEnvironment,
+  WorkbenchRelayError,
+} from "./workbench";
 
 /** Result of a successful interactive OAuth sign-in. */
 export interface OAuthAuthResult extends OAuthTokens {
   /** The authenticated user's username, if it could be retrieved. */
   userName: string;
+}
+
+/** Tokens plus the `client_id` the flow that obtained them registered under. */
+interface AuthorizeResult {
+  clientId: string;
+  tokenResponse: OAuthTokenResponse;
 }
 
 // Fallback device poll interval when the server omits `interval` (RFC 8628).
@@ -33,10 +47,10 @@ const SLOW_DOWN_INCREMENT_MS = 5_000;
  * `Uri.parse(url)`. VS Code's `env.openExternal(Uri.parse(...))` mis-encodes
  * nested/redirect query params (e.g. the percent-encoded `redirect_uri` in an
  * OAuth authorize URL) — the same hazard the Connect Cloud flow documents in
- * multiStepHelper. Passing the string preserves the exact encoding. This routes
- * to the user's browser in desktop, remote, and web hosts alike, which is why
- * the device flow (browser Positron on Workbench) can rely on it — mirroring
- * ConnectAuthTokenActivator.openTokenClaimUrl, the flow proven to work there.
+ * multiStepHelper, and the same reason Workbench's own VS Code extension passes a
+ * string (`rstudio-workbench-vscode-ext` `src/utils/oauthClient.ts`). Passing the
+ * string preserves the exact encoding. This routes to the user's browser in
+ * desktop, remote, and web hosts alike.
  */
 async function openExternalUrl(url: string): Promise<void> {
   // @ts-expect-error env.openExternal is typed for Uri, but the string overload
@@ -47,9 +61,9 @@ async function openExternalUrl(url: string): Promise<void> {
 /**
  * Drives the interactive Connect OAuth sign-in from the credential stepper,
  * mirroring rsconnect-python's login command: discover metadata (if not already
- * provided), register a public client, run the Authorization Code + PKCE flow
- * over a loopback listener, and fall back to the device flow when a loopback
- * port can't be bound. Analogous to {@link ConnectAuthTokenActivator}.
+ * provided), register a public client, and run the Authorization Code + PKCE
+ * flow, choosing a redirect transport that works in the current environment
+ * (see {@link authorize}). Analogous to {@link ConnectAuthTokenActivator}.
  */
 export class ConnectOAuthActivator {
   private readonly client: OAuthClient;
@@ -81,15 +95,7 @@ export class ConnectOAuthActivator {
 
   /** Runs the full sign-in flow and returns tokens for a new OAuth credential. */
   async authenticate(): Promise<OAuthAuthResult> {
-    const registration = await showProgress(
-      "Registering with Posit Connect",
-      this.viewId,
-      () =>
-        this.client.registerClient(this.metadata, [OAUTH_LOOPBACK_REDIRECT]),
-    );
-    const clientId = registration.client_id;
-
-    const tokenResponse = await this.authorize(clientId);
+    const { clientId, tokenResponse } = await this.authorize();
 
     const tokens: OAuthTokens = {
       oauthClientId: clientId,
@@ -103,41 +109,149 @@ export class ConnectOAuthActivator {
   }
 
   /**
-   * A loopback redirect only works when the extension host and the user's
-   * browser are on the same machine. In a web UI (e.g. Positron served by Posit
-   * Workbench in a browser) or a remote setup (Remote-SSH, Codespaces, WSL), the
-   * browser cannot reach `127.0.0.1` on the extension host — the loopback socket
-   * binds fine on the server but the redirect never arrives, so it would hang
-   * until timeout. Detect those environments up front and use the device flow.
+   * Chooses a redirect transport for the Authorization Code + PKCE flow and runs
+   * it, falling back to the device flow when the browser can't deliver the
+   * redirect back to the extension host. In order:
+   *
+   * 1. `positPublisher.useDeviceCodeAuth` — an explicit user override, honored
+   *    first so it always wins.
+   * 2. **Posit Workbench** (`RS_SERVER_URL` + `RS_SERVER_ADDRESS` set) — browser
+   *    VS Code/Positron. Loopback is unreachable from the user's browser here,
+   *    but Workbench relays the code through `/oauth_redirect_callback` +
+   *    `/oauth_code?state=`. Requires the Workbench URL to be allowlisted in
+   *    Connect's redirect URIs, so registration can fail — fall back to device.
+   * 3. **Loopback** (`http://127.0.0.1:<port>/callback`) — only when the
+   *    extension host and browser share a machine: a desktop UI with no
+   *    `remoteName`. In any web UI or remote setup (Remote-SSH, Codespaces, WSL)
+   *    the socket binds fine on the host but the redirect never arrives, so it
+   *    would hang until timeout.
+   * 4. **Device flow** — the universal fallback.
    */
-  private isLoopbackViable(): boolean {
-    // Explicit override: `positPublisher.useDeviceCodeAuth` forces the
-    // device-code flow regardless of environment (e.g. when the loopback
-    // redirect can't complete even on desktop).
-    const useDeviceCodeAuth = workspace
+  private async authorize(): Promise<AuthorizeResult> {
+    if (this.deviceCodeForced()) {
+      logger.info(
+        "positPublisher.useDeviceCodeAuth is enabled; using the OAuth device flow.",
+      );
+      return this.deviceCodeFlow();
+    }
+
+    const workbench = detectWorkbench();
+    if (workbench) {
+      logger.info(
+        "Detected a Posit Workbench session; using its OAuth redirect relay " +
+          `at ${workbench.externalServerUrl}.`,
+      );
+      const result = await this.tryWorkbenchFlow(workbench);
+      if (result) {
+        return result;
+      }
+      return this.deviceCodeFlow();
+    }
+
+    if (env.uiKind !== UIKind.Desktop || env.remoteName) {
+      logger.info(
+        "A loopback redirect is unreachable from the browser in this " +
+          `environment (uiKind=${env.uiKind === UIKind.Web ? "web" : "desktop"}, ` +
+          `remote=${env.remoteName ?? "none"}); using the OAuth device flow.`,
+      );
+      return this.deviceCodeFlow();
+    }
+
+    const result = await this.tryLoopbackFlow();
+    if (result) {
+      return result;
+    }
+    return this.deviceCodeFlow();
+  }
+
+  /** Whether the user has forced the device-code flow via settings. */
+  private deviceCodeForced(): boolean {
+    return workspace
       .getConfiguration("positPublisher")
       .get<boolean>("useDeviceCodeAuth", false);
-    if (useDeviceCodeAuth) {
-      return false;
-    }
-    return env.uiKind === UIKind.Desktop && !env.remoteName;
   }
 
   /**
-   * Runs the Authorization Code + PKCE flow over loopback, falling back to the
-   * device flow in web/remote environments (where loopback is unreachable) or
-   * when the loopback listener can't start.
+   * Authorization Code + PKCE through Posit Workbench's OAuth redirect relay,
+   * the mechanism Workbench's own VS Code extension uses. Returns `undefined`
+   * when the relay can't be used in this deployment (unreachable, or Connect
+   * hasn't allowlisted the Workbench redirect URI) so the caller can fall back;
+   * rethrows when the user's authorization attempt itself failed.
    */
-  private async authorize(clientId: string): Promise<OAuthTokenResponse> {
-    if (!this.isLoopbackViable()) {
+  private async tryWorkbenchFlow(
+    workbench: WorkbenchEnvironment,
+  ): Promise<AuthorizeResult | undefined> {
+    const redirectUri = workbenchRedirectUri(workbench);
+
+    if (!(await isWorkbenchRelayReachable(workbench, this.insecure))) {
       logger.info(
-        "Loopback redirect is not usable in this environment " +
-          `(uiKind=${env.uiKind === UIKind.Web ? "web" : "desktop"}, ` +
-          `remote=${env.remoteName ?? "none"}); using the OAuth device flow.`,
+        "The Posit Workbench OAuth redirect relay did not respond; falling " +
+          "back to the OAuth device flow.",
       );
-      return this.authorizeWithDeviceCode(clientId);
+      return undefined;
     }
 
+    let clientId: string;
+    try {
+      clientId = await this.register(redirectUri);
+    } catch (err) {
+      // Connect rejects a non-loopback redirect URI unless an administrator has
+      // added it to the allowed redirect URIs, so this is the expected outcome
+      // on a Workbench deployment Connect doesn't know about.
+      logger.info(
+        `Posit Connect did not accept the Posit Workbench redirect URI ` +
+          `${redirectUri} (${getMessageFromError(err)}); falling back to the ` +
+          "OAuth device flow. An administrator can allow this URI on Connect " +
+          "to enable browser sign-in here.",
+      );
+      return undefined;
+    }
+
+    const { verifier, challenge } = generatePkcePair();
+    const state = generateState();
+
+    const authorizeUrl = this.client.buildAuthorizeUrl(this.metadata, {
+      clientId,
+      redirectUri,
+      codeChallenge: challenge,
+      state,
+    });
+    await openExternalUrl(authorizeUrl);
+
+    let code: string;
+    try {
+      code = await showProgress(
+        "Waiting for authorization in your browser…",
+        this.viewId,
+        () => pollWorkbenchAuthCode(workbench, state, this.insecure),
+      );
+    } catch (err) {
+      if (err instanceof WorkbenchRelayError && !err.terminal) {
+        logger.info(
+          `The Posit Workbench OAuth relay failed (${err.message}); falling ` +
+            "back to the OAuth device flow.",
+        );
+        return undefined;
+      }
+      throw err;
+    }
+
+    const tokenResponse = await this.client.exchangeAuthCode(this.metadata, {
+      code,
+      codeVerifier: verifier,
+      redirectUri,
+      clientId,
+    });
+    return { clientId, tokenResponse };
+  }
+
+  /**
+   * Authorization Code + PKCE over a loopback listener on the extension host.
+   * Returns `undefined` when a loopback port can't be bound so the caller can
+   * fall back to the device flow.
+   */
+  private async tryLoopbackFlow(): Promise<AuthorizeResult | undefined> {
+    const clientId = await this.register(OAUTH_LOOPBACK_REDIRECT);
     const { verifier, challenge } = generatePkcePair();
     const state = generateState();
 
@@ -149,7 +263,7 @@ export class ConnectOAuthActivator {
         `Loopback listener unavailable (${getMessageFromError(err)}); ` +
           "falling back to OAuth device flow.",
       );
-      return this.authorizeWithDeviceCode(clientId);
+      return undefined;
     }
 
     try {
@@ -167,21 +281,33 @@ export class ConnectOAuthActivator {
         () => loopback.waitForCode(),
       );
 
-      return await this.client.exchangeAuthCode(this.metadata, {
+      const tokenResponse = await this.client.exchangeAuthCode(this.metadata, {
         code,
         codeVerifier: verifier,
         redirectUri: loopback.redirectUri,
         clientId,
       });
+      return { clientId, tokenResponse };
     } finally {
       loopback.close();
     }
   }
 
+  /** Registers a public client for a single redirect URI (RFC 7591). */
+  private register(redirectUri: string): Promise<string> {
+    return showProgress("Registering with Posit Connect", this.viewId, () =>
+      this.client
+        .registerClient(this.metadata, [redirectUri])
+        .then((registration) => registration.client_id),
+    );
+  }
+
   /** RFC 8628 device flow: show the user code, then poll until authorized. */
-  private async authorizeWithDeviceCode(
-    clientId: string,
-  ): Promise<OAuthTokenResponse> {
+  private async deviceCodeFlow(): Promise<AuthorizeResult> {
+    // The device flow has no redirect, but Connect's dynamic client registration
+    // still requires at least one redirect URI. Register the loopback URI, which
+    // Connect always accepts.
+    const clientId = await this.register(OAUTH_LOOPBACK_REDIRECT);
     const device = await this.client.startDeviceAuth(this.metadata, clientId);
 
     const verificationUri =
@@ -200,11 +326,12 @@ export class ConnectOAuthActivator {
     // the browser is up first, matching the token-claim flow's ordering.
     await openExternalUrl(verificationUri);
 
-    return showProgress(
+    const tokenResponse = await showProgress(
       `Waiting for device authorization (code ${device.user_code})…`,
       this.viewId,
       () => this.pollDeviceToken(clientId, device),
     );
+    return { clientId, tokenResponse };
   }
 
   private async pollDeviceToken(

--- a/extensions/vscode/src/auth/oauth/client.test.ts
+++ b/extensions/vscode/src/auth/oauth/client.test.ts
@@ -1,0 +1,307 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPost = vi.fn();
+
+vi.mock("./httpClient", () => ({
+  createOAuthHttpClient: vi.fn(() => ({ post: mockPost })),
+  OAUTH_TIMEOUT_MS: 30_000,
+}));
+
+import { OAuthClient, OAuthError, tokenExpiresAt } from "./client";
+import { OAuthMetadata } from "./types";
+
+const METADATA: OAuthMetadata = {
+  issuer: "https://connect.example.com",
+  authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+  token_endpoint: "https://connect.example.com/oauth/v1/token",
+  registration_endpoint: "https://connect.example.com/oauth/v1/register",
+  device_authorization_endpoint:
+    "https://connect.example.com/oauth/v1/device/authorize",
+};
+
+function client(): OAuthClient {
+  return new OAuthClient(false);
+}
+
+/** Parses the URLSearchParams-encoded body of the Nth mockPost call. */
+function formBody(callIndex = 0): URLSearchParams {
+  const body = mockPost.mock.calls[callIndex]?.[1];
+  return new URLSearchParams(String(body));
+}
+
+beforeEach(() => {
+  mockPost.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("registerClient", () => {
+  it("POSTs client metadata and returns the registration", async () => {
+    mockPost.mockResolvedValue({
+      status: 201,
+      data: { client_id: "client-abc", client_name: "posit-publisher" },
+    });
+
+    const reg = await client().registerClient(METADATA, [
+      "http://127.0.0.1/callback",
+    ]);
+
+    expect(reg.client_id).toBe("client-abc");
+    const [url, body] = mockPost.mock.calls[0]!;
+    expect(url).toBe(METADATA.registration_endpoint);
+    expect(body.client_name).toBe("posit-publisher");
+    expect(body.redirect_uris).toEqual(["http://127.0.0.1/callback"]);
+    expect(body.token_endpoint_auth_method).toBe("none");
+    expect(body.response_types).toEqual(["code"]);
+    expect(body.grant_types).toContain("authorization_code");
+    expect(body.grant_types).toContain("refresh_token");
+  });
+
+  it("omits the device-code grant when the server does not advertise the device endpoint", async () => {
+    mockPost.mockResolvedValue({
+      status: 201,
+      data: { client_id: "client-abc" },
+    });
+    const noDevice: OAuthMetadata = {
+      ...METADATA,
+      device_authorization_endpoint: undefined,
+    };
+
+    await client().registerClient(noDevice, ["http://127.0.0.1/callback"]);
+
+    const [, body] = mockPost.mock.calls[0]!;
+    expect(body.grant_types).toEqual(["authorization_code", "refresh_token"]);
+  });
+
+  it("throws when the server does not advertise registration", async () => {
+    const noReg: OAuthMetadata = {
+      ...METADATA,
+      registration_endpoint: undefined,
+    };
+    await expect(
+      client().registerClient(noReg, ["http://127.0.0.1/callback"]),
+    ).rejects.toBeInstanceOf(OAuthError);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("throws an OAuthError carrying the server error code", async () => {
+    mockPost.mockResolvedValue({
+      status: 400,
+      data: {
+        error: "invalid_redirect_uri",
+        error_description: "Redirect URI not allowed",
+      },
+    });
+
+    const err = await client()
+      .registerClient(METADATA, ["vscode://x"])
+      .catch((e) => e);
+
+    expect(err).toBeInstanceOf(OAuthError);
+    expect(err.code).toBe("invalid_redirect_uri");
+    expect(err.message).toBe("Redirect URI not allowed");
+  });
+});
+
+describe("buildAuthorizeUrl", () => {
+  it("builds an authorize URL with PKCE + state params", () => {
+    const url = new URL(
+      client().buildAuthorizeUrl(METADATA, {
+        clientId: "client-abc",
+        redirectUri: "http://127.0.0.1:5000/callback",
+        codeChallenge: "challenge-xyz",
+        state: "state-123",
+      }),
+    );
+
+    expect(url.origin + url.pathname).toBe(METADATA.authorization_endpoint);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("client-abc");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://127.0.0.1:5000/callback",
+    );
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-xyz");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe("state-123");
+  });
+});
+
+describe("exchangeAuthCode", () => {
+  it("POSTs the authorization_code grant and returns tokens", async () => {
+    mockPost.mockResolvedValue({
+      status: 200,
+      data: {
+        access_token: "at",
+        token_type: "Bearer",
+        refresh_token: "rt",
+        expires_in: 3600,
+      },
+    });
+
+    const tokens = await client().exchangeAuthCode(METADATA, {
+      code: "the-code",
+      codeVerifier: "the-verifier",
+      redirectUri: "http://127.0.0.1:5000/callback",
+      clientId: "client-abc",
+    });
+
+    expect(tokens.access_token).toBe("at");
+    const body = formBody();
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("the-code");
+    expect(body.get("code_verifier")).toBe("the-verifier");
+    expect(body.get("redirect_uri")).toBe("http://127.0.0.1:5000/callback");
+    expect(body.get("client_id")).toBe("client-abc");
+  });
+
+  it("throws when the token response lacks an access_token", async () => {
+    mockPost.mockResolvedValue({
+      status: 400,
+      data: { error: "invalid_grant" },
+    });
+    await expect(
+      client().exchangeAuthCode(METADATA, {
+        code: "x",
+        codeVerifier: "y",
+        redirectUri: "http://127.0.0.1/callback",
+        clientId: "c",
+      }),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+});
+
+describe("refreshToken", () => {
+  it("POSTs the refresh_token grant", async () => {
+    mockPost.mockResolvedValue({
+      status: 200,
+      data: { access_token: "at2", token_type: "Bearer", refresh_token: "rt2" },
+    });
+
+    const tokens = await client().refreshToken(METADATA, {
+      clientId: "client-abc",
+      refreshToken: "old-rt",
+    });
+
+    expect(tokens.access_token).toBe("at2");
+    const body = formBody();
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("old-rt");
+    expect(body.get("client_id")).toBe("client-abc");
+  });
+
+  it("throws on refresh failure", async () => {
+    mockPost.mockResolvedValue({
+      status: 400,
+      data: { error: "invalid_grant", error_description: "expired" },
+    });
+    await expect(
+      client().refreshToken(METADATA, {
+        clientId: "c",
+        refreshToken: "bad",
+      }),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+});
+
+describe("startDeviceAuth", () => {
+  it("returns the device authorization response", async () => {
+    mockPost.mockResolvedValue({
+      status: 200,
+      data: {
+        device_code: "dc",
+        user_code: "WXYZ-1234",
+        verification_uri: "https://connect.example.com/device",
+        verification_uri_complete:
+          "https://connect.example.com/device?user_code=WXYZ-1234",
+        expires_in: 600,
+        interval: 5,
+      },
+    });
+
+    const device = await client().startDeviceAuth(METADATA, "client-abc");
+
+    expect(device.user_code).toBe("WXYZ-1234");
+    const body = formBody();
+    expect(body.get("client_id")).toBe("client-abc");
+  });
+
+  it("throws when device flow is unsupported", async () => {
+    const noDevice: OAuthMetadata = {
+      ...METADATA,
+      device_authorization_endpoint: undefined,
+    };
+    await expect(
+      client().startDeviceAuth(noDevice, "c"),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+});
+
+describe("pollDeviceToken", () => {
+  const params = { clientId: "client-abc", deviceCode: "dc" };
+
+  it("returns done + tokens once issued", async () => {
+    mockPost.mockResolvedValue({
+      status: 200,
+      data: { access_token: "at", token_type: "Bearer" },
+    });
+    const result = await client().pollDeviceToken(METADATA, params);
+    expect(result).toEqual({
+      done: true,
+      response: { access_token: "at", token_type: "Bearer" },
+    });
+  });
+
+  it("returns not-done for authorization_pending", async () => {
+    mockPost.mockResolvedValue({
+      status: 400,
+      data: { error: "authorization_pending" },
+    });
+    const result = await client().pollDeviceToken(METADATA, params);
+    expect(result).toEqual({ done: false, slowDown: false });
+  });
+
+  it("returns slowDown for slow_down", async () => {
+    mockPost.mockResolvedValue({
+      status: 400,
+      data: { error: "slow_down" },
+    });
+    const result = await client().pollDeviceToken(METADATA, params);
+    expect(result).toEqual({ done: false, slowDown: true });
+  });
+
+  it("throws on a terminal error such as expired_token", async () => {
+    mockPost.mockResolvedValue({
+      status: 400,
+      data: { error: "expired_token" },
+    });
+    const err = await client()
+      .pollDeviceToken(METADATA, params)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(OAuthError);
+    expect(err.code).toBe("expired_token");
+  });
+});
+
+describe("tokenExpiresAt", () => {
+  it("computes an ISO expiry from expires_in", () => {
+    const before = Date.now();
+    const iso = tokenExpiresAt({
+      access_token: "a",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    const ms = new Date(iso).getTime();
+    expect(ms).toBeGreaterThanOrEqual(before + 3600 * 1000 - 1000);
+    expect(ms).toBeLessThanOrEqual(Date.now() + 3600 * 1000 + 1000);
+  });
+
+  it("returns empty string when expires_in is absent", () => {
+    expect(tokenExpiresAt({ access_token: "a", token_type: "Bearer" })).toBe(
+      "",
+    );
+  });
+});

--- a/extensions/vscode/src/auth/oauth/client.ts
+++ b/extensions/vscode/src/auth/oauth/client.ts
@@ -1,0 +1,289 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import type { AxiosInstance } from "axios";
+import { createOAuthHttpClient } from "./httpClient";
+import {
+  ClientRegistration,
+  DeviceAuthResponse,
+  OAuthMetadata,
+  OAuthTokenResponse,
+  OAUTH_CLIENT_NAME,
+} from "./types";
+
+// OAuth error codes we branch on (RFC 6749 / RFC 7591 / RFC 8628).
+export const INVALID_CLIENT = "invalid_client";
+export const AUTHORIZATION_PENDING = "authorization_pending";
+export const SLOW_DOWN = "slow_down";
+export const EXPIRED_TOKEN = "expired_token";
+export const ACCESS_DENIED = "access_denied";
+
+const FORM_HEADERS = { "Content-Type": "application/x-www-form-urlencoded" };
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+/** An error returned by a Connect OAuth endpoint. */
+export class OAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+    public readonly httpStatus?: number,
+  ) {
+    super(message);
+    this.name = "OAuthError";
+  }
+}
+
+function isRecord(data: unknown): data is Record<string, unknown> {
+  return typeof data === "object" && data !== null;
+}
+
+function isTokenResponse(data: unknown): data is OAuthTokenResponse {
+  return (
+    isRecord(data) &&
+    typeof data.access_token === "string" &&
+    typeof data.token_type === "string"
+  );
+}
+
+function isClientRegistration(data: unknown): data is ClientRegistration {
+  return isRecord(data) && typeof data.client_id === "string";
+}
+
+function isDeviceAuthResponse(data: unknown): data is DeviceAuthResponse {
+  return (
+    isRecord(data) &&
+    typeof data.device_code === "string" &&
+    typeof data.user_code === "string" &&
+    typeof data.verification_uri === "string" &&
+    typeof data.expires_in === "number"
+  );
+}
+
+/** Builds an {@link OAuthError} from an endpoint's `{ error, error_description }`. */
+function toOAuthError(
+  status: number,
+  data: unknown,
+  fallback: string,
+): OAuthError {
+  if (isRecord(data)) {
+    const code = typeof data.error === "string" ? data.error : undefined;
+    const description =
+      typeof data.error_description === "string"
+        ? data.error_description
+        : undefined;
+    return new OAuthError(description ?? code ?? fallback, code, status);
+  }
+  return new OAuthError(fallback, undefined, status);
+}
+
+function ok(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+/** Result of a single device-token poll. */
+export type DevicePollResult =
+  | { done: false; slowDown: boolean }
+  | { done: true; response: OAuthTokenResponse };
+
+/**
+ * Client for Connect's OAuth 2.0 authorization server. Mirrors the mechanism in
+ * rsconnect-python's `rsconnect/oauth.py`: RFC 7591 dynamic client registration,
+ * Authorization Code + PKCE, RFC 8628 device flow, and refresh-token exchange.
+ * All requests honor the TLS verification setting via `insecure`.
+ */
+export class OAuthClient {
+  private readonly http: AxiosInstance;
+
+  constructor(insecure: boolean) {
+    this.http = createOAuthHttpClient(insecure);
+  }
+
+  /**
+   * Registers a public OAuth client with Connect (RFC 7591). Connect derives a
+   * deterministic, secret-less `client_id` from the client name + redirect URIs.
+   */
+  async registerClient(
+    metadata: OAuthMetadata,
+    redirectUris: string[],
+  ): Promise<ClientRegistration> {
+    if (!metadata.registration_endpoint) {
+      throw new OAuthError(
+        "This Connect server does not advertise OAuth dynamic client registration.",
+      );
+    }
+    // Only advertise the device-code grant when the server supports it, matching
+    // rsconnect-python (rsconnect/oauth.py register_client). A strict RFC 7591
+    // server may reject an unsupported grant type.
+    const grantTypes = ["authorization_code", "refresh_token"];
+    if (metadata.device_authorization_endpoint) {
+      grantTypes.push(DEVICE_CODE_GRANT);
+    }
+    const resp = await this.http.post(
+      metadata.registration_endpoint,
+      {
+        client_name: OAUTH_CLIENT_NAME,
+        redirect_uris: redirectUris,
+        token_endpoint_auth_method: "none",
+        grant_types: grantTypes,
+        response_types: ["code"],
+      },
+      { headers: { "Content-Type": "application/json" } },
+    );
+    if (!ok(resp.status) || !isClientRegistration(resp.data)) {
+      throw toOAuthError(
+        resp.status,
+        resp.data,
+        "Failed to register an OAuth client with Connect.",
+      );
+    }
+    return resp.data;
+  }
+
+  /**
+   * Builds the authorization-request URL for the Authorization Code + PKCE flow.
+   */
+  buildAuthorizeUrl(
+    metadata: OAuthMetadata,
+    params: {
+      clientId: string;
+      redirectUri: string;
+      codeChallenge: string;
+      state: string;
+    },
+  ): string {
+    const url = new URL(metadata.authorization_endpoint);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", params.clientId);
+    url.searchParams.set("redirect_uri", params.redirectUri);
+    url.searchParams.set("code_challenge", params.codeChallenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("state", params.state);
+    return url.toString();
+  }
+
+  /** Exchanges an authorization code (+ PKCE verifier) for tokens. */
+  exchangeAuthCode(
+    metadata: OAuthMetadata,
+    params: {
+      code: string;
+      codeVerifier: string;
+      redirectUri: string;
+      clientId: string;
+    },
+  ): Promise<OAuthTokenResponse> {
+    return this.tokenRequest(
+      metadata,
+      new URLSearchParams({
+        grant_type: "authorization_code",
+        code: params.code,
+        redirect_uri: params.redirectUri,
+        client_id: params.clientId,
+        code_verifier: params.codeVerifier,
+      }),
+    );
+  }
+
+  /** Exchanges a refresh token for a fresh access token (RFC 6749 §6). */
+  refreshToken(
+    metadata: OAuthMetadata,
+    params: { clientId: string; refreshToken: string },
+  ): Promise<OAuthTokenResponse> {
+    return this.tokenRequest(
+      metadata,
+      new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: params.clientId,
+        refresh_token: params.refreshToken,
+      }),
+    );
+  }
+
+  /** Starts the RFC 8628 device authorization flow. */
+  async startDeviceAuth(
+    metadata: OAuthMetadata,
+    clientId: string,
+  ): Promise<DeviceAuthResponse> {
+    if (!metadata.device_authorization_endpoint) {
+      throw new OAuthError(
+        "This Connect server does not advertise the OAuth device flow.",
+      );
+    }
+    const resp = await this.http.post(
+      metadata.device_authorization_endpoint,
+      new URLSearchParams({ client_id: clientId }).toString(),
+      { headers: FORM_HEADERS },
+    );
+    if (!ok(resp.status) || !isDeviceAuthResponse(resp.data)) {
+      throw toOAuthError(
+        resp.status,
+        resp.data,
+        "Failed to start OAuth device authorization.",
+      );
+    }
+    return resp.data;
+  }
+
+  /**
+   * Performs a single device-token poll. Returns `{ done: false }` while the
+   * user has not yet authorized (`authorization_pending`, or `slow_down` which
+   * asks the caller to back off), `{ done: true, response }` once tokens are
+   * issued, and throws {@link OAuthError} on a terminal error (`expired_token`,
+   * `access_denied`, `invalid_client`, …).
+   */
+  async pollDeviceToken(
+    metadata: OAuthMetadata,
+    params: { clientId: string; deviceCode: string },
+  ): Promise<DevicePollResult> {
+    const resp = await this.http.post(
+      metadata.token_endpoint,
+      new URLSearchParams({
+        grant_type: DEVICE_CODE_GRANT,
+        device_code: params.deviceCode,
+        client_id: params.clientId,
+      }).toString(),
+      { headers: FORM_HEADERS },
+    );
+    if (ok(resp.status) && isTokenResponse(resp.data)) {
+      return { done: true, response: resp.data };
+    }
+    const err = toOAuthError(
+      resp.status,
+      resp.data,
+      "Device authorization failed.",
+    );
+    if (err.code === AUTHORIZATION_PENDING) {
+      return { done: false, slowDown: false };
+    }
+    if (err.code === SLOW_DOWN) {
+      return { done: false, slowDown: true };
+    }
+    throw err;
+  }
+
+  private async tokenRequest(
+    metadata: OAuthMetadata,
+    body: URLSearchParams,
+  ): Promise<OAuthTokenResponse> {
+    const resp = await this.http.post(
+      metadata.token_endpoint,
+      body.toString(),
+      {
+        headers: FORM_HEADERS,
+      },
+    );
+    if (!ok(resp.status) || !isTokenResponse(resp.data)) {
+      throw toOAuthError(resp.status, resp.data, "OAuth token request failed.");
+    }
+    return resp.data;
+  }
+}
+
+/**
+ * Computes an ISO-8601 expiry timestamp from a token response's `expires_in`
+ * (seconds from now), or "" when the server did not provide one.
+ */
+export function tokenExpiresAt(response: OAuthTokenResponse): string {
+  if (typeof response.expires_in !== "number") {
+    return "";
+  }
+  return new Date(Date.now() + response.expires_in * 1000).toISOString();
+}

--- a/extensions/vscode/src/auth/oauth/discovery.test.ts
+++ b/extensions/vscode/src/auth/oauth/discovery.test.ts
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+
+vi.mock("./httpClient", () => ({
+  createOAuthHttpClient: vi.fn(() => ({ get: mockGet })),
+  OAUTH_TIMEOUT_MS: 30_000,
+}));
+
+vi.mock("src/logging", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { discoverOAuthMetadata } from "./discovery";
+
+const VALID_METADATA = {
+  issuer: "https://connect.example.com",
+  authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+  token_endpoint: "https://connect.example.com/oauth/v1/token",
+  registration_endpoint: "https://connect.example.com/oauth/v1/register",
+};
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("discoverOAuthMetadata", () => {
+  it("returns metadata on a 200 with the required endpoints", async () => {
+    mockGet.mockResolvedValue({ status: 200, data: VALID_METADATA });
+
+    const metadata = await discoverOAuthMetadata(
+      "https://connect.example.com",
+      false,
+    );
+
+    expect(metadata).toEqual(VALID_METADATA);
+    expect(mockGet).toHaveBeenCalledWith(
+      "https://connect.example.com/.well-known/oauth-authorization-server",
+    );
+  });
+
+  it("strips a trailing slash from the server URL when building the probe URL", async () => {
+    mockGet.mockResolvedValue({ status: 200, data: VALID_METADATA });
+    await discoverOAuthMetadata("https://connect.example.com/", false);
+    expect(mockGet).toHaveBeenCalledWith(
+      "https://connect.example.com/.well-known/oauth-authorization-server",
+    );
+  });
+
+  it("returns null on 404", async () => {
+    mockGet.mockResolvedValue({ status: 404, data: "Not Found" });
+    expect(
+      await discoverOAuthMetadata("https://connect.example.com", false),
+    ).toBeNull();
+  });
+
+  it("returns null when the body is missing required endpoints", async () => {
+    mockGet.mockResolvedValue({
+      status: 200,
+      data: { issuer: "https://connect.example.com" },
+    });
+    expect(
+      await discoverOAuthMetadata("https://connect.example.com", false),
+    ).toBeNull();
+  });
+
+  it("returns null when the body is a non-JSON string (HTML proxy)", async () => {
+    mockGet.mockResolvedValue({ status: 200, data: "<html>login</html>" });
+    expect(
+      await discoverOAuthMetadata("https://connect.example.com", false),
+    ).toBeNull();
+  });
+
+  it("returns null on a network/TLS failure", async () => {
+    mockGet.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(
+      await discoverOAuthMetadata("https://connect.example.com", false),
+    ).toBeNull();
+  });
+});

--- a/extensions/vscode/src/auth/oauth/discovery.ts
+++ b/extensions/vscode/src/auth/oauth/discovery.ts
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { logger } from "src/logging";
+import { createOAuthHttpClient } from "./httpClient";
+import { OAuthMetadata } from "./types";
+
+const WELL_KNOWN_PATH = "/.well-known/oauth-authorization-server";
+
+/** Joins a server URL and a well-known path without doubling slashes. */
+function wellKnownUrl(serverUrl: string): string {
+  return serverUrl.replace(/\/+$/, "") + WELL_KNOWN_PATH;
+}
+
+/**
+ * Type guard for the minimal RFC 8414 metadata Publisher requires: an object
+ * carrying string `token_endpoint` and `authorization_endpoint`. Optional fields
+ * on {@link OAuthMetadata} stay optional.
+ */
+function isOAuthMetadata(data: unknown): data is OAuthMetadata {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "token_endpoint" in data &&
+    typeof data.token_endpoint === "string" &&
+    "authorization_endpoint" in data &&
+    typeof data.authorization_endpoint === "string"
+  );
+}
+
+/**
+ * Probes a Connect server for OAuth 2.0 authorization-server metadata
+ * (RFC 8414). Returns the parsed metadata only when the server responds 200
+ * with a document that carries a `token_endpoint` (and `authorization_endpoint`,
+ * which every flow needs). Returns `null` when OAuth is unavailable — a 404, a
+ * non-JSON/HTML body (e.g. an auth proxy), a network/TLS failure, or metadata
+ * missing the required endpoints — so callers can fall back to token/API-key
+ * auth.
+ *
+ * Honors the TLS verification setting via `insecure`.
+ */
+export async function discoverOAuthMetadata(
+  serverUrl: string,
+  insecure: boolean,
+): Promise<OAuthMetadata | null> {
+  const url = wellKnownUrl(serverUrl);
+  const client = createOAuthHttpClient(insecure);
+
+  let status: number;
+  let data: unknown;
+  try {
+    const resp = await client.get(url);
+    status = resp.status;
+    data = resp.data;
+  } catch (err) {
+    // Network/TLS failure — treat as "OAuth not available" and let the caller
+    // fall back. The subsequent auth flow will surface any connectivity error.
+    logger.debug(
+      `OAuth discovery request failed for ${serverUrl}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  }
+
+  if (status !== 200) {
+    logger.debug(`OAuth discovery returned HTTP ${status} for ${serverUrl}`);
+    return null;
+  }
+
+  if (!isOAuthMetadata(data)) {
+    logger.debug(
+      `OAuth discovery response for ${serverUrl} is missing required endpoints`,
+    );
+    return null;
+  }
+
+  return data;
+}

--- a/extensions/vscode/src/auth/oauth/httpClient.ts
+++ b/extensions/vscode/src/auth/oauth/httpClient.ts
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import https from "https";
+import type { ClientRequest, IncomingMessage } from "http";
+import axios from "axios";
+import type { AxiosInstance, AxiosRequestConfig } from "axios";
+
+/** Request timeout for OAuth endpoints (ms). */
+export const OAUTH_TIMEOUT_MS = 30_000;
+
+/**
+ * Builds an axios instance for talking to Connect's OAuth endpoints, honoring
+ * the extension's TLS verification setting.
+ *
+ * When `insecure` is true this both installs a permissive https.Agent and a
+ * per-request transport that forces `rejectUnauthorized: false` — the same
+ * two-pronged approach `@posit-dev/connect-api`'s client uses, because VS Code's
+ * proxy patch discards the Agent option on its own.
+ */
+export function createOAuthHttpClient(insecure: boolean): AxiosInstance {
+  const config: AxiosRequestConfig = {
+    timeout: OAUTH_TIMEOUT_MS,
+    // Never throw on non-2xx — OAuth error responses (400/401) carry meaningful
+    // JSON bodies (e.g. `authorization_pending`, `invalid_client`) that callers
+    // must inspect.
+    validateStatus: () => true,
+  };
+
+  if (insecure) {
+    config.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+    config.transport = {
+      request: (
+        reqOptions: https.RequestOptions,
+        callback: (res: IncomingMessage) => void,
+      ): ClientRequest =>
+        https.request({ ...reqOptions, rejectUnauthorized: false }, callback),
+    };
+  }
+
+  return axios.create(config);
+}

--- a/extensions/vscode/src/auth/oauth/index.ts
+++ b/extensions/vscode/src/auth/oauth/index.ts
@@ -17,4 +17,12 @@ export type { OAuthAuthResult } from "./activator";
 export { generatePkcePair, generateState } from "./pkce";
 export { startLoopbackServer } from "./loopback";
 export type { LoopbackHandle } from "./loopback";
+export {
+  detectWorkbench,
+  isWorkbenchRelayReachable,
+  pollWorkbenchAuthCode,
+  workbenchRedirectUri,
+  WorkbenchRelayError,
+} from "./workbench";
+export type { WorkbenchEnvironment } from "./workbench";
 export * from "./types";

--- a/extensions/vscode/src/auth/oauth/index.ts
+++ b/extensions/vscode/src/auth/oauth/index.ts
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+export { discoverOAuthMetadata } from "./discovery";
+export {
+  OAuthClient,
+  OAuthError,
+  tokenExpiresAt,
+  INVALID_CLIENT,
+  AUTHORIZATION_PENDING,
+  SLOW_DOWN,
+  EXPIRED_TOKEN,
+  ACCESS_DENIED,
+} from "./client";
+export type { DevicePollResult } from "./client";
+export { ConnectOAuthActivator } from "./activator";
+export type { OAuthAuthResult } from "./activator";
+export { generatePkcePair, generateState } from "./pkce";
+export { startLoopbackServer } from "./loopback";
+export type { LoopbackHandle } from "./loopback";
+export * from "./types";

--- a/extensions/vscode/src/auth/oauth/loopback.test.ts
+++ b/extensions/vscode/src/auth/oauth/loopback.test.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { describe, expect, it } from "vitest";
+import { renderPage } from "./loopback";
+
+describe("renderPage", () => {
+  it("is a self-contained HTML page with the inlined Connect logo and message", () => {
+    const html = renderPage(
+      "success",
+      "Authentication complete",
+      "You're signed in to Posit Connect.",
+    );
+
+    expect(html.startsWith("<!doctype html>")).toBe(true);
+    // Connect wordmark inlined (no external resource requests). The only
+    // http(s) URL allowed is the SVG xmlns namespace, never a src/href fetch.
+    expect(html).toContain('class="logo"');
+    expect(html).toContain('aria-label="Posit Connect"');
+    expect(html).not.toMatch(/(?:src|href)\s*=\s*["']https?:/i);
+    expect(html).not.toContain("<script");
+    // Title and message are rendered.
+    expect(html).toContain("Authentication complete");
+    expect(html).toContain("You're signed in to Posit Connect.");
+    // Success icon.
+    expect(html).toContain('aria-label="Success"');
+  });
+
+  it("uses the error status icon for the error variant", () => {
+    const html = renderPage("error", "Authentication failed", "Try again.");
+    expect(html).toContain('aria-label="Failed"');
+    expect(html).not.toContain('aria-label="Success"');
+    expect(html).toContain("Authentication failed");
+  });
+});

--- a/extensions/vscode/src/auth/oauth/loopback.ts
+++ b/extensions/vscode/src/auth/oauth/loopback.ts
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import http from "http";
+
+/** A running loopback redirect listener for the Authorization Code flow. */
+export interface LoopbackHandle {
+  /** The `http://127.0.0.1:<port>/callback` URI to use as the redirect. */
+  redirectUri: string;
+  /**
+   * Resolves with the authorization `code` once the browser hits the callback
+   * with a matching `state`. Rejects on `state` mismatch, an `error` response,
+   * a missing code, or timeout.
+   */
+  waitForCode(): Promise<string>;
+  /** Stops the listener and clears the timeout. Safe to call more than once. */
+  close(): void;
+}
+
+function respondHtml(
+  res: http.ServerResponse,
+  title: string,
+  message: string,
+): void {
+  const body = `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body style="font-family: system-ui, sans-serif; text-align: center; padding-top: 4rem;"><h2>${title}</h2><p>${message}</p></body></html>`;
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(body);
+}
+
+/**
+ * Starts a loopback HTTP server on an ephemeral `127.0.0.1` port to receive the
+ * OAuth Authorization Code callback (RFC 8252). Resolves once the socket is
+ * bound; rejects if a port can't be bound (the caller then falls back to the
+ * device flow).
+ *
+ * @param expectedState the CSRF `state` the callback must echo back
+ * @param timeoutMs how long to wait for the callback before rejecting
+ */
+export function startLoopbackServer(
+  expectedState: string,
+  // 600s (10 min) matches rsconnect-python's _CALLBACK_TIMEOUT_SECONDS.
+  timeoutMs = 600_000,
+): Promise<LoopbackHandle> {
+  return new Promise((resolveHandle, rejectHandle) => {
+    let resolveCode: (code: string) => void;
+    let rejectCode: (err: Error) => void;
+    const codePromise = new Promise<string>((res, rej) => {
+      resolveCode = res;
+      rejectCode = rej;
+    });
+
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== "/callback") {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      const error = url.searchParams.get("error");
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+
+      if (error) {
+        respondHtml(res, "Authentication failed", "You can close this tab.");
+        rejectCode(new Error(`Authorization failed: ${error}`));
+        return;
+      }
+      if (state !== expectedState) {
+        respondHtml(res, "Authentication failed", "You can close this tab.");
+        rejectCode(new Error("Authorization state mismatch (possible CSRF)."));
+        return;
+      }
+      if (!code) {
+        respondHtml(res, "Authentication failed", "You can close this tab.");
+        rejectCode(new Error("Authorization response was missing a code."));
+        return;
+      }
+
+      respondHtml(
+        res,
+        "Authentication complete",
+        "You can close this tab and return to your editor.",
+      );
+      resolveCode(code);
+    });
+
+    const timer = setTimeout(() => {
+      rejectCode(new Error("Timed out waiting for browser authorization."));
+    }, timeoutMs);
+
+    server.once("error", (err) => {
+      clearTimeout(timer);
+      rejectHandle(err);
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        clearTimeout(timer);
+        server.close();
+        rejectHandle(new Error("Could not determine loopback server port."));
+        return;
+      }
+      const { port } = address;
+      resolveHandle({
+        redirectUri: `http://127.0.0.1:${port}/callback`,
+        waitForCode: () => codePromise,
+        close: () => {
+          clearTimeout(timer);
+          server.close();
+        },
+      });
+    });
+  });
+}

--- a/extensions/vscode/src/auth/oauth/loopback.ts
+++ b/extensions/vscode/src/auth/oauth/loopback.ts
@@ -16,14 +16,75 @@ export interface LoopbackHandle {
   close(): void;
 }
 
+// Posit Connect wordmark, inlined verbatim from posit-dev/connect
+// (ui/images/logoConnect.svg) so the loopback page is fully self-contained and
+// renders with no network access. `.cls-1` (wordmark) is recolored for dark mode
+// in the page CSS below; `.cls-2` is the blue mark, which reads on both themes.
+const CONNECT_LOGO_SVG = `<svg class="logo" role="img" aria-label="Posit Connect" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 301.06 84.05"><defs><style>.cls-1{fill:#404041;}.cls-2{fill:#447099;}</style></defs><path class="cls-1" d="M136.05,49.79c-1.44,2.04-3.42,3.64-5.95,4.79-2.53,1.15-5.29,1.73-8.3,1.73-5.52,0-9.91-1.63-13.17-4.89-3.26-3.26-4.89-7.62-4.89-13.07,0-5.12,1.66-9.39,4.97-12.82,3.31-3.43,7.64-5.14,13-5.14,3.08,0,5.84.56,8.28,1.68,2.44,1.12,4.28,2.58,5.52,4.39l-4.01,3.81c-2.44-2.71-5.6-4.06-9.48-4.06-3.61,0-6.51,1.1-8.68,3.31-2.17,2.21-3.26,5.15-3.26,8.83s1.13,6.58,3.39,8.81c2.26,2.22,5.19,3.34,8.81,3.34,4.25,0,7.66-1.54,10.24-4.62l3.56,3.91Z"/><path class="cls-1" d="M141.27,33.06c2.59-2.56,5.95-3.84,10.06-3.84s7.48,1.28,10.09,3.84c2.61,2.56,3.91,5.81,3.91,9.76s-1.3,7.15-3.91,9.71c-2.61,2.56-5.97,3.84-10.09,3.84s-7.38-1.28-10.01-3.84c-2.63-2.56-3.94-5.8-3.94-9.71s1.3-7.2,3.89-9.76ZM145.53,48.71c1.49,1.56,3.42,2.33,5.8,2.33s4.36-.75,5.85-2.26c1.49-1.51,2.23-3.5,2.23-5.97s-.77-4.47-2.31-6c-1.54-1.52-3.46-2.28-5.77-2.28s-4.27.75-5.77,2.26-2.26,3.51-2.26,6.02c0,2.37.74,4.34,2.23,5.9Z"/><path class="cls-1" d="M169.01,29.82h5.72v2.36c1.97-1.94,4.65-2.91,8.03-2.91,6.99,0,10.49,3.96,10.49,11.89v14.75h-5.72v-14.3c0-2.48-.52-4.26-1.56-5.37-1.04-1.1-2.66-1.66-4.87-1.66-1.4,0-2.68.39-3.81,1.18-1.14.79-1.99,1.86-2.56,3.24v16.91h-5.72v-26.09Z"/><path class="cls-1" d="M198.14,29.82h5.72v2.36c1.97-1.94,4.65-2.91,8.03-2.91,6.99,0,10.49,3.96,10.49,11.89v14.75h-5.72v-14.3c0-2.48-.52-4.26-1.56-5.37-1.04-1.1-2.66-1.66-4.87-1.66-1.4,0-2.68.39-3.81,1.18-1.14.79-1.99,1.86-2.56,3.24v16.91h-5.72v-26.09Z"/><path class="cls-1" d="M249.95,51.05c-2.64,3.55-6.17,5.32-10.59,5.32s-7.6-1.23-10.16-3.69-3.84-5.75-3.84-9.86,1.18-7.24,3.54-9.78c2.36-2.54,5.64-3.81,9.86-3.81,3.55,0,6.47,1.1,8.78,3.29,2.31,2.19,3.46,5.08,3.46,8.66,0,.87-.1,2.09-.3,3.66h-19.37c.23,2.01,1.09,3.55,2.56,4.62,1.47,1.07,3.33,1.61,5.57,1.61,2.94,0,5.27-1.15,6.97-3.46l3.51,3.46ZM233.8,35.84c-1.24.97-2.04,2.31-2.41,4.01h13.7c-.23-1.77-.92-3.13-2.06-4.06s-2.64-1.4-4.52-1.4-3.48.49-4.72,1.45Z"/><path class="cls-1" d="M279.12,49.94c-1.04,2.04-2.58,3.62-4.62,4.74-2.04,1.12-4.23,1.68-6.57,1.68-4.22,0-7.61-1.24-10.19-3.71-2.58-2.48-3.86-5.75-3.86-9.83s1.27-7.16,3.81-9.73c2.54-2.58,5.85-3.86,9.93-3.86,2.61,0,4.91.54,6.9,1.63,1.99,1.09,3.42,2.52,4.29,4.29l-4.27,2.81c-1.71-2.27-3.93-3.41-6.67-3.41-2.37,0-4.32.77-5.82,2.31-1.51,1.54-2.26,3.53-2.26,5.97s.79,4.34,2.38,5.9,3.69,2.33,6.3,2.33c2.74,0,4.93-1.24,6.57-3.71l4.06,2.61Z"/><path class="cls-1" d="M280.34,29.82h4.52v-5.37h5.72v5.37h8.43v5.32h-8.43v10.08c0,2.07.26,3.54.78,4.39.52.85,1.38,1.28,2.58,1.28,1.34,0,2.58-.74,3.71-2.21l3.41,3.21c-.74,1.27-1.81,2.31-3.24,3.11-1.42.8-3,1.2-4.74,1.2-2.54,0-4.55-.8-6.02-2.41-1.47-1.61-2.21-3.93-2.21-6.97v-11.69h-4.52v-5.32Z"/><rect class="cls-2" x="37.94" y="22.72" width="38.34" height="38.34" rx="2.17" ry="2.17" transform="translate(-12.89 52.65) rotate(-45)"/><path class="cls-2" d="M15.67,43.36c-.74-.74-.74-1.94,0-2.68L49.31,7.05l-6.5-6.5c-.74-.74-1.94-.74-2.68,0L0,40.69c-.74.74-.74,1.94,0,2.68l40.13,40.13c.74.74,1.94.74,2.68,0l6.5-6.5L15.67,43.36Z"/></svg>`;
+
+type PageVariant = "success" | "error";
+
+const STATUS_ICONS: Record<PageVariant, string> = {
+  success: `<svg class="status" viewBox="0 0 56 56" role="img" aria-label="Success"><circle cx="28" cy="28" r="28" fill="#1a7f37"/><path d="M17 29l7.5 7.5L39 21" fill="none" stroke="#fff" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+  error: `<svg class="status" viewBox="0 0 56 56" role="img" aria-label="Failed"><circle cx="28" cy="28" r="28" fill="#cf222e"/><path d="M19 19l18 18M37 19L19 37" fill="none" stroke="#fff" stroke-width="4.5" stroke-linecap="round"/></svg>`,
+};
+
+/**
+ * Renders the self-contained HTML page shown in the user's browser after the
+ * OAuth redirect (success or error). Exported for testing/preview.
+ */
+export function renderPage(
+  variant: PageVariant,
+  title: string,
+  message: string,
+): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #f5f6f8; color: #1f2328; padding: 24px; }
+.card { width: min(92vw, 440px); background: #fff; border: 1px solid rgba(0,0,0,.06);
+  border-radius: 14px; padding: 40px 40px 34px; text-align: center;
+  box-shadow: 0 1px 2px rgba(0,0,0,.06), 0 14px 34px rgba(0,0,0,.10); }
+.logo { display: block; width: 184px; height: auto; margin: 0 auto 24px; }
+.status { display: block; width: 56px; height: 56px; margin: 0 auto 18px; }
+h1 { font-size: 20px; font-weight: 600; margin: 0 0 8px; letter-spacing: -.01em; }
+p { font-size: 14px; line-height: 1.55; margin: 0; color: #57606a; }
+@media (prefers-color-scheme: dark) {
+  body { background: #1e1e1e; color: #e6edf3; }
+  .card { background: #252526; border-color: rgba(255,255,255,.08);
+    box-shadow: 0 1px 2px rgba(0,0,0,.4), 0 14px 34px rgba(0,0,0,.55); }
+  p { color: #9aa4af; }
+  .logo .cls-1 { fill: #e6edf3; }
+}
+</style>
+</head>
+<body>
+<main class="card">
+${CONNECT_LOGO_SVG}
+${STATUS_ICONS[variant]}
+<h1>${title}</h1>
+<p>${message}</p>
+</main>
+</body>
+</html>`;
+}
+
 function respondHtml(
   res: http.ServerResponse,
+  variant: PageVariant,
   title: string,
   message: string,
 ): void {
-  const body = `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body style="font-family: system-ui, sans-serif; text-align: center; padding-top: 4rem;"><h2>${title}</h2><p>${message}</p></body></html>`;
   res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-  res.end(body);
+  res.end(renderPage(variant, title, message));
 }
 
 /**
@@ -60,26 +121,29 @@ export function startLoopbackServer(
       const code = url.searchParams.get("code");
       const state = url.searchParams.get("state");
 
+      const failureMessage =
+        "Something went wrong signing in. You can close this tab and try again from your editor.";
       if (error) {
-        respondHtml(res, "Authentication failed", "You can close this tab.");
+        respondHtml(res, "error", "Authentication failed", failureMessage);
         rejectCode(new Error(`Authorization failed: ${error}`));
         return;
       }
       if (state !== expectedState) {
-        respondHtml(res, "Authentication failed", "You can close this tab.");
+        respondHtml(res, "error", "Authentication failed", failureMessage);
         rejectCode(new Error("Authorization state mismatch (possible CSRF)."));
         return;
       }
       if (!code) {
-        respondHtml(res, "Authentication failed", "You can close this tab.");
+        respondHtml(res, "error", "Authentication failed", failureMessage);
         rejectCode(new Error("Authorization response was missing a code."));
         return;
       }
 
       respondHtml(
         res,
+        "success",
         "Authentication complete",
-        "You can close this tab and return to your editor.",
+        "You're signed in to Posit Connect. You can close this tab and return to your editor.",
       );
       resolveCode(code);
     });

--- a/extensions/vscode/src/auth/oauth/pkce.test.ts
+++ b/extensions/vscode/src/auth/oauth/pkce.test.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import crypto from "crypto";
+import { describe, expect, it } from "vitest";
+import { generatePkcePair, generateState } from "./pkce";
+
+describe("generatePkcePair", () => {
+  it("produces a verifier and an S256 challenge derived from it", () => {
+    const { verifier, challenge } = generatePkcePair();
+
+    // Verifier is base64url (no +/= padding) and within RFC 7636 length bounds.
+    expect(verifier).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+
+    // challenge === BASE64URL(SHA256(verifier))
+    const expected = crypto
+      .createHash("sha256")
+      .update(verifier)
+      .digest("base64url");
+    expect(challenge).toBe(expected);
+  });
+
+  it("produces a unique verifier each call", () => {
+    expect(generatePkcePair().verifier).not.toBe(generatePkcePair().verifier);
+  });
+});
+
+describe("generateState", () => {
+  it("produces a random base64url string", () => {
+    const state = generateState();
+    expect(state).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(generateState()).not.toBe(state);
+  });
+});

--- a/extensions/vscode/src/auth/oauth/pkce.ts
+++ b/extensions/vscode/src/auth/oauth/pkce.ts
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import crypto from "crypto";
+import { PkcePair } from "./types";
+
+/** Base64url-encode a buffer (RFC 7636 uses base64url with no padding). */
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString("base64url");
+}
+
+/**
+ * Generates a PKCE code verifier + S256 challenge pair (RFC 7636).
+ * The verifier is 32 random bytes base64url-encoded (43 chars), well within the
+ * 43–128 char range the spec allows. The challenge is BASE64URL(SHA256(verifier)).
+ */
+export function generatePkcePair(): PkcePair {
+  const verifier = base64UrlEncode(crypto.randomBytes(32));
+  const challenge = base64UrlEncode(
+    crypto.createHash("sha256").update(verifier).digest(),
+  );
+  return { verifier, challenge };
+}
+
+/**
+ * Generates a random `state` value for CSRF protection on the authorization
+ * request (16 random bytes, base64url-encoded).
+ */
+export function generateState(): string {
+  return base64UrlEncode(crypto.randomBytes(16));
+}

--- a/extensions/vscode/src/auth/oauth/types.ts
+++ b/extensions/vscode/src/auth/oauth/types.ts
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+/**
+ * OAuth 2.0 authorization-server metadata (RFC 8414), as advertised by Connect
+ * at `/.well-known/oauth-authorization-server`. Only the fields Publisher uses
+ * are typed; the document may contain more.
+ */
+export interface OAuthMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  device_authorization_endpoint?: string;
+  revocation_endpoint?: string;
+  response_types_supported?: string[];
+  grant_types_supported?: string[];
+  code_challenge_methods_supported?: string[];
+  token_endpoint_auth_methods_supported?: string[];
+}
+
+/** Dynamic client registration response (RFC 7591). */
+export interface ClientRegistration {
+  client_id: string;
+  client_name?: string;
+  redirect_uris?: string[];
+  client_id_issued_at?: number;
+}
+
+/** Token endpoint success response (RFC 6749 §5.1). */
+export interface OAuthTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+/** Device authorization response (RFC 8628 §3.2). */
+export interface DeviceAuthResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+/** The tokens + client id Publisher persists for an OAuth credential. */
+export interface OAuthTokens {
+  oauthClientId: string;
+  accessToken: string;
+  refreshToken: string;
+  /** ISO-8601 timestamp when the access token expires, or "" if unknown. */
+  tokenExpiresAt: string;
+}
+
+/** PKCE code verifier + S256 challenge pair (RFC 7636). */
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+/**
+ * The client name registered with Connect's OAuth server via dynamic client
+ * registration. Matches rsconnect-python's convention of a stable, descriptive
+ * client name.
+ */
+export const OAUTH_CLIENT_NAME = "posit-publisher";
+
+/**
+ * The redirect URI registered with Connect (loopback, no explicit port).
+ * Connect accepts any loopback redirect URI and matches it against the actual
+ * authorize/callback URI ignoring the port (RFC 8252), so the ephemeral
+ * loopback-server port does not need to be known at registration time. Mirrors
+ * rsconnect-python's `http://127.0.0.1/callback`.
+ */
+export const OAUTH_LOOPBACK_REDIRECT = "http://127.0.0.1/callback";

--- a/extensions/vscode/src/auth/oauth/workbench.test.ts
+++ b/extensions/vscode/src/auth/oauth/workbench.test.ts
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+
+vi.mock("./httpClient", () => ({
+  createOAuthHttpClient: vi.fn(() => ({ get: mockGet })),
+  OAUTH_TIMEOUT_MS: 30_000,
+}));
+
+vi.mock("src/logging", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("src/utils/errors", () => ({
+  getMessageFromError: (e: unknown) => String(e),
+}));
+
+import {
+  detectWorkbench,
+  isWorkbenchRelayReachable,
+  pollWorkbenchAuthCode,
+  workbenchRedirectUri,
+  WORKBENCH_POLL_MS,
+} from "./workbench";
+
+const WORKBENCH = {
+  externalServerUrl: "https://workbench.example.com",
+  serverAddress: "http://localhost:8787",
+};
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("detectWorkbench", () => {
+  it("returns both URLs when Workbench sets them", () => {
+    expect(
+      detectWorkbench({
+        RS_SERVER_URL: "https://workbench.example.com",
+        RS_SERVER_ADDRESS: "http://localhost:8787",
+      }),
+    ).toEqual(WORKBENCH);
+  });
+
+  it("strips the query string and trailing slashes Workbench appends", () => {
+    expect(
+      detectWorkbench({
+        RS_SERVER_URL: "https://workbench.example.com/?token=abc",
+        RS_SERVER_ADDRESS: "http://localhost:8787/",
+      }),
+    ).toEqual(WORKBENCH);
+  });
+
+  it("returns undefined outside Workbench", () => {
+    expect(detectWorkbench({})).toBeUndefined();
+  });
+
+  it("returns undefined when only one of the two URLs is set", () => {
+    expect(
+      detectWorkbench({ RS_SERVER_URL: "https://workbench.example.com" }),
+    ).toBeUndefined();
+    expect(
+      detectWorkbench({ RS_SERVER_ADDRESS: "http://localhost:8787" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a non-HTTP(S) URL", () => {
+    expect(
+      detectWorkbench({
+        RS_SERVER_URL: "workbench.example.com",
+        RS_SERVER_ADDRESS: "http://localhost:8787",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("workbenchRedirectUri", () => {
+  it("targets Workbench's generic OAuth relay on the browser-reachable URL", () => {
+    expect(workbenchRedirectUri(WORKBENCH)).toBe(
+      "https://workbench.example.com/oauth_redirect_callback",
+    );
+  });
+});
+
+describe("isWorkbenchRelayReachable", () => {
+  it.each([400, 404, 429, 503])(
+    "treats a %i from the relay route as reachable",
+    async (status) => {
+      mockGet.mockResolvedValue({ status, data: "" });
+      expect(await isWorkbenchRelayReachable(WORKBENCH, false)).toBe(true);
+      expect(mockGet).toHaveBeenCalledWith(
+        "http://localhost:8787/oauth_code?state=posit-publisher-probe",
+      );
+    },
+  );
+
+  it("is unreachable when the route is absent or proxied away", async () => {
+    mockGet.mockResolvedValue({ status: 200, data: "<html>login</html>" });
+    expect(await isWorkbenchRelayReachable(WORKBENCH, false)).toBe(false);
+  });
+
+  it("is unreachable on a connection failure", async () => {
+    mockGet.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await isWorkbenchRelayReachable(WORKBENCH, false)).toBe(false);
+  });
+});
+
+describe("pollWorkbenchAuthCode", () => {
+  it("polls the host-reachable address until the code arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGet
+        .mockResolvedValueOnce({ status: 404, data: "" })
+        .mockResolvedValueOnce({ status: 200, data: { code: "auth-code" } });
+
+      const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
+      await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS * 2 + 100);
+
+      expect(await promise).toBe("auth-code");
+      expect(mockGet).toHaveBeenCalledWith(
+        "http://localhost:8787/oauth_code?state=state-123",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps polling through the load-shedding statuses", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGet
+        .mockResolvedValueOnce({ status: 429, data: "" })
+        .mockResolvedValueOnce({ status: 503, data: "" })
+        .mockResolvedValueOnce({ status: 200, data: { code: "auth-code" } });
+
+      const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
+      await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS * 3 + 100);
+
+      expect(await promise).toBe("auth-code");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws when the relay reports the request was denied", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue({ status: 403, data: "" });
+
+      const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
+      const assertion = expect(promise).rejects.toThrow(
+        "Authorization was denied.",
+      );
+      await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS + 100);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws on an unexpected status", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue({ status: 500, data: "" });
+
+      const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
+      const assertion = expect(promise).rejects.toThrow("500");
+      await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS + 100);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws when the deadline passes without a code", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue({ status: 404, data: "" });
+
+      const promise = pollWorkbenchAuthCode(
+        WORKBENCH,
+        "state-123",
+        false,
+        WORKBENCH_POLL_MS * 2,
+      );
+      const assertion = expect(promise).rejects.toThrow("Timed out");
+      await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS * 3);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/vscode/src/auth/oauth/workbench.ts
+++ b/extensions/vscode/src/auth/oauth/workbench.ts
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { logger } from "src/logging";
+import { getMessageFromError } from "src/utils/errors";
+import { createOAuthHttpClient } from "./httpClient";
+
+/**
+ * The Posit Workbench session Publisher is running inside, when it is.
+ *
+ * Workbench serves VS Code and Positron through the browser, so a loopback
+ * redirect on the extension host is unreachable from the user's browser. It does
+ * however expose a generic OAuth relay — `/oauth_redirect_callback` records the
+ * authorization code against the `state` parameter, and `/oauth_code?state=`
+ * hands it back once (single-use). That relay is the redirect target Publisher
+ * uses in Workbench, exactly as Workbench's own VS Code extension does
+ * (`rstudio-workbench-vscode-ext` `src/utils/oauthClient.ts`).
+ */
+export interface WorkbenchEnvironment {
+  /**
+   * Browser-reachable Workbench base URL, from `RS_SERVER_URL`. This is what the
+   * `redirect_uri` must be built from, since the OAuth provider redirects the
+   * user's browser there.
+   */
+  externalServerUrl: string;
+  /**
+   * Host-reachable Workbench base URL, from `RS_SERVER_ADDRESS` (typically
+   * `http://localhost:8787`). Polling for the code goes here — it bypasses the
+   * browser session cookie the external URL would require.
+   */
+  serverAddress: string;
+}
+
+/**
+ * A failure of the Workbench OAuth relay. `terminal` distinguishes "this
+ * environment can't use the relay, try another flow" (e.g. the relay is
+ * unreachable) from "the user's authorization attempt itself failed" (denied or
+ * timed out), which should be surfaced rather than silently retried in another
+ * flow.
+ */
+export class WorkbenchRelayError extends Error {
+  constructor(
+    message: string,
+    public readonly terminal: boolean,
+  ) {
+    super(message);
+    this.name = "WorkbenchRelayError";
+  }
+}
+
+/** Workbench's generic OAuth redirect target (registers `state` → `code`). */
+const WORKBENCH_REDIRECT_PATH = "/oauth_redirect_callback";
+/** Workbench's single-use code lookup, keyed by `state`. */
+const WORKBENCH_CODE_PATH = "/oauth_code";
+
+/** How often to ask Workbench whether the code has arrived. */
+export const WORKBENCH_POLL_MS = 5_000;
+/** How long to wait for the user to finish authorizing in their browser. */
+export const WORKBENCH_TIMEOUT_MS = 600_000;
+
+/**
+ * Statuses that mean "not yet" rather than "failed" — Workbench 404s until the
+ * redirect lands, and can shed load with 429/503. Mirrors the retry set in both
+ * Workbench's homepage client and its VS Code extension.
+ */
+const RETRY_STATUSES = [404, 429, 503];
+
+/**
+ * A `state` value used only to probe that the relay route exists. Never sent to
+ * Connect, so it can be a fixed string.
+ */
+const PROBE_STATE = "posit-publisher-probe";
+
+/**
+ * Normalizes a Workbench-provided base URL: drops any query string (Workbench
+ * appends one to `RS_SERVER_URL`) and trailing slashes, and rejects anything
+ * that isn't HTTP(S).
+ */
+function normalizeBaseUrl(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const withoutQuery = value.trim().split("?", 1)[0] ?? "";
+  const trimmed = withoutQuery.replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/**
+ * Detects a Posit Workbench session from the environment variables Workbench
+ * sets on every session (`SessionConstants.hpp`). Returns `undefined` when not
+ * running under Workbench, or when either URL is missing/not HTTP(S) — in which
+ * case the relay can't be used and the caller falls back to the device flow.
+ */
+export function detectWorkbench(
+  env: NodeJS.ProcessEnv = process.env,
+): WorkbenchEnvironment | undefined {
+  const externalServerUrl = normalizeBaseUrl(env.RS_SERVER_URL);
+  const serverAddress = normalizeBaseUrl(env.RS_SERVER_ADDRESS);
+  if (!externalServerUrl || !serverAddress) {
+    return undefined;
+  }
+  return { externalServerUrl, serverAddress };
+}
+
+/**
+ * The `redirect_uri` to register with Connect and send in the authorize request
+ * when running under Workbench. Connect only accepts non-loopback redirect URIs
+ * that an administrator has allowlisted, so this requires the Workbench URL to
+ * be listed in Connect's `AllowedRedirectURIs` for the OAuth flow to be usable;
+ * otherwise registration fails and the caller falls back to the device flow.
+ */
+export function workbenchRedirectUri(workbench: WorkbenchEnvironment): string {
+  return `${workbench.externalServerUrl}${WORKBENCH_REDIRECT_PATH}`;
+}
+
+function isCodeResponse(data: unknown): data is { code: string } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "code" in data &&
+    typeof data.code === "string" &&
+    data.code !== ""
+  );
+}
+
+/**
+ * Verifies the relay is reachable before the browser is sent anywhere, so an
+ * unusable Workbench deployment falls back to the device flow immediately
+ * instead of after a long poll. A well-formed `GET /oauth_code?state=` for an
+ * unknown state answers 404 — anything other than a reachable HTTP response
+ * (connection refused, TLS failure, proxy HTML) means the relay isn't usable.
+ */
+export async function isWorkbenchRelayReachable(
+  workbench: WorkbenchEnvironment,
+  insecure: boolean,
+): Promise<boolean> {
+  try {
+    const http = createOAuthHttpClient(insecure);
+    const resp = await http.get(
+      `${workbench.serverAddress}${WORKBENCH_CODE_PATH}?state=${encodeURIComponent(PROBE_STATE)}`,
+    );
+    // 404 is the expected answer for an unknown state; 400 (missing/invalid
+    // state) and the load-shedding statuses still prove the route exists.
+    return [400, 404, 429, 503].includes(resp.status);
+  } catch (err) {
+    logger.debug(
+      `Posit Workbench OAuth relay is not reachable: ${getMessageFromError(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Polls Workbench's OAuth relay for the authorization code recorded against
+ * `state`. Resolves with the code, or throws a {@link WorkbenchRelayError} when
+ * the user denied the request, the relay reports an unexpected failure, or the
+ * deadline passes.
+ */
+export async function pollWorkbenchAuthCode(
+  workbench: WorkbenchEnvironment,
+  state: string,
+  insecure: boolean,
+  timeoutMs: number = WORKBENCH_TIMEOUT_MS,
+): Promise<string> {
+  const http = createOAuthHttpClient(insecure);
+  const url = `${workbench.serverAddress}${WORKBENCH_CODE_PATH}?state=${encodeURIComponent(state)}`;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, WORKBENCH_POLL_MS));
+
+    const resp = await http.get(url);
+    if (resp.status === 200 && isCodeResponse(resp.data)) {
+      return resp.data.code;
+    }
+    if (resp.status === 403) {
+      // The relay records an empty code when the provider returned an error, so
+      // a 403 means the user (or Connect) denied the request. Terminal: retrying
+      // in another flow would just ask the user to deny it again.
+      throw new WorkbenchRelayError("Authorization was denied.", true);
+    }
+    if (!RETRY_STATUSES.includes(resp.status)) {
+      throw new WorkbenchRelayError(
+        `Posit Workbench returned an unexpected status (${resp.status}) while waiting for authorization.`,
+        false,
+      );
+    }
+    logger.debug(
+      `Waiting for the Posit Workbench OAuth redirect (status ${resp.status}).`,
+    );
+  }
+
+  throw new WorkbenchRelayError(
+    "Timed out waiting for authorization in your browser.",
+    true,
+  );
+}

--- a/extensions/vscode/src/credentials/service.test.ts
+++ b/extensions/vscode/src/credentials/service.test.ts
@@ -39,6 +39,34 @@ vi.mock("src/constants", () => ({
   CONNECT_CLOUD_ENV: "production",
 }));
 
+const oauthMocks = vi.hoisted(() => ({
+  discoverOAuthMetadata: vi.fn(),
+  refreshToken: vi.fn(),
+  registerClient: vi.fn(),
+}));
+
+vi.mock("src/auth/oauth", () => ({
+  discoverOAuthMetadata: oauthMocks.discoverOAuthMetadata,
+  OAuthClient: class {
+    refreshToken = oauthMocks.refreshToken;
+    registerClient = oauthMocks.registerClient;
+  },
+  OAuthError: class OAuthError extends Error {
+    constructor(
+      message: string,
+      public readonly code?: string,
+    ) {
+      super(message);
+      this.name = "OAuthError";
+    }
+  },
+  INVALID_CLIENT: "invalid_client",
+  tokenExpiresAt: () => "2099-01-01T00:00:00.000Z",
+  OAUTH_LOOPBACK_REDIRECT: "http://127.0.0.1/callback",
+}));
+
+import { OAuthError } from "src/auth/oauth";
+
 describe("CredentialsService", () => {
   let secrets: mockSecretStorage;
   let service: CredentialsService;
@@ -366,6 +394,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "",
         serverType: ServerType.CONNECT,
         snowflakeConnection: "",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toEqual({
@@ -384,6 +416,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "my-private-key",
         serverType: ServerType.CONNECT,
         snowflakeConnection: "",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toEqual({
@@ -401,6 +437,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "my-private-key",
         serverType: ServerType.CONNECT,
         snowflakeConnection: "",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toEqual({
@@ -420,6 +460,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "",
         serverType: ServerType.CONNECT,
         snowflakeConnection: "",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toEqual({
@@ -439,6 +483,10 @@ describe("connectAPIOptionsFromCredential", () => {
           privateKey: "",
           serverType: ServerType.CONNECT,
           snowflakeConnection: "",
+          guid: GUID("test-guid"),
+          refreshToken: "",
+          accessToken: "",
+          oauthClientId: "",
         },
         { rejectUnauthorized: false, timeout: 5000 },
       );
@@ -486,6 +534,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "",
         serverType: ServerType.SNOWFLAKE,
         snowflakeConnection: "default",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toMatchObject({
@@ -503,6 +555,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "connect-private-key",
         serverType: ServerType.SNOWFLAKE,
         snowflakeConnection: "default",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toMatchObject({
@@ -521,6 +577,10 @@ describe("connectAPIOptionsFromCredential", () => {
         privateKey: "",
         serverType: ServerType.SNOWFLAKE,
         snowflakeConnection: "default",
+        guid: GUID("test-guid"),
+        refreshToken: "",
+        accessToken: "",
+        oauthClientId: "",
       });
 
       expect(result).toMatchObject({
@@ -541,6 +601,10 @@ describe("connectAPIOptionsFromCredential", () => {
           privateKey: "",
           serverType: ServerType.SNOWFLAKE,
           snowflakeConnection: "default",
+          guid: GUID("test-guid"),
+          refreshToken: "",
+          accessToken: "",
+          oauthClientId: "",
         },
         { rejectUnauthorized: false },
       );
@@ -560,6 +624,10 @@ describe("connectAPIOptionsFromCredential", () => {
           privateKey: "",
           serverType: ServerType.SNOWFLAKE,
           snowflakeConnection: "nonexistent",
+          guid: GUID("test-guid"),
+          refreshToken: "",
+          accessToken: "",
+          oauthClientId: "",
         }),
       ).rejects.toThrow("nonexistent");
     });
@@ -573,6 +641,10 @@ describe("connectAPIOptionsFromCredential", () => {
           privateKey: "",
           serverType: ServerType.SNOWFLAKE,
           snowflakeConnection: "bad-authenticator",
+          guid: GUID("test-guid"),
+          refreshToken: "",
+          accessToken: "",
+          oauthClientId: "",
         }),
       ).rejects.toThrow("unsupported authenticator type");
     });
@@ -1198,6 +1270,229 @@ describe("CredentialsService.getSnowflakeToken", () => {
           ).rejects.toThrow(`${authenticator} auth failed`);
         });
       });
+    });
+  });
+});
+
+describe("CredentialsService OAuth", () => {
+  let secrets: mockSecretStorage;
+  let service: CredentialsService;
+
+  beforeEach(() => {
+    secrets = new mockSecretStorage();
+    service = new CredentialsService(secrets);
+    oauthMocks.discoverOAuthMetadata.mockReset();
+    oauthMocks.refreshToken.mockReset();
+    oauthMocks.registerClient.mockReset();
+  });
+
+  describe("create validation", () => {
+    test("creates an OAuth Connect credential", async () => {
+      const cred = await service.create({
+        name: "OAuth Cred",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        oauthClientId: "client-abc",
+        accessToken: "at",
+        refreshToken: "rt",
+        tokenExpiresAt: "2099-01-01T00:00:00.000Z",
+      });
+
+      expect(cred.oauthClientId).toBe("client-abc");
+      expect(cred.accessToken).toBe("at");
+      expect(cred.refreshToken).toBe("rt");
+      expect(cred.apiKey).toBe("");
+      expect(cred.token).toBe("");
+    });
+
+    test("rejects OAuth combined with an API key", async () => {
+      await expect(
+        service.create({
+          name: "Bad",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          oauthClientId: "client-abc",
+          accessToken: "at",
+          apiKey: "key",
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+    });
+
+    test("rejects OAuth combined with token+privateKey", async () => {
+      await expect(
+        service.create({
+          name: "Bad",
+          url: "https://connect.example.com",
+          serverType: ServerType.CONNECT,
+          oauthClientId: "client-abc",
+          accessToken: "at",
+          token: "t",
+          privateKey: "pk",
+        }),
+      ).rejects.toThrow(IncompleteCredentialError);
+    });
+  });
+
+  describe("update", () => {
+    test("merges a patch and persists it, preserving guid", async () => {
+      const created = await service.create({
+        name: "OAuth Cred",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        oauthClientId: "client-abc",
+        accessToken: "at",
+        refreshToken: "rt",
+      });
+
+      const updated = await service.update(created.guid, {
+        accessToken: "at2",
+        refreshToken: "rt2",
+      });
+
+      expect(updated.guid).toBe(created.guid);
+      expect(updated.accessToken).toBe("at2");
+      expect(updated.refreshToken).toBe("rt2");
+      expect(updated.oauthClientId).toBe("client-abc");
+
+      const reloaded = await service.get(created.guid);
+      expect(reloaded.accessToken).toBe("at2");
+    });
+
+    test("throws when the credential does not exist", async () => {
+      await expect(
+        service.update(GUID("missing"), { accessToken: "x" }),
+      ).rejects.toThrow(CredentialNotFoundError);
+    });
+  });
+
+  describe("connectAPIOptionsFromCredential (OAuth)", () => {
+    test("returns bearer options with a working refresh callback", async () => {
+      const created = await service.create({
+        name: "OAuth Cred",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        oauthClientId: "client-abc",
+        accessToken: "at",
+        refreshToken: "rt",
+      });
+
+      const options = await connectAPIOptionsFromCredential(service, created);
+      expect(options).toMatchObject({
+        url: "https://connect.example.com",
+        accessToken: "at",
+      });
+      expect(typeof options.refreshAccessToken).toBe("function");
+
+      // Invoking the callback refreshes + persists the rotated tokens.
+      oauthMocks.discoverOAuthMetadata.mockResolvedValue({
+        token_endpoint: "https://connect.example.com/oauth/v1/token",
+        authorization_endpoint:
+          "https://connect.example.com/oauth/v1/authorize",
+      });
+      oauthMocks.refreshToken.mockResolvedValue({
+        access_token: "at2",
+        token_type: "Bearer",
+        refresh_token: "rt2",
+        expires_in: 3600,
+      });
+
+      const newToken = await options.refreshAccessToken!();
+      expect(newToken).toBe("at2");
+      const reloaded = await service.get(created.guid);
+      expect(reloaded.accessToken).toBe("at2");
+      expect(reloaded.refreshToken).toBe("rt2");
+    });
+  });
+
+  describe("refreshOAuthToken", () => {
+    const metadata = {
+      token_endpoint: "https://connect.example.com/oauth/v1/token",
+      authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+      registration_endpoint: "https://connect.example.com/oauth/v1/register",
+    };
+
+    test("refreshes, persists rotated tokens, and returns the new access token", async () => {
+      const created = await service.create({
+        name: "OAuth Cred",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        oauthClientId: "client-abc",
+        accessToken: "at",
+        refreshToken: "rt",
+      });
+      oauthMocks.discoverOAuthMetadata.mockResolvedValue(metadata);
+      oauthMocks.refreshToken.mockResolvedValue({
+        access_token: "at2",
+        token_type: "Bearer",
+        refresh_token: "rt2",
+        expires_in: 3600,
+      });
+
+      const token = await service.refreshOAuthToken(
+        {
+          guid: created.guid,
+          url: created.url,
+          oauthClientId: created.oauthClientId,
+          refreshToken: created.refreshToken,
+        },
+        false,
+      );
+
+      expect(token).toBe("at2");
+      const reloaded = await service.get(created.guid);
+      expect(reloaded.accessToken).toBe("at2");
+      expect(reloaded.refreshToken).toBe("rt2");
+      expect(reloaded.tokenExpiresAt).toBe("2099-01-01T00:00:00.000Z");
+    });
+
+    test("re-registers the client on invalid_client and retries", async () => {
+      const created = await service.create({
+        name: "OAuth Cred",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        oauthClientId: "old-client",
+        accessToken: "at",
+        refreshToken: "rt",
+      });
+      oauthMocks.discoverOAuthMetadata.mockResolvedValue(metadata);
+      oauthMocks.refreshToken
+        .mockRejectedValueOnce(new OAuthError("invalid", "invalid_client"))
+        .mockResolvedValueOnce({
+          access_token: "at2",
+          token_type: "Bearer",
+          refresh_token: "rt2",
+        });
+      oauthMocks.registerClient.mockResolvedValue({ client_id: "new-client" });
+
+      const token = await service.refreshOAuthToken(
+        {
+          guid: created.guid,
+          url: created.url,
+          oauthClientId: created.oauthClientId,
+          refreshToken: created.refreshToken,
+        },
+        false,
+      );
+
+      expect(token).toBe("at2");
+      expect(oauthMocks.registerClient).toHaveBeenCalledTimes(1);
+      const reloaded = await service.get(created.guid);
+      expect(reloaded.oauthClientId).toBe("new-client");
+    });
+
+    test("throws when discovery fails", async () => {
+      oauthMocks.discoverOAuthMetadata.mockResolvedValue(null);
+      await expect(
+        service.refreshOAuthToken(
+          {
+            guid: GUID("g"),
+            url: "https://connect.example.com",
+            oauthClientId: "c",
+            refreshToken: "rt",
+          },
+          false,
+        ),
+      ).rejects.toThrow();
     });
   });
 });

--- a/extensions/vscode/src/credentials/service.test.ts
+++ b/extensions/vscode/src/credentials/service.test.ts
@@ -1445,6 +1445,40 @@ describe("CredentialsService OAuth", () => {
       expect(reloaded.tokenExpiresAt).toBe("2099-01-01T00:00:00.000Z");
     });
 
+    test("keeps the current refresh token when the server omits a new one", async () => {
+      const created = await service.create({
+        name: "OAuth Cred",
+        url: "https://connect.example.com",
+        serverType: ServerType.CONNECT,
+        oauthClientId: "client-abc",
+        accessToken: "at",
+        refreshToken: "rt",
+      });
+      oauthMocks.discoverOAuthMetadata.mockResolvedValue(metadata);
+      // No refresh_token in the response (server did not rotate it).
+      oauthMocks.refreshToken.mockResolvedValue({
+        access_token: "at2",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+
+      const token = await service.refreshOAuthToken(
+        {
+          guid: created.guid,
+          url: created.url,
+          oauthClientId: created.oauthClientId,
+          refreshToken: created.refreshToken,
+        },
+        false,
+      );
+
+      expect(token).toBe("at2");
+      const reloaded = await service.get(created.guid);
+      expect(reloaded.accessToken).toBe("at2");
+      // The existing refresh token is preserved.
+      expect(reloaded.refreshToken).toBe("rt");
+    });
+
     test("re-registers the client on invalid_client and retries", async () => {
       const created = await service.create({
         name: "OAuth Cred",

--- a/extensions/vscode/src/credentials/service.ts
+++ b/extensions/vscode/src/credentials/service.ts
@@ -27,6 +27,14 @@ import {
 import { CONNECT_CLOUD_ENV } from "src/constants";
 import config from "src/config";
 import { logger } from "src/logging";
+import {
+  discoverOAuthMetadata,
+  OAuthClient,
+  OAuthError,
+  INVALID_CLIENT,
+  tokenExpiresAt,
+  OAUTH_LOOPBACK_REDIRECT,
+} from "src/auth/oauth";
 
 // Upper bound on how long to wait for snowflake-sdk's destroy() callback before
 // giving up. destroy() is async and, on a wedged connection, may never invoke
@@ -46,6 +54,8 @@ export interface CreateCredentialInput {
   accessToken?: string;
   token?: string;
   privateKey?: string;
+  oauthClientId?: string;
+  tokenExpiresAt?: string;
 }
 
 /**
@@ -60,12 +70,16 @@ export async function connectAPIOptionsFromCredential(
   service: CredentialsService,
   credential: Pick<
     Credential,
+    | "guid"
     | "url"
     | "apiKey"
     | "token"
     | "privateKey"
     | "serverType"
     | "snowflakeConnection"
+    | "accessToken"
+    | "refreshToken"
+    | "oauthClientId"
   >,
   extra?: Pick<ConnectAPIOptions, "rejectUnauthorized" | "timeout">,
 ): Promise<ConnectAPIOptions> {
@@ -74,6 +88,30 @@ export async function connectAPIOptionsFromCredential(
     credential.snowflakeConnection
   ) {
     return await service.buildSnowflakeOptions(credential, extra);
+  }
+
+  // OAuth bearer credential. The refresh callback is invoked by the client on a
+  // 401: it refreshes the access token (re-registering the client if Connect
+  // reports it as deleted), persists the rotated tokens back to SecretStorage,
+  // and returns the new access token for a single retry. If refresh fails the
+  // client surfaces a SessionExpiredError for the caller to prompt re-auth.
+  if (credential.oauthClientId && credential.accessToken) {
+    const insecure = extra?.rejectUnauthorized === false;
+    return {
+      url: credential.url,
+      accessToken: credential.accessToken,
+      refreshAccessToken: () =>
+        service.refreshOAuthToken(
+          {
+            guid: credential.guid,
+            url: credential.url,
+            oauthClientId: credential.oauthClientId,
+            refreshToken: credential.refreshToken,
+          },
+          insecure,
+        ),
+      ...extra,
+    };
   }
 
   if (credential.token && credential.privateKey) {
@@ -124,25 +162,31 @@ export class CredentialsService {
       Boolean(input.refreshToken) &&
       Boolean(input.accessToken);
     const tokenAuthPresent = Boolean(input.token) && Boolean(input.privateKey);
+    const oauthPresent =
+      Boolean(input.oauthClientId) && Boolean(input.accessToken);
 
     switch (input.serverType) {
-      case ServerType.CONNECT:
-        if (
-          (connectPresent && tokenAuthPresent) ||
-          (!connectPresent && !tokenAuthPresent) ||
-          snowflakePresent ||
-          connectCloudPresent
-        ) {
+      case ServerType.CONNECT: {
+        // Exactly one of API key / token+key / OAuth, and no Snowflake or Cloud
+        // fields.
+        const connectMethods = [
+          connectPresent,
+          tokenAuthPresent,
+          oauthPresent,
+        ].filter(Boolean).length;
+        if (connectMethods !== 1 || snowflakePresent || connectCloudPresent) {
           throw new IncompleteCredentialError(
-            "Connect credential requires either an API Key or Token+PrivateKey (but not both)",
+            "Connect credential requires exactly one of: an API Key, Token+PrivateKey, or OAuth",
           );
         }
         break;
+      }
       case ServerType.SNOWFLAKE:
         if (
           !snowflakePresent ||
           (connectPresent && tokenAuthPresent) ||
           (!connectPresent && !tokenAuthPresent) ||
+          oauthPresent ||
           connectCloudPresent
         ) {
           throw new IncompleteCredentialError(
@@ -155,7 +199,8 @@ export class CredentialsService {
           !connectCloudPresent ||
           connectPresent ||
           snowflakePresent ||
-          tokenAuthPresent
+          tokenAuthPresent ||
+          Boolean(input.oauthClientId)
         ) {
           throw new IncompleteCredentialError(
             "Connect Cloud credential requires accountId, accountName, refreshToken, and accessToken",
@@ -200,6 +245,8 @@ export class CredentialsService {
         input.serverType === ServerType.CONNECT_CLOUD ? CONNECT_CLOUD_ENV : "",
       token: input.token || "",
       privateKey: input.privateKey || "",
+      oauthClientId: input.oauthClientId || "",
+      tokenExpiresAt: input.tokenExpiresAt || "",
     };
 
     // Conflict check against existing credentials
@@ -219,6 +266,83 @@ export class CredentialsService {
       throw new CredentialNotFoundError(guid);
     }
     await deleteCredential(this.secrets, guid);
+  }
+
+  /**
+   * Merges a partial update into an existing credential (by GUID) and persists
+   * it. Used to write back rotated OAuth tokens without disturbing the rest of
+   * the record. `guid` and `serverType` cannot be changed.
+   */
+  async update(
+    guid: GUID,
+    patch: Partial<Omit<Credential, "guid" | "serverType">>,
+  ): Promise<Credential> {
+    const cred = await getCredential(this.secrets, guid);
+    if (!cred) {
+      throw new CredentialNotFoundError(guid);
+    }
+    const updated: Credential = { ...cred, ...patch, guid: cred.guid };
+    await storeCredential(this.secrets, updated);
+    return updated;
+  }
+
+  /**
+   * Refreshes a Connect OAuth access token using the stored refresh token and
+   * persists the rotated tokens (Connect issues single-use refresh tokens, so
+   * the new refresh token must be saved). If Connect reports the client id as
+   * `invalid_client` (deleted server-side), the public client is re-registered
+   * — its id is deterministic — and the refresh is retried. Returns the fresh
+   * access token. Throws when discovery or refresh ultimately fails; the caller
+   * (the ConnectAPI client) surfaces that as a re-authentication prompt.
+   */
+  async refreshOAuthToken(
+    credential: Pick<Credential, "guid" | "url" | "oauthClientId"> & {
+      refreshToken: string;
+    },
+    insecure: boolean,
+  ): Promise<string> {
+    const metadata = await discoverOAuthMetadata(credential.url, insecure);
+    if (!metadata) {
+      throw new Error(
+        "Connect no longer advertises OAuth; please sign in again.",
+      );
+    }
+
+    const oauthClient = new OAuthClient(insecure);
+    let clientId = credential.oauthClientId;
+
+    let response;
+    try {
+      response = await oauthClient.refreshToken(metadata, {
+        clientId,
+        refreshToken: credential.refreshToken,
+      });
+    } catch (err) {
+      if (!(err instanceof OAuthError) || err.code !== INVALID_CLIENT) {
+        throw err;
+      }
+      // Client id was deleted on the server; re-register (deterministic id) and
+      // retry the refresh once.
+      const registration = await oauthClient.registerClient(metadata, [
+        OAUTH_LOOPBACK_REDIRECT,
+      ]);
+      clientId = registration.client_id;
+      response = await oauthClient.refreshToken(metadata, {
+        clientId,
+        refreshToken: credential.refreshToken,
+      });
+    }
+
+    await this.update(credential.guid, {
+      oauthClientId: clientId,
+      accessToken: response.access_token,
+      // Connect rotates refresh tokens (single-use); persist the new one when
+      // provided, otherwise keep the current token.
+      refreshToken: response.refresh_token || credential.refreshToken,
+      tokenExpiresAt: tokenExpiresAt(response),
+    });
+
+    return response.access_token;
   }
 
   async reset(): Promise<void> {

--- a/extensions/vscode/src/credentials/storage.test.ts
+++ b/extensions/vscode/src/credentials/storage.test.ts
@@ -75,6 +75,24 @@ describe("credentialSecretStorage", () => {
       const result = parseCredentialRecord("not json");
       expect(result).toBeUndefined();
     });
+
+    test("backfills OAuth fields added after v1 for older records", () => {
+      // Simulate a credential stored before oauthClientId/tokenExpiresAt existed.
+      const cred = credentialFactory.build();
+      const legacy: Record<string, unknown> = { ...cred };
+      delete legacy.oauthClientId;
+      delete legacy.tokenExpiresAt;
+
+      const json = JSON.stringify({ version: 1, credential: legacy });
+      const result = parseCredentialRecord(json);
+
+      expect(result).toBeDefined();
+      expect(result?.oauthClientId).toBe("");
+      expect(result?.tokenExpiresAt).toBe("");
+      // The rest of the record is preserved.
+      expect(result?.guid).toBe(cred.guid);
+      expect(result?.apiKey).toBe(cred.apiKey);
+    });
   });
 
   describe("storeCredential", () => {

--- a/extensions/vscode/src/credentials/storage.ts
+++ b/extensions/vscode/src/credentials/storage.ts
@@ -29,6 +29,15 @@ const REQUIRED_CREDENTIAL_FIELDS: (keyof Credential)[] = [
   "serverType",
 ];
 
+// String fields added after the v1 envelope shipped. They are NOT required: a
+// credential stored before they existed simply lacks them, so we backfill "" on
+// read rather than rejecting the record. This keeps existing API-key/token
+// credentials working with no migration (envelope version stays 1).
+const OPTIONAL_CREDENTIAL_FIELDS: ("oauthClientId" | "tokenExpiresAt")[] = [
+  "oauthClientId",
+  "tokenExpiresAt",
+];
+
 /**
  * Parse and validate a JSON credential record from SecretStorage.
  * Returns the credential if valid, or undefined if malformed.
@@ -56,6 +65,14 @@ export function parseCredentialRecord(json: string): Credential | undefined {
           `Credential record is missing or has invalid field: ${field}`,
         );
         return undefined;
+      }
+    }
+
+    // Backfill string fields introduced after v1 so records written before they
+    // existed still load (and downstream code can treat them as always-present).
+    for (const field of OPTIONAL_CREDENTIAL_FIELDS) {
+      if (typeof cred[field] !== "string") {
+        cred[field] = "";
       }
     }
 

--- a/extensions/vscode/src/logging.ts
+++ b/extensions/vscode/src/logging.ts
@@ -8,3 +8,20 @@ export const logger: LogOutputChannel = window.createOutputChannel(
   "Posit Publisher",
   { log: true },
 );
+
+/**
+ * Records a sign-in diagnostic to both the "Posit Publisher" output channel and
+ * the host's developer console.
+ *
+ * The duplication is deliberate. In a browser-based host — Positron or VS Code
+ * served by Posit Workbench — the developer console is the log a user can
+ * actually open, read, and paste back when reporting that browser sign-in
+ * misbehaved, and it is where the extension's other diagnostics already land.
+ * The output channel keeps the same lines alongside the rest of Publisher's
+ * logging for desktop users. Pass only environment facts, transport decisions,
+ * and failure reasons — never tokens, authorization codes, or PKCE verifiers.
+ */
+export function logSignInDiagnostic(message: string): void {
+  logger.info(message);
+  console.log(`Posit Publisher: ${message}`);
+}

--- a/extensions/vscode/src/logging.ts
+++ b/extensions/vscode/src/logging.ts
@@ -8,20 +8,3 @@ export const logger: LogOutputChannel = window.createOutputChannel(
   "Posit Publisher",
   { log: true },
 );
-
-/**
- * Records a sign-in diagnostic to both the "Posit Publisher" output channel and
- * the host's developer console.
- *
- * The duplication is deliberate. In a browser-based host — Positron or VS Code
- * served by Posit Workbench — the developer console is the log a user can
- * actually open, read, and paste back when reporting that browser sign-in
- * misbehaved, and it is where the extension's other diagnostics already land.
- * The output channel keeps the same lines alongside the rest of Publisher's
- * logging for desktop users. Pass only environment facts, transport decisions,
- * and failure reasons — never tokens, authorization codes, or PKCE verifiers.
- */
-export function logSignInDiagnostic(message: string): void {
-  logger.info(message);
-  console.log(`Posit Publisher: ${message}`);
-}

--- a/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
+++ b/extensions/vscode/src/multiStepInputs/multiStepHelper.ts
@@ -31,6 +31,17 @@ class InputFlowAction {
   static resume = new InputFlowAction();
 }
 
+/**
+ * Whether a rejection means the user dismissed the stepper rather than something
+ * failing. Steps that catch their own errors need this: pressing Escape rejects
+ * with `AbortError` and hiding the input box rejects with the `InputFlowAction`
+ * navigation sentinels, none of which carry a message — so reporting one as an
+ * error produces a diagnostic that names no cause ("did not complete: .").
+ */
+export function isCancellation(err: unknown): boolean {
+  return err instanceof AbortError || err instanceof InputFlowAction;
+}
+
 export function isQuickPickItem(d: QuickPickItem | string): d is QuickPickItem {
   return typeof d !== "string";
 }

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -212,8 +212,14 @@ vi.mock("src/utils/testCredentials", () => ({
   testAuthentication: vi.fn(() => Promise.resolve({})),
 }));
 
+const tokenActivatorMocks = vi.hoisted(() => ({
+  activateToken: vi.fn(),
+}));
+
 vi.mock("src/auth/ConnectAuthTokenActivator", () => ({
-  ConnectAuthTokenActivator: vi.fn(),
+  ConnectAuthTokenActivator: class {
+    activateToken = tokenActivatorMocks.activateToken;
+  },
   TokenAuthResult: {},
 }));
 
@@ -317,9 +323,11 @@ describe("newConnectCredential OAuth path", () => {
     stepControl.quickPickLabel = "API Key";
   });
 
-  test("offers OAuth as an option and creates an OAuth credential when selected", async () => {
-    // The auth-method QuickPick offers OAuth (Recommended); select it.
-    stepControl.quickPickLabel = "OAuth (Recommended)";
+  test("browser sign-in uses OAuth when the server advertises it", async () => {
+    // The auth-method picker shows "Sign in with a browser"; on an OAuth server
+    // that routes to the OAuth flow (the user never sees the OAuth vs token
+    // distinction).
+    stepControl.quickPickLabel = "Sign in with a browser";
     oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
       token_endpoint: "https://connect.example.com/oauth/v1/token",
       authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
@@ -388,7 +396,42 @@ describe("newConnectCredential OAuth path", () => {
     );
   });
 
-  test("falls back to the token/API-key flow when OAuth is unavailable", async () => {
+  test("browser sign-in uses the token flow when the server has no OAuth", async () => {
+    // No OAuth → "Sign in with a browser" routes to the legacy token flow, still
+    // presented to the user as a browser sign-in (no token ever shown).
+    stepControl.quickPickLabel = "Sign in with a browser";
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue(null);
+    tokenActivatorMocks.activateToken.mockResolvedValue({
+      token: "T-token",
+      privateKey: "priv-key",
+      userName: "publisher1",
+      serverUrl: "https://connect.example.com",
+    });
+    const { inputCredentialNameStep } =
+      await import("src/multiStepInputs/common");
+    vi.mocked(inputCredentialNameStep).mockResolvedValue("connect.example.com");
+
+    await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(oauthStepperMocks.authenticate).not.toHaveBeenCalled();
+    expect(tokenActivatorMocks.activateToken).toHaveBeenCalledTimes(1);
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "T-token",
+        privateKey: "priv-key",
+        apiKey: undefined,
+        oauthClientId: undefined,
+      }),
+    );
+  });
+
+  test("creates an API-key credential when the user picks API key (no OAuth)", async () => {
+    stepControl.quickPickLabel = "API Key";
     oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue(null);
     const { inputCredentialNameStep } =
       await import("src/multiStepInputs/common");
@@ -402,7 +445,6 @@ describe("newConnectCredential OAuth path", () => {
     );
 
     expect(oauthStepperMocks.authenticate).not.toHaveBeenCalled();
-    // The API-key path was taken (the QuickPick mock selects "API Key").
     expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         apiKey: "mock-api-key-value",

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -12,6 +12,10 @@ const inputBoxResponses: Record<string, string> = {
   inputAPIKey: "mock-api-key-value",
 };
 
+// Which auth-method QuickPick option the mock selects. Defaults to "API Key"
+// so existing tests take the API-key path; OAuth tests override it.
+const stepControl = { quickPickLabel: "API Key" };
+
 // Mock the MultiStepInput module with a real step-through implementation
 vi.mock("./multiStepHelper", () => {
   class AbortError extends Error {}
@@ -36,7 +40,8 @@ vi.mock("./multiStepHelper", () => {
               showQuickPick: vi.fn(
                 ({ items }: { items: { label: string }[] }) => {
                   return Promise.resolve(
-                    items.find((i) => i.label === "API Key") || items[0],
+                    items.find((i) => i.label === stepControl.quickPickLabel) ||
+                      items[0],
                   );
                 },
               ),
@@ -232,6 +237,7 @@ vi.mock("src/utils/errors", () => ({
 describe("newConnectCredential cancellation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stepControl.quickPickLabel = "API Key";
 
     // Default: server does not support OAuth, so the token/API-key flow runs.
     oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue(null);
@@ -296,10 +302,11 @@ describe("newConnectCredential cancellation", () => {
 describe("newConnectCredential OAuth path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stepControl.quickPickLabel = "API Key";
     mockCredentialsServiceList.mockResolvedValue([]);
     mockCredentialsServiceCreate.mockResolvedValue({
       guid: "credential-oauth",
-      name: "publisher1",
+      name: "connect.example.com",
       url: "https://connect.example.com",
       serverType: ServerType.CONNECT,
     });
@@ -307,9 +314,12 @@ describe("newConnectCredential OAuth path", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    stepControl.quickPickLabel = "API Key";
   });
 
-  test("defaults to OAuth (no method prompt) and creates an OAuth credential", async () => {
+  test("offers OAuth as an option and creates an OAuth credential when selected", async () => {
+    // The auth-method QuickPick offers OAuth (Recommended); select it.
+    stepControl.quickPickLabel = "OAuth (Recommended)";
     oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
       token_endpoint: "https://connect.example.com/oauth/v1/token",
       authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
@@ -323,7 +333,9 @@ describe("newConnectCredential OAuth path", () => {
     });
     const { inputCredentialNameStep } =
       await import("src/multiStepInputs/common");
-    vi.mocked(inputCredentialNameStep).mockResolvedValue("publisher1");
+    // Name defaults to the server hostname (like the token flow), not the
+    // OAuth username.
+    vi.mocked(inputCredentialNameStep).mockResolvedValue("connect.example.com");
 
     const result = await newConnectCredential(
       "test-view-id",
@@ -347,6 +359,32 @@ describe("newConnectCredential OAuth path", () => {
     );
     expect(result).toEqual(
       expect.objectContaining({ guid: "credential-oauth" }),
+    );
+  });
+
+  test("does not launch OAuth when the user picks API key on an OAuth-capable server", async () => {
+    stepControl.quickPickLabel = "API Key";
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
+      token_endpoint: "https://connect.example.com/oauth/v1/token",
+      authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+    });
+    const { inputCredentialNameStep } =
+      await import("src/multiStepInputs/common");
+    vi.mocked(inputCredentialNameStep).mockResolvedValue("connect.example.com");
+
+    await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(oauthStepperMocks.authenticate).not.toHaveBeenCalled();
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "mock-api-key-value",
+        oauthClientId: undefined,
+      }),
     );
   });
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -237,6 +237,7 @@ vi.mock("src/auth/oauth", () => ({
 
 vi.mock("src/utils/errors", () => ({
   getMessageFromError: vi.fn((e: unknown) => String(e)),
+  describeError: vi.fn((e: unknown) => String(e)),
   getSummaryStringFromError: vi.fn((loc: string, e: unknown) => `${loc}: ${e}`),
 }));
 

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -40,7 +40,16 @@ vi.mock("./multiStepHelper", () => {
                   );
                 },
               ),
-              showInfoMessage: vi.fn(() => Promise.resolve()),
+              showInfoMessage: vi.fn(
+                async (params?: { apiFunction?: () => Promise<unknown> }) => {
+                  // Drive the polling primitive by invoking apiFunction once,
+                  // mirroring a successful (single) poll.
+                  if (params && typeof params.apiFunction === "function") {
+                    return await params.apiFunction();
+                  }
+                  return undefined;
+                },
+              ),
             };
 
             try {
@@ -203,6 +212,18 @@ vi.mock("src/auth/ConnectAuthTokenActivator", () => ({
   TokenAuthResult: {},
 }));
 
+const oauthStepperMocks = vi.hoisted(() => ({
+  discoverOAuthMetadata: vi.fn(),
+  authenticate: vi.fn(),
+}));
+
+vi.mock("src/auth/oauth", () => ({
+  discoverOAuthMetadata: oauthStepperMocks.discoverOAuthMetadata,
+  ConnectOAuthActivator: class {
+    authenticate = oauthStepperMocks.authenticate;
+  },
+}));
+
 vi.mock("src/utils/errors", () => ({
   getMessageFromError: vi.fn((e: unknown) => String(e)),
   getSummaryStringFromError: vi.fn((loc: string, e: unknown) => `${loc}: ${e}`),
@@ -211,6 +232,9 @@ vi.mock("src/utils/errors", () => ({
 describe("newConnectCredential cancellation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Default: server does not support OAuth, so the token/API-key flow runs.
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue(null);
 
     mockCredentialsServiceList.mockResolvedValue([]);
     mockCredentialsServiceCreate.mockResolvedValue({
@@ -266,5 +290,86 @@ describe("newConnectCredential cancellation", () => {
       }),
     );
     expect(result).toEqual(expect.objectContaining({ guid: "credential-123" }));
+  });
+});
+
+describe("newConnectCredential OAuth path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCredentialsServiceList.mockResolvedValue([]);
+    mockCredentialsServiceCreate.mockResolvedValue({
+      guid: "credential-oauth",
+      name: "publisher1",
+      url: "https://connect.example.com",
+      serverType: ServerType.CONNECT,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("defaults to OAuth (no method prompt) and creates an OAuth credential", async () => {
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
+      token_endpoint: "https://connect.example.com/oauth/v1/token",
+      authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+    });
+    oauthStepperMocks.authenticate.mockResolvedValue({
+      oauthClientId: "client-abc",
+      accessToken: "at",
+      refreshToken: "rt",
+      tokenExpiresAt: "2099-01-01T00:00:00.000Z",
+      userName: "publisher1",
+    });
+    const { inputCredentialNameStep } =
+      await import("src/multiStepInputs/common");
+    vi.mocked(inputCredentialNameStep).mockResolvedValue("publisher1");
+
+    const result = await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(oauthStepperMocks.authenticate).toHaveBeenCalledTimes(1);
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oauthClientId: "client-abc",
+        accessToken: "at",
+        refreshToken: "rt",
+        tokenExpiresAt: "2099-01-01T00:00:00.000Z",
+        // No API key or token+privateKey on the OAuth path.
+        apiKey: undefined,
+        token: undefined,
+        privateKey: undefined,
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ guid: "credential-oauth" }),
+    );
+  });
+
+  test("falls back to the token/API-key flow when OAuth is unavailable", async () => {
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue(null);
+    const { inputCredentialNameStep } =
+      await import("src/multiStepInputs/common");
+    vi.mocked(inputCredentialNameStep).mockResolvedValue("My Server");
+
+    await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(oauthStepperMocks.authenticate).not.toHaveBeenCalled();
+    // The API-key path was taken (the QuickPick mock selects "API Key").
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "mock-api-key-value",
+        oauthClientId: undefined,
+      }),
+    );
   });
 });

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -46,7 +46,7 @@ import {
   OAuthAuthResult,
   OAuthMetadata,
 } from "src/auth/oauth";
-import { logSignInDiagnostic } from "src/logging";
+import { logger } from "src/logging";
 
 // Internal auth mechanisms. OAUTH and TOKEN are both surfaced to the user as a
 // single "sign in with a browser" choice — the user never sees a token, so the
@@ -552,12 +552,12 @@ export async function newConnectCredential(
       // an error popup — see isCancellation for why a dismissal must not take
       // this path.
       if (isCancellation(e)) {
-        logSignInDiagnostic("OAuth sign-in was dismissed before it completed.");
+        logger.debug("OAuth sign-in was dismissed before it completed.");
       } else {
         // describeError, not getMessageFromError: the latter returns "" for any
         // throw it doesn't recognize.
         const reason = describeError(e);
-        logSignInDiagnostic(`OAuth sign-in failed: ${reason}`);
+        logger.debug(`OAuth sign-in failed: ${reason}`);
         window.showErrorMessage(
           `OAuth sign-in did not complete: ${reason}. You can use an API key instead.`,
         );

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -45,6 +45,10 @@ import {
   OAuthMetadata,
 } from "src/auth/oauth";
 
+// Internal auth mechanisms. OAUTH and TOKEN are both surfaced to the user as a
+// single "sign in with a browser" choice — the user never sees a token, so the
+// distinction is an implementation detail resolved by whether the server
+// advertises OAuth.
 enum AuthMethod {
   API_KEY = "apiKey",
   TOKEN = "token",
@@ -53,20 +57,8 @@ enum AuthMethod {
 
 enum AuthMethodName {
   API_KEY = "API Key",
-  TOKEN = "Token Authentication (Legacy)",
-  OAUTH = "OAuth (Recommended)",
+  BROWSER = "Sign in with a browser",
 }
-
-const getAuthMethod = (authMethodName: AuthMethodName) => {
-  switch (authMethodName) {
-    case AuthMethodName.API_KEY:
-      return AuthMethod.API_KEY;
-    case AuthMethodName.TOKEN:
-      return AuthMethod.TOKEN;
-    case AuthMethodName.OAUTH:
-      return AuthMethod.OAUTH;
-  }
-};
 
 export async function newConnectCredential(
   viewId: string,
@@ -113,10 +105,6 @@ export async function newConnectCredential(
 
   const isApiKey = (authMethod: AuthMethod) => {
     return authMethod === AuthMethod.API_KEY;
-  };
-
-  const isOAuth = (authMethod: AuthMethod) => {
-    return authMethod === AuthMethod.OAUTH;
   };
 
   async function getSnowflakeToken(
@@ -359,20 +347,14 @@ export async function newConnectCredential(
   // Step: Select authentication method (Connect only)
   // ***************************************************************
   async function inputAuthMethod(input: MultiStepInput, state: MultiStepState) {
-    // Offer OAuth (recommended) only when the server advertised it during the
-    // URL step; otherwise present the token/API-key choices as before.
+    // Two choices, always: a browser sign-in (recommended) and a manual API
+    // key. The browser option is OAuth when the server advertises it, otherwise
+    // the token flow — both open the browser and never expose a token, so the
+    // user sees one consistent "sign in with a browser" option either way.
     const authMethods = [
-      ...(oauthMetadata
-        ? [
-            {
-              label: AuthMethodName.OAUTH,
-              description: "Sign in through your browser",
-            },
-          ]
-        : []),
       {
-        label: AuthMethodName.TOKEN,
-        description: "Generate a token in your browser",
+        label: AuthMethodName.BROWSER,
+        description: "Recommended — no API key to copy",
       },
       {
         label: AuthMethodName.API_KEY,
@@ -386,14 +368,12 @@ export async function newConnectCredential(
       totalSteps: 0,
       placeholder: "Select authentication method",
       items: authMethods,
-      // First item is the default: OAuth when available, else token auth.
+      // Browser sign-in is the default.
       activeItem: authMethods[0],
       buttons: [],
       shouldResume: () => Promise.resolve(false),
       ignoreFocusOut: true,
     });
-
-    authMethod = getAuthMethod(pick.label as AuthMethodName);
 
     // Clear auth fields from other methods so back-navigation can't leave a
     // credential with mixed material.
@@ -408,17 +388,8 @@ export async function newConnectCredential(
       state.data.privateKey = undefined;
     };
 
-    if (isOAuth(authMethod)) {
-      state.data.apiKey = undefined;
-      clearToken();
-      return {
-        name: step.INPUT_OAUTH,
-        step: (input: MultiStepInput) => steps[step.INPUT_OAUTH](input, state),
-        skipStepHistory: true,
-      };
-    }
-
-    if (isApiKey(authMethod)) {
+    if (pick.label === AuthMethodName.API_KEY) {
+      authMethod = AuthMethod.API_KEY;
       clearToken();
       clearOAuth();
       return {
@@ -428,8 +399,18 @@ export async function newConnectCredential(
       };
     }
 
-    // Token authentication.
+    // Browser sign-in: OAuth when supported, else the token flow.
     state.data.apiKey = undefined;
+    if (oauthMetadata) {
+      authMethod = AuthMethod.OAUTH;
+      clearToken();
+      return {
+        name: step.INPUT_OAUTH,
+        step: (input: MultiStepInput) => steps[step.INPUT_OAUTH](input, state),
+        skipStepHistory: true,
+      };
+    }
+    authMethod = AuthMethod.TOKEN;
     clearOAuth();
     return {
       name: step.INPUT_TOKEN,

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -354,7 +354,7 @@ export async function newConnectCredential(
     const authMethods = [
       {
         label: AuthMethodName.BROWSER,
-        description: "Recommended — no API key to copy",
+        description: "Recommended",
       },
       {
         label: AuthMethodName.API_KEY,

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -38,6 +38,12 @@ import {
   ConnectAuthTokenActivator,
   TokenAuthResult,
 } from "src/auth/ConnectAuthTokenActivator";
+import {
+  ConnectOAuthActivator,
+  discoverOAuthMetadata,
+  OAuthAuthResult,
+  OAuthMetadata,
+} from "src/auth/oauth";
 
 enum AuthMethod {
   API_KEY = "apiKey",
@@ -71,6 +77,8 @@ export async function newConnectCredential(
   let serverType: ServerType = ServerType.CONNECT;
   const productName: ProductName = ProductName.CONNECT;
   let authMethod: AuthMethod = AuthMethod.TOKEN;
+  // OAuth metadata discovered for the entered server (null when unsupported).
+  let oauthMetadata: OAuthMetadata | null = null;
 
   enum step {
     INPUT_SERVER_URL = "inputServerUrl",
@@ -79,6 +87,7 @@ export async function newConnectCredential(
     INPUT_CRED_NAME = "inputCredentialName",
     INPUT_AUTH_METHOD = "inputAuthMethod",
     INPUT_TOKEN = "inputToken",
+    INPUT_OAUTH = "inputOAuth",
   }
 
   const steps: Record<
@@ -91,6 +100,7 @@ export async function newConnectCredential(
     [step.INPUT_CRED_NAME]: inputCredentialName,
     [step.INPUT_AUTH_METHOD]: inputAuthMethod,
     [step.INPUT_TOKEN]: inputToken,
+    [step.INPUT_OAUTH]: inputOAuth,
   };
 
   const isToken = (authMethod: AuthMethod) => {
@@ -144,6 +154,15 @@ export async function newConnectCredential(
     );
   };
 
+  const isValidOAuth = () => {
+    // OAuth requires a registered client id and an access token.
+    return (
+      isConnect(serverType) &&
+      isString(state.data.oauthClientId) &&
+      isString(state.data.accessToken)
+    );
+  };
+
   // ***************************************************************
   // Order of all steps for creating a new Connect credential
   // ***************************************************************
@@ -175,13 +194,20 @@ export async function newConnectCredential(
         snowflakeConnection: <string | undefined>undefined, // eventual type is string
         token: <string | undefined>undefined, // token ID for token authentication
         privateKey: <string | undefined>undefined, // private key for token authentication
+        oauthClientId: <string | undefined>undefined, // OAuth dynamic-client-registration id
+        accessToken: <string | undefined>undefined, // OAuth access token
+        refreshToken: <string | undefined>undefined, // OAuth refresh token
+        tokenExpiresAt: <string | undefined>undefined, // OAuth access-token expiry (ISO)
       },
       promptStepNumbers: {},
       isValid: () => {
         return (
           isString(state.data.name) &&
           isString(state.data.url) &&
-          (isValidApiKeyAuth() || isValidTokenAuth() || isValidSnowflakeAuth())
+          (isValidApiKeyAuth() ||
+            isValidTokenAuth() ||
+            isValidSnowflakeAuth() ||
+            isValidOAuth())
         );
       },
     };
@@ -301,6 +327,27 @@ export async function newConnectCredential(
       };
     }
 
+    // Probe for OAuth support (RFC 8414). When the server advertises it, default
+    // to OAuth with no method prompt; otherwise keep the token/API-key flow.
+    const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
+    oauthMetadata = await showProgress(
+      "Checking authentication options",
+      viewId,
+      () =>
+        discoverOAuthMetadata(
+          serverUrl,
+          !extensionSettings.verifyCertificates(),
+        ),
+    );
+
+    if (oauthMetadata) {
+      return {
+        name: step.INPUT_OAUTH,
+        step: (input: MultiStepInput) => steps[step.INPUT_OAUTH](input, state),
+        skipStepHistory: true,
+      };
+    }
+
     return {
       name: step.INPUT_AUTH_METHOD,
       step: (input: MultiStepInput) =>
@@ -411,6 +458,91 @@ export async function newConnectCredential(
     } catch (_e) {
       // Error handling is done within the ConnectAuthTokenActivator
       return;
+    }
+
+    return {
+      name: step.INPUT_CRED_NAME,
+      step: (input: MultiStepInput) =>
+        steps[step.INPUT_CRED_NAME](input, state),
+    };
+  }
+
+  // ***************************************************************
+  // Step: Sign in with OAuth (Connect only, when the server supports it)
+  // ***************************************************************
+  async function inputOAuth(input: MultiStepInput, state: MultiStepState) {
+    const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
+
+    // Defensive: should only be reached when metadata was discovered.
+    if (!oauthMetadata) {
+      return {
+        name: step.INPUT_AUTH_METHOD,
+        step: (input: MultiStepInput) =>
+          steps[step.INPUT_AUTH_METHOD](input, state),
+      };
+    }
+
+    const activator = new ConnectOAuthActivator(
+      serverUrl,
+      oauthMetadata,
+      viewId,
+      !extensionSettings.verifyCertificates(),
+    );
+
+    try {
+      const resp = await input.showInfoMessage<
+        OAuthAuthResult,
+        InfoMessageParameters<OAuthAuthResult>
+      >({
+        title: state.title,
+        step: 0,
+        totalSteps: 0,
+        enabled: false,
+        busy: true,
+        value: `Signing in to ${serverUrl}`,
+        valueSelection: [0, 0],
+        validationMessage: {
+          message:
+            "Complete sign-in in your browser, or press 'Escape' to use an API key instead.",
+          severity: InputBoxValidationSeverity.Info,
+        },
+        prompt: "",
+        shouldResume: () => Promise.resolve(false),
+        ignoreFocusOut: true,
+        apiFunction: async () => ({
+          data: await activator.authenticate(),
+          intervalAdjustment: 0,
+        }),
+        exitPollingCondition: (r) => Boolean(r.data),
+      });
+
+      state.data.oauthClientId = resp.data?.oauthClientId;
+      state.data.accessToken = resp.data?.accessToken;
+      state.data.refreshToken = resp.data?.refreshToken;
+      state.data.tokenExpiresAt = resp.data?.tokenExpiresAt;
+
+      // Clear any other auth material picked up from a prior path.
+      state.data.apiKey = undefined;
+      state.data.token = undefined;
+      state.data.privateKey = undefined;
+
+      // Suggest the authenticated username as the credential name.
+      if (!state.data.name && resp.data?.userName) {
+        state.data.name = resp.data.userName;
+      }
+    } catch (e) {
+      // Escape (AbortError) or an OAuth failure both divert to the manual
+      // auth-method chooser so an API key is always reachable.
+      if (!(e instanceof AbortError)) {
+        window.showErrorMessage(
+          `OAuth sign-in did not complete: ${getMessageFromError(e)}. You can use an API key instead.`,
+        );
+      }
+      return {
+        name: step.INPUT_AUTH_METHOD,
+        step: (input: MultiStepInput) =>
+          steps[step.INPUT_AUTH_METHOD](input, state),
+      };
     }
 
     return {
@@ -608,8 +740,18 @@ export async function newConnectCredential(
     throw new AbortError();
   }
 
-  const { name, url, apiKey, token, privateKey, snowflakeConnection } =
-    state.data;
+  const {
+    name,
+    url,
+    apiKey,
+    token,
+    privateKey,
+    snowflakeConnection,
+    oauthClientId,
+    accessToken,
+    refreshToken,
+    tokenExpiresAt,
+  } = state.data;
 
   if (!isString(name) || !isString(url)) {
     return undefined;
@@ -628,6 +770,10 @@ export async function newConnectCredential(
       snowflakeConnection: isString(snowflakeConnection)
         ? snowflakeConnection
         : undefined,
+      oauthClientId: isString(oauthClientId) ? oauthClientId : undefined,
+      accessToken: isString(accessToken) ? accessToken : undefined,
+      refreshToken: isString(refreshToken) ? refreshToken : undefined,
+      tokenExpiresAt: isString(tokenExpiresAt) ? tokenExpiresAt : undefined,
     });
   } catch (error: unknown) {
     const summary = getSummaryStringFromError("credentials::add", error);

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -48,11 +48,13 @@ import {
 enum AuthMethod {
   API_KEY = "apiKey",
   TOKEN = "token",
+  OAUTH = "oauth",
 }
 
 enum AuthMethodName {
   API_KEY = "API Key",
-  TOKEN = "Token Authentication",
+  TOKEN = "Token Authentication (Legacy)",
+  OAUTH = "OAuth (Recommended)",
 }
 
 const getAuthMethod = (authMethodName: AuthMethodName) => {
@@ -61,6 +63,8 @@ const getAuthMethod = (authMethodName: AuthMethodName) => {
       return AuthMethod.API_KEY;
     case AuthMethodName.TOKEN:
       return AuthMethod.TOKEN;
+    case AuthMethodName.OAUTH:
+      return AuthMethod.OAUTH;
   }
 };
 
@@ -109,6 +113,10 @@ export async function newConnectCredential(
 
   const isApiKey = (authMethod: AuthMethod) => {
     return authMethod === AuthMethod.API_KEY;
+  };
+
+  const isOAuth = (authMethod: AuthMethod) => {
+    return authMethod === AuthMethod.OAUTH;
   };
 
   async function getSnowflakeToken(
@@ -327,8 +335,8 @@ export async function newConnectCredential(
       };
     }
 
-    // Probe for OAuth support (RFC 8414). When the server advertises it, default
-    // to OAuth with no method prompt; otherwise keep the token/API-key flow.
+    // Probe for OAuth support (RFC 8414) so the auth-method step can offer it
+    // (as the recommended option) when the server advertises it.
     const serverUrl = typeof state.data.url === "string" ? state.data.url : "";
     oauthMetadata = await showProgress(
       "Checking authentication options",
@@ -339,14 +347,6 @@ export async function newConnectCredential(
           !extensionSettings.verifyCertificates(),
         ),
     );
-
-    if (oauthMetadata) {
-      return {
-        name: step.INPUT_OAUTH,
-        step: (input: MultiStepInput) => steps[step.INPUT_OAUTH](input, state),
-        skipStepHistory: true,
-      };
-    }
 
     return {
       name: step.INPUT_AUTH_METHOD,
@@ -359,10 +359,20 @@ export async function newConnectCredential(
   // Step: Select authentication method (Connect only)
   // ***************************************************************
   async function inputAuthMethod(input: MultiStepInput, state: MultiStepState) {
+    // Offer OAuth (recommended) only when the server advertised it during the
+    // URL step; otherwise present the token/API-key choices as before.
     const authMethods = [
+      ...(oauthMetadata
+        ? [
+            {
+              label: AuthMethodName.OAUTH,
+              description: "Sign in through your browser",
+            },
+          ]
+        : []),
       {
         label: AuthMethodName.TOKEN,
-        description: "Recommended - one click connection",
+        description: "Generate a token in your browser",
       },
       {
         label: AuthMethodName.API_KEY,
@@ -376,7 +386,8 @@ export async function newConnectCredential(
       totalSteps: 0,
       placeholder: "Select authentication method",
       items: authMethods,
-      activeItem: authMethods[0], // Token authentication is default
+      // First item is the default: OAuth when available, else token auth.
+      activeItem: authMethods[0],
       buttons: [],
       shouldResume: () => Promise.resolve(false),
       ignoreFocusOut: true,
@@ -384,10 +395,32 @@ export async function newConnectCredential(
 
     authMethod = getAuthMethod(pick.label as AuthMethodName);
 
-    if (isApiKey(authMethod)) {
-      // clear token (in case user navigated back to change auth method)
+    // Clear auth fields from other methods so back-navigation can't leave a
+    // credential with mixed material.
+    const clearOAuth = () => {
+      state.data.oauthClientId = undefined;
+      state.data.accessToken = undefined;
+      state.data.refreshToken = undefined;
+      state.data.tokenExpiresAt = undefined;
+    };
+    const clearToken = () => {
       state.data.token = undefined;
       state.data.privateKey = undefined;
+    };
+
+    if (isOAuth(authMethod)) {
+      state.data.apiKey = undefined;
+      clearToken();
+      return {
+        name: step.INPUT_OAUTH,
+        step: (input: MultiStepInput) => steps[step.INPUT_OAUTH](input, state),
+        skipStepHistory: true,
+      };
+    }
+
+    if (isApiKey(authMethod)) {
+      clearToken();
+      clearOAuth();
       return {
         name: step.INPUT_API_KEY,
         step: (input: MultiStepInput) =>
@@ -395,8 +428,9 @@ export async function newConnectCredential(
       };
     }
 
-    // clear api key (in case user navigated back to change auth method)
+    // Token authentication.
     state.data.apiKey = undefined;
+    clearOAuth();
     return {
       name: step.INPUT_TOKEN,
       step: (input: MultiStepInput) => steps[step.INPUT_TOKEN](input, state),
@@ -526,10 +560,8 @@ export async function newConnectCredential(
       state.data.token = undefined;
       state.data.privateKey = undefined;
 
-      // Suggest the authenticated username as the credential name.
-      if (!state.data.name && resp.data?.userName) {
-        state.data.name = resp.data.userName;
-      }
+      // Leave the credential name for inputCredentialName to default to the
+      // server hostname, matching the token-based flow (the user can edit it).
     } catch (e) {
       // Escape (AbortError) or an OAuth failure both divert to the manual
       // auth-method chooser so an API key is always reachable.

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -7,6 +7,7 @@ import {
   MultiStepInput,
   MultiStepState,
   QuickPickItemWithIndex,
+  isCancellation,
   isQuickPickItemWithIndex,
   isString,
 } from "./multiStepHelper";
@@ -16,6 +17,7 @@ import { InputBoxValidationSeverity, window } from "vscode";
 import { Credential, ServerType, ProductName } from "src/api";
 import type { SnowflakeConnection } from "src/snowflake/types";
 import {
+  describeError,
   getMessageFromError,
   getSummaryStringFromError,
 } from "src/utils/errors";
@@ -44,6 +46,7 @@ import {
   OAuthAuthResult,
   OAuthMetadata,
 } from "src/auth/oauth";
+import { logSignInDiagnostic } from "src/logging";
 
 // Internal auth mechanisms. OAUTH and TOKEN are both surfaced to the user as a
 // single "sign in with a browser" choice — the user never sees a token, so the
@@ -544,11 +547,19 @@ export async function newConnectCredential(
       // Leave the credential name for inputCredentialName to default to the
       // server hostname, matching the token-based flow (the user can edit it).
     } catch (e) {
-      // Escape (AbortError) or an OAuth failure both divert to the manual
-      // auth-method chooser so an API key is always reachable.
-      if (!(e instanceof AbortError)) {
+      // A dismissal or an OAuth failure both divert to the manual auth-method
+      // chooser so an API key is always reachable. Only a real failure warrants
+      // an error popup — see isCancellation for why a dismissal must not take
+      // this path.
+      if (isCancellation(e)) {
+        logSignInDiagnostic("OAuth sign-in was dismissed before it completed.");
+      } else {
+        // describeError, not getMessageFromError: the latter returns "" for any
+        // throw it doesn't recognize.
+        const reason = describeError(e);
+        logSignInDiagnostic(`OAuth sign-in failed: ${reason}`);
         window.showErrorMessage(
-          `OAuth sign-in did not complete: ${getMessageFromError(e)}. You can use an API key instead.`,
+          `OAuth sign-in did not complete: ${reason}. You can use an API key instead.`,
         );
       }
       return {

--- a/extensions/vscode/src/test/unit-test-utils/factories.ts
+++ b/extensions/vscode/src/test/unit-test-utils/factories.ts
@@ -124,5 +124,7 @@ export const credentialFactory = Factory.define<Credential>(({ sequence }) => ({
   cloudEnvironment: "",
   token: "",
   privateKey: "",
+  oauthClientId: "",
+  tokenExpiresAt: "",
   serverType: ServerType.CONNECT,
 }));

--- a/extensions/vscode/src/utils/errors.test.ts
+++ b/extensions/vscode/src/utils/errors.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "vitest";
 import { AxiosError, AxiosHeaders } from "axios";
 import {
+  describeError,
   getSummaryStringFromError,
   getMessageFromError,
   isConnectionRefusedError,
@@ -179,5 +180,53 @@ describe("getMessageFromError", () => {
       const error = new AxiosError("Network Error", "ERR_NETWORK");
       expect(getMessageFromError(error)).toBe("Network Error");
     });
+  });
+});
+
+describe("describeError", () => {
+  test("passes through a message getMessageFromError can extract", () => {
+    expect(describeError(new Error("boom"))).toBe("boom");
+    expect(describeError(new AxiosError("Network Error", "ERR_NETWORK"))).toBe(
+      "Network Error",
+    );
+  });
+
+  test("falls back to the error class name when the message is empty", () => {
+    // The case that rendered as "sign-in did not complete: ." — a thrown Error
+    // carrying no message at all.
+    expect(describeError(new Error())).toBe("Error");
+
+    class AbortError extends Error {}
+    expect(describeError(new AbortError())).toBe("AbortError");
+  });
+
+  test("describes non-Error throws", () => {
+    expect(describeError("plain string")).toBe("plain string");
+    expect(describeError({ status: 500 })).toBe('{"status":500}');
+  });
+
+  test("never returns an empty string", () => {
+    // Sentinels like InputFlowAction are bare class instances: no message, no
+    // useful name, and they serialize to "{}".
+    class InputFlowAction {}
+    for (const value of [
+      undefined,
+      null,
+      "",
+      {},
+      new InputFlowAction(),
+      Object.assign(new Error(), { name: "" }),
+    ]) {
+      expect(describeError(value)).not.toBe("");
+    }
+    expect(describeError(new InputFlowAction())).toBe(
+      "no error details were reported",
+    );
+  });
+
+  test("survives an error that cannot be serialized", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(describeError(circular)).toBe("no error details were reported");
   });
 });

--- a/extensions/vscode/src/utils/errors.ts
+++ b/extensions/vscode/src/utils/errors.ts
@@ -64,6 +64,42 @@ export const getMessageFromError = (error: unknown): string => {
   return "";
 };
 
+/**
+ * Like `getMessageFromError`, but never returns an empty string.
+ *
+ * `getMessageFromError` yields "" for anything it doesn't recognize — a non-Error
+ * throw, an Error with an empty message, a control-flow sentinel — which makes
+ * interpolated diagnostics name no cause at all ("sign-in did not complete: .").
+ * Use this wherever the message is the only thing a user or a log will see.
+ */
+export const describeError = (error: unknown): string => {
+  const message = getMessageFromError(error);
+  if (message) {
+    return message;
+  }
+  if (error instanceof Error) {
+    // `name` is only meaningful when a subclass sets it — `class Foo extends
+    // Error {}` inherits the literal "Error" — so prefer the constructor name
+    // once `name` turns out to be the generic default.
+    if (error.name && error.name !== "Error") {
+      return error.name;
+    }
+    const ctor = error.constructor?.name;
+    if (ctor && ctor !== "Object") {
+      return ctor;
+    }
+  }
+  try {
+    const text = typeof error === "string" ? error : JSON.stringify(error);
+    if (text && text !== "{}" && text !== '""') {
+      return text;
+    }
+  } catch {
+    // Not serializable (circular, or a throwing toJSON); use the generic text.
+  }
+  return "no error details were reported";
+};
+
 export const getAPIURLFromError = (error: unknown) => {
   if (axios.isAxiosError(error) && error.config) {
     return {

--- a/extensions/vscode/src/views/deployProgress.ts
+++ b/extensions/vscode/src/views/deployProgress.ts
@@ -7,6 +7,7 @@ import type { CloudPublishStep } from "src/publish/connectCloudPublish";
 import type { EventStream } from "src/events";
 import type { EventStreamMessage, EventSubscriptionTarget } from "src/api";
 import type { ErrorCode } from "src/utils/errorTypes";
+import { logger } from "src/logging";
 
 // Union of all possible publish step types (standard Connect + Cloud)
 export type AnyPublishStep = PublishStep | CloudPublishStep;
@@ -95,6 +96,13 @@ export type DeployProgressOptions = {
   onComplete: () => void;
   /** Called when the user cancels the deployment (e.g. to send PUBLISH_CANCEL to webview). */
   onCancel?: () => void;
+  /**
+   * Called with the thrown error when the deployment fails (not on cancel).
+   * Lets the caller react to specific failures — e.g. prompt OAuth
+   * re-authentication on a {@link SessionExpiredError}. Any error it throws is
+   * swallowed so it can't disrupt progress teardown.
+   */
+  onError?: (err: unknown) => void | Promise<void>;
   stream: EventStream;
   serverUrl: string;
   title: string;
@@ -143,7 +151,8 @@ export function isServerLogStep(step: AnyPublishStep): boolean {
  * feeding events into the Publishing Log tree view via the EventStream.
  */
 export function runDeployWithProgress(options: DeployProgressOptions): void {
-  const { deploy, onComplete, onCancel, stream, serverUrl, title } = options;
+  const { deploy, onComplete, onCancel, onError, stream, serverUrl, title } =
+    options;
 
   window.withProgress(
     {
@@ -338,6 +347,22 @@ export function runDeployWithProgress(options: DeployProgressOptions): void {
         stream.injectMessage(
           makeMessage("publish/failure", failureData, lastErrCode),
         );
+
+        // Give the caller a chance to react to the failure (e.g. prompt OAuth
+        // re-authentication). Never let a handler error break teardown.
+        if (onError) {
+          try {
+            await onError(err);
+          } catch (handlerErr) {
+            logger.error(
+              `Deploy onError handler threw: ${
+                handlerErr instanceof Error
+                  ? handlerErr.message
+                  : String(handlerErr)
+              }`,
+            );
+          }
+        }
       } finally {
         onComplete();
       }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -42,8 +42,9 @@ import {
   IntegrationRequest,
   UpdateConfigWithDefaults,
 } from "src/api";
-import { ConnectAPI, GUID } from "@posit-dev/connect-api";
+import { ConnectAPI, GUID, SessionExpiredError } from "@posit-dev/connect-api";
 import type { Integration } from "@posit-dev/connect-api";
+import { ConnectOAuthActivator } from "src/auth/oauth";
 import {
   ConnectCloudAPI,
   ContentID,
@@ -75,7 +76,11 @@ import { getPythonInterpreterPath, getRInterpreterPath } from "../utils/vscode";
 import { getInterpreterDefaults } from "src/interpreters";
 import { scanRPackages } from "src/interpreters/rPackages";
 import { scanPythonDependencies } from "src/interpreters/scanPythonDependencies";
-import { getSummaryStringFromError } from "src/utils/errors";
+import {
+  getSummaryStringFromError,
+  getMessageFromError,
+} from "src/utils/errors";
+import type { Credential } from "src/api/types/credentials";
 import { getNonce } from "src/utils/getNonce";
 import { getUri } from "src/utils/getUri";
 import { runDeployWithProgress } from "src/views/deployProgress";
@@ -377,6 +382,9 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
     configurationName: string,
     projectDir: string,
     secrets?: Record<string, string>,
+    // Guards the OAuth re-auth retry so a persistently-failing session can't
+    // loop: a re-authenticated deploy runs with isRetry=true and won't re-prompt.
+    isRetry = false,
   ) {
     try {
       const credential = this.state.findCredential(credentialName);
@@ -526,6 +534,14 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
               signal,
             }),
           ...progressOptions,
+          onError: (err) =>
+            this.handleDeployError(err, credential, isRetry, {
+              deploymentName,
+              credentialName,
+              configurationName,
+              projectDir,
+              secrets,
+            }),
         });
       }
     } catch (error: unknown) {
@@ -550,6 +566,80 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       msg.content.configurationName,
       msg.content.projectDir,
       msg.content.secrets,
+    );
+  }
+
+  /**
+   * Reacts to a failed deployment. When an OAuth session could not be refreshed
+   * (SessionExpiredError), prompts the user to sign in again, persists the new
+   * tokens, and retries the deployment once. Other failures are already surfaced
+   * by runDeployWithProgress, so this is a no-op for them.
+   */
+  private async handleDeployError(
+    err: unknown,
+    credential: Credential,
+    isRetry: boolean,
+    deployArgs: {
+      deploymentName: string;
+      credentialName: string;
+      configurationName: string;
+      projectDir: string;
+      secrets?: Record<string, string>;
+    },
+  ): Promise<void> {
+    if (
+      isRetry ||
+      !(err instanceof SessionExpiredError) ||
+      !credential.oauthClientId
+    ) {
+      return;
+    }
+
+    const choice = await window.showWarningMessage(
+      `Your session for "${credential.name}" has expired. Sign in again to finish deploying?`,
+      "Sign In",
+      "Cancel",
+    );
+    if (choice !== "Sign In") {
+      return;
+    }
+
+    const activator = await ConnectOAuthActivator.forServer(
+      credential.url,
+      Views.HomeView,
+      !extensionSettings.verifyCertificates(),
+    );
+    if (!activator) {
+      window.showErrorMessage(
+        `${credential.url} no longer supports OAuth sign-in.`,
+      );
+      return;
+    }
+
+    try {
+      const result = await activator.authenticate();
+      await this.state.credentialsService.update(credential.guid, {
+        oauthClientId: result.oauthClientId,
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        tokenExpiresAt: result.tokenExpiresAt,
+      });
+      await this.refreshCredentials();
+    } catch (reauthErr) {
+      window.showErrorMessage(
+        `Sign-in failed: ${getMessageFromError(reauthErr)}`,
+      );
+      return;
+    }
+
+    // Retry the deployment once with the refreshed credential.
+    await this.initiateDeployment(
+      deployArgs.deploymentName,
+      deployArgs.credentialName,
+      deployArgs.configurationName,
+      deployArgs.projectDir,
+      deployArgs.secrets,
+      true,
     );
   }
 

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -3,7 +3,7 @@
 import crypto from "crypto";
 import { Readable } from "stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ConnectAPI } from "./client.js";
+import { ConnectAPI, SessionExpiredError } from "./client.js";
 import { ContentID, BundleID, TaskID } from "./types.js";
 import type { UserDTO, ContentDetailsDTO } from "./types.js";
 
@@ -21,12 +21,15 @@ vi.mock("axios", () => {
   type InterceptorFn = (
     value: Record<string, unknown>,
   ) => Record<string, unknown>;
+  type RejectedFn = (
+    error: unknown,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
 
   function createInterceptorManager() {
-    const handlers: InterceptorFn[] = [];
+    const handlers: { fulfilled?: InterceptorFn; rejected?: RejectedFn }[] = [];
     return {
-      use: (fn: InterceptorFn) => {
-        handlers.push(fn);
+      use: (fulfilled?: InterceptorFn, rejected?: RejectedFn) => {
+        handlers.push({ fulfilled, rejected });
       },
       _handlers: handlers,
     };
@@ -62,9 +65,11 @@ vi.mock("axios", () => {
             headers,
           };
 
-          // Apply request interceptors
+          // Apply request interceptors (fulfilled only — mirrors real usage)
           for (const handler of reqInterceptors._handlers) {
-            cfg = handler(cfg);
+            if (handler.fulfilled) {
+              cfg = handler.fulfilled(cfg);
+            }
           }
 
           // Merge headerStore into cfg so tests can inspect signed headers
@@ -72,23 +77,30 @@ vi.mock("axios", () => {
             cfg._signedHeaders = headerStore;
           }
 
-          let resp = await mockRequest(cfg);
-          const validate =
-            (cfg.validateStatus as ((s: number) => boolean) | undefined) ??
-            ((s: number) => s >= 200 && s < 300);
-          if (!validate(resp.status as number)) {
-            throw Object.assign(
-              new Error(`Request failed with status code ${resp.status}`),
-              { isAxiosError: true, response: resp },
-            );
-          }
+          // Dispatch, producing a promise that resolves on 2xx and rejects
+          // (with an axios-shaped error carrying `config`) otherwise. Response
+          // interceptors are then chained via .then(fulfilled, rejected) so
+          // rejected handlers (e.g. the OAuth 401 refresh/retry) run exactly as
+          // real axios chains them.
+          let promise: Promise<Record<string, unknown>> = (async () => {
+            const resp = await mockRequest(cfg);
+            const validate =
+              (cfg.validateStatus as ((s: number) => boolean) | undefined) ??
+              ((s: number) => s >= 200 && s < 300);
+            if (!validate(resp.status as number)) {
+              throw Object.assign(
+                new Error(`Request failed with status code ${resp.status}`),
+                { isAxiosError: true, response: resp, config: cfg },
+              );
+            }
+            return resp;
+          })();
 
-          // Apply response interceptors
           for (const handler of resInterceptors._handlers) {
-            resp = handler(resp);
+            promise = promise.then(handler.fulfilled, handler.rejected);
           }
 
-          return resp;
+          return promise;
         }
 
         return {
@@ -246,6 +258,110 @@ describe("Authorization header", () => {
         }),
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OAuth bearer auth + refresh
+// ---------------------------------------------------------------------------
+
+describe("OAuth bearer auth", () => {
+  const ACCESS = "access-token-abc";
+
+  it("sends Authorization: Bearer <accessToken> on requests", async () => {
+    mockRequest.mockResolvedValue(jsonResponse(validUserDTO()));
+
+    const client = new ConnectAPI({ url: BASE_URL, accessToken: ACCESS });
+    await client.getCurrentUser();
+
+    const cfg = mockRequest.mock.calls.at(-1)?.[0];
+    expect(cfg._signedHeaders?.Authorization).toBe(`Bearer ${ACCESS}`);
+  });
+
+  it("refreshes once on 401 and retries with the new token", async () => {
+    const refreshAccessToken = vi.fn().mockResolvedValue("access-token-new");
+    mockRequest
+      .mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse(validUserDTO()));
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      accessToken: ACCESS,
+      refreshAccessToken,
+    });
+    const user = await client.getCurrentUser();
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(user.username).toBe("publisher1");
+    // The retried request carries the refreshed bearer token.
+    const retryCfg = mockRequest.mock.calls[1]?.[0];
+    expect(retryCfg._signedHeaders?.Authorization).toBe(
+      "Bearer access-token-new",
+    );
+  });
+
+  it("throws SessionExpiredError when the refresh callback fails", async () => {
+    const refreshAccessToken = vi
+      .fn()
+      .mockRejectedValue(new Error("refresh boom"));
+    mockRequest.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      accessToken: ACCESS,
+      refreshAccessToken,
+    });
+
+    await expect(client.getCurrentUser()).rejects.toBeInstanceOf(
+      SessionExpiredError,
+    );
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws SessionExpiredError without refreshing twice when the retry still 401s", async () => {
+    const refreshAccessToken = vi.fn().mockResolvedValue("access-token-new");
+    mockRequest.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      accessToken: ACCESS,
+      refreshAccessToken,
+    });
+
+    await expect(client.getCurrentUser()).rejects.toBeInstanceOf(
+      SessionExpiredError,
+    );
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replay a streamed body on 401 (surfaces SessionExpiredError, no refresh)", async () => {
+    const refreshAccessToken = vi.fn().mockResolvedValue("access-token-new");
+    mockRequest.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    const client = new ConnectAPI({
+      url: BASE_URL,
+      accessToken: ACCESS,
+      refreshAccessToken,
+    });
+    const body = Readable.from(Buffer.from("bundle-bytes"));
+
+    await expect(
+      client.uploadBundle(ContentID("c1"), body, 12, "checksum"),
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+    // The consumed stream must not be replayed, so no refresh is attempted.
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("propagates the raw 401 (not SessionExpiredError) when no refresh callback is provided", async () => {
+    mockRequest.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    const client = new ConnectAPI({ url: BASE_URL, accessToken: ACCESS });
+    const err = await client.getCurrentUser().catch((e) => e);
+
+    expect(err).not.toBeInstanceOf(SessionExpiredError);
+    expect(err).toBeInstanceOf(Error);
   });
 });
 

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -6,6 +6,13 @@ import type { ClientRequest, IncomingMessage } from "http";
 import axios from "axios";
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
+declare module "axios" {
+  interface InternalAxiosRequestConfig {
+    /** Internal flag: this request was already retried after an OAuth refresh. */
+    _oauthRetried?: boolean;
+  }
+}
+
 import { md5Checksum, signRequestWithChecksum } from "./auth.js";
 import type {
   AllSettings,
@@ -41,6 +48,23 @@ export class ConnectAPIError extends Error {
   ) {
     super(message);
     this.name = "ConnectAPIError";
+  }
+}
+
+/**
+ * Thrown when an OAuth bearer session can no longer be used — either the silent
+ * token refresh failed, or a request still returned 401 after a refresh+retry.
+ * Callers (e.g. the publish flow) can catch this to prompt interactive
+ * re-authentication. Subclasses {@link ConnectAPIError} with `httpStatus: 401`
+ * so existing status-based handling still treats it as an auth failure.
+ */
+export class SessionExpiredError extends ConnectAPIError {
+  constructor(
+    message = "Your Connect session has expired. Please sign in again.",
+    public readonly cause?: unknown,
+  ) {
+    super(message, 401);
+    this.name = "SessionExpiredError";
   }
 }
 
@@ -82,6 +106,7 @@ export class ConnectAPI {
     const hasApiKey = !!options.apiKey;
     const hasToken = !!options.token && !!options.privateKey;
     const hasSnowflake = !!options.snowflakeToken;
+    const hasBearer = !!options.accessToken;
 
     // Allow no credentials (for URL reachability checks), but reject
     // partial token auth (token without privateKey or vice versa).
@@ -205,6 +230,58 @@ export class ConnectAPI {
       }
       return config;
     });
+
+    // OAuth bearer auth. The Authorization header is set on every request from a
+    // mutable token so that a token refreshed mid-session (below) is picked up
+    // by subsequent and retried requests.
+    if (hasBearer) {
+      let accessToken = options.accessToken!;
+      const refreshAccessToken = options.refreshAccessToken;
+
+      this.client.interceptors.request.use((reqConfig) => {
+        reqConfig.headers.set("Authorization", `Bearer ${accessToken}`);
+        return reqConfig;
+      });
+
+      // On a single 401, call the caller-provided refresh callback, swap in the
+      // fresh token, and replay the original request once. The `_oauthRetried`
+      // flag rides on the request config so a retry that still 401s does not
+      // loop; instead it surfaces a SessionExpiredError for the caller to
+      // prompt re-authentication. If no refresh callback was provided, 401s
+      // propagate unchanged.
+      if (refreshAccessToken) {
+        this.client.interceptors.response.use(undefined, async (error) => {
+          if (!axios.isAxiosError(error) || error.response?.status !== 401) {
+            throw error;
+          }
+          const config = error.config;
+          if (!config || config._oauthRetried) {
+            throw new SessionExpiredError(undefined, error);
+          }
+
+          // A streamed request body (e.g. a bundle upload) has already been
+          // consumed and cannot be replayed, so don't attempt a refresh+retry
+          // that would resend an empty body. Surface a clean session-expired
+          // error instead. In practice this is near-impossible: the token is
+          // refreshed by the first (non-streamed) call of a publish, seconds
+          // before any upload.
+          if (config.data instanceof Readable) {
+            throw new SessionExpiredError(undefined, error);
+          }
+
+          let refreshed: string;
+          try {
+            refreshed = await refreshAccessToken();
+          } catch (refreshErr) {
+            throw new SessionExpiredError(undefined, refreshErr);
+          }
+
+          accessToken = refreshed;
+          config._oauthRetried = true;
+          return this.client.request(config);
+        });
+      }
+    }
   }
 
   /**

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -8,7 +8,11 @@ import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
 declare module "axios" {
   interface InternalAxiosRequestConfig {
-    /** Internal flag: this request was already retried after an OAuth refresh. */
+    /**
+     * Prevents infinite retry loops: set after the first 401-triggered OAuth
+     * refresh+retry so a still-401 retry surfaces SessionExpiredError instead of
+     * refreshing again.
+     */
     _oauthRetried?: boolean;
   }
 }

--- a/packages/connect-api/src/index.ts
+++ b/packages/connect-api/src/index.ts
@@ -1,6 +1,11 @@
 // Copyright (C) 2026 by Posit Software, PBC.
 
-export { ConnectAPI, ConnectAPIError, isCertificateError } from "./client.js";
+export {
+  ConnectAPI,
+  ConnectAPIError,
+  SessionExpiredError,
+  isCertificateError,
+} from "./client.js";
 
 export { ContentID, BundleID, TaskID, UserID, GUID } from "./types.js";
 

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -33,6 +33,8 @@ interface ApiKeyAuth extends ConnectAPIBaseOptions {
   token?: never;
   privateKey?: never;
   snowflakeToken?: never;
+  accessToken?: never;
+  refreshAccessToken?: never;
 }
 
 interface TokenAuth extends ConnectAPIBaseOptions {
@@ -42,6 +44,8 @@ interface TokenAuth extends ConnectAPIBaseOptions {
   /** Base64-encoded DER PKCS#1 RSA private key for token-based authentication. */
   privateKey: string;
   snowflakeToken?: never;
+  accessToken?: never;
+  refreshAccessToken?: never;
 }
 
 interface SnowflakeApiKeyAuth extends ConnectAPIBaseOptions {
@@ -51,6 +55,8 @@ interface SnowflakeApiKeyAuth extends ConnectAPIBaseOptions {
   apiKey: string;
   token?: never;
   privateKey?: never;
+  accessToken?: never;
+  refreshAccessToken?: never;
 }
 
 interface SnowflakeTokenAuth extends ConnectAPIBaseOptions {
@@ -61,12 +67,40 @@ interface SnowflakeTokenAuth extends ConnectAPIBaseOptions {
   token: string;
   /** Base64-encoded DER PKCS#1 RSA private key for Connect token-based authentication. */
   privateKey: string;
+  accessToken?: never;
+  refreshAccessToken?: never;
+}
+
+/**
+ * OAuth 2.0 bearer-token authentication for Connect (RFC 6749).
+ * The access token is sent as `Authorization: Bearer <accessToken>`.
+ *
+ * When {@link BearerAuth.refreshAccessToken} is supplied, the client will, on a
+ * single 401 response, call it to obtain a fresh access token and retry the
+ * request once. The callback owns discovery/refresh/persistence; the client only
+ * swaps in the returned token.
+ */
+interface BearerAuth extends ConnectAPIBaseOptions {
+  /** OAuth access token, sent via `Authorization: Bearer`. */
+  accessToken: string;
+  /**
+   * Called once when a request returns 401. Should return a freshly refreshed
+   * access token (or throw if refresh is impossible). The client retries the
+   * original request a single time with the returned token.
+   */
+  refreshAccessToken?: () => Promise<string>;
+  apiKey?: never;
+  token?: never;
+  privateKey?: never;
+  snowflakeToken?: never;
 }
 
 interface NoAuth extends ConnectAPIBaseOptions {
   apiKey?: never;
   token?: never;
   privateKey?: never;
+  accessToken?: never;
+  refreshAccessToken?: never;
   /** Optional Snowflake token for legacy credentials without Connect auth.
    *  These will not work, but still need to be loadable for users to transition
    *  to new credentials with Connect auth.
@@ -75,7 +109,12 @@ interface NoAuth extends ConnectAPIBaseOptions {
 }
 
 export type ConnectAPIOptions =
-  ApiKeyAuth | TokenAuth | SnowflakeApiKeyAuth | SnowflakeTokenAuth | NoAuth;
+  | ApiKeyAuth
+  | TokenAuth
+  | BearerAuth
+  | SnowflakeApiKeyAuth
+  | SnowflakeTokenAuth
+  | NoAuth;
 
 // ---------------------------------------------------------------------------
 // User types

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -189,13 +189,17 @@ Cypress.Commands.add("setAdminCredentials", () => {
     "http://connect-publisher-e2e:3939{enter}",
   );
 
-  // Select API key auth method (second row)
+  // Select API key auth method. Match by aria-label rather than row index:
+  // OAuth-capable servers add an "OAuth (Recommended)" row at the top, which
+  // would shift a positional selector.
   cy.get(".quick-input-and-message input").should(
     "have.attr",
     "placeholder",
     "Select authentication method",
   );
-  cy.get(".quick-input-list .monaco-list-row").eq(1).click();
+  cy.get(
+    '.quick-input-list .monaco-list-row[aria-label="API Key, Manually enter an API key"]',
+  ).click();
 
   // Enter API key
   cy.get(".quick-input-message").should(

--- a/test/e2e/tests/credentials.cy.js
+++ b/test/e2e/tests/credentials.cy.js
@@ -48,7 +48,11 @@ describe("Credentials Section", () => {
       "Select authentication method",
     );
 
-    cy.get(".quick-input-list .monaco-list-row").eq(1).click();
+    // Select API key by aria-label, not row index: OAuth-capable servers add an
+    // "OAuth (Recommended)" row at the top that would shift a positional match.
+    cy.get(
+      '.quick-input-list .monaco-list-row[aria-label="API Key, Manually enter an API key"]',
+    ).click();
 
     cy.get(".quick-input-message").should(
       "include.text",


### PR DESCRIPTION
Closes #3878.

## What

Adds OAuth sign-in for self-hosted Posit Connect credentials, mirroring the mechanism shipped in `rsconnect-python` (`rsconnect/oauth.py`): RFC 8414 discovery, RFC 7591 dynamic client registration, Authorization Code + PKCE, device code, and bearer tokens with refresh.

When creating a Connect credential, the auth-method picker shows **two options**:

- **Sign in with a browser** (Recommended)
- **API Key** (manually enter an API key)

"Sign in with a browser" routes to **OAuth** when the server advertises it (via the `.well-known` probe) and to the existing **token** flow when it doesn't. The user never sees the OAuth-vs-token distinction — both open the browser and no token is ever shown. **Existing API-key / token+key credentials are untouched** (no migration).

## Connect version requirements

- **OAuth** (discovery + DCR + Auth Code/PKCE + refresh) requires **Posit Connect 2026.02.0+**. Against older servers, the browser sign-in transparently uses the existing token flow.
- The **device-code** flow requires **Posit Connect 2026.06.0+** (the device authorization endpoint).

## How it works

- **Discovery probe** on the entered URL (`/.well-known/oauth-authorization-server`) decides whether the browser sign-in uses OAuth or the token flow.
- **Redirect transport is chosen by environment, not by socket bind.** `ConnectOAuthActivator.authorize()` tries, in order:
  1. **`positPublisher.useDeviceCodeAuth`** — explicit user override, honored first so it always wins.
  2. **Posit Workbench relay** (`RS_SERVER_URL` + `RS_SERVER_ADDRESS` set) — real Auth Code + PKCE in browser-served VS Code / Positron. See below.
  3. **Loopback** (`http://127.0.0.1:<port>/callback`) — desktop UI with no `remoteName`, i.e. extension host and browser share a machine. Zero Connect config: DCR accepts a loopback redirect and authorize matches it with RFC 8252 port flexibility.
  4. **Device code** — the universal fallback.

  Client registration moved *into* each flow, since each registers its own `redirect_uri`.
- **Bearer + refresh** live in `@posit-dev/connect-api`: a `BearerAuth` option sends `Authorization: Bearer`, and on a 401 calls a caller-supplied refresh callback, retries once, else throws `SessionExpiredError`. Streamed bodies (bundle upload) are never replayed.
- **Single refresh/persist chokepoint:** `connectAPIOptionsFromCredential` emits the bearer variant with a callback that refreshes (re-registering on `invalid_client`, keeping the current refresh token when the server doesn't rotate it), persists rotated tokens, and returns the new access token — so all existing ConnectAPI call sites get silent refresh for free.
- **Publish re-auth:** refresh is transparent; if it fails, the deploy prompts interactive re-auth (reusing `oauthClientId`), persists, and retries once.
- **Credential name** defaults to the server hostname (editable), matching the token flow.
- **Loopback callback page** is a self-contained branded card (inlined Posit Connect logo, success/error status icon on its own line, light/dark support, friendly copy) served on `127.0.0.1` — no external resource requests.

## Browser Positron / VS Code on Posit Workbench

Workbench serves both IDEs through the browser, where a loopback socket binds fine on the extension host but is unreachable from the user's browser. Workbench exposes a **generic OAuth relay** — the same one Workbench's own VS Code extension uses (`rstudio-workbench-vscode-ext` `src/utils/oauthClient.ts`) — which makes the real Authorization Code + PKCE flow work there:

```
redirect_uri = <RS_SERVER_URL>/oauth_redirect_callback      # browser-reachable
poll         = <RS_SERVER_ADDRESS>/oauth_code?state=...     # host-reachable
```

`/oauth_redirect_callback` records `state → code` in Workbench's `oauth2_state` table on redirect; `/oauth_code?state=` returns it exactly once (404 until it lands). Both routes are registered unconditionally (`ServerOpenIDAuth.cpp:394-395`), and the mechanism is identical for Positron and VS Code.

Because the Workbench URL is not a loopback URI, **a Connect administrator must allow `https://<workbench-url>/oauth_redirect_callback`** as a redirect URI for this path to be used. Publisher handles both directions automatically:

- Probes the relay before opening any browser, so an unreachable deployment falls back to device code immediately rather than after a long poll.
- Falls back to device code when Connect rejects the Workbench redirect URI at registration, logging the URI an admin would need to allow.
- **Surfaces** a terminal failure (user denied, timed out) instead of silently re-prompting in another flow.

`positPublisher.useDeviceCodeAuth` is now documented as a **backup** toggle rather than the fix for browser IDEs, since automatic selection covers those environments.

## Credential model

Adds `oauthClientId` + `tokenExpiresAt`, mutually exclusive with `apiKey` and `token`+`privateKey`. Storage is migration-safe (older records backfill the new fields to `""`; envelope version unchanged).

## Redirect design note (why no Connect code change)

No change to Connect's *default* allowlist is needed. Allowlisting `vscode://`/`positron://` deep links would not help the browser/Workbench case: a custom scheme has no local desktop app to catch it in a browser tab; Connect's existing `https://vscode.dev/redirect` default only bounces to Microsoft's `vscode://` scheme, not forks like Positron; and `env.asExternalUri` in a web IDE resolves to a dynamic, per-deployment origin that can't be a static allowlist entry. (Explored and dismissed in now-closed posit-dev/connect#41662.) The Workbench relay solves the web case instead, using per-deployment allowlisting an admin already controls.

## Testing

- Unit (Vitest): discovery 200/404/HTML/network; DCR (+ conditional device grant, `invalid_client` re-register); PKCE S256; auth-code / device / refresh exchanges (+ refresh-token rotation kept when omitted); credential validation + option order; storage backfill; `update`/`refreshOAuthToken`; connect-api bearer header + 401→refresh→retry + refresh-failure + streamed-body guard; stepper (browser→OAuth, browser→token, API-key with/without OAuth).
- Workbench module: env detection (query/trailing-slash normalization, partial/non-HTTP rejection), redirect-URI construction, relay reachability probe (400/404/429/503 reachable; HTML/ECONNREFUSED not), code polling (retry statuses, denial, unexpected status, timeout).
- Activator transport selection: desktop→loopback, loopback-bind-failure→device, web-outside-Workbench→device, remote→device, override wins even in Workbench; Workbench relay happy path (registered redirect URI, authorize params, raw-string open, poll, exchange) plus all three fallbacks and the terminal-failure passthrough.
- `eslint src` clean, typecheck 0 errors, Prettier clean, esbuild bundle builds. Extension Vitest **107 files / 1918 pass** (+4 todo, full suite including the Quarto/R integration + smoke suites); connect-api Vitest **138 pass**.
- e2e: legacy API-key credential flow selectors switched from row index to aria-label so they're robust to the new picker.

## Out of scope / follow-ups

- Connect Cloud SSO; shared credential store with rsconnect-python (#3376).
- Fully removing the token/key choice (#4204).
- e2e/Cypress coverage for the browser-OAuth path (coordinate with #3709) and extending #3858.
- Manual smoke test against a live Workbench-served Positron/VS Code session with the Workbench redirect URI allowed on Connect (unit tests cover routing + HTTP mechanics, not a live proxy round-trip).

🤖 Draft — opening for early review.

