### PR TITLE
Fix OAuth browser sign-in fallback compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser sign-in now falls back to the legacy token flow when Connect advertises OAuth without dynamic client registration, or when device authorization is selected or needed as a fallback but the server does not advertise it. This includes forced device-code mode. (#4347)
+
 ## [2.10.0]
 
 ### Added

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -104,7 +104,10 @@ vi.mock("./workbench", async () => {
   };
 });
 
-import { ConnectOAuthActivator } from "./activator";
+import {
+  ConnectOAuthActivator,
+  OAuthTransportUnavailableError,
+} from "./activator";
 import { OAuthMetadata } from "./types";
 import { WorkbenchRelayError } from "./workbench";
 
@@ -116,6 +119,27 @@ const METADATA: OAuthMetadata = {
   device_authorization_endpoint:
     "https://connect.example.com/oauth/v1/device/authorize",
 };
+
+const NO_DEVICE_METADATA: OAuthMetadata = {
+  issuer: METADATA.issuer,
+  authorization_endpoint: METADATA.authorization_endpoint,
+  token_endpoint: METADATA.token_endpoint,
+  registration_endpoint: METADATA.registration_endpoint,
+};
+
+const NO_REGISTRATION_METADATA: OAuthMetadata = {
+  issuer: METADATA.issuer,
+  authorization_endpoint: METADATA.authorization_endpoint,
+  token_endpoint: METADATA.token_endpoint,
+  device_authorization_endpoint: METADATA.device_authorization_endpoint,
+};
+
+function makeOAuthError(
+  message: string,
+  code: string,
+): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
+}
 
 const WORKBENCH = {
   externalServerUrl: "https://workbench.example.com",
@@ -138,6 +162,24 @@ function makeActivator(): ConnectOAuthActivator {
   );
 }
 
