### PR TITLE
feat: add custom user-agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Publisher now sends a User-Agent header (e.g. PositPublisher/2.11.4) on requests to Posit Connect and Connect Cloud. (#4355)
+
 ### Fixed
 
 - Browser sign-in now falls back to the legacy token flow when Connect advertises OAuth without dynamic client registration, or when device authorization is selected or needed as a fallback but the server does not advertise it. This includes forced device-code mode. (#4347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Publisher now sends a User-Agent header (e.g. PositPublisher/2.11.4) on requests to Posit Connect and Connect Cloud. (#4355)
+- Publisher now sends a User-Agent header (e.g. PositPublisher/2.11.4) on its HTTP requests, including those to Posit Connect and Connect Cloud. (#4355)
 
 ### Fixed
 

--- a/extensions/vscode/src/auth/ConnectAuthTokenActivator.test.ts
+++ b/extensions/vscode/src/auth/ConnectAuthTokenActivator.test.ts
@@ -19,6 +19,13 @@ vi.mock("vscode", () => ({
   env: {
     openExternal: vi.fn(),
   },
+  extensions: {
+    getExtension: vi.fn(),
+  },
+}));
+
+vi.mock("src/utils/userAgent", () => ({
+  getUserAgent: () => "PositPublisher/test",
 }));
 
 vi.mock("src/utils/progress", () => ({
@@ -110,6 +117,7 @@ describe("ConnectAuthTokenActivator", () => {
       privateKey: "test-private-key-123",
       snowflakeToken: undefined,
       rejectUnauthorized: undefined,
+      userAgent: "PositPublisher/test",
     });
     expect(result).toEqual({
       token: "test-token-123",
@@ -194,6 +202,7 @@ describe("ConnectAuthTokenActivator", () => {
       privateKey: "test-private-key-123",
       snowflakeToken: undefined,
       rejectUnauthorized: false,
+      userAgent: "PositPublisher/test",
     });
     expect(result.userName).toBe("testuser");
   });
@@ -269,6 +278,7 @@ describe("ConnectAuthTokenActivator", () => {
       privateKey: "test-private-key-123",
       snowflakeToken: "snowflake-session-token",
       rejectUnauthorized: undefined,
+      userAgent: "PositPublisher/test",
     });
   });
 

--- a/extensions/vscode/src/auth/ConnectAuthTokenActivator.ts
+++ b/extensions/vscode/src/auth/ConnectAuthTokenActivator.ts
@@ -6,6 +6,7 @@ import { generateToken } from "./generateToken";
 import { logger } from "src/logging";
 import { getMessageFromError } from "src/utils/errors";
 import { showProgress } from "src/utils/progress";
+import { getUserAgent } from "src/utils/userAgent";
 
 export interface TokenAuthResult {
   token: string;
@@ -107,6 +108,7 @@ export class ConnectAuthTokenActivator {
           privateKey,
           snowflakeToken: this.snowflakeToken,
           rejectUnauthorized: this.insecure ? false : undefined,
+          userAgent: getUserAgent(),
         });
 
         while (!isClaimed && attempt < maxAttempts) {

--- a/extensions/vscode/src/auth/generateToken.test.ts
+++ b/extensions/vscode/src/auth/generateToken.test.ts
@@ -10,6 +10,10 @@ import {
 
 vi.mock("src/logging");
 
+vi.mock("src/utils/userAgent", () => ({
+  getUserAgent: () => "PositPublisher/test",
+}));
+
 // ---------------------------------------------------------------------------
 // Mock discoverServerURL
 // ---------------------------------------------------------------------------

--- a/extensions/vscode/src/auth/generateToken.ts
+++ b/extensions/vscode/src/auth/generateToken.ts
@@ -3,6 +3,7 @@
 import crypto from "crypto";
 import { ConnectAPI } from "@posit-dev/connect-api";
 import { discoverServerURL } from "src/utils/url";
+import { getUserAgent } from "src/utils/userAgent";
 import { logger } from "src/logging";
 
 /**
@@ -69,6 +70,7 @@ export async function generateToken(
       url: urlToTest,
       snowflakeToken,
       rejectUnauthorized: insecure ? false : undefined,
+      userAgent: getUserAgent(),
     });
 
     const response = await client.registerToken(tokenId, publicKey);

--- a/extensions/vscode/src/auth/oauth/activator.test.ts
+++ b/extensions/vscode/src/auth/oauth/activator.test.ts
@@ -41,6 +41,9 @@ vi.mock("vscode", () => ({
       get: (_key: string, _def?: unknown) => h.forceDeviceCode,
     }),
   },
+  extensions: {
+    getExtension: vi.fn(),
+  },
 }));
 
 vi.mock("src/logging", () => ({

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -6,6 +6,7 @@ import { ConnectAPI } from "@posit-dev/connect-api";
 import { logger } from "src/logging";
 import { describeError, getMessageFromError } from "src/utils/errors";
 import { showProgress } from "src/utils/progress";
+import { getUserAgent } from "src/utils/userAgent";
 import { OAuthClient, tokenExpiresAt } from "./client";
 import { discoverOAuthMetadata } from "./discovery";
 import { startLoopbackServer } from "./loopback";
@@ -39,7 +40,8 @@ interface AuthorizeResult {
 }
 
 export type OAuthTransportUnavailableReason =
-  "missingDeviceAuthorizationEndpoint" | "missingRegistrationEndpoint";
+  | "missingDeviceAuthorizationEndpoint"
+  | "missingRegistrationEndpoint";
 
 /**
  * Raised when Connect metadata deterministically lacks a capability required by
@@ -468,6 +470,7 @@ export class ConnectOAuthActivator {
         url: this.serverUrl,
         accessToken,
         rejectUnauthorized: this.insecure ? false : undefined,
+        userAgent: getUserAgent(),
       });
       const user = await api.getCurrentUser();
       return user.username;

--- a/extensions/vscode/src/auth/oauth/activator.ts
+++ b/extensions/vscode/src/auth/oauth/activator.ts
@@ -40,8 +40,7 @@ interface AuthorizeResult {
 }
 
 export type OAuthTransportUnavailableReason =
-  | "missingDeviceAuthorizationEndpoint"
-  | "missingRegistrationEndpoint";
+  "missingDeviceAuthorizationEndpoint" | "missingRegistrationEndpoint";
 
 /**
  * Raised when Connect metadata deterministically lacks a capability required by

--- a/extensions/vscode/src/auth/oauth/httpClient.ts
+++ b/extensions/vscode/src/auth/oauth/httpClient.ts
@@ -4,6 +4,7 @@ import https from "https";
 import type { ClientRequest, IncomingMessage } from "http";
 import axios from "axios";
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
+import { getUserAgent } from "src/utils/userAgent";
 
 /** Request timeout for OAuth endpoints (ms). */
 export const OAUTH_TIMEOUT_MS = 30_000;
@@ -24,6 +25,7 @@ export function createOAuthHttpClient(insecure: boolean): AxiosInstance {
     // JSON bodies (e.g. `authorization_pending`, `invalid_client`) that callers
     // must inspect.
     validateStatus: () => true,
+    headers: { "User-Agent": getUserAgent() },
   };
 
   if (insecure) {

--- a/extensions/vscode/src/connect_content_fs.test.ts
+++ b/extensions/vscode/src/connect_content_fs.test.ts
@@ -55,6 +55,9 @@ vi.mock("vscode", () => ({
       get: () => true,
     }),
   },
+  extensions: {
+    getExtension: vi.fn(),
+  },
 }));
 
 import {

--- a/extensions/vscode/src/credentials/service.test.ts
+++ b/extensions/vscode/src/credentials/service.test.ts
@@ -22,7 +22,11 @@ import {
   IncompleteCredentialError,
 } from "./errors";
 
-vi.mock("vscode");
+vi.mock("vscode", () => ({
+  extensions: {
+    getExtension: vi.fn(),
+  },
+}));
 vi.mock("src/logging");
 vi.mock("src/snowflake/connections");
 vi.mock("snowflake-sdk");
@@ -403,6 +407,7 @@ describe("connectAPIOptionsFromCredential", () => {
       expect(result).toEqual({
         url: "https://connect.example.com",
         apiKey: "my-key",
+        userAgent: "PositPublisher/unknown",
       });
     });
   });
@@ -426,6 +431,7 @@ describe("connectAPIOptionsFromCredential", () => {
         url: "https://connect.example.com",
         token: "my-token",
         privateKey: "my-private-key",
+        userAgent: "PositPublisher/unknown",
       });
     });
 
@@ -447,6 +453,7 @@ describe("connectAPIOptionsFromCredential", () => {
         url: "https://connect.example.com",
         token: "my-token",
         privateKey: "my-private-key",
+        userAgent: "PositPublisher/unknown",
       });
     });
   });
