### PR TITLE
Expose diagnostic tools as Positron commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Browser sign-in now works in VS Code and Positron served through Posit Workbench, completing the sign-in through Workbench's OAuth redirect instead of falling back to a code you confirm by hand. This requires a Connect administrator to allow your Workbench server's `/oauth_redirect_callback` URL as a redirect URI; when it isn't allowed, Publisher falls back to the device-code flow automatically. (#3878)
 - Added a `positPublisher.useDeviceCodeAuth` setting as a backup for environments where browser sign-in can't finish redirecting back to the editor. Publisher normally chooses a working redirect on its own, so enable this only if sign-in is having trouble. The device-code flow requires Posit Connect 2026.06.0 or later. (#3878)
 - AI assistants (Positron Assistant, GitHub Copilot, and other tool-capable chat clients) can now deploy your project to Posit Connect or Connect Cloud: they can inspect the project, confirm a deployment plan with you, and publish it end-to-end, then open the credential-creation UI when a credential is missing. When your intent is clear from context, the assistant can pre-fill the server URL and start browser sign-in for you automatically, then continue the deployment once you finish. Secrets are never passed through the assistant. (#4305)
+- Positron Assistant can now access Publisher's deployment-failure logs and configuration diagnostics when troubleshooting deployment problems. (#4336)
 
 ### Changed
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -80,6 +80,26 @@
     ],
     "commands": [
       {
+        "command": "posit.publisher.agent.troubleshootDeploymentFailure",
+        "title": "Troubleshoot Deployment Failure",
+        "category": "Posit Publisher",
+        "agent": {
+          "description": "When the user asks about a deployment failure to Connect or Connect Cloud (e.g., \"why did my deployment fail?\", \"troubleshoot deployment error\", or similar), use this command proactively to retrieve and analyze the latest deployment logs, even if the user does not tell you to use it explicitly. Use the log data to provide a targeted diagnosis and troubleshooting steps.",
+          "args": [],
+          "returns": "The latest Publisher deployment logs as text."
+        }
+      },
+      {
+        "command": "posit.publisher.agent.troubleshootConfigurationError",
+        "title": "Troubleshoot Deployment Configuration Error",
+        "category": "Posit Publisher",
+        "agent": {
+          "description": "When the user asks about deployment configuration errors (e.g., \"can you help to fix my deployment configuration?\", \"what is wrong with my configuration?\", \"what is a proper content type for my deployment configuration?\", or similar), use this command proactively to gather information in order to provide a solution, even if the user does not explicitly mention the command.",
+          "args": [],
+          "returns": "Diagnostic guidance for the selected deployment configuration as an array of text instructions."
+        }
+      },
+      {
         "command": "posit.publisher.agent.planDeployment",
         "title": "Plan a Deployment",
         "category": "Posit Publisher",
@@ -451,6 +471,14 @@
         }
       ],
       "commandPalette": [
+        {
+          "command": "posit.publisher.agent.troubleshootDeploymentFailure",
+          "when": "false"
+        },
+        {
+          "command": "posit.publisher.agent.troubleshootConfigurationError",
+          "when": "false"
+        },
         {
           "command": "posit.publisher.agent.planDeployment",
           "when": "false"

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -106,8 +106,12 @@ const homeViewCommands = {
 
 // Agent-compatible commands surfaced to Positron's `positron.ai` allow-list
 // (see posit-dev/positron#15077). These wrap the same logic as the `vscode.lm`
-// deploy tools so the operations are reachable via both host mechanisms.
+// tools so the operations are reachable via both host mechanisms.
 const agentCommands = {
+  TroubleshootDeploymentFailure:
+    "posit.publisher.agent.troubleshootDeploymentFailure",
+  TroubleshootConfigurationError:
+    "posit.publisher.agent.troubleshootConfigurationError",
   PlanDeployment: "posit.publisher.agent.planDeployment",
   DeployContent: "posit.publisher.agent.deployContent",
   AddCredential: "posit.publisher.agent.addCredential",

--- a/extensions/vscode/src/llm/index.ts
+++ b/extensions/vscode/src/llm/index.ts
@@ -30,11 +30,13 @@ export function registerLLMTooling(
 ) {
   const clientVersion = context.extension.packageJSON.version || "unknown";
 
-  // The three deploy tools are constructed once and exposed two ways so they
+  // The tools are constructed once and exposed two ways so they
   // work in every host: as `vscode.lm` tools (path 1, tagged `positron-assistant`)
   // and as agent-compatible VSCode commands driven by Positron's `positron.ai`
   // allow-list (path 2, see posit-dev/positron#15077). Both paths call the same
   // tool `run()` method.
+  const publishFailureTool = new PublishFailureTroubleshootTool();
+  const configurationTool = new ConfigurationTroubleshootTool(state);
   const planTool = new PlanDeploymentTool(state);
   const deployTool = new DeployContentTool(
     state,
@@ -47,11 +49,11 @@ export function registerLLMTooling(
     // Path 1 — vscode.lm Language Model Tools.
     lm.registerTool(
       "publish-content_troubleshootDeploymentFailure",
-      new PublishFailureTroubleshootTool(),
+      publishFailureTool,
     ),
     lm.registerTool(
       "publish-content_troubleshootConfigurationError",
-      new ConfigurationTroubleshootTool(state),
+      configurationTool,
     ),
     lm.registerTool("publish-content_planDeployment", planTool),
     lm.registerTool("publish-content_deployContent", deployTool),
@@ -63,6 +65,13 @@ export function registerLLMTooling(
     // declared in package.json's contributes.commands entries, sometimes the
     // same values spread positionally in that order. normalizeAgentCommandArgs
     // detects which shape arrived and produces the object `run()` expects.
+    commands.registerCommand(Commands.Agent.TroubleshootDeploymentFailure, () =>
+      publishFailureTool.run(),
+    ),
+    commands.registerCommand(
+      Commands.Agent.TroubleshootConfigurationError,
+      () => configurationTool.run(),
+    ),
     commands.registerCommand(
       Commands.Agent.PlanDeployment,
       (...raw: unknown[]) =>

--- a/extensions/vscode/src/llm/tooling/troubleshoot/configurationTroubleshootTool.ts
+++ b/extensions/vscode/src/llm/tooling/troubleshoot/configurationTroubleshootTool.ts
@@ -30,53 +30,53 @@ export class ConfigurationTroubleshootTool implements LanguageModelTool<never> {
     _options: LanguageModelToolInvocationOptions<never>,
     _token: CancellationToken,
   ): Promise<LanguageModelToolResult> {
+    const diagnosticParts = await this.run();
+    return new LanguageModelToolResult(
+      diagnosticParts.map((part) => new LanguageModelTextPart(part)),
+    );
+  }
+
+  async run(): Promise<string[]> {
     const config = await this.state.getSelectedConfiguration();
     if (!config) {
       // There is no existing selected configuration.
-      return this.noopToolResult();
+      return [this.noopMessage()];
     }
 
     if (isConfigurationError(config)) {
       // Help with current configuration error
-      return this.helpWithConfigErrorToolResult(config);
+      return [this.helpWithConfigErrorMessage(config)];
     }
 
     if (this.isUnknownSet(config)) {
       // Help with content type "unknown"
-      return this.helpWithUnknownToolResult(config);
+      return this.helpWithUnknownMessages(config);
     }
 
-    return new LanguageModelToolResult([
-      new LanguageModelTextPart(
-        "Nothing seems to be wrong with the current deployment configuration.",
-      ),
-    ]);
+    return [
+      "Nothing seems to be wrong with the current deployment configuration.",
+    ];
   }
 
   private isUnknownSet(config: Configuration) {
     return config.configuration.type === ContentType.UNKNOWN;
   }
 
-  private noopToolResult() {
-    const noopMsg = `The user does not have a selected deployment configuration,
+  private noopMessage() {
+    return `The user does not have a selected deployment configuration,
 so there is nothing to help with at the moment. A deployment configuration needs to be selected
 or the user should start a new deployment first, and in case of configuration errors, then this tool can be used to help the user.`;
-
-    return new LanguageModelToolResult([new LanguageModelTextPart(noopMsg)]);
   }
 
-  private helpWithConfigErrorToolResult(config: ConfigurationError) {
+  private helpWithConfigErrorMessage(config: ConfigurationError) {
     const { error, configurationPath } = config;
-    const toolInstruction = `The current deployment configuration file has the following error
+    return `The current deployment configuration file has the following error
 "${error.msg}", read the deployment configuration file at ${configurationPath} to find possible solutions
 that help the user get past this error. Offer the user help to edit the deployment configuration file,
 present the possible changes and ask for permission to do it.`;
-    return new LanguageModelToolResult([
-      new LanguageModelTextPart(toolInstruction),
-    ]);
   }
 
-  private helpWithUnknownToolResult(config: Configuration) {
+  private helpWithUnknownMessages(config: Configuration) {
     const { projectDir, configurationPath } = config;
     const readProjectDirInstruction = `Take a look to the files under ${projectDir} to see 
 if you can help the user find a proper content type to be used that is not "unknown".
@@ -96,12 +96,10 @@ If the "[quarto]" section is added:
 - Include "markdown" within the "engines" field only if the project does not require R nor Python.
 `;
 
-    return new LanguageModelToolResult([
-      new LanguageModelTextPart(
-        this.contentTypesInstructions(configurationPath),
-      ),
-      new LanguageModelTextPart(readProjectDirInstruction),
-    ]);
+    return [
+      this.contentTypesInstructions(configurationPath),
+      readProjectDirInstruction,
+    ];
   }
 
   private contentTypesInstructions(configPath: string): string {

--- a/extensions/vscode/src/llm/tooling/troubleshoot/publishFailureTroubleshootTool.ts
+++ b/extensions/vscode/src/llm/tooling/troubleshoot/publishFailureTroubleshootTool.ts
@@ -14,7 +14,10 @@ export class PublishFailureTroubleshootTool implements LanguageModelTool<never> 
     _options: LanguageModelToolInvocationOptions<never>,
     _token: CancellationToken,
   ): LanguageModelToolResult {
-    const logsData = LogsViewProvider.getLogsText();
-    return new LanguageModelToolResult([new LanguageModelTextPart(logsData)]);
+    return new LanguageModelToolResult([new LanguageModelTextPart(this.run())]);
+  }
+
+  run(): string {
+    return LogsViewProvider.getLogsText();
   }
 }

--- a/test/extension-contract-tests/src/contracts/llm-tools.test.ts
+++ b/test/extension-contract-tests/src/contracts/llm-tools.test.ts
@@ -19,24 +19,32 @@ import type {
 // Mock internal dependencies. The tool modules transitively pull in the heavy
 // src/toml + src/api + src/state graph, so we stub them to keep this contract
 // focused on the registration wiring (and to avoid loading that graph).
+// Shared run() spies so we can assert the path-2 command handlers dispatch to
+// the same tool instances used by the vscode.lm registrations.
+const {
+  publishFailureRun,
+  configurationRun,
+  planRun,
+  deployRun,
+  addCredentialRun,
+} = vi.hoisted(() => ({
+  publishFailureRun: vi.fn(() => "deployment logs"),
+  configurationRun: vi.fn(async () => ["configuration guidance"]),
+  planRun: vi.fn(),
+  deployRun: vi.fn(),
+  addCredentialRun: vi.fn(),
+}));
+
 vi.mock("src/llm/tooling/troubleshoot/publishFailureTroubleshootTool", () => ({
   PublishFailureTroubleshootTool: vi.fn(function () {
-    return { name: "publish-failure" };
+    return { run: publishFailureRun };
   }),
 }));
 
 vi.mock("src/llm/tooling/troubleshoot/configurationTroubleshootTool", () => ({
   ConfigurationTroubleshootTool: vi.fn(function () {
-    return { name: "config-error" };
+    return { run: configurationRun };
   }),
-}));
-
-// Shared run() spies for the three deploy tools so we can assert the path-2
-// command handlers forward their single object argument into run().
-const { planRun, deployRun, addCredentialRun } = vi.hoisted(() => ({
-  planRun: vi.fn(),
-  deployRun: vi.fn(),
-  addCredentialRun: vi.fn(),
 }));
 
 vi.mock("src/llm/tooling/deploy/planDeploymentTool", () => ({
@@ -114,6 +122,8 @@ describe("llm-tools contract", () => {
 
   // Path 2 — agent-compatible commands for Positron's positron.ai allow-list.
   it.each([
+    "posit.publisher.agent.troubleshootDeploymentFailure",
+    "posit.publisher.agent.troubleshootConfigurationError",
     "posit.publisher.agent.planDeployment",
     "posit.publisher.agent.deployContent",
     "posit.publisher.agent.addCredential",
@@ -124,6 +134,28 @@ describe("llm-tools contract", () => {
       commandId,
       expect.any(Function),
     );
+  });
+
+  it("troubleshootDeploymentFailure command dispatches to the tool", () => {
+    register();
+
+    const result = handlerFor(
+      "posit.publisher.agent.troubleshootDeploymentFailure",
+    )();
+
+    expect(publishFailureRun).toHaveBeenCalledOnce();
+    expect(result).toBe("deployment logs");
+  });
+
+  it("troubleshootConfigurationError command dispatches to the tool", async () => {
+    register();
+
+    const result = await handlerFor(
+      "posit.publisher.agent.troubleshootConfigurationError",
+    )();
+
+    expect(configurationRun).toHaveBeenCalledOnce();
+    expect(result).toEqual(["configuration guidance"]);
   });
 
   it("planDeployment command forwards its input object into run()", () => {


### PR DESCRIPTION
## Summary

- contribute the existing deployment-failure and configuration-error diagnostics as Positron agent-compatible commands
- register both commands during extension activation and delegate to the same implementations used by `vscode.lm`
- cover command registration and result dispatch in the extension contract tests

## Testing

- `npm test --workspace=test/extension-contract-tests`
- `npm run lint --workspace=extensions/vscode -- --quiet`
- `npm run check:conformance --workspace=test/extension-contract-tests`
- `npm run esbuild-base --workspace=extensions/vscode -- --minify`
- Prettier and `git diff --check`

Closes #4336