+function makeActivatorWithoutDeviceFlow(): ConnectOAuthActivator {
+  return new ConnectOAuthActivator(
+    "https://connect.example.com",
+    NO_DEVICE_METADATA,
+    "view-id",
+    false,
+  );
+}
+
+function makeActivatorWithoutRegistration(): ConnectOAuthActivator {
+  return new ConnectOAuthActivator(
+    "https://connect.example.com",
+    NO_REGISTRATION_METADATA,
+    "view-id",
+    false,
+  );
+}
+
 /** Makes the loopback transport succeed end to end. */
 function stubLoopbackSuccess(): void {
   h.startLoopbackServer.mockResolvedValue({
@@ -152,12 +194,22 @@ beforeEach(() => {
   h.uiKind = 1;
   h.remoteName = undefined;
   h.forceDeviceCode = false;
-  h.registerClient.mockResolvedValue({ client_id: "client-abc" });
-  h.buildAuthorizeUrl.mockReturnValue("https://connect.example.com/authorize");
-  h.exchangeAuthCode.mockResolvedValue(TOKENS);
-  h.getCurrentUser.mockResolvedValue({ username: "publisher1" });
-  // Not in Workbench unless a test says so.
-  h.detectWorkbench.mockReturnValue(undefined);
+  h.registerClient.mockReset().mockResolvedValue({ client_id: "client-abc" });
+  h.buildAuthorizeUrl
+    .mockReset()
+    .mockReturnValue("https://connect.example.com/authorize");
+  h.exchangeAuthCode.mockReset().mockResolvedValue(TOKENS);
+  h.startDeviceAuth.mockReset();
+  h.pollDeviceToken.mockReset();
+  h.startLoopbackServer.mockReset();
+  h.detectWorkbench.mockReset().mockReturnValue(undefined);
+  h.isWorkbenchRelayReachable.mockReset();
+  h.pollWorkbenchAuthCode.mockReset();
+  h.getCurrentUser.mockReset().mockResolvedValue({ username: "publisher1" });
+  h.openExternal.mockReset().mockResolvedValue(true);
+  h.loggerDebug
+    .mockReset()
+    .mockImplementation((..._args: unknown[]) => undefined);
 });
 
 afterEach(() => {
@@ -165,6 +217,29 @@ afterEach(() => {
 });
 
 describe("ConnectOAuthActivator transport selection", () => {
+  it("reports missing registration before selecting a transport", async () => {
+    let error: unknown;
+    try {
+      await makeActivatorWithoutRegistration().authenticate();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(OAuthTransportUnavailableError);
+    expect(error).toMatchObject({
+      reason: "missingRegistrationEndpoint",
+      message:
+        "Posit Connect does not advertise a dynamic client registration endpoint required for OAuth sign-in.",
+    });
+    expect(h.detectWorkbench).not.toHaveBeenCalled();
+    expect(h.isWorkbenchRelayReachable).not.toHaveBeenCalled();
+    expect(h.pollWorkbenchAuthCode).not.toHaveBeenCalled();
+    expect(h.registerClient).not.toHaveBeenCalled();
+    expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    expect(h.openExternal).not.toHaveBeenCalled();
+  });
+
   it("uses loopback on desktop (local)", async () => {
     stubLoopbackSuccess();
 
@@ -177,6 +252,24 @@ describe("ConnectOAuthActivator transport selection", () => {
     expect(h.registerClient).toHaveBeenCalledWith(METADATA, [
       "http://127.0.0.1/callback",
     ]);
+    expect(result).toMatchObject({
+      oauthClientId: "client-abc",
+      accessToken: "at",
+      refreshToken: "rt",
+      userName: "publisher1",
+    });
+  });
+
+  it("uses loopback on desktop when device flow is not advertised", async () => {
+    stubLoopbackSuccess();
+
+    const result = await makeActivatorWithoutDeviceFlow().authenticate();
+
+    expect(h.startLoopbackServer).toHaveBeenCalledTimes(1);
+    expect(h.registerClient).toHaveBeenCalledWith(NO_DEVICE_METADATA, [
+      "http://127.0.0.1/callback",
+    ]);
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       oauthClientId: "client-abc",
       accessToken: "at",
@@ -213,6 +306,37 @@ describe("ConnectOAuthActivator transport selection", () => {
 
     expect(h.startLoopbackServer).not.toHaveBeenCalled();
     expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { name: "web UI", uiKind: 2, remoteName: undefined },
+    { name: "remote host", uiKind: 1, remoteName: "ssh-remote" },
+  ])(
+    "reports OAuth transport unavailable in a $name when device flow is not advertised",
+    async ({ uiKind, remoteName }) => {
+      h.uiKind = uiKind;
+      h.remoteName = remoteName;
+
+      await expect(
+        makeActivatorWithoutDeviceFlow().authenticate(),
+      ).rejects.toBeInstanceOf(OAuthTransportUnavailableError);
+
+      expect(h.startLoopbackServer).not.toHaveBeenCalled();
+      expect(h.registerClient).not.toHaveBeenCalled();
+      expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports OAuth transport unavailable when device code is forced without an endpoint", async () => {
+    h.forceDeviceCode = true;
+
+    await expect(
+      makeActivatorWithoutDeviceFlow().authenticate(),
+    ).rejects.toBeInstanceOf(OAuthTransportUnavailableError);
+
+    expect(h.registerClient).not.toHaveBeenCalled();
+    expect(h.startLoopbackServer).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
   });
 
   it("uses the device flow when useDeviceCodeAuth is enabled, even in Workbench", async () => {
@@ -272,6 +396,22 @@ describe("ConnectOAuthActivator Posit Workbench flow", () => {
     });
   });
 
+  it("runs auth code + PKCE through Workbench when device flow is not advertised", async () => {
+    const result = await makeActivatorWithoutDeviceFlow().authenticate();
+
+    const redirectUri = "https://workbench.example.com/oauth_redirect_callback";
+    expect(h.registerClient).toHaveBeenCalledWith(NO_DEVICE_METADATA, [
+      redirectUri,
+    ]);
+    expect(h.pollWorkbenchAuthCode).toHaveBeenCalledTimes(1);
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      oauthClientId: "client-abc",
+      accessToken: "at",
+      userName: "publisher1",
+    });
+  });
+
   it("falls back to the device flow when the relay is unreachable", async () => {
     h.isWorkbenchRelayReachable.mockResolvedValue(false);
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
@@ -283,10 +423,23 @@ describe("ConnectOAuthActivator Posit Workbench flow", () => {
     expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
   });
 
+  it("reports OAuth transport unavailable when the relay is unreachable and device flow is not advertised", async () => {
+    h.isWorkbenchRelayReachable.mockResolvedValue(false);
+
+    await expect(
+      makeActivatorWithoutDeviceFlow().authenticate(),
+    ).rejects.toBeInstanceOf(OAuthTransportUnavailableError);
+
+    expect(h.registerClient).not.toHaveBeenCalled();
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+  });
+
   it("falls back to the device flow when Connect rejects the Workbench redirect URI", async () => {
     // Connect only accepts non-loopback redirect URIs an administrator has
     // allowlisted, so registration is where an unlisted Workbench URL fails.
-    h.registerClient.mockRejectedValueOnce(new Error("invalid redirect_uri"));
+    h.registerClient.mockRejectedValueOnce(
+      makeOAuthError("invalid redirect_uri", "invalid_redirect_uri"),
+    );
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
 
     await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
@@ -299,6 +452,35 @@ describe("ConnectOAuthActivator Posit Workbench flow", () => {
     ]);
   });
 
+  it("rethrows non-redirect Workbench registration failures without device auth", async () => {
+    const registrationError = makeOAuthError(
+      "Connect returned an internal server error.",
+      "server_error",
+    );
+    h.registerClient.mockRejectedValueOnce(registrationError);
+
+    await expect(makeActivator().authenticate()).rejects.toBe(
+      registrationError,
+    );
+
+    expect(h.registerClient).toHaveBeenCalledTimes(1);
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+    expect(h.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("reports OAuth transport unavailable when Connect rejects the Workbench redirect and device flow is not advertised", async () => {
+    h.registerClient.mockRejectedValueOnce(
+      makeOAuthError("invalid redirect_uri", "invalid_redirect_uri"),
+    );
+
+    await expect(
+      makeActivatorWithoutDeviceFlow().authenticate(),
+    ).rejects.toBeInstanceOf(OAuthTransportUnavailableError);
+
+    expect(h.registerClient).toHaveBeenCalledTimes(1);
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
+  });
+
   it("falls back to the device flow on a non-terminal relay failure", async () => {
     h.pollWorkbenchAuthCode.mockRejectedValue(
       new WorkbenchRelayError("unexpected status (500)", false),
@@ -307,6 +489,24 @@ describe("ConnectOAuthActivator Posit Workbench flow", () => {
 
     await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
     expect(h.startDeviceAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports OAuth transport unavailable when the relay fails during polling and device flow is not advertised", async () => {
+    h.pollWorkbenchAuthCode.mockRejectedValue(
+      new WorkbenchRelayError(
+        "Posit Workbench became unreachable while waiting for authorization: ECONNRESET",
+        false,
+      ),
+    );
+
+    await expect(
+      makeActivatorWithoutDeviceFlow().authenticate(),
+    ).rejects.toMatchObject({
+      name: "OAuthTransportUnavailableError",
+      reason: "missingDeviceAuthorizationEndpoint",
+    });
+
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
   });
 
   it("surfaces a terminal relay failure instead of retrying elsewhere", async () => {
@@ -363,7 +563,9 @@ describe("ConnectOAuthActivator sign-in diagnostics", () => {
     h.uiKind = 2;
     h.detectWorkbench.mockReturnValue(WORKBENCH);
     h.isWorkbenchRelayReachable.mockResolvedValue(true);
-    h.registerClient.mockRejectedValueOnce(new Error("invalid redirect_uri"));
+    h.registerClient.mockRejectedValueOnce(
+      makeOAuthError("invalid redirect_uri", "invalid_redirect_uri"),
+    );
     h.startDeviceAuth.mockRejectedValue(new Error("DEVICE_PATH"));
 
     await expect(makeActivator().authenticate()).rejects.toThrow("DEVICE_PATH");
@@ -415,6 +617,22 @@ describe("ConnectOAuthActivator sign-in diagnostics", () => {
     ]) {
       expect(signInLog()).not.toContain(secret);
     }
+  });
+});
+
+describe("ConnectOAuthActivator legacy token fallback", () => {
+  it("reports OAuth transport unavailable when loopback cannot bind and device flow is not advertised", async () => {
+    h.startLoopbackServer.mockRejectedValue(new Error("EADDRINUSE"));
+
+    await expect(
+      makeActivatorWithoutDeviceFlow().authenticate(),
+    ).rejects.toBeInstanceOf(OAuthTransportUnavailableError);
+
+    expect(h.registerClient).toHaveBeenCalledWith(NO_DEVICE_METADATA, [
+      "http://127.0.0.1/callback",
+    ]);
+    expect(h.startLoopbackServer).toHaveBeenCalledTimes(1);
+    expect(h.startDeviceAuth).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -38,6 +38,29 @@ interface AuthorizeResult {
   tokenResponse: OAuthTokenResponse;
 }
 
+export type OAuthTransportUnavailableReason =
+  "missingDeviceAuthorizationEndpoint" | "missingRegistrationEndpoint";
+
+/**
+ * Raised when Connect metadata deterministically lacks a capability required by
+ * the selected OAuth flow.
+ *
+ * Operational registration, network, authorization, and polling failures retain
+ * their original error so callers do not mistake them for compatibility cases.
+ */
+export class OAuthTransportUnavailableError extends Error {
+  constructor(
+    public readonly reason: OAuthTransportUnavailableReason = "missingDeviceAuthorizationEndpoint",
+  ) {
+    super(
+      reason === "missingRegistrationEndpoint"
+        ? "Posit Connect does not advertise a dynamic client registration endpoint required for OAuth sign-in."
+        : "Posit Connect does not advertise an OAuth device authorization endpoint.",
+    );
+    this.name = "OAuthTransportUnavailableError";
+  }
+}
+
 // Fallback device poll interval when the server omits `interval` (RFC 8628).
 const DEFAULT_DEVICE_POLL_MS = 5_000;
 const SLOW_DOWN_INCREMENT_MS = 5_000;
@@ -56,6 +79,22 @@ async function openExternalUrl(url: string): Promise<void> {
   // @ts-expect-error env.openExternal is typed for Uri, but the string overload
   // is what preserves nested-redirect encoding (see comment above).
   await env.openExternal(url);
+}
+
+function isInvalidRedirectUriError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (
+    "code" in error &&
+    (error as { code?: unknown }).code === "invalid_redirect_uri"
+  ) {
+    return true;
+  }
+  const message = error.message.trim().toLowerCase();
+  return (
+    message === "invalid redirect_uri" || message === "invalid redirect uri"
+  );
 }
 
 /**
@@ -125,9 +164,22 @@ export class ConnectOAuthActivator {
    *    `remoteName`. In any web UI or remote setup (Remote-SSH, Codespaces, WSL)
    *    the socket binds fine on the host but the redirect never arrives, so it
    *    would hang until timeout.
-   * 4. **Device flow** — the universal fallback.
+   * 4. **Device flow** — the fallback when advertised by Connect.
+   *
+   * Dynamic client registration is required by every flow. When it is absent,
+   * or when the selected flow reaches unadvertised device authorization, throws
+   * {@link OAuthTransportUnavailableError}. Other OAuth failures are propagated
+   * unchanged.
    */
   private async authorize(): Promise<AuthorizeResult> {
+    if (!this.metadata.registration_endpoint) {
+      logger.debug(
+        "OAuth sign-in is unavailable because Posit Connect did not advertise " +
+          "a dynamic client registration endpoint.",
+      );
+      throw new OAuthTransportUnavailableError("missingRegistrationEndpoint");
+    }
+
     const workbench = detectWorkbench();
 
     if (this.deviceCodeForced()) {
@@ -199,9 +251,9 @@ export class ConnectOAuthActivator {
   /**
    * Authorization Code + PKCE through Posit Workbench's OAuth redirect relay,
    * the mechanism Workbench's own VS Code extension uses. Returns `undefined`
-   * when the relay can't be used in this deployment (unreachable, or Connect
-   * hasn't allowlisted the Workbench redirect URI) so the caller can fall back;
-   * rethrows when the user's authorization attempt itself failed.
+   * when the relay is unavailable or Connect rejects the Workbench redirect
+   * URI, allowing the caller to apply the device-or-legacy fallback cascade.
+   * Terminal failures and unrelated errors are rethrown.
    */
   private async tryWorkbenchFlow(
     workbench: WorkbenchEnvironment,
@@ -221,9 +273,17 @@ export class ConnectOAuthActivator {
     try {
       clientId = await this.register(redirectUri);
     } catch (err) {
-      // Connect rejects a non-loopback redirect URI unless an administrator has
-      // added it to the allowed redirect URIs, so this is the expected outcome
-      // on a Workbench deployment Connect doesn't know about.
+      // A rejected Workbench redirect URI means this authorization-code
+      // transport is unavailable. Preserve all other registration failures so
+      // network, server, and unrelated OAuth errors are not treated as a
+      // transport compatibility case.
+      if (!isInvalidRedirectUriError(err)) {
+        logger.debug(
+          `OAuth client registration for the Posit Workbench redirect failed ` +
+            `and cannot fall back: ${describeError(err)}`,
+        );
+        throw err;
+      }
       this.logFallback(
         "Posit Workbench redirect relay",
         `Posit Connect did not accept the redirect URI ${redirectUri} ` +
@@ -334,6 +394,16 @@ export class ConnectOAuthActivator {
 
   /** RFC 8628 device flow: show the user code, then poll until authorized. */
   private async deviceCodeFlow(): Promise<AuthorizeResult> {
+    if (!this.metadata.device_authorization_endpoint) {
+      logger.debug(
+        "OAuth device-code sign-in is unavailable because Posit Connect did " +
+          "not advertise a device authorization endpoint.",
+      );
+      throw new OAuthTransportUnavailableError(
+        "missingDeviceAuthorizationEndpoint",
+      );
+    }
+
     // The device flow has no redirect, but Connect's dynamic client registration
     // still requires at least one redirect URI. Register the loopback URI, which
     // Connect always accepts.

--- a/extensions/vscode/src/auth/oauth/index.ts
+++ b/extensions/vscode/src/auth/oauth/index.ts
@@ -12,8 +12,14 @@ export {
   ACCESS_DENIED,
 } from "./client";
 export type { DevicePollResult } from "./client";
-export { ConnectOAuthActivator } from "./activator";
-export type { OAuthAuthResult } from "./activator";
+export {
+  ConnectOAuthActivator,
+  OAuthTransportUnavailableError,
+} from "./activator";
+export type {
+  OAuthAuthResult,
+  OAuthTransportUnavailableReason,
+} from "./activator";
 export { generatePkcePair, generateState } from "./pkce";
 export { startLoopbackServer } from "./loopback";
 export type { LoopbackHandle } from "./loopback";

--- a/extensions/vscode/src/auth/oauth/workbench.test.ts
+++ b/extensions/vscode/src/auth/oauth/workbench.test.ts
@@ -21,6 +21,7 @@ import {
   detectWorkbench,
   isWorkbenchRelayReachable,
   pollWorkbenchAuthCode,
+  WorkbenchRelayError,
   workbenchRedirectUri,
   WORKBENCH_POLL_MS,
 } from "./workbench";
@@ -154,9 +155,10 @@ describe("pollWorkbenchAuthCode", () => {
       mockGet.mockResolvedValue({ status: 403, data: "" });
 
       const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
-      const assertion = expect(promise).rejects.toThrow(
-        "Authorization was denied.",
-      );
+      const assertion = expect(promise).rejects.toMatchObject({
+        message: "Authorization was denied.",
+        terminal: true,
+      });
       await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS + 100);
       await assertion;
     } finally {
@@ -170,7 +172,30 @@ describe("pollWorkbenchAuthCode", () => {
       mockGet.mockResolvedValue({ status: 500, data: "" });
 
       const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
-      const assertion = expect(promise).rejects.toThrow("500");
+      const assertion = expect(promise).rejects.toMatchObject({
+        message:
+          "Posit Workbench returned an unexpected status (500) while waiting for authorization.",
+        terminal: false,
+      });
+      await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS + 100);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports a polling connection failure as a non-terminal relay error", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGet.mockRejectedValue(new Error("ECONNRESET"));
+
+      const promise = pollWorkbenchAuthCode(WORKBENCH, "state-123", false);
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "WorkbenchRelayError",
+        terminal: false,
+        message:
+          "Posit Workbench became unreachable while waiting for authorization: Error: ECONNRESET",
+      } satisfies Partial<WorkbenchRelayError>);
       await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS + 100);
       await assertion;
     } finally {
@@ -189,7 +214,10 @@ describe("pollWorkbenchAuthCode", () => {
         false,
         WORKBENCH_POLL_MS * 2,
       );
-      const assertion = expect(promise).rejects.toThrow("Timed out");
+      const assertion = expect(promise).rejects.toMatchObject({
+        message: "Timed out waiting for authorization in your browser.",
+        terminal: true,
+      });
       await vi.advanceTimersByTimeAsync(WORKBENCH_POLL_MS * 3);
       await assertion;
     } finally {

--- a/extensions/vscode/src/auth/oauth/workbench.ts
+++ b/extensions/vscode/src/auth/oauth/workbench.ts
@@ -171,7 +171,15 @@ export async function pollWorkbenchAuthCode(
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, WORKBENCH_POLL_MS));
 
-    const resp = await http.get(url);
+    let resp;
+    try {
+      resp = await http.get(url);
+    } catch (err) {
+      throw new WorkbenchRelayError(
+        `Posit Workbench became unreachable while waiting for authorization: ${getMessageFromError(err)}`,
+        false,
+      );
+    }
     if (resp.status === 200 && isCodeResponse(resp.data)) {
       return resp.data.code;
     }

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.test.ts
@@ -3,6 +3,14 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { ServerType } from "src/api/types/contentRecords";
 import { newConnectCredential } from "./newConnectCredential";
+import {
+  fetchSnowflakeConnections,
+  findExistingCredentialByURL,
+  getExistingCredentials,
+  inputCredentialNameStep,
+} from "src/multiStepInputs/common";
+import { isConnect, isSnowflake } from "src/utils/multiStepHelpers";
+import { window } from "vscode";
 
 const CANCEL = Symbol("cancel");
 
@@ -88,6 +96,7 @@ vi.mock("./multiStepHelper", () => {
     },
     isString: (d: unknown): d is string => typeof d === "string",
     isQuickPickItemWithIndex: vi.fn(() => false),
+    isCancellation: (e: unknown) => e === CANCEL,
   };
 });
 
@@ -233,11 +242,29 @@ const oauthStepperMocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
 }));
 
+const OAuthTransportUnavailableErrorMock = vi.hoisted(() => {
+  return class OAuthTransportUnavailableError extends Error {
+    constructor(
+      public readonly reason:
+        | "missingDeviceAuthorizationEndpoint"
+        | "missingRegistrationEndpoint" = "missingDeviceAuthorizationEndpoint",
+    ) {
+      super(
+        reason === "missingRegistrationEndpoint"
+          ? "Posit Connect does not advertise a dynamic client registration endpoint required for OAuth sign-in."
+          : "Posit Connect does not advertise an OAuth device authorization endpoint.",
+      );
+      this.name = "OAuthTransportUnavailableError";
+    }
+  };
+});
+
 vi.mock("src/auth/oauth", () => ({
   discoverOAuthMetadata: oauthStepperMocks.discoverOAuthMetadata,
   ConnectOAuthActivator: class {
     authenticate = oauthStepperMocks.authenticate;
   },
+  OAuthTransportUnavailableError: OAuthTransportUnavailableErrorMock,
 }));
 
 vi.mock("src/utils/errors", () => ({
@@ -256,9 +283,32 @@ vi.mock("src/logging", () => ({
   },
 }));
 
+function resetMutableMocks(): void {
+  vi.clearAllMocks();
+  stepControl.quickPickLabel = "API Key";
+  shownInputBoxSteps.length = 0;
+
+  vi.mocked(fetchSnowflakeConnections)
+    .mockReset()
+    .mockResolvedValue({ connections: [], connectionQuickPicks: [] });
+  vi.mocked(findExistingCredentialByURL).mockReset().mockReturnValue(undefined);
+  vi.mocked(getExistingCredentials).mockReset().mockResolvedValue([]);
+  vi.mocked(inputCredentialNameStep)
+    .mockReset()
+    .mockResolvedValue("My Credential");
+  vi.mocked(isConnect).mockReset().mockReturnValue(true);
+  vi.mocked(isSnowflake).mockReset().mockReturnValue(false);
+
+  oauthStepperMocks.discoverOAuthMetadata.mockReset().mockResolvedValue(null);
+  oauthStepperMocks.authenticate.mockReset();
+  tokenActivatorMocks.activateToken.mockReset();
+  mockCredentialsServiceList.mockReset().mockResolvedValue([]);
+  mockCredentialsServiceCreate.mockReset();
+}
+
 describe("newConnectCredential cancellation", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetMutableMocks();
     stepControl.quickPickLabel = "API Key";
 
     // Default: server does not support OAuth, so the token/API-key flow runs.
@@ -323,7 +373,7 @@ describe("newConnectCredential cancellation", () => {
 
 describe("newConnectCredential OAuth path", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetMutableMocks();
     stepControl.quickPickLabel = "API Key";
     mockCredentialsServiceList.mockResolvedValue([]);
     mockCredentialsServiceCreate.mockResolvedValue({
@@ -446,6 +496,132 @@ describe("newConnectCredential OAuth path", () => {
     );
   });
 
+  test.each([
+    {
+      reason: "missingDeviceAuthorizationEndpoint" as const,
+      message:
+        "Posit Connect does not advertise an OAuth device authorization endpoint.",
+    },
+    {
+      reason: "missingRegistrationEndpoint" as const,
+      message:
+        "Posit Connect does not advertise a dynamic client registration endpoint required for OAuth sign-in.",
+    },
+  ])(
+    "browser sign-in falls back to the token flow for $reason",
+    async ({ reason, message }) => {
+      stepControl.quickPickLabel = "Sign in with a browser";
+      oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
+        token_endpoint: "https://connect.example.com/oauth/v1/token",
+        authorization_endpoint:
+          "https://connect.example.com/oauth/v1/authorize",
+      });
+      const { OAuthTransportUnavailableError } = await import("src/auth/oauth");
+      const transportError = new OAuthTransportUnavailableError(reason);
+      expect(transportError).toMatchObject({ reason, message });
+      oauthStepperMocks.authenticate.mockRejectedValue(transportError);
+      tokenActivatorMocks.activateToken.mockResolvedValue({
+        token: "T-token",
+        privateKey: "priv-key",
+        userName: "publisher1",
+        serverUrl: "https://connect.example.com",
+      });
+      const { inputCredentialNameStep } =
+        await import("src/multiStepInputs/common");
+      vi.mocked(inputCredentialNameStep).mockResolvedValue(
+        "connect.example.com",
+      );
+
+      await newConnectCredential(
+        "test-view-id",
+        "Create a New Credential",
+        mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+        "https://connect.example.com",
+      );
+
+      expect(oauthStepperMocks.authenticate).toHaveBeenCalledTimes(1);
+      expect(tokenActivatorMocks.activateToken).toHaveBeenCalledTimes(1);
+      expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: "T-token",
+          privateKey: "priv-key",
+          apiKey: undefined,
+          oauthClientId: undefined,
+          accessToken: undefined,
+          refreshToken: undefined,
+          tokenExpiresAt: undefined,
+        }),
+      );
+      expect(window.showErrorMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  test("generic OAuth failures return to the picker without token fallback", async () => {
+    stepControl.quickPickLabel = "Sign in with a browser";
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
+      token_endpoint: "https://connect.example.com/oauth/v1/token",
+      authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+    });
+    oauthStepperMocks.authenticate.mockImplementationOnce(() => {
+      // Choose a reachable next step after the OAuth error is handled.
+      stepControl.quickPickLabel = "API Key";
+      throw new Error("OAuth server rejected sign-in");
+    });
+
+    await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(oauthStepperMocks.authenticate).toHaveBeenCalledTimes(1);
+    expect(tokenActivatorMocks.activateToken).not.toHaveBeenCalled();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      "OAuth sign-in did not complete: Error: OAuth server rejected sign-in. You can use an API key instead.",
+    );
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "mock-api-key-value",
+        token: undefined,
+        privateKey: undefined,
+        oauthClientId: undefined,
+      }),
+    );
+  });
+
+  test("OAuth cancellation returns to the picker without token fallback or an error", async () => {
+    stepControl.quickPickLabel = "Sign in with a browser";
+    oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue({
+      token_endpoint: "https://connect.example.com/oauth/v1/token",
+      authorization_endpoint: "https://connect.example.com/oauth/v1/authorize",
+    });
+    oauthStepperMocks.authenticate.mockImplementationOnce(() => {
+      // Choose a reachable next step after the dismissal is handled.
+      stepControl.quickPickLabel = "API Key";
+      throw CANCEL;
+    });
+
+    await newConnectCredential(
+      "test-view-id",
+      "Create a New Credential",
+      mockCredentialsService as unknown as import("src/credentials/service").CredentialsService,
+      "https://connect.example.com",
+    );
+
+    expect(oauthStepperMocks.authenticate).toHaveBeenCalledTimes(1);
+    expect(tokenActivatorMocks.activateToken).not.toHaveBeenCalled();
+    expect(window.showErrorMessage).not.toHaveBeenCalled();
+    expect(mockCredentialsServiceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "mock-api-key-value",
+        token: undefined,
+        privateKey: undefined,
+        oauthClientId: undefined,
+      }),
+    );
+  });
+
   test("creates an API-key credential when the user picks API key (no OAuth)", async () => {
     stepControl.quickPickLabel = "API Key";
     oauthStepperMocks.discoverOAuthMetadata.mockResolvedValue(null);
@@ -472,7 +648,7 @@ describe("newConnectCredential OAuth path", () => {
 
 describe("newConnectCredential authMethodHint", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetMutableMocks();
     // The picker would pick API Key if shown — the hint must bypass it.
     stepControl.quickPickLabel = "API Key";
     mockCredentialsServiceList.mockResolvedValue([]);
@@ -553,7 +729,7 @@ describe("newConnectCredential authMethodHint", () => {
 
 describe("newConnectCredential auto-proceed with a supplied server URL", () => {
   beforeEach(async () => {
-    vi.clearAllMocks();
+    resetMutableMocks();
     shownInputBoxSteps.length = 0;
     stepControl.quickPickLabel = "API Key";
     mockCredentialsServiceList.mockResolvedValue([]);

--- a/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
+++ b/extensions/vscode/src/multiStepInputs/newConnectCredential.ts
@@ -45,6 +45,7 @@ import {
   discoverOAuthMetadata,
   OAuthAuthResult,
   OAuthMetadata,
+  OAuthTransportUnavailableError,
 } from "src/auth/oauth";
 import { logger } from "src/logging";
 
@@ -629,6 +630,21 @@ export async function newConnectCredential(
       // Leave the credential name for inputCredentialName to default to the
       // server hostname, matching the token-based flow (the user can edit it).
     } catch (e) {
+      if (e instanceof OAuthTransportUnavailableError) {
+        logger.debug(`${e.message} Using legacy browser token authentication.`);
+        authMethod = AuthMethod.TOKEN;
+        state.data.oauthClientId = undefined;
+        state.data.accessToken = undefined;
+        state.data.refreshToken = undefined;
+        state.data.tokenExpiresAt = undefined;
+        return {
+          name: step.INPUT_TOKEN,
+          step: (input: MultiStepInput) =>
+            steps[step.INPUT_TOKEN](input, state),
+          skipStepHistory: true,
+        };
+      }
+
       // A dismissal or an OAuth failure both divert to the manual auth-method
       // chooser so an API key is always reachable. Only a real failure warrants
       // an error popup — see isCancellation for why a dismissal must not take

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -45,7 +45,10 @@ import {
 } from "src/api";
 import { ConnectAPI, GUID, SessionExpiredError } from "@posit-dev/connect-api";
 import type { Integration } from "@posit-dev/connect-api";
-import { ConnectOAuthActivator } from "src/auth/oauth";
+import {
+  ConnectOAuthActivator,
+  OAuthTransportUnavailableError,
+} from "src/auth/oauth";
 import {
   ConnectCloudAPI,
   ContentID,
@@ -716,6 +719,16 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
       });
       await this.refreshCredentials();
     } catch (reauthErr) {
+      if (reauthErr instanceof OAuthTransportUnavailableError) {
+        const missingCapability =
+          reauthErr.reason === "missingRegistrationEndpoint"
+            ? "dynamic client registration"
+            : "device authorization";
+        window.showErrorMessage(
+          `OAuth reauthentication is unavailable for ${credential.url} because the server does not advertise ${missingCapability}. The existing credential was not changed; create a new credential to use legacy browser sign-in or an API key.`,
+        );
+        return;
+      }
       window.showErrorMessage(
         `Sign-in failed: ${getMessageFromError(reauthErr)}`,
       );


### PR DESCRIPTION
## Summary

- preserve the browser authentication cascade when Connect advertises OAuth without every required capability
- fall back from unavailable Workbench, remote, loopback, or device transports to legacy browser token authentication
- classify Workbench relay polling connection failures as nonterminal while keeping denial and timeout terminal
- preserve expired OAuth credentials and provide actionable guidance when reauthentication cannot use OAuth
- add compatibility-matrix, negative-path, and order-independent test coverage

Fixes #4347

## Verification

- `npx vitest run src/auth/oauth src/multiStepInputs/newConnectCredential.test.ts` — 90 tests passed
- focused tests pass with shuffled execution (`--sequence.shuffle --sequence.seed=17`)
- `npx tsc --noEmit --project tsconfig.json`
- focused ESLint checks
- Prettier and `git diff --check`