@@ -468,6 +475,7 @@ describe("connectAPIOptionsFromCredential", () => {
 
       expect(result).toEqual({
         url: "https://connect.example.com",
+        userAgent: "PositPublisher/unknown",
       });
     });
   });
@@ -496,6 +504,7 @@ describe("connectAPIOptionsFromCredential", () => {
         apiKey: "my-key",
         rejectUnauthorized: false,
         timeout: 5000,
+        userAgent: "PositPublisher/unknown",
       });
     });
   });

--- a/extensions/vscode/src/credentials/service.ts
+++ b/extensions/vscode/src/credentials/service.ts
@@ -84,12 +84,14 @@ export async function connectAPIOptionsFromCredential(
   >,
   extra?: Pick<ConnectAPIOptions, "rejectUnauthorized" | "timeout">,
 ): Promise<ConnectAPIOptions> {
+  const userAgent = getUserAgent();
+
   if (
     credential.serverType === ServerType.SNOWFLAKE &&
     credential.snowflakeConnection
   ) {
     const options = await service.buildSnowflakeOptions(credential, extra);
-    return { ...options, userAgent: getUserAgent() };
+    return { ...options, userAgent };
   }
 
   // OAuth bearer credential. The refresh callback is invoked by the client on a
@@ -112,8 +114,8 @@ export async function connectAPIOptionsFromCredential(
           },
           insecure,
         ),
