### PR TITLE
fix(llm): reload credentials before deployment

### DIFF
--- a/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
+++ b/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
@@ -70,6 +70,7 @@ function makeTool(overrides: {
 }) {
   const state = {
     findCredential: vi.fn(() => overrides.credential),
+    refreshCredentials: vi.fn(),
     credentialsService: {
       list: vi.fn(() =>
         (overrides.credentialNames ?? []).map((name) => ({ name })),
@@ -257,6 +258,48 @@ describe("DeployContentTool", () => {
     expect(parse(res).status).toBe("needs-credential");
   });
 
+  test("reloads credentials before reporting a stored credential missing", async () => {
+    const credential = {
+      name: "prod",
+      url: "https://c",
+      serverType: ServerType.CONNECT,
+      accountName: "",
+    };
+    let cacheLoaded = false;
+    const findCredential = vi.fn(() =>
+      cacheLoaded ? credential : undefined,
+    );
+    const refreshCredentials = vi.fn(async () => {
+      cacheLoaded = true;
+    });
+    const deployProject = vi.fn(() => ({
+      status: "success",
+      result: {
+        contentId: "abc",
+        dashboardUrl: "https://c/dash",
+        directUrl: "https://c/d",
+        logsUrl: "https://c/l",
+      },
+    }));
+    const state = {
+      findCredential,
+      refreshCredentials,
+      credentialsService: { list: vi.fn(() => [{ name: "prod" }]) },
+    };
+    // @ts-expect-error minimal mocks for the unit test
+    const tool = new DeployContentTool(state, { deployProject }, "9.9.9");
+
+    const res = await tool.invoke(
+      opts({ directory: ".", entrypoint: "app.py", credentialName: "prod" }),
+      {} as CancellationToken,
+    );
+
+    expect(refreshCredentials).toHaveBeenCalledOnce();
+    expect(findCredential).toHaveBeenCalledTimes(2);
+    expect(deployProject).toHaveBeenCalled();
+    expect(parse(res).status).toBe("success");
+  });
+
   test("returns needs-content-type when detected type is unknown and none supplied", async () => {
     const { inspectProject } = await import("src/inspect");
     (
@@ -328,6 +371,7 @@ describe("DeployContentTool", () => {
         serverType: ServerType.CONNECT,
         accountName: "",
       })),
+      refreshCredentials: vi.fn(),
       credentialsService: { list: vi.fn(() => []) },
     };
     const deployProject = vi.fn(() => ({

--- a/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
+++ b/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
@@ -266,7 +266,7 @@ describe("DeployContentTool", () => {
       accountName: "",
     };
     let cacheLoaded = false;
-    const findCredential = vi.fn(() => cacheLoaded ? credential : undefined);
+    const findCredential = vi.fn(() => (cacheLoaded ? credential : undefined));
     const refreshCredentials = vi.fn(async () => {
       cacheLoaded = true;
     });

--- a/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
+++ b/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
@@ -267,8 +267,9 @@ describe("DeployContentTool", () => {
     };
     let cacheLoaded = false;
     const findCredential = vi.fn(() => (cacheLoaded ? credential : undefined));
-    const refreshCredentials = vi.fn(async () => {
+    const refreshCredentials = vi.fn(() => {
       cacheLoaded = true;
+      return Promise.resolve();
     });
     const deployProject = vi.fn(() => ({
       status: "success",

--- a/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
+++ b/extensions/vscode/src/llm/tooling/deploy/deployContentTool.test.ts
@@ -266,9 +266,7 @@ describe("DeployContentTool", () => {
       accountName: "",
     };
     let cacheLoaded = false;
-    const findCredential = vi.fn(() =>
-      cacheLoaded ? credential : undefined,
-    );
+    const findCredential = vi.fn(() => cacheLoaded ? credential : undefined);
     const refreshCredentials = vi.fn(async () => {
       cacheLoaded = true;
     });

--- a/extensions/vscode/src/llm/tooling/deploy/deployContentTool.ts
+++ b/extensions/vscode/src/llm/tooling/deploy/deployContentTool.ts
@@ -157,7 +157,15 @@ export class DeployContentTool implements LanguageModelTool<DeployContentInput> 
       const absDir = resolvedDir.absPath;
       const relDir = relativeProjectDir(absDir, root);
 
-      const credential = this.state.findCredential(credentialName);
+      let credential = this.state.findCredential(credentialName);
+      if (!credential) {
+        // planDeployment reads SecretStorage directly, while PublisherState
+        // may still be loading its in-memory cache during extension startup.
+        // Refresh before reporting that a credential is missing so the two
+        // agent tools cannot disagree about an existing stored credential.
+        await this.state.refreshCredentials();
+        credential = this.state.findCredential(credentialName);
+      }
       if (!credential) {
         const all = await this.state.credentialsService.list();
         return {

--- a/extensions/vscode/src/llm/types.ts
+++ b/extensions/vscode/src/llm/types.ts
@@ -16,6 +16,7 @@ export interface LLMToolingContext {
 
 export interface LLMToolingState {
   readonly credentialsService: Pick<CredentialsService, "list">;
+  refreshCredentials(): Promise<void>;
   findCredential(name: string): Credential | undefined;
   getSelectedConfiguration(): Promise<
     Configuration | ConfigurationError | undefined

--- a/test/extension-contract-tests/src/contracts/llm-tools.test.ts
+++ b/test/extension-contract-tests/src/contracts/llm-tools.test.ts
@@ -70,6 +70,7 @@ const state: LLMToolingState = {
   credentialsService: {
     list: async () => [],
   },
+  refreshCredentials: async () => {},
   findCredential: () => undefined,
   getSelectedConfiguration: async () => undefined,
 };


### PR DESCRIPTION
### Summary
- Reload Publisher credentials before `deployContent` reports `needs-credential`.
- Prevent a stale in-memory cache from disagreeing with `planDeployment` during extension startup.
- Add regression coverage for the cache-miss/reload path.

### Verification
- `git diff --check`
- Package JSON validation
- Focused Vitest test attempted, but dependencies are not installed in this checkout (`vitest: command not found`).

@joshyam-k @dotNomad please review.