### PR TITLE
ci(positron): run Positron API tests on ubuntu-latest

### DIFF
--- a/.github/workflows/positron-api-tests.yaml
+++ b/.github/workflows/positron-api-tests.yaml
@@ -1,13 +1,14 @@
 name: Positron-API-Tests
-on: [workflow_call]
+on:
+  workflow_call:
+  workflow_dispatch:
 permissions:
   contents: read
 env:
   POSITRON_CHANNEL: stable
 jobs:
   test:
-    # @posit-dev/positron-test-electron currently supports macOS only.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -30,16 +31,17 @@ jobs:
         id: cache
         with:
           path: ./extensions/vscode/.positron-test
-          key: positron-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
+          key: positron-${{ runner.os }}-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
       - run: npm ci --no-audit --no-fund
       - name: Run Positron API tests
-        uses: posit-dev/setup-positron@main
+        uses: posit-dev/setup-positron@v1
         with:
           positron-channel: ${{ env.POSITRON_CHANNEL }}
           working-directory: extensions/vscode
-          run: npm run test-positron
+          # Positron is an Electron app and needs a display server on Linux.
+          run: xvfb-run -a npm run test-positron
       - uses: actions/cache/save@v6
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ./extensions/vscode/.positron-test
-          key: positron-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
+          key: positron-${{ runner.os }}-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}

--- a/extensions/vscode/CLAUDE.md
+++ b/extensions/vscode/CLAUDE.md
@@ -46,7 +46,8 @@ npm run test-unit
 # Run only Mocha integration tests (opens VSCode test instance)
 npm test
 
-# Run Positron API integration tests (downloads a Positron build; macOS only)
+# Run Positron API integration tests (downloads a Positron build)
+# On Linux, prefix with `xvfb-run -a` when running headless.
 npm run test-positron
 ```
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -952,7 +952,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@posit-dev/mock-connect": "*",
-    "@posit-dev/positron-test-electron": "^0.0.2",
+    "@posit-dev/positron-test-electron": "^0.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/mocha": "^10.0.2",
     "@types/node": "^22.0.0",

--- a/extensions/vscode/scripts/run-positron-tests.mjs
+++ b/extensions/vscode/scripts/run-positron-tests.mjs
@@ -10,8 +10,9 @@
 // first). Set POSITRON_CHANNEL=daily to test against a daily Positron build
 // (default: stable).
 //
-// NOTE: the released @posit-dev/positron-test-electron supports macOS only;
-// Windows/Linux support has landed upstream and is pending an npm release.
+// NOTE: on Linux, Positron is an Electron app and needs a display server, so
+// wrap the command in `xvfb-run` when running headless (as the
+// Positron-API-Tests GitHub Actions workflow does).
 
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/extensions/vscode/src/test/positron/README.md
+++ b/extensions/vscode/src/test/positron/README.md
@@ -30,13 +30,15 @@ npm run test-positron          # against the latest stable Positron
 POSITRON_CHANNEL=daily npm run test-positron   # against a daily build
 ```
 
-> **Note:** the released `@posit-dev/positron-test-electron` supports **macOS
-> only**; Windows/Linux support has landed upstream
-> ([posit-dev/positron-test-electron#3](https://github.com/posit-dev/positron-test-electron/issues/3))
-> and is pending an npm release. Until then, on other platforms rely on the
-> `Positron-API-Tests` GitHub Actions workflow
-> (`.github/workflows/positron-api-tests.yaml`), which runs on every PR and
-> push to `main`.
+On Linux, Positron needs a display server, so run it under `xvfb-run` when
+headless:
+
+```bash
+xvfb-run -a npm run test-positron
+```
+
+> **Note:** the suite also runs in CI on every PR and push to `main` via the
+> `Positron-API-Tests` workflow (`.github/workflows/positron-api-tests.yaml`).
 
 The interpreter-discovery tests expect a Python and an R installation that
 Positron can discover on the machine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@posit-dev/mock-connect": "*",
-        "@posit-dev/positron-test-electron": "^0.0.2",
+        "@posit-dev/positron-test-electron": "^0.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/mocha": "^10.0.2",
         "@types/node": "^22.0.0",
@@ -2439,9 +2439,9 @@
       "link": true
     },
     "node_modules/@posit-dev/positron-test-electron": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.2.tgz",
-      "integrity": "sha512-betE+lg9R6qom5cHafmimF9bJ9yWUhATj9JxzRNDAPCh9CLisQ8iSxfIv+RL+x+r7frGT0H018Y7ekb4JxW2vA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.3.tgz",
+      "integrity": "sha512-MQYKCoB9JlGd70QLV0BVTezzGljIduLskeczDLVZ/4ECuYKAtuVFHvXFLDv5BUoarSxHkc0cT6r9k7DwrSni3A==",
       "dev": true,
       "dependencies": {
         "@vscode/test-electron": "^2.4.1"


### PR DESCRIPTION
Moves the `Positron-API-Tests` workflow from `macos-latest` to `ubuntu-latest`. Linux Actions minutes bill at roughly 1/10 the macOS rate.

Part of posit-dev/positron#15281. The suite itself landed in #4298.

## Changes

Beyond the runner line, four things were required:

1. **`xvfb-run -a` wrap.** Positron is an Electron app and needs a display server on Linux. `posit-dev/setup-positron` is a thin composite step that only runs the command it is handed, so it provides none. Without this the run fails with `Missing X server or $DISPLAY` and then dies with SIGSEGV.
2. **`@posit-dev/positron-test-electron` → `^0.0.3`.** 0.0.2's platform table is `darwin-arm64`/`darwin-x64` only; `linux-x64` and `win32-x64` descriptors land in 0.0.3 (the latest published version). The bump is in `extensions/vscode/package.json` with the root workspace `package-lock.json` updated to match.
3. **`posit-dev/setup-positron@v1`** instead of `@main`, so upstream changes to the action can't break CI here.
4. **`${{ runner.os }}` in the Positron download cache key**, on both the restore and the save step. The cache layout is `.positron-test/<channel>/<version>/<platform>`, so under an OS-less key a stale same-day macOS entry would restore, set `cache-hit=true`, suppress the save step, and the Linux build would never get cached that day.

Also:

- Added `workflow_dispatch` alongside `workflow_call` so the suite can be triggered manually (`e2e.yaml` already does both). This is what made the pre-merge verification below possible.
- Replaced the "macOS only" notes in `scripts/run-positron-tests.mjs`, `src/test/positron/README.md`, and `extensions/vscode/CLAUDE.md` with the `xvfb-run` recipe for headless Linux runs. Unrelated `darwin` platform switches in extension source are untouched.

## Verification

Dispatched on a fork before opening this PR ([run](https://github.com/jonvanausdeln/publisher/actions/runs/32176545448), commit `4b9ac8d8`). A green job alone doesn't prove the tests ran, so from the log:

```
Run xvfb-run -a npm run test-positron
  ✔ Positron injects the acquirePositronApi global
  ✔ Publisher activates in Positron
  ✔ resolves the Python interpreter from Positron's preferred runtime (2051ms)
  ✔ resolves the R interpreter from Positron's preferred runtime
  4 passing (3s)
Extension host test runner exit code: 0
Exit code:   0
```

Both interpreter-discovery tests pass, so `actions/setup-python@v7` and `r-lib/actions/setup-r@v2` resolve on ubuntu and Positron's runtime discovery finds both. `positron-channel: stable` works on Linux — the 0.0.3 README's "stable not available on Linux/Windows yet" caveat is stale. Wall clock was ~5 minutes.

No CHANGELOG entry: CI-only, no user-facing behavior change.