+      userAgent,
       ...extra,
-      userAgent: getUserAgent(),
     };
   }
 
@@ -122,22 +124,22 @@ export async function connectAPIOptionsFromCredential(
       url: credential.url,
       token: credential.token,
       privateKey: credential.privateKey,
+      userAgent,
       ...extra,
-      userAgent: getUserAgent(),
     };
   }
   if (credential.apiKey) {
     return {
       url: credential.url,
       apiKey: credential.apiKey,
+      userAgent,
       ...extra,
-      userAgent: getUserAgent(),
     };
   }
   return {
     url: credential.url,
+    userAgent,
     ...extra,
-    userAgent: getUserAgent(),
   };
 }
 

--- a/extensions/vscode/src/credentials/service.ts
+++ b/extensions/vscode/src/credentials/service.ts
@@ -27,6 +27,7 @@ import {
 import { CONNECT_CLOUD_ENV } from "src/constants";
 import config from "src/config";
 import { logger } from "src/logging";
+import { getUserAgent } from "src/utils/userAgent";
 import {
   discoverOAuthMetadata,
   OAuthClient,
@@ -87,7 +88,8 @@ export async function connectAPIOptionsFromCredential(
     credential.serverType === ServerType.SNOWFLAKE &&
     credential.snowflakeConnection
   ) {
-    return await service.buildSnowflakeOptions(credential, extra);
+    const options = await service.buildSnowflakeOptions(credential, extra);
+    return { ...options, userAgent: getUserAgent() };
   }
 
   // OAuth bearer credential. The refresh callback is invoked by the client on a
@@ -111,6 +113,7 @@ export async function connectAPIOptionsFromCredential(
           insecure,
         ),
       ...extra,
+      userAgent: getUserAgent(),
     };
   }
 
@@ -120,6 +123,7 @@ export async function connectAPIOptionsFromCredential(
       token: credential.token,
       privateKey: credential.privateKey,
       ...extra,
+      userAgent: getUserAgent(),
     };
   }
   if (credential.apiKey) {
@@ -127,11 +131,13 @@ export async function connectAPIOptionsFromCredential(
       url: credential.url,
       apiKey: credential.apiKey,
       ...extra,
+      userAgent: getUserAgent(),
     };
   }
   return {
     url: credential.url,
     ...extra,
+    userAgent: getUserAgent(),
   };
 }
 

--- a/extensions/vscode/src/multiStepInputs/common.ts
+++ b/extensions/vscode/src/multiStepInputs/common.ts
@@ -45,6 +45,7 @@ import {
   cloudEnvironmentBaseUrls,
 } from "@posit-dev/connect-cloud-api";
 import { CONNECT_CLOUD_ENVIRONMENT } from "../constants";
+import { getUserAgent } from "../utils/userAgent";
 
 // Search for the first credential that includes
 // the targetURL.
@@ -124,7 +125,7 @@ export const fetchSnowflakeConnections = async (
 
 // Fetch the device auth for Connect Cloud
 export const fetchDeviceAuth = async (): Promise<ApiResponse<DeviceAuth>> => {
-  const client = new CloudAuthClient(CONNECT_CLOUD_ENVIRONMENT);
+  const client = new CloudAuthClient(CONNECT_CLOUD_ENVIRONMENT, getUserAgent());
   const response = await client.createDeviceAuth();
   return { data: toDeviceAuth(response), intervalAdjustment: 0 };
 };
@@ -133,7 +134,7 @@ export const fetchDeviceAuth = async (): Promise<ApiResponse<DeviceAuth>> => {
 export const fetchAuthToken = async (
   deviceCode: string,
 ): Promise<ApiResponse<AuthToken>> => {
-  const client = new CloudAuthClient(CONNECT_CLOUD_ENVIRONMENT);
+  const client = new CloudAuthClient(CONNECT_CLOUD_ENVIRONMENT, getUserAgent());
   try {
     const response = await client.exchangeToken({
       grant_type: "urn:ietf:params:oauth:grant-type:device_code",
@@ -163,6 +164,7 @@ export const fetchConnectCloudAccounts = async (
   const client = new ConnectCloudAPI({
     apiBaseUrl: cloudEnvironmentBaseUrls[CONNECT_CLOUD_ENVIRONMENT],
     accessToken,
+    userAgent: getUserAgent(),
   });
 
   // Check if this is a new user (authenticated with auth service but

--- a/extensions/vscode/src/multiStepInputs/newDeployment.ts
+++ b/extensions/vscode/src/multiStepInputs/newDeployment.ts
@@ -11,7 +11,6 @@ import {
 } from "src/multiStepInputs/multiStepHelper";
 import {
   commands,
-  extensions,
   InputBoxValidationSeverity,
   QuickPickItem,
   QuickPickItemKind,
@@ -39,6 +38,7 @@ import {
   getRInterpreterPath,
 } from "src/utils/vscode";
 import { getSummaryStringFromError } from "src/utils/errors";
+import { getExtensionVersion } from "src/utils/userAgent";
 import { newConfigFileNameFromTitle, newDeploymentName } from "src/utils/names";
 import { updateFileList } from "src/configFiles";
 import {
@@ -909,9 +909,7 @@ export async function newDeployment(
       existingNames = [];
     }
     const contentRecordName = newDeploymentName(existingNames);
-    const clientVersion =
-      extensions.getExtension("posit.publisher")?.packageJSON.version ||
-      "unknown";
+    const clientVersion = getExtensionVersion();
     newContentRecord = await createDeploymentRecord({
       saveName: contentRecordName,
       projectDir: newDeploymentData.entrypoint.inspectionResult.projectDir,

--- a/extensions/vscode/src/snowflake/discovery.test.ts
+++ b/extensions/vscode/src/snowflake/discovery.test.ts
@@ -23,6 +23,9 @@ vi.mock("@posit-dev/connect-api", async (importOriginal) => {
 
 vi.mock("src/logging");
 vi.mock("./connections");
+vi.mock("src/utils/userAgent", () => ({
+  getUserAgent: () => "PositPublisher/test",
+}));
 
 import { ConnectAPI } from "@posit-dev/connect-api";
 import { listConnections } from "./connections";
@@ -70,6 +73,7 @@ describe("discoverSnowflakeConnections", () => {
       url: "https://example.snowflakecomputing.app",
       snowflakeToken: "sf-token-123",
       timeout: 30000,
+      userAgent: "PositPublisher/test",
     });
   });
 

--- a/extensions/vscode/src/snowflake/discovery.ts
+++ b/extensions/vscode/src/snowflake/discovery.ts
@@ -6,6 +6,7 @@ import { listConnections } from "./connections";
 import { getListOfPossibleURLs } from "../utils/url";
 import { logger } from "src/logging";
 import { CredentialsService } from "src/credentials/service";
+import { getUserAgent } from "src/utils/userAgent";
 import type { SnowflakeConnection } from "./types";
 
 const VALIDATION_TIMEOUT_MS = 30_000;
@@ -37,6 +38,7 @@ export async function discoverSnowflakeConnections(
           url: candidateUrl,
           snowflakeToken: token,
           timeout: VALIDATION_TIMEOUT_MS,
+          userAgent: getUserAgent(),
         });
 
         try {

--- a/extensions/vscode/src/utils/testCredentials.test.ts
+++ b/extensions/vscode/src/utils/testCredentials.test.ts
@@ -24,6 +24,10 @@ vi.mock("@posit-dev/connect-api", async (importOriginal) => {
   };
 });
 
+vi.mock("src/utils/userAgent", () => ({
+  getUserAgent: () => "PositPublisher/test",
+}));
+
 import { ConnectAPI } from "@posit-dev/connect-api";
 
 const mockUser = {

--- a/extensions/vscode/src/utils/testCredentials.ts
+++ b/extensions/vscode/src/utils/testCredentials.ts
@@ -8,6 +8,7 @@ import { ServerType } from "src/api/types/contentRecords";
 import { TestResult } from "src/api/types/credentials";
 import type { ErrorCode } from "src/utils/errorTypes";
 import { serverTypeFromURL, discoverServerURL } from "src/utils/url";
+import { getUserAgent } from "src/utils/userAgent";
 
 const CERTIFICATE_ERROR_PATTERNS = [
   "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
@@ -97,6 +98,7 @@ export async function testServerURL(
       url: urlToTest,
       rejectUnauthorized: !params.insecure,
       timeout: DEFAULT_TIMEOUT_MS,
+      userAgent: getUserAgent(),
     });
 
     try {
@@ -167,6 +169,7 @@ export async function testAuthentication(
       ...auth,
       rejectUnauthorized: !params.insecure,
       timeout: DEFAULT_TIMEOUT_MS,
+      userAgent: getUserAgent(),
     });
 
     const result = await client.testAuthentication();

--- a/extensions/vscode/src/utils/userAgent.test.ts
+++ b/extensions/vscode/src/utils/userAgent.test.ts
@@ -9,7 +9,23 @@ vi.mock("vscode", () => ({
 }));
 
 import { extensions } from "vscode";
-import { getUserAgent } from "./userAgent";
+import { getExtensionVersion, getUserAgent } from "./userAgent";
+
+describe("getExtensionVersion", () => {
+  test("returns the version when the extension is found", () => {
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      packageJSON: { version: "2.11.4" },
+    } as ReturnType<typeof extensions.getExtension>);
+
+    expect(getExtensionVersion()).toBe("2.11.4");
+  });
+
+  test("falls back to unknown when the extension is not found", () => {
+    vi.mocked(extensions.getExtension).mockReturnValue(undefined);
+
+    expect(getExtensionVersion()).toBe("unknown");
+  });
+});
 
 describe("getUserAgent", () => {
   test("returns PositPublisher/<version> when the extension is found", () => {

--- a/extensions/vscode/src/utils/userAgent.test.ts
+++ b/extensions/vscode/src/utils/userAgent.test.ts
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("vscode", () => ({
+  extensions: {
+    getExtension: vi.fn(),
+  },
+}));
+
+import { extensions } from "vscode";
+import { getUserAgent } from "./userAgent";
+
+describe("getUserAgent", () => {
+  test("returns PositPublisher/<version> when the extension is found", () => {
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      packageJSON: { version: "2.11.4" },
+    } as ReturnType<typeof extensions.getExtension>);
+
+    expect(getUserAgent()).toBe("PositPublisher/2.11.4");
+  });
+
+  test("falls back to unknown when the extension is not found", () => {
+    vi.mocked(extensions.getExtension).mockReturnValue(undefined);
+
+    expect(getUserAgent()).toBe("PositPublisher/unknown");
+  });
+});

--- a/extensions/vscode/src/utils/userAgent.ts
+++ b/extensions/vscode/src/utils/userAgent.ts
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 by Posit Software, PBC.
+
+import { extensions } from "vscode";
+
+/**
+ * Builds the User-Agent header value sent on requests to Connect and Connect
+ * Cloud, e.g. "PositPublisher/2.11.4".
+ */
+export function getUserAgent(): string {
+  const version =
+    extensions.getExtension("posit.publisher")?.packageJSON.version ||
+    "unknown";
+  return `PositPublisher/${version}`;
+}

--- a/extensions/vscode/src/utils/userAgent.ts
+++ b/extensions/vscode/src/utils/userAgent.ts
@@ -3,12 +3,19 @@
 import { extensions } from "vscode";
 
 /**
+ * Returns the installed extension's version, e.g. "2.11.4", or "unknown" when
+ * it cannot be determined.
+ */
+export function getExtensionVersion(): string {
+  return (
+    extensions.getExtension("posit.publisher")?.packageJSON.version || "unknown"
+  );
+}
+
+/**
  * Builds the User-Agent header value sent on requests to Connect and Connect
  * Cloud, e.g. "PositPublisher/2.11.4".
  */
 export function getUserAgent(): string {
-  const version =
-    extensions.getExtension("posit.publisher")?.packageJSON.version ||
-    "unknown";
-  return `PositPublisher/${version}`;
+  return `PositPublisher/${getExtensionVersion()}`;
 }

--- a/extensions/vscode/src/views/homeView.ts
+++ b/extensions/vscode/src/views/homeView.ts
@@ -87,6 +87,7 @@ import {
 import type { Credential } from "src/api/types/credentials";
 import { getNonce } from "src/utils/getNonce";
 import { getUri } from "src/utils/getUri";
+import { getUserAgent } from "src/utils/userAgent";
 import { runDeployWithProgress, DeployOutcome } from "src/views/deployProgress";
 import { connectPublish } from "src/publish/connectPublish";
 import { connectCloudPublish } from "src/publish/connectCloudPublish";
@@ -483,6 +484,7 @@ export class HomeViewProvider implements WebviewViewProvider, Disposable {
             credential.refreshToken = tokens.refresh_token;
             await storeCredential(this.context.secrets, credential);
           },
+          userAgent: getUserAgent(),
         });
 
         return await runDeployWithProgress({

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -444,6 +444,50 @@ describe("timeout option", () => {
 });
 
 // ---------------------------------------------------------------------------
+// User-Agent header
+// ---------------------------------------------------------------------------
+
+describe("User-Agent header", () => {
+  const USER_AGENT = "posit-publisher/1.2.3";
+
+  it("sets User-Agent when provided with an API key", () => {
+    new ConnectAPI({
+      url: BASE_URL,
+      apiKey: API_KEY,
+      userAgent: USER_AGENT,
+    });
+
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Key ${API_KEY}`,
+          "User-Agent": USER_AGENT,
+        }),
+      }),
+    );
+  });
+
+  it("sets User-Agent when provided with no auth", () => {
+    new ConnectAPI({ url: BASE_URL, userAgent: USER_AGENT });
+
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": USER_AGENT,
+        }),
+      }),
+    );
+  });
+
+  it("does not set User-Agent when omitted", () => {
+    new ConnectAPI({ url: BASE_URL, apiKey: API_KEY });
+
+    const call = vi.mocked(axios.create).mock.calls.at(-1)?.[0];
+    expect(call?.headers).not.toHaveProperty("User-Agent");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // testAuthentication
 // ---------------------------------------------------------------------------
 

--- a/packages/connect-api/src/client.test.ts
+++ b/packages/connect-api/src/client.test.ts
@@ -485,6 +485,13 @@ describe("User-Agent header", () => {
     const call = vi.mocked(axios.create).mock.calls.at(-1)?.[0];
     expect(call?.headers).not.toHaveProperty("User-Agent");
   });
+
+  it("does not set User-Agent when empty", () => {
+    new ConnectAPI({ url: BASE_URL, apiKey: API_KEY, userAgent: "" });
+
+    const call = vi.mocked(axios.create).mock.calls.at(-1)?.[0];
+    expect(call?.headers).not.toHaveProperty("User-Agent");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -161,7 +161,7 @@ export class ConnectAPI {
       config.timeout = options.timeout;
     }
 
-    if (options.userAgent !== undefined) {
+    if (options.userAgent) {
       config.headers = { ...config.headers, "User-Agent": options.userAgent };
     }
 

--- a/packages/connect-api/src/client.ts
+++ b/packages/connect-api/src/client.ts
@@ -161,6 +161,10 @@ export class ConnectAPI {
       config.timeout = options.timeout;
     }
 
+    if (options.userAgent !== undefined) {
+      config.headers = { ...config.headers, "User-Agent": options.userAgent };
+    }
+
     this.client = axios.create(config);
 
     // For token auth, add a request interceptor that computes per-request signing headers

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -25,7 +25,7 @@ interface ConnectAPIBaseOptions {
   /** Whether to verify TLS certificates. Defaults to true. */
   rejectUnauthorized?: boolean;
   timeout?: number; // request timeout in milliseconds
-  /** Value for the User-Agent header sent on every request. When omitted, axios's default is used. */
+  /** Value for the User-Agent header sent on every request. When omitted or empty, axios's default is used. */
   userAgent?: string;
 }
 

--- a/packages/connect-api/src/types.ts
+++ b/packages/connect-api/src/types.ts
@@ -25,6 +25,8 @@ interface ConnectAPIBaseOptions {
   /** Whether to verify TLS certificates. Defaults to true. */
   rejectUnauthorized?: boolean;
   timeout?: number; // request timeout in milliseconds
+  /** Value for the User-Agent header sent on every request. When omitted, axios's default is used. */
+  userAgent?: string;
 }
 
 interface ApiKeyAuth extends ConnectAPIBaseOptions {

--- a/packages/connect-cloud-api/src/auth.test.ts
+++ b/packages/connect-cloud-api/src/auth.test.ts
@@ -209,4 +209,84 @@ describe("CloudAuthClient", () => {
       await expect(client.createDeviceAuth()).rejects.toThrow("Network error");
     });
   });
+
+  describe("userAgent", () => {
+    it("includes User-Agent on exchangeToken when provided", async () => {
+      mockPost.mockResolvedValue({ data: tokenResponse });
+
+      const client = new CloudAuthClient(
+        CloudEnvironment.Production,
+        "posit-publisher/1.2.3",
+      );
+      await client.exchangeToken({
+        grant_type: "refresh_token",
+        refresh_token: "my-refresh-token",
+      });
+
+      const [, , config] = mockPost.mock.calls[0];
+      expect(config.headers["User-Agent"]).toBe("posit-publisher/1.2.3");
+      expect(config.headers["Content-Type"]).toBe(
+        "application/x-www-form-urlencoded",
+      );
+    });
+
+    it("omits User-Agent on exchangeToken when not provided", async () => {
+      mockPost.mockResolvedValue({ data: tokenResponse });
+
+      const client = new CloudAuthClient(CloudEnvironment.Production);
+      await client.exchangeToken({
+        grant_type: "refresh_token",
+        refresh_token: "my-refresh-token",
+      });
+
+      const [, , config] = mockPost.mock.calls[0];
+      expect(config.headers).not.toHaveProperty("User-Agent");
+    });
+
+    it("includes User-Agent on createDeviceAuth when provided", async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          device_code: "test-device-code",
+          user_code: "ABCD-1234",
+          verification_uri: "https://login.posit.cloud/activate",
+          verification_uri_complete:
+            "https://login.posit.cloud/activate?user_code=ABCD-1234",
+          expires_in: 900,
+          interval: 5,
+        },
+      });
+
+      const client = new CloudAuthClient(
+        CloudEnvironment.Production,
+        "posit-publisher/1.2.3",
+      );
+      await client.createDeviceAuth();
+
+      const [, , config] = mockPost.mock.calls[0];
+      expect(config.headers["User-Agent"]).toBe("posit-publisher/1.2.3");
+      expect(config.headers["Content-Type"]).toBe(
+        "application/x-www-form-urlencoded",
+      );
+    });
+
+    it("omits User-Agent on createDeviceAuth when not provided", async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          device_code: "test-device-code",
+          user_code: "ABCD-1234",
+          verification_uri: "https://login.posit.cloud/activate",
+          verification_uri_complete:
+            "https://login.posit.cloud/activate?user_code=ABCD-1234",
+          expires_in: 900,
+          interval: 5,
+        },
+      });
+
+      const client = new CloudAuthClient(CloudEnvironment.Production);
+      await client.createDeviceAuth();
+
+      const [, , config] = mockPost.mock.calls[0];
+      expect(config.headers).not.toHaveProperty("User-Agent");
+    });
+  });
 });

--- a/packages/connect-cloud-api/src/auth.ts
+++ b/packages/connect-cloud-api/src/auth.ts
@@ -23,10 +23,17 @@ const AUTH_SCOPE = "vivid";
 export class CloudAuthClient {
   private readonly baseUrl: string;
   private readonly clientId: string;
+  private readonly userAgent?: string;
 
-  constructor(environment: CloudEnvironment) {
+  constructor(environment: CloudEnvironment, userAgent?: string) {
     this.baseUrl = cloudAuthBaseUrls[environment];
     this.clientId = cloudAuthClientIds[environment];
+    this.userAgent = userAgent;
+  }
+
+  /** Headers to merge into every request, carrying the User-Agent when configured. */
+  private headers(base: Record<string, string>): Record<string, string> {
+    return this.userAgent ? { ...base, "User-Agent": this.userAgent } : base;
   }
 
   /**
@@ -44,7 +51,9 @@ export class CloudAuthClient {
       `${this.baseUrl}/oauth/device/authorize`,
       body,
       {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: this.headers({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
       },
     );
 
@@ -73,7 +82,9 @@ export class CloudAuthClient {
       `${this.baseUrl}/oauth/token`,
       body,
       {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: this.headers({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
       },
     );
 

--- a/packages/connect-cloud-api/src/client.test.ts
+++ b/packages/connect-cloud-api/src/client.test.ts
@@ -43,8 +43,8 @@ vi.mock("axios", () => {
     const resp = await mockRequest(processedConfig);
     const validate =
       (processedConfig.validateStatus as
-        | ((s: number) => boolean)
-        | undefined) ?? ((s: number) => s >= 200 && s < 300);
+        ((s: number) => boolean) | undefined) ??
+      ((s: number) => s >= 200 && s < 300);
     if (!validate(resp.status as number)) {
       throw Object.assign(
         new Error(`Request failed with status code ${resp.status}`),

--- a/packages/connect-cloud-api/src/client.test.ts
+++ b/packages/connect-cloud-api/src/client.test.ts
@@ -43,8 +43,8 @@ vi.mock("axios", () => {
     const resp = await mockRequest(processedConfig);
     const validate =
       (processedConfig.validateStatus as
-        ((s: number) => boolean) | undefined) ??
-      ((s: number) => s >= 200 && s < 300);
+        | ((s: number) => boolean)
+        | undefined) ?? ((s: number) => s >= 200 && s < 300);
     if (!validate(resp.status as number)) {
       throw Object.assign(
         new Error(`Request failed with status code ${resp.status}`),
@@ -192,6 +192,89 @@ describe("Authorization header", () => {
           Authorization: `Bearer ${ACCESS_TOKEN}`,
         }),
       }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User-Agent header
+// ---------------------------------------------------------------------------
+
+describe("User-Agent header", () => {
+  it("includes User-Agent in the axios.create config when provided", () => {
+    new ConnectCloudAPI({
+      apiBaseUrl: BASE_URL,
+      accessToken: ACCESS_TOKEN,
+      userAgent: "posit-publisher/1.2.3",
+    });
+
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: { "User-Agent": "posit-publisher/1.2.3" },
+      }),
+    );
+  });
+
+  it("omits headers from the axios.create config when not provided", () => {
+    createClient();
+
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: BASE_URL,
+    });
+  });
+
+  it("includes User-Agent on the direct upload POST when provided", async () => {
+    mockRequest.mockResolvedValue(jsonResponse(null, 200));
+
+    const client = new ConnectCloudAPI({
+      apiBaseUrl: BASE_URL,
+      accessToken: ACCESS_TOKEN,
+      userAgent: "posit-publisher/1.2.3",
+    });
+    const body = Readable.from(Buffer.from([1]));
+    await client.uploadBundle("https://upload.example.com/presigned", body, 1);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://upload.example.com/presigned",
+      body,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "posit-publisher/1.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("omits User-Agent on the direct upload POST when not provided", async () => {
+    mockRequest.mockResolvedValue(jsonResponse(null, 200));
+
+    const client = createClient();
+    const body = Readable.from(Buffer.from([1]));
+    await client.uploadBundle("https://upload.example.com/presigned", body, 1);
+
+    const calls = (axios.post as ReturnType<typeof vi.fn>).mock.calls;
+    const [, , config] = calls[calls.length - 1];
+    expect(config.headers).not.toHaveProperty("User-Agent");
+  });
+
+  it("forwards userAgent to CloudAuthClient used for token refresh", async () => {
+    const userResponse: UserResponse = { account_roles: {} };
+    mockRequest
+      .mockResolvedValueOnce(textResponse("Unauthorized", 401, "Unauthorized"))
+      .mockResolvedValueOnce(jsonResponse(userResponse));
+
+    const client = new ConnectCloudAPI({
+      apiBaseUrl: BASE_URL,
+      accessToken: ACCESS_TOKEN,
+      refreshToken: "test-refresh-token",
+      environment: CloudEnvironment.Production,
+      userAgent: "posit-publisher/1.2.3",
+    });
+    await client.getCurrentUser();
+
+    expect(MockCloudAuthClientConstructor).toHaveBeenCalledWith(
+      CloudEnvironment.Production,
+      "posit-publisher/1.2.3",
     );
   });
 });
@@ -636,9 +719,16 @@ const mockExchangeToken = vi.fn().mockResolvedValue({
   scope: "vivid",
 });
 
+const MockCloudAuthClientConstructor = vi.fn();
+
 vi.mock("./auth.js", () => ({
   CloudAuthClient: class MockCloudAuthClient {
-    constructor(public environment: CloudEnvironment) {}
+    constructor(
+      public environment: CloudEnvironment,
+      public userAgent?: string,
+    ) {
+      MockCloudAuthClientConstructor(environment, userAgent);
+    }
     exchangeToken = mockExchangeToken;
   },
 }));

--- a/packages/connect-cloud-api/src/client.ts
+++ b/packages/connect-cloud-api/src/client.ts
@@ -36,15 +36,20 @@ export class ConnectCloudAPI {
   private refreshToken?: string;
   private readonly environment?: CloudEnvironment;
   private readonly onTokenRefresh?: (tokens: TokenResponse) => Promise<void>;
+  private readonly userAgent?: string;
 
   constructor(options: ConnectCloudAPIOptions) {
     this.accessToken = options.accessToken;
     this.refreshToken = options.refreshToken;
     this.environment = options.environment;
     this.onTokenRefresh = options.onTokenRefresh;
+    this.userAgent = options.userAgent;
 
     this.client = axios.create({
       baseURL: options.apiBaseUrl,
+      ...(this.userAgent && {
+        headers: { "User-Agent": this.userAgent },
+      }),
     });
 
     // Use request interceptor to set auth header dynamically (token may change after refresh)
@@ -71,7 +76,7 @@ export class ConnectCloudAPI {
       throw new Error("Token refresh not configured");
     }
 
-    const authClient = new CloudAuthClient(this.environment!);
+    const authClient = new CloudAuthClient(this.environment!, this.userAgent);
     const tokens = await authClient.exchangeToken({
       grant_type: "refresh_token",
       refresh_token: this.refreshToken!,
@@ -221,6 +226,7 @@ export class ConnectCloudAPI {
       headers: {
         "Content-Type": "application/gzip",
         "Content-Length": contentLength,
+        ...(this.userAgent && { "User-Agent": this.userAgent }),
       },
       maxRedirects: 0,
       signal,

--- a/packages/connect-cloud-api/src/types.ts
+++ b/packages/connect-cloud-api/src/types.ts
@@ -23,7 +23,7 @@ export interface ConnectCloudAPIOptions {
   environment?: CloudEnvironment;
   /** Called after successful token refresh so caller can persist new tokens. */
   onTokenRefresh?: (tokens: TokenResponse) => Promise<void>;
-  /** Value for the User-Agent header sent on every request. When omitted, axios's default is used. */
+  /** Value for the User-Agent header sent on every request. When omitted or empty, axios's default is used. */
   userAgent?: string;
 }
 

--- a/packages/connect-cloud-api/src/types.ts
+++ b/packages/connect-cloud-api/src/types.ts
@@ -23,6 +23,8 @@ export interface ConnectCloudAPIOptions {
   environment?: CloudEnvironment;
   /** Called after successful token refresh so caller can persist new tokens. */
   onTokenRefresh?: (tokens: TokenResponse) => Promise<void>;
+  /** Value for the User-Agent header sent on every request. When omitted, axios's default is used. */
+  userAgent?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

## Intent

Set a custom, versioned User-Agent header when making backend calls.

Fixes #4355 

## Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- - [ ] Bug Fix <!-- A change which fixes an existing issue -->
- - [x] New Feature <!-- A change which adds additional functionality -->
- - [ ] Breaking Change <!-- A breaking change which causes existing functionality to change -->
- - [ ] Documentation <!-- User or developer documentation -->
- - [ ] Refactor <!-- Code restructuring -->
- - [ ] Tooling <!-- Build, CI, or release scripts and configuration -->

## Approach

Added optional userAgent to every location where we construct an axios HTTP client.

Added a user agent helper and an extension version helper.

## User Impact

No direct impact on the user of the extension; Connect / Connect Cloud admins can identify the source of traffic coming from Publisher.

## Automated Tests

Added tests for all new code.

## Directions for Reviewers

<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->

- [x] I have updated the _root_ [